### PR TITLE
e2e: wait for the config PATCH response before reloading (#973)

### DIFF
--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -246,7 +246,7 @@ notes in the spec. Un-`fixme` each as its behaviour is settled.
 ## Preferences round-trip — `preferences-persist.spec.js`
 | Test | Covers | Status |
 | --- | --- | --- |
-| a compact-mode change is PATCHed and survives a reload | The whole path a preference travels: control → store → the `useAppConfig` watcher's PATCH to `/users/me/config` → read back on the next load. Asserts the request body carried the new value rather than trusting the store, so a broken persistence watcher cannot pass | ✅ |
+| a compact-mode change is PATCHed and survives a reload | The whole path a preference travels: control → store → the `useAppConfig` watcher's PATCH to `/users/me/config` → read back on the next load. Waits for the PATCH *response* before reloading and asserts the request body carried the new value, so a broken persistence watcher cannot pass and a reload cannot cancel the write mid-flight (#973). Forces compact mode off through the API first, so a retry after a failed attempt cannot pass on the store's default | ✅ |
 
 ## Keyboard shortcuts dialog — `shortcuts-dialog.spec.js`
 | Test | Covers | Status |

--- a/frontend/e2e/specs/preferences-persist.spec.js
+++ b/frontend/e2e/specs/preferences-persist.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures/test.js";
 
 // Preferences take a long road: a control writes a store, a watcher notices and
 // PATCHes /users/me/config, and the next session reads it back. The Phase 3
@@ -9,6 +9,53 @@ import { test, expect } from "@playwright/test";
 //
 // Compact mode is the cheapest control to drive: a real button in the toolbar's
 // Grid-view menu, writing straight to the grid store.
+
+/**
+ * Force compact mode OFF through the API, so a click can only ever turn it on.
+ *
+ * Load-bearing, not tidiness. `useGridStore` initialises `compactMode` to false
+ * for an owner session, so a test that starts from compact ON would assert the
+ * reload produced OFF - which the store's pre-fetch default already satisfies,
+ * before the config GET has even landed. That assertion passes without the
+ * server having stored anything. Nothing guarantees the starting state: the
+ * suite shares one mutable backend, and CI runs with `retries: 1`, so a failed
+ * attempt would otherwise hand the next one exactly that vacuous pass.
+ */
+async function resetCompactMode(apiContext) {
+  const res = await apiContext.patch("/api/v1/users/me/config", {
+    data: { compact_mode: false },
+  });
+  expect(res.ok()).toBe(true);
+}
+
+/**
+ * Resolve once a config PATCH carrying `key` has been ANSWERED by the backend.
+ *
+ * The watcher fires the PATCH the moment the store changes, so an assertion on
+ * the request alone is satisfied while it is still in flight; reloading on the
+ * next line cancels it and the server never stores the change (#973). Arm this
+ * BEFORE the click, await it before reloading.
+ *
+ * The status is deliberately NOT part of the predicate: a non-2xx PATCH should
+ * fail on `expect(res.ok())` naming the status, not time out as a non-match.
+ */
+function configPatched(page, key) {
+  return page.waitForResponse(
+    (res) => {
+      if (
+        !res.url().includes("/users/me/config") ||
+        res.request().method() !== "PATCH"
+      ) {
+        return false;
+      }
+      const body = res.request().postDataJSON();
+      return Boolean(body) && key in body;
+    },
+    // Playwright's default action timeout is 0 (= no timeout), which would turn
+    // a missing PATCH into a bare 30 s test timeout instead of naming the wait.
+    { timeout: 10_000 },
+  );
+}
 
 /** Open the toolbar's "Grid view" menu and return its Compact toggle. */
 async function openViewMenu(page) {
@@ -21,14 +68,9 @@ async function openViewMenu(page) {
 test.describe("preferences round-trip", () => {
   test("a compact-mode change is PATCHed and survives a reload", async ({
     page,
+    apiContext,
   }) => {
-    const patches = [];
-    await page.route("**/users/me/config", async (route) => {
-      if (route.request().method() === "PATCH") {
-        patches.push(route.request().postDataJSON());
-      }
-      await route.continue();
-    });
+    await resetCompactMode(apiContext);
 
     await page.goto("/");
     await expect(page.locator(".thumbnail-card").first()).toBeVisible({
@@ -36,21 +78,16 @@ test.describe("preferences round-trip", () => {
     });
 
     const compact = await openViewMenu(page);
-    const wasOn = await compact.evaluate((el) =>
-      el.classList.contains("tbm-btn--on"),
-    );
+    const patched = configPatched(page, "compact_mode");
     await compact.click();
 
-    // The change reached the server, not just the store.
-    await expect
-      .poll(() => patches.some((p) => p && "compact_mode" in p), {
-        timeout: 10_000,
-      })
-      .toBe(true);
-    const sent = patches.filter((p) => p && "compact_mode" in p).pop();
-    expect(sent.compact_mode).toBe(!wasOn);
+    // The change reached the server AND the server accepted it, not just the store.
+    const res = await patched;
+    expect(res.ok()).toBe(true);
+    expect(res.request().postDataJSON().compact_mode).toBe(true);
 
-    // And it is what the next session gets.
+    // And it is what the next session gets. Compact ON cannot come from the
+    // store's default, so this only passes if the backend stored the change.
     await page.reload();
     await expect(page.locator(".thumbnail-card").first()).toBeVisible({
       timeout: 15_000,
@@ -62,9 +99,11 @@ test.describe("preferences round-trip", () => {
           afterReload.evaluate((el) => el.classList.contains("tbm-btn--on")),
         { timeout: 10_000 },
       )
-      .toBe(!wasOn);
+      .toBe(true);
 
-    // Put it back so the shared fixture is left as it was found.
-    await afterReload.click();
+    // Leave the shared fixture as it was found. Through the API rather than a
+    // second click: the watcher early-returns while a config fetch is still in
+    // flight, so a UI restore can legitimately send nothing at all to wait for.
+    await resetCompactMode(apiContext);
   });
 });

--- a/frontend/e2e/specs/preferences-persist.spec.js
+++ b/frontend/e2e/specs/preferences-persist.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "../fixtures/test.js";
+import { test, expect } from '../fixtures/test.js'
 
 // Preferences take a long road: a control writes a store, a watcher notices and
 // PATCHes /users/me/config, and the next session reads it back. The Phase 3
@@ -21,11 +21,11 @@ import { test, expect } from "../fixtures/test.js";
  * suite shares one mutable backend, and CI runs with `retries: 1`, so a failed
  * attempt would otherwise hand the next one exactly that vacuous pass.
  */
-async function resetCompactMode(apiContext) {
-  const res = await apiContext.patch("/api/v1/users/me/config", {
+async function compactModeOff(apiContext) {
+  const res = await apiContext.patch('/api/v1/users/me/config', {
     data: { compact_mode: false },
-  });
-  expect(res.ok()).toBe(true);
+  })
+  expect(res.ok()).toBe(true)
 }
 
 /**
@@ -43,67 +43,67 @@ function configPatched(page, key) {
   return page.waitForResponse(
     (res) => {
       if (
-        !res.url().includes("/users/me/config") ||
-        res.request().method() !== "PATCH"
+        !res.url().includes('/users/me/config') ||
+        res.request().method() !== 'PATCH'
       ) {
-        return false;
+        return false
       }
-      const body = res.request().postDataJSON();
-      return Boolean(body) && key in body;
+      const body = res.request().postDataJSON()
+      return Boolean(body) && key in body
     },
     // Playwright's default action timeout is 0 (= no timeout), which would turn
     // a missing PATCH into a bare 30 s test timeout instead of naming the wait.
     { timeout: 10_000 },
-  );
+  )
 }
 
 /** Open the toolbar's "Grid view" menu and return its Compact toggle. */
 async function openViewMenu(page) {
-  await page.locator(".bar-btn:has(.mdi-view-grid)").first().click();
-  const compact = page.locator(".tbm-btn--compact");
-  await expect(compact).toBeVisible();
-  return compact;
+  await page.locator('.bar-btn:has(.mdi-view-grid)').first().click()
+  const compact = page.locator('.tbm-btn--compact')
+  await expect(compact).toBeVisible()
+  return compact
 }
 
-test.describe("preferences round-trip", () => {
-  test("a compact-mode change is PATCHed and survives a reload", async ({
+test.describe('preferences round-trip', () => {
+  test('a compact-mode change is PATCHed and survives a reload', async ({
     page,
     apiContext,
   }) => {
-    await resetCompactMode(apiContext);
+    await compactModeOff(apiContext)
 
-    await page.goto("/");
-    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+    await page.goto('/')
+    await expect(page.locator('.thumbnail-card').first()).toBeVisible({
       timeout: 15_000,
-    });
+    })
 
-    const compact = await openViewMenu(page);
-    const patched = configPatched(page, "compact_mode");
-    await compact.click();
+    const compact = await openViewMenu(page)
+    const patched = configPatched(page, 'compact_mode')
+    await compact.click()
 
     // The change reached the server AND the server accepted it, not just the store.
-    const res = await patched;
-    expect(res.ok()).toBe(true);
-    expect(res.request().postDataJSON().compact_mode).toBe(true);
+    const res = await patched
+    expect(res.ok()).toBe(true)
+    expect(res.request().postDataJSON().compact_mode).toBe(true)
 
     // And it is what the next session gets. Compact ON cannot come from the
     // store's default, so this only passes if the backend stored the change.
-    await page.reload();
-    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+    await page.reload()
+    await expect(page.locator('.thumbnail-card').first()).toBeVisible({
       timeout: 15_000,
-    });
-    const afterReload = await openViewMenu(page);
+    })
+    const afterReload = await openViewMenu(page)
     await expect
-      .poll(
-        () =>
-          afterReload.evaluate((el) => el.classList.contains("tbm-btn--on")),
-        { timeout: 10_000 },
-      )
-      .toBe(true);
+      .poll(() => afterReload.evaluate((el) => el.classList.contains('tbm-btn--on')), {
+        timeout: 10_000,
+      })
+      .toBe(true)
 
-    // Leave the shared fixture as it was found. Through the API rather than a
-    // second click: the watcher early-returns while a config fetch is still in
-    // flight, so a UI restore can legitimately send nothing at all to wait for.
-    await resetCompactMode(apiContext);
-  });
-});
+    // Undo this test's own write, so the shared backend is left with compact
+    // mode off - the state this test forced on the way in, not whatever it
+    // found. Through the API rather than a second click: the watcher
+    // early-returns while a config fetch is still in flight, so a UI restore
+    // can legitimately send nothing at all to wait for.
+    await compactModeOff(apiContext)
+  })
+})


### PR DESCRIPTION
Fixes #973.

## The race

`preferences-persist.spec.js` recorded the `PATCH /users/me/config` from inside a `page.route()` handler, i.e. at **interception**, before `route.continue()` had forwarded it. The poll that gated the reload was therefore satisfied while the request was still in flight, and `page.reload()` on the next line tore the page down and cancelled it. The server never stored the change, the reload read the old value, and the assertion went red on unrelated branches.

## The change

- `configPatched(page, key)` — a `page.waitForResponse` on `PATCH /users/me/config` carrying `key`, armed before the click and awaited before the reload. Same shape as the existing `scoreWritten()` in `rating.spec.js`, which solves the identical optimistic-write race for star ratings. The `page.route()` interception and its `patches` array are gone; the payload assertion reads off the response's request instead.
- It waits with an explicit `{ timeout: 10_000 }`. Playwright's default action timeout is `0` (= no timeout), so an omitted one turns a missing PATCH into a bare 30 s test timeout instead of naming the wait — the config's `expect: { timeout: 10_000 }` does not apply here.
- The status is asserted on the awaited response (`expect(res.ok()).toBe(true)`) rather than folded into the predicate, so a 401/422/500 fails naming the status instead of timing out as a non-match.
- `resetCompactMode()` forces compact mode off through the API before the run. This closes a second, quieter hole: `useGridStore` initialises `compactMode` to `false`, so an attempt starting from compact ON would assert the reload produced OFF — which the store's pre-fetch default already satisfies, before the config GET lands. With `retries: 1` in CI, a failed attempt would hand the next one exactly that vacuous pass. `rating.spec.js` has the same guard, and says there why it is load-bearing.
- The restore at the end goes through the API too. The old second click could legitimately send nothing at all: `patchConfigUIOptions` early-returns while a config fetch is in flight, so awaiting a PATCH that is never sent would hang the test.
- `docs/regular-tests.md` updated to match.

## Verification

- The issue's deterministic repro (3 s delay on the PATCH, nothing else changed): the **old** spec fails at the reported line with `Expected: false / Received: true`; the **new** spec passes.
- Undelayed: passes, `--repeat-each=3` green.
- Mutation check — deleting the `compact_mode` branch from `patchConfigUIOptions` turns the spec red with `page.waitForResponse: Timeout 10000ms exceeded`, so the assertion is live and the failure names the wait.
- eslint and prettier clean.

## Adversarial review, answered

Two of its findings I did not act on:

- *"first vs last matching PATCH"* — the old code took the **last** compact_mode PATCH (`.pop()`), the new one takes the **first**. That is not a weakening: the store has already flipped by the time any PATCH is built, so the first one carries the new value, and asserting on it is the tighter claim.
- *"`postDataJSON()` can throw on a non-JSON body and terminally reject the wait"* — true in principle, but the only writer to this endpoint is our own client and it always sends JSON. A `try/catch` there would be defending against a case that cannot arise, so it stays out.