### PR TITLE
Give the CLI full in-app documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,7 @@ jobs:
           tests/test_characters_api.py
           tests/test_checkpoint_hash_finder.py
           tests/test_ci_shards.py
+          tests/test_cli_documentation.py
           tests/test_clip_text_embedding_similarity.py
           tests/test_comfyui_api_prompt_extraction.py
           tests/test_comfyui_pixlstash_saver.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@
 - The documented Windows plugin directory was missing a path component. It is
   `%LOCALAPPDATA%\pixlstash\pixlstash\image-plugins\user\`, which is why hand-copying
   a plugin to the path the README gave appeared to do nothing.
+- Both command lines now document themselves in full. Every `pixlstash-cli`
+  verb explains itself under `<command> --help` rather than only listing its
+  arguments, the exit codes a script needs are in the top-level help, and
+  `pixlstash-server` names itself in its usage line instead of `app.py`.
+- Removed `pixlstash-server --retag-and-embed`. It was accepted and documented
+  but never read by anything, so it silently did nothing.
 
 # [1.9.0]
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -312,7 +312,7 @@ Modules **off** the server import path (`tagger_plugins/wd14.py`, `tagger_plugin
 | [pixlstash/pixl_logging.py](../pixlstash/pixl_logging.py) | Uvicorn log config + coloured formatter. |
 | [pixlstash/stacking.py](../pixlstash/stacking.py) | Picture stacking (duplicates / variants). |
 | [pixlstash/image_loading_dataset_prepper.py](../pixlstash/image_loading_dataset_prepper.py) | Dataset preparation utilities for offline training scripts. |
-| [pixlstash/cli.py](../pixlstash/cli.py) | CLI entry point (`pixlstash-cli`). Two verb groups: `libraries` (create/attach/detach/relocate/backup/rename) and `plugins` (install/list/remove). Only the `libraries` group opens the hub — see §8.1. |
+| [pixlstash/cli.py](../pixlstash/cli.py) | CLI entry point (`pixlstash-cli`). Two verb groups: `libraries` (list/create/attach/detach/relocate/backup/prepare-legacy-identity/rename) and `plugins` (install/list/remove). Only the `libraries` group opens the hub — see §8.1. |
 | [pixlstash/plugin_install.py](../pixlstash/plugin_install.py) | Backs `pixlstash-cli plugins`. Classifies a plugin source with `ast` (never by importing it), resolves the destination, and copies it. See §8.1. |
 
 ---

--- a/pixlstash/app.py
+++ b/pixlstash/app.py
@@ -211,34 +211,60 @@ def _force_utf8_streams():
             )
 
 
-def main():
-    _force_utf8_streams()
-    parser = argparse.ArgumentParser(description=f"Run the {APP_NAME} server.")
+def build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser for the server entry point."""
+    parser = argparse.ArgumentParser(
+        prog=f"{APP_NAME}-server",
+        description=(
+            f"Run the {APP_NAME} server. In a source checkout, where the "
+            "entry point is not on PATH, the same options are accepted by "
+            f"`python -m {APP_NAME}.app`."
+        ),
+        epilog=(
+            "Every option acts during startup and the server then runs "
+            "normally, except --clear-embeddings, which does its work and "
+            "exits. Libraries and plugins are managed with a separate "
+            f"command, `{APP_NAME}-cli`."
+        ),
+    )
     parser.add_argument(
         "--server-config",
         type=str,
         default=SERVER_CONFIG_PATH,
-        help="Path to server config file.",
+        metavar="PATH",
+        help=(
+            "Path to the server config file, which is created on first run "
+            f"if it is missing (default: {SERVER_CONFIG_PATH})."
+        ),
     )
     parser.add_argument(
         "--remove-password",
         action="store_true",
-        help="Cause the server to recreate the password on next login.",
-    )
-    parser.add_argument(
-        "--retag-and-embed",
-        action="store_true",
-        help="Re-tag all images and refresh text embeddings in the database.",
+        help=(
+            "Clear the stored username and password hash and log out every "
+            "signed-in session, so the next sign-in sets them again. The "
+            "server starts as usual afterwards."
+        ),
     )
     parser.add_argument(
         "--clear-embeddings",
         action="store_true",
-        help="Clear all text embeddings for all images (does not touch tags).",
+        help=(
+            "Clear every picture's text and image embeddings, then exit "
+            "without starting the server. Tags are not touched, and the "
+            "embeddings are recomputed in the background the next time the "
+            "server runs."
+        ),
     )
     parser.add_argument(
         "--bootstrap",
         action="store_true",
-        help=("Run interactive first-run setup for storage path, port, and HTTPS."),
+        help=(
+            "Run the interactive first-run setup — storage path, port, HTTPS, "
+            "then the username and password — even if a config file already "
+            "exists, and start the server afterwards. It needs a terminal: "
+            "with stdin redirected the setup is skipped."
+        ),
     )
     parser.add_argument(
         "--cleanup-missing-pictures",
@@ -259,7 +285,12 @@ def main():
             "Example: --path-map /mnt/photos:/data/photos"
         ),
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main():
+    _force_utf8_streams()
+    args = build_parser().parse_args()
 
     ran_bootstrap = _bootstrap_server_config(args.server_config, force=args.bootstrap)
     Server.DEFAULT_CLEANUP_MISSING_PICTURES = bool(args.cleanup_missing_pictures)

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -41,21 +41,54 @@ EXIT_OK = 0
 EXIT_REFUSED = 1
 EXIT_HUB_UNAVAILABLE = 3
 
+# Shown under every top-level `--help`. Exit codes belong in the help output
+# rather than only in this file's docstring: a script calling the CLI has to
+# tell "you asked for something I will not do" apart from "I could not open
+# the hub", and nothing else tells it.
+EPILOG = """\
+Every command has its own help, e.g.
+  pixlstash-cli libraries backup --help
+
+Exit codes:
+  0  the command did what it says
+  1  refused for a reason you can act on, or you answered no to a prompt
+  2  the command line itself was wrong
+  3  the hub database could not be opened
+"""
+
+# Every verb that names a library accepts the same three forms, so they are
+# documented in one place rather than drifting apart across five parsers.
+LIBRARY_ARG_HELP = (
+    "Which library: its name, its id from `list`, or its uuid. Quote a name "
+    "containing spaces; digits are matched against ids before names. A "
+    "detached library is not in `list` and answers only to its id or uuid."
+)
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Return the argument parser for the library CLI."""
     parser = argparse.ArgumentParser(
         prog="pixlstash-cli",
+        # Wrapped by hand: RawDescriptionHelpFormatter prints the description
+        # as written, which is the price of an epilog that keeps its layout.
         description=(
-            "PixlStash command line. Run this on the machine hosting "
+            "PixlStash command line. Run this on the machine hosting\n"
             "PixlStash, signed in as the user that owns it."
         ),
+        epilog=EPILOG,
+        # Keeps the epilog's exit-code list on separate lines instead of
+        # reflowing it into a paragraph.
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--hub",
         default=None,
         metavar="PATH",
-        help=f"Hub database to use (default: {default_hub_path()}).",
+        help=(
+            f"Hub database to use (default: {default_hub_path()}). Used by the "
+            "`libraries` commands; `plugins` never opens the hub. Global "
+            "options go before the group name."
+        ),
     )
     # Only the library verbs need the hub. Opening it for `plugins` would make
     # plugin installation fail on a machine that has never run the server.
@@ -75,12 +108,27 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = libraries.add_subparsers(dest="command", required=True)
 
     list_parser = subparsers.add_parser(
-        "list", help="Show the registered libraries and which one is active."
+        "list",
+        help="Show the registered libraries and which one is active.",
+        description=(
+            "Print every registered library with its id, name and folder. "
+            "`*` marks the active one; `(not found)` marks a registration "
+            "whose folder is missing — reconnect the drive, or point it "
+            "somewhere new with `relocate`."
+        ),
     )
     list_parser.set_defaults(handler=_cmd_list)
 
     create_parser = subparsers.add_parser(
-        "create", help="Create a folder, start an empty library in it, register it."
+        "create",
+        help="Create a folder, start an empty library in it, register it.",
+        description=(
+            "Create the folder, initialise an empty library in it, and "
+            "register it. A folder that already holds vault.db is refused; "
+            "use `attach` for that one. The first library on an installation "
+            "becomes the active one; any later library has to be switched to "
+            "in Settings › Libraries."
+        ),
     )
     create_parser.add_argument("folder", help="Folder to create the library in.")
     create_parser.add_argument(
@@ -89,7 +137,18 @@ def build_parser() -> argparse.ArgumentParser:
     create_parser.set_defaults(handler=_cmd_create)
 
     attach_parser = subparsers.add_parser(
-        "attach", help="Register a library that already exists on disk."
+        "attach",
+        help="Register a library that already exists on disk.",
+        description=(
+            "Register a library folder that already exists. The folder must "
+            "hold vault.db, and any login or tokens inside that vault are "
+            "ignored rather than imported. Attaching a library that was "
+            "detached earlier revives its original registration, and with it "
+            "the share links and API tokens issued from it — but only while "
+            "the folder still holds that same library; a different one at "
+            "that path is registered as a new library and the old tokens stay "
+            "inert. Overlapping an existing library warns rather than refuses."
+        ),
     )
     attach_parser.add_argument("folder", help="Folder containing vault.db.")
     attach_parser.add_argument(
@@ -100,15 +159,29 @@ def build_parser() -> argparse.ArgumentParser:
     detach_parser = subparsers.add_parser(
         "detach",
         help="Forget a library. No files are removed and nothing in the folder changes.",
+        description=(
+            "Deregister a library. No files are removed and nothing inside "
+            "the folder changes. The registration is kept rather than "
+            "deleted, so attaching this library again brings back its share "
+            "links and API tokens; until then they are inert. The active "
+            "library is refused — switch to another one first."
+        ),
     )
-    detach_parser.add_argument("library", help="Library name or id from `list`.")
+    detach_parser.add_argument("library", help=LIBRARY_ARG_HELP)
     detach_parser.set_defaults(handler=_cmd_detach)
 
     relocate_parser = subparsers.add_parser(
         "relocate",
         help="Point a library at a folder that has moved, keeping its share links.",
+        description=(
+            "Point an existing registration at a folder that has moved. The "
+            "library keeps its identity, so its share links and API tokens "
+            "keep working; detaching and attaching at the new path would mint "
+            "a new identity and leave them inert. The new folder must hold "
+            "vault.db."
+        ),
     )
-    relocate_parser.add_argument("library", help="Library name or id from `list`.")
+    relocate_parser.add_argument("library", help=LIBRARY_ARG_HELP)
     relocate_parser.add_argument("folder", help="Where the library now lives.")
     relocate_parser.set_defaults(handler=_cmd_relocate)
 
@@ -119,10 +192,14 @@ def build_parser() -> argparse.ArgumentParser:
             "Writes a consistent copy even while the library is open. The "
             "archive contains your credentials, so it is written owner-readable "
             "only; pictures in reference folders are outside the library and are "
-            "not included."
+            "not included. An existing destination file is never overwritten. "
+            "There is no restore verb: you unpack the archive yourself. It is "
+            "a zstd-compressed tar (a plain tar with --no-compress) holding "
+            "manifest.json, vault.db, hub.db and — unless --metadata-only was "
+            "given — the library's own files under images/."
         ),
     )
-    backup_parser.add_argument("library", help="Library name or id from `list`.")
+    backup_parser.add_argument("library", help=LIBRARY_ARG_HELP)
     backup_parser.add_argument(
         "destination", help="Output file, or a folder to write a dated name into."
     )
@@ -141,14 +218,31 @@ def build_parser() -> argparse.ArgumentParser:
     migrate_parser = subparsers.add_parser(
         "prepare-legacy-identity",
         help="Explicitly approve one legacy owner/token migration before startup.",
+        description=(
+            "Approve moving one older library's owner and API tokens out of "
+            "its vault.db and into the hub. Needed once, before the first "
+            "normal start, on an installation that predates the hub: startup "
+            "deliberately will not guess which vault to trust. This records "
+            "the approval and nothing else — the copy, the verification and "
+            "the blanking of the old identity happen the next time PixlStash "
+            "starts."
+        ),
     )
     migrate_parser.add_argument(
         "folder", help="Legacy library folder containing vault.db."
     )
     migrate_parser.set_defaults(handler=_cmd_prepare_legacy_identity)
 
-    rename_parser = subparsers.add_parser("rename", help="Change a library's name.")
-    rename_parser.add_argument("library", help="Library name or id from `list`.")
+    rename_parser = subparsers.add_parser(
+        "rename",
+        help="Change a library's name.",
+        description=(
+            "Change a library's display name. Nothing on disk moves and no "
+            "link changes. Names are unique, so a name another library "
+            "already holds is refused."
+        ),
+    )
+    rename_parser.add_argument("library", help=LIBRARY_ARG_HELP)
     rename_parser.add_argument("new_name", help="The new display name.")
     rename_parser.set_defaults(handler=_cmd_rename)
 
@@ -173,6 +267,15 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
     install_parser = commands.add_parser(
         "install",
         help="Install a plugin from the plugins repository, a zip, a folder or a .py.",
+        description=(
+            "Read the source without importing it, work out whether it is a "
+            "captioning plugin or an image filter, and copy it into the "
+            "matching user plugin directory (`plugins list` prints both "
+            "paths). Prints the plan and asks before writing anything unless "
+            "--yes is given. A captioning plugin is loaded when the server "
+            "next starts; an image filter appears the next time the Filters "
+            "menu is listed."
+        ),
     )
     install_parser.add_argument(
         "source",
@@ -213,12 +316,29 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
     install_parser.set_defaults(handler=_cmd_plugins_install)
 
     list_parser = commands.add_parser(
-        "list", help="Show the installed plugins, grouped by kind."
+        "list",
+        help="Show the installed plugins, grouped by kind.",
+        description=(
+            "Print both plugin directories and what is installed in them. "
+            "`!` marks a plugin that will not load as it stands and `*` one "
+            "that replaces a built-in. Nothing is imported here, so a failure "
+            "that only happens at import — a missing dependency, say — is not "
+            "visible in this listing."
+        ),
     )
     list_parser.set_defaults(handler=_cmd_plugins_list)
 
     remove_parser = commands.add_parser(
-        "remove", help="Delete an installed plugin. This removes files."
+        "remove",
+        help="Delete an installed plugin. This removes files.",
+        description=(
+            "Delete an installed plugin's file or folder, after printing the "
+            "exact path and asking, unless --yes is given. The path deleted "
+            "is always inside one of the two plugin directories. Removing a "
+            "plugin that replaces a built-in filter brings the built-in back; "
+            "removing a captioning plugin takes effect when the server next "
+            "starts."
+        ),
     )
     remove_parser.add_argument("name", help="Plugin name from `plugins list`.")
     remove_parser.add_argument(

--- a/tests/ci_test_durations.json
+++ b/tests/ci_test_durations.json
@@ -3,9 +3,10 @@
   "note": "Per-test wall clock in seconds (setup + call + teardown), used by --ci-shard to balance the backend gate's shards by time. Regenerate with scripts/record_test_durations.py. Stale or missing entries are safe: those tests fall back to their round-robin position.",
   "recorded_from": [
     "GitHub Actions CI run 31312307563 (develop @ a66d8b999f4ef0bca8e725eb61d89ffdf90bedaf), backend gate shards",
-    "local run for tests/test_security_supported_versions.py (newly gated; the rest of the map is unchanged)"
+    "local run for tests/test_security_supported_versions.py (newly gated; the rest of the map is unchanged)",
+    "local run for tests/test_cli_documentation.py (newly gated; the rest of the map is unchanged)"
   ],
-  "test_count": 2480,
+  "test_count": 2488,
   "total_seconds": 6518.81,
   "durations": {
     "tests/multi_project_authz/test_generic_field_reader_allowlist.py::test_bbox_is_serialised_exactly_as_the_relationship_path_did": 4.0,
@@ -482,6 +483,14 @@
     "tests/test_ci_shards.py::test_unusable_duration_maps_degrade_to_round_robin[truncated.json-{\"durations\": {\"tests/a.py::t\": 1.0]": 0.0,
     "tests/test_ci_shards.py::test_unusable_duration_maps_degrade_to_round_robin[wrong_shape.json-[\"tests/a.py::t\", 1.0]]": 0.0,
     "tests/test_ci_shards.py::test_windows_subset_files_all_exist": 0.0,
+    "tests/test_cli_documentation.py::test_entry_points_are_named_as_they_are_installed": 0.0,
+    "tests/test_cli_documentation.py::test_every_command_has_a_description": 0.0,
+    "tests/test_cli_documentation.py::test_every_parameter_has_help": 0.0,
+    "tests/test_cli_documentation.py::test_every_subcommand_is_listed_with_a_summary": 0.0,
+    "tests/test_cli_documentation.py::test_no_parameter_is_documented_without_being_read[app]": 0.0,
+    "tests/test_cli_documentation.py::test_no_parameter_is_documented_without_being_read[cli]": 0.0,
+    "tests/test_cli_documentation.py::test_the_help_is_the_documentation_it_claims_to_be": 0.0,
+    "tests/test_cli_documentation.py::test_the_walk_reaches_every_command": 0.0,
     "tests/test_clip_text_embedding_similarity.py::test_clip_text_embedding_similarity_measures[Clementine holding a black assault rifle]": 3.34,
     "tests/test_clip_text_embedding_similarity.py::test_embedding_storage_and_retrieval": 0.21,
     "tests/test_clip_text_embedding_similarity.py::test_picture_embedding_storage_and_retrieval": 0.23,

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -1,0 +1,154 @@
+"""The command line documents itself: every command, every parameter.
+
+``--help`` is the only documentation someone at a terminal has, so a flag added
+without a ``help=``, or a verb added without a ``description=``, is a hole that
+nothing else in this repository notices. These tests walk both entry points'
+parsers and fail on the hole rather than waiting for a user to find it.
+
+They also fail on the opposite mistake, which #960 turned up: ``--retag-and-embed``
+was parsed and documented for its whole life and never read by anything, so the
+help promised work the server does not do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from pixlstash import app, cli
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Keyed by the module that owns each parser, so the test below can look the
+# expected prog up in pyproject.toml rather than restate it here.
+PARSERS = {cli: cli.build_parser(), app: app.build_parser()}
+
+
+def _walk(parser: argparse.ArgumentParser, path: str):
+    """Yield ``(command path, parser)`` for *parser* and every parser under it."""
+    yield path, parser
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        for name, subparser in action.choices.items():
+            yield from _walk(subparser, f"{path} {name}")
+
+
+def _all_parsers():
+    for module, parser in PARSERS.items():
+        yield from _walk(parser, parser.prog)
+
+
+def test_the_walk_reaches_every_command():
+    """Guards the guardrails: these walk argparse internals.
+
+    ``_actions`` and ``_choices_actions`` are private, so a change in argparse
+    would not raise here — the loops below would simply find nothing and pass.
+    A floor on what the walk reaches turns that silence into a failure.
+    """
+    walked = {path for path, _parser in _all_parsers()}
+    assert "pixlstash-cli libraries backup" in walked
+    assert "pixlstash-server" in walked
+    # 2 roots + 2 groups + 8 library verbs + 3 plugin verbs, at least.
+    assert len(walked) >= 15, walked
+
+
+def test_entry_points_are_named_as_they_are_installed():
+    """The usage line has to name a command the reader can actually type.
+
+    ``pixlstash-server`` used to report itself as ``app.py``, which is neither
+    the console script nor the ``python -m`` form. Read from pyproject.toml
+    rather than restated, so renaming a console script and not its parser is
+    the failure it should be.
+    """
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    scripts = pyproject["project"]["scripts"]
+    for module, parser in PARSERS.items():
+        entry_points = [
+            name
+            for name, target in scripts.items()
+            if target.split(":")[0] == module.__name__
+        ]
+        assert entry_points == [parser.prog], (
+            f"{module.__name__} calls itself {parser.prog!r}; "
+            f"pyproject.toml installs it as {entry_points}"
+        )
+
+
+def test_every_command_has_a_description():
+    """`<command> --help` must say what the command does, not only list flags."""
+    missing = [path for path, parser in _all_parsers() if not parser.description]
+    assert not missing, f"no description under --help for: {missing}"
+
+
+def test_every_subcommand_is_listed_with_a_summary():
+    """The one-line summary in the parent's command list."""
+    missing = []
+    for path, parser in _all_parsers():
+        for action in parser._actions:
+            if not isinstance(action, argparse._SubParsersAction):
+                continue
+            for choice in action._choices_actions:
+                if not choice.help:
+                    missing.append(f"{path} {choice.dest}")
+    assert not missing, f"no summary in the command list for: {missing}"
+
+
+def test_every_parameter_has_help():
+    """Positionals and options alike, on every parser."""
+    missing = []
+    for path, parser in _all_parsers():
+        for action in parser._actions:
+            if isinstance(action, argparse._HelpAction):
+                continue
+            # A subparsers action is documented by its choices, checked above.
+            if isinstance(action, argparse._SubParsersAction):
+                continue
+            if not action.help:
+                missing.append(f"{path}: {action.dest}")
+    assert not missing, f"no help text for: {missing}"
+
+
+def test_the_help_is_the_documentation_it_claims_to_be():
+    """A shape check on the two claims the tests above cannot see.
+
+    Both are load-bearing for anyone scripting the CLI: the exit codes appear
+    nowhere else, and ``--hub`` silently does nothing for ``plugins``.
+    """
+    parser = PARSERS[cli]
+    text = parser.format_help()
+    assert "Exit codes:" in text
+    for code in (cli.EXIT_OK, cli.EXIT_REFUSED, cli.EXIT_HUB_UNAVAILABLE):
+        assert f"\n  {code}  " in text, f"exit code {code} is not documented"
+
+    # The caveat, not the sentence carrying it: `--hub` has to name the group
+    # it does nothing for, and rewording that is not a regression.
+    hub = next(action for action in parser._actions if action.dest == "hub")
+    assert "plugins" in hub.help
+
+
+@pytest.mark.parametrize("module", [cli, app], ids=["cli", "app"])
+def test_no_parameter_is_documented_without_being_read(module):
+    """Every declared parameter is consumed somewhere in its own module.
+
+    An option nobody reads is worse than an undocumented one: the help states
+    it does something, and it does nothing at all.
+
+    A substring search, deliberately: it is a lint, not a proof. A parameter
+    read through ``getattr`` or handed to another module would need an
+    exemption here, and both entry points read theirs as ``args.<dest>``.
+    """
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    unread = []
+    for _path, parser in _walk(module.build_parser(), module.__name__):
+        for action in parser._actions:
+            if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+                continue
+            if f"args.{action.dest}" not in source:
+                unread.append(action.dest)
+    assert not unread, f"{module.__name__} declares parameters nothing reads: {unread}"


### PR DESCRIPTION
Closes #960.

`--help` is the only documentation a person at a terminal has, and it did not cover the CLI. Every `pixlstash-cli` verb had a one-line summary in its parent's command list, but only `backup` had a `description=`, so `pixlstash-cli libraries prepare-legacy-identity --help` printed a usage line, one positional and nothing about what a legacy identity migration is or when you need it. The exit codes a script has to branch on were documented only in a source docstring. `pixlstash-server` announced itself as `app.py`, which is neither the console script nor the `python -m` form.

## What changed

**`pixlstash-cli`** — a `description=` on every verb, written from the code that implements it: what `create` refuses and which library becomes active, that `attach` never imports credentials and when re-attaching does and does not revive share links, that `detach` keeps the registration and refuses the active library, why `relocate` exists rather than detach-and-attach, what the backup archive actually contains and how to unpack it, what `prepare-legacy-identity` records and what it leaves for start-up, and the marker legends for `libraries list` and `plugins list`. The top-level help gained an epilog with the exit codes, `--hub` now says it applies to `libraries` and never to `plugins`, and the five verbs that name a library share one help string that covers name, id and uuid.

**`pixlstash-server`** — parser extracted to `build_parser()`, `prog="pixlstash-server"`, and three help strings corrected against the code: `--remove-password` also clears the username and logs out every session, `--clear-embeddings` clears image embeddings as well as text ones and exits *without starting the server*, `--bootstrap` also prompts for the username and password and needs a terminal.

**Removed `--retag-and-embed`.** It was parsed, documented, and read by nothing — `grep` finds no other reference anywhere in the repo. It has silently done nothing for its whole life.

**`tests/test_cli_documentation.py`** — the guardrail, so "full coverage" survives the next flag: every command has a description, every parameter has help, every subcommand has a summary, the exit codes in the epilog match the constants, both parsers name themselves as `pyproject.toml` installs them, and no parameter is declared that its own module never reads (which is how `--retag-and-embed` was found). Mutation-checked: dropping a description, dropping a help string, and adding a dead flag each turn it red.

`docs/backend_architecture.md`'s module table listed six of the eight `libraries` verbs; it now lists all eight.

## Answering the pre-push adversarial pass

It found no secrets and no private data. Of its substantive findings, seven were right and are fixed in this branch before the push: the backup archive is zstd-compressed by default with the library's files under `images/` and absent entirely under `--metadata-only` (the first draft said "a tar" holding them unconditionally); re-attaching only revives tokens when the folder still holds the same library, which the registry enforces by fingerprint and my first draft promised unconditionally; digits resolve as an id before a name and a detached library is not in `list`; `--bootstrap` and `--remove-password` each did more than they said. On the guardrail it was also right that the `prog` test was a tautology and that a private-argparse change would have degraded the walk to a silent pass — both now fail loudly, and the one assertion that froze an English sentence checks the `--hub` help's substance instead.

Two objections I disagree with, for the reviewer to weigh:

- **"Removing `--retag-and-embed` is a breaking change; suppress it instead."** Suppressing it keeps a flag that accepts your instruction and ignores it. Nothing in this repository passes it, and a wrapper that does is better off failing loudly than believing it re-tagged a library. It is listed as a removal in the CHANGELOG.
- **"Hand-editing `tests/ci_test_durations.json` is unnecessary."** It is, in general — but gating a new file without it drops the map's coverage of gated files below the 90% floor, and `test_recorded_durations_actually_balance_the_gate` fails. I measured that before adding the seven entries. They are locally recorded `0.0`s, in the shape the file already carries for `test_security_supported_versions.py`.
