### PR TITLE
Restore the model-folders button to the shelf toolbar

### DIFF
--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -22,13 +22,20 @@ container queries today**):
 **Model shelf toolbar** (`ModelShelf.vue`, `.shelf-toolbar`, container
 `shelfbar toolbar`) — added 2026-08-15, after this record was written:
 
-- Left: title → count → Add (accent) → stack sweep
+- Left: title → count → Add (accent) → stack sweep → Model folders
 - Right: Group → Sort split-button → Show → separator → **UndoControl** →
   TbGlobalActions
 
 It was shipped without the tail at all, so both app-wide controls simply
 vanished on `/models`; it now follows Decision 1 as written rather than
 inventing a third arrangement.
+
+`Model folders` rejoined the left group on 2026-08-16, having been dropped by
+the #904 consolidation. **The shelf bar still has no ladder**: it declares
+`container-name: shelfbar toolbar` and writes no `@container` rule, and there is
+no `TbOverflowMenu` on it, so Decision 2 is unimplemented here and the bar now
+carries seven focusable controls plus the tail with nothing to fold. Writing
+that ladder is open work, not something this record already decided.
 
 So undo/redo sits mid-left in the grid and right-adjacent-to-TbGlobalActions in
 Duplicates. A user who learns one position loses it in the other view. That is

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2159,11 +2159,13 @@ collapse a folder of the same name.
 **Everything that changes a file lives on the row or in the selection bar,
 never in the toolbar** (#896). The toolbar is where the view is switched, so a
 mutating control beside `Sort` and `Show` would be one stray click from a
-different question. The audit is over a **named set, not a judgement**: the six
-controls the shelf puts in its own bar are `+ Add ▾`, `Stack training runs`,
-`Model folders`, `Group`, `Sort` (a split button, so its direction toggle rides
-with it) and `Show`. All six hold. `Group`, `Sort` and `Show` write only view
-state. The other three each open something and write nothing on the press:
+different question. The audit is over a **named set, not a judgement**, and the
+set is counted in **focusable controls**, because a tab stop is a stray-press
+target whatever it is grouped with visually. The shelf puts **seven** in its own
+bar: `+ Add ▾`, `Stack training runs`, `Model folders`, `Group`, the `Sort`
+direction toggle, the `Sort` menu, and `Show`. All seven hold. `Group`, both
+halves of `Sort`, and `Show` write only view state. The other three each open
+something and write nothing on the press:
 `+ Add ▾` opens a menu, and its `Import from ai-toolkit` item is confirmed
 against a listing of the runs it found; `Stack training runs` opens the dry run,
 with the applying half behind the dialog's own confirmation; `Model folders`
@@ -2176,8 +2178,8 @@ The **app-wide tail is outside this set and outside the rule**: `UndoControl`
 writes on the press by design, and it, `Settings` and the stats toggle are not
 the shelf's controls at all — they are the canonical tail every view carries,
 ruled off by a separator (see the toolbar section above). Adding a control to
-the shelf's own bar means adding it to the six and re-running this audit; adding
-one to the tail is a different document.
+the shelf's own bar means adding it to the seven and re-running this audit;
+adding one to the tail is a different document.
 
 **The bar states the count AND what the selection weighs**, `40 models selected
 · 12.4 GB`, in the `·` separator the grid's own `SelectionBar` uses. The size is
@@ -2757,20 +2759,24 @@ the fix must not be two navigations away in Settings — and the toolbar button 
 what keeps it reachable once the empty state has unmounted, which is exactly
 when rescan, relocate and forget start to matter. Because more than one control
 opens it, `ModelShelf.vue` holds a `folderInvoker` and `openFolders(invoker)`
-takes the control to return focus to. Only one door needs to name one: the
+takes the control to return focus to. **Every door names one**, and names the
+control that will still be there rather than the element pressed: the
 `Add folder…` item names the **Add button behind it**, because the item itself
-unmounts with the menu. The other two name nothing and ride the fallback, which
-is the always-mounted toolbar button — right for the toolbar button trivially,
-and right for the empty-state button because the first scan unmounts it. Both
-paths are asserted against a real `document.activeElement`; the earlier
-`event.currentTarget` version of this was dead code, since every call site
-passed no event at all.
+unmounts with the menu. The fallback is the always-mounted toolbar button, and
+it exists for exactly one case — the empty-state button unmounting underneath
+its own dialog when the first scan finds something. That case is asserted, along
+with the two ordinary ones, against a real `document.activeElement`; drop the
+`isConnected` check and the suite goes red. The earlier `event.currentTarget`
+version of all this was dead code: no call site ever passed an event.
 
-The button takes **no `bar-btn--open`**, unlike the sweep beside it: that class
-is for a menu activator, and `AppDialog` sets `:scrim="true"`, so the highlight
-is painted under the scrim for exactly as long as it applies. It carries
-`aria-haspopup="dialog"` and no `aria-expanded` — focus moves into the dialog
-rather than into anything the button owns.
+Neither this button nor the stack sweep takes **`bar-btn--open`**. `App.css`
+declares that class for "the toolbar button while its MENU is open", and both
+open an `AppDialog`, which sets `:scrim="true"` — so the highlight is painted
+under the scrim for exactly as long as it applies, and neither button has the
+chevron the rule rotates. `Group`, `Sort` and `Show` keep it because they really
+are menus. Both carry `aria-haspopup="dialog"` and neither carries
+`aria-expanded`: focus moves into the dialog rather than into anything the
+button owns.
 
 `FolderBrowser.vue` is reused whole as the host-path picker, and
 `registeredPaths` is what stops the API's duplicate 409 rather than reporting
@@ -2837,9 +2843,10 @@ the row's fields are captured *before* the request that destroys them.
 
 Rows are a plain `<ul role="list">` of real `<button>`s, deliberately **not**
 `role="listbox"` / `role="option"`: nothing here is selected, and interactive
-controls inside an `option` are unreachable to a screen reader. Both openers
-restore focus to the control that was pressed, falling back to the toolbar
-button when the empty-state button has unmounted underneath the dialog.
+controls inside an `option` are unreachable to a screen reader. All **three**
+openers restore focus to the control that was pressed — see the folder-registry
+section above for how, and for the one case (the empty-state button unmounting
+underneath its own dialog) that the fallback exists to catch.
 
 ---
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1735,11 +1735,13 @@ which is a filed gap rather than a pattern to copy.
 **The toolbar changes the VIEW, and almost nothing else (#904).** The resolved
 design consolidates it: one accented, labelled `+ Add ▾` menu holding the three
 ways a model gets onto the shelf (a folder, a loose file, an ai-toolkit import),
-the stack-detection sweep beside it as an icon, then the view controls on the
-right. Add and the sweep are the only two things there that are not view
-controls, and they sit together apart from them because neither has a selection
-to hang on — Add makes a row that does not exist yet and the sweep proposes over
-the whole shelf — and both open something before they write anything. **Every
+the stack-detection sweep beside it as an icon, the `Model folders` registry
+button beside that, then the view controls on the right. Those three are the
+only things there that are not view controls, and they sit together apart from
+them because each passes the same test: **it opens something, it writes nothing
+on the press, and it has no selection to hang on** — Add makes a row that does
+not exist yet, the sweep proposes over the whole shelf, and `Model folders`
+edits the registry the shelf reads rather than anything in it. **Every
 other verb lives on the row's context menu or in the selection pill**, so a
 mutation is never one stray click from a view switch.
 
@@ -2157,15 +2159,25 @@ collapse a folder of the same name.
 **Everything that changes a file lives on the row or in the selection bar,
 never in the toolbar** (#896). The toolbar is where the view is switched, so a
 mutating control beside `Sort` and `Show` would be one stray click from a
-different question. The four toolbar buttons are audited against that rule and
-all four hold: `Show` and `Sort` write only view state; `Model folders` and
-`Import from ai-toolkit` open a dialog and write nothing on the press, and the
-import is confirmed against a listing of the runs it found. `Group training
-runs` is the same shape — it opens the dry run, and the applying half is behind
-the dialog's own confirmation. Import and detection stay in the toolbar because
-neither has a selection to act on: their subject is a source folder full of
-files the shelf does not list yet, so there is no row and no selection to hang
-them off.
+different question. The audit is over a **named set, not a judgement**: the six
+controls the shelf puts in its own bar are `+ Add ▾`, `Stack training runs`,
+`Model folders`, `Group`, `Sort` (a split button, so its direction toggle rides
+with it) and `Show`. All six hold. `Group`, `Sort` and `Show` write only view
+state. The other three each open something and write nothing on the press:
+`+ Add ▾` opens a menu, and its `Import from ai-toolkit` item is confirmed
+against a listing of the runs it found; `Stack training runs` opens the dry run,
+with the applying half behind the dialog's own confirmation; `Model folders`
+opens the registry dialog. Those three stay in the toolbar because none has a
+selection to act on — their subject is a source folder full of files the shelf
+does not list yet, or the list of such folders itself, so there is no row and no
+selection to hang them off.
+
+The **app-wide tail is outside this set and outside the rule**: `UndoControl`
+writes on the press by design, and it, `Settings` and the stats toggle are not
+the shelf's controls at all — they are the canonical tail every view carries,
+ruled off by a separator (see the toolbar section above). Adding a control to
+the shelf's own bar means adding it to the six and re-running this audit; adding
+one to the tail is a different document.
 
 **The bar states the count AND what the selection weighs**, `40 models selected
 · 12.4 GB`, in the `·` separator the grid's own `SelectionBar` uses. The size is
@@ -2691,10 +2703,12 @@ front of you. Both stores are refreshed afterwards, for the reason the import
 refreshes both: the shelf gained a row and the destination folder's file count
 and `shelf_bytes` moved with it, so the drive bands are stale too.
 
-**The toolbar button is hidden, not disabled, when no `source` folder is
-registered** — unlike the selection bar's verbs, which are about a selection the
-reader just made and therefore owe an explanation in a tooltip. This is about a
-folder they have not set up, which the folders dialog is the place to say.
+**The `Import from ai-toolkit` item is hidden, not disabled, when no `source`
+folder is registered** — unlike the selection bar's verbs, which are about a
+selection the reader just made and therefore owe an explanation in a tooltip.
+This is about a folder they have not set up, which the folders dialog is the
+place to say. Since #904 it is an item inside `+ Add ▾` behind a
+`v-if="hasSourceFolder"`, not a toolbar button of its own.
 
 **Receipts are notices, not `useActionReceipt`.** That composable is built on
 `useOperationStore`, which is the vault-only operation log with undo keycaps —
@@ -2736,11 +2750,31 @@ its own overrides (the container-query fold, the icon-trigger accent) and
 #### Registering the folders the shelf reads
 
 `ModelFoldersDialog.vue` (`components/panels/`) is the registry surface,
-opened from a `bar-btn--boxed` beside `Show` and from the empty state's own
-button. The empty state is the moment the folder list matters, so the fix must
-not be two navigations away in Settings. `FolderBrowser.vue` is reused whole as
-the host-path picker, and `registeredPaths` is what stops the API's duplicate
-409 rather than reporting it.
+opened from three doors: the toolbar's `bar-btn--boxed` `Model folders` button
+beside the stack sweep, the `+ Add ▾` menu's `Add folder…` item, and the empty
+state's own button. The empty state is the moment the folder list matters, so
+the fix must not be two navigations away in Settings — and the toolbar button is
+what keeps it reachable once the empty state has unmounted, which is exactly
+when rescan, relocate and forget start to matter. Because more than one control
+opens it, `ModelShelf.vue` holds a `folderInvoker` and `openFolders(invoker)`
+takes the control to return focus to. Only one door needs to name one: the
+`Add folder…` item names the **Add button behind it**, because the item itself
+unmounts with the menu. The other two name nothing and ride the fallback, which
+is the always-mounted toolbar button — right for the toolbar button trivially,
+and right for the empty-state button because the first scan unmounts it. Both
+paths are asserted against a real `document.activeElement`; the earlier
+`event.currentTarget` version of this was dead code, since every call site
+passed no event at all.
+
+The button takes **no `bar-btn--open`**, unlike the sweep beside it: that class
+is for a menu activator, and `AppDialog` sets `:scrim="true"`, so the highlight
+is painted under the scrim for exactly as long as it applies. It carries
+`aria-haspopup="dialog"` and no `aria-expanded` — focus moves into the dialog
+rather than into anything the button owns.
+
+`FolderBrowser.vue` is reused whole as the host-path picker, and
+`registeredPaths` is what stops the API's duplicate 409 rather than reporting
+it.
 
 Four states are designed rather than left to fail on click:
 

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -2339,6 +2339,62 @@ describe("the manual stack verb", () => {
   });
 });
 
+describe("the model-folders door", () => {
+  // Deleted once already, in the toolbar consolidation for #904, and nothing in
+  // this suite noticed: the shelf kept rendering the dialog with no control left
+  // to open it. Asserted on a POPULATED shelf, because the empty state's own
+  // button unmounts exactly when the registry starts needing edits.
+  it("opens the folders dialog from the toolbar", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const folders = wrapper.find(
+      '.shelf-toolbar button[aria-label="Model folders"]',
+    );
+    expect(folders.exists()).toBe(true);
+    expect(
+      wrapper.findComponent({ name: "ModelFoldersDialog" }).props("open"),
+    ).toBe(false);
+
+    await folders.trigger("click");
+    expect(
+      wrapper.findComponent({ name: "ModelFoldersDialog" }).props("open"),
+    ).toBe(true);
+  });
+
+  // Focus return needs a real document, because `activeElement` is the whole
+  // assertion and a detached wrapper has none. Both doors are asserted: the
+  // toolbar button rides the fallback, and the Add item names the Add button
+  // because the item itself unmounts with the menu. Deleting either half of
+  // the plumbing — the `folderInvoker` write or the `.focus()` — fails this.
+  async function closeFoldersFrom(wrapper, opener) {
+    await opener.trigger("click");
+    wrapper.findComponent({ name: "ModelFoldersDialog" }).vm.$emit("close");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+  }
+
+  it("hands focus back to whichever door opened it", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    document.body.appendChild(wrapper.element);
+
+    const folders = wrapper.find(
+      '.shelf-toolbar button[aria-label="Model folders"]',
+    );
+    await closeFoldersFrom(wrapper, folders);
+    expect(document.activeElement).toBe(folders.element);
+
+    const add = wrapper.find(
+      '.shelf-toolbar button[title="Add models to the shelf"]',
+    );
+    const addItem = wrapper
+      .findAll(".shelf-mi")
+      .find((b) => b.text().includes("Add folder"));
+    await closeFoldersFrom(wrapper, addItem);
+    expect(document.activeElement).toBe(add.element);
+
+    wrapper.unmount();
+  });
+});
+
 describe("Escape", () => {
   // The key is handled on the WINDOW, so every assertion here needs a real
   // event path out of the shelf — a detached wrapper's keydown bubbles into

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -2393,6 +2393,38 @@ describe("the model-folders door", () => {
 
     wrapper.unmount();
   });
+
+  it("returns to the empty-state button, until the first scan unmounts it", async () => {
+    // The empty state is the one door that can disappear underneath its own
+    // dialog. While it is still there it gets focus back like any other — a
+    // reader who opened it to look and closed without adding must not be
+    // thrown to a toolbar icon they never pressed. Once a scan has found
+    // something the button is gone, and THAT is what the `isConnected`
+    // fallback is for.
+    const wrapper = await mountShelf([]);
+    document.body.appendChild(wrapper.element);
+    const store = useModelShelfStore();
+
+    const emptyBtn = wrapper
+      .findAll(".shelf-state button")
+      .find((b) => b.text().includes("Add a model folder"));
+    await closeFoldersFrom(wrapper, emptyBtn);
+    expect(document.activeElement).toBe(emptyBtn.element);
+
+    // Now the scan lands while the dialog is open: the empty state unmounts.
+    await emptyBtn.trigger("click");
+    store.rows = [adapter({ id: 1 })];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".shelf-state").exists()).toBe(false);
+    wrapper.findComponent({ name: "ModelFoldersDialog" }).vm.$emit("close");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).toBe(
+      wrapper.find('.shelf-toolbar button[aria-label="Model folders"]').element,
+    );
+
+    wrapper.unmount();
+  });
 });
 
 describe("Escape", () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -116,10 +116,10 @@
       <button
         ref="stacksBtnRef"
         class="bar-btn bar-btn--boxed"
-        :class="{ 'bar-btn--open': stacksOpen }"
         type="button"
         title="Stack training runs — review proposed stacks"
         aria-label="Stack training runs"
+        aria-haspopup="dialog"
         @click="stacksOpen = true"
       >
         <v-icon size="19">mdi-layers-plus</v-icon>
@@ -134,20 +134,23 @@
            store always exists), so a permanent number beside Show's identical
            pill would mean something else entirely.
 
-           No `bar-btn--open` either, unlike Group/Sort/Show and unlike the
-           sweep beside it: that class is documented for a MENU activator, and
-           `AppDialog` sets `:scrim="true"`, so the highlight would be painted
-           under the scrim for the whole time it applies. It is a dialog, so
-           `aria-haspopup` says so and `aria-expanded` does not — focus moves
-           into the dialog rather than into anything this button owns. -->
+           No `bar-btn--open`, and the sweep above lost its copy in the same
+           change: `App.css` declares that class for "the toolbar button while
+           its MENU is open", and both of these open an `AppDialog`, which sets
+           `:scrim="true"`. The highlight is painted under the scrim for exactly
+           as long as it applies, and neither button has the chevron the rule
+           rotates. Group/Sort/Show keep it because they really are menus.
+           `aria-haspopup="dialog"` on both, and `aria-expanded` on neither:
+           focus moves into the dialog rather than into anything the button
+           owns. -->
       <button
         ref="foldersBtnRef"
         class="bar-btn bar-btn--boxed"
         type="button"
-        title="Model folders"
+        title="Model folders — add, rescan, move or forget a folder"
         aria-label="Model folders"
         aria-haspopup="dialog"
-        @click="openFolders()"
+        @click="openFolders(foldersBtnRef)"
       >
         <v-icon size="19">mdi-folder-multiple-outline</v-icon>
       </button>
@@ -388,9 +391,11 @@
           machine. Add the folder where you keep them.
         </p>
         <button
+          ref="emptyFoldersBtnRef"
           class="tbm-action tbm-action--primary"
           type="button"
-          @click="openFolders()"
+          aria-haspopup="dialog"
+          @click="openFolders(emptyFoldersBtnRef)"
         >
           Add a model folder
         </button>
@@ -1048,6 +1053,10 @@ const groupMenuOpen = ref(false);
 // that place — it unmounts with the menu.
 const addBtnRef = ref(null);
 const foldersBtnRef = ref(null);
+// The empty state's own door. Unlike the two above it is NOT always mounted —
+// the first scan that finds a model replaces the empty state with the list —
+// which is the case `closeFolders`' `isConnected` check exists for.
+const emptyFoldersBtnRef = ref(null);
 const selBarRef = ref(null);
 /** Read once, dismissed for this visit; a refetch says it again. */
 const offlineDismissed = ref(false);
@@ -1806,14 +1815,14 @@ async function onFilePicked(path) {
 const folderInvoker = shallowRef(null);
 
 /**
- * @param {HTMLElement|null} invoker Control to hand focus back to on close.
- *   The caller names it rather than the event supplying it, because the Add
- *   menu's item is gone by the time the dialog closes and its durable stand-in
- *   is the Add button behind it. Omit it and the toolbar's folder button is
- *   used, which is what the empty-state button does — it unmounts too.
+ * @param {HTMLElement} invoker Control to hand focus back to on close. Every
+ *   door names one, and names the durable control rather than the pressed
+ *   element: the `Add folder…` item is gone by the time the dialog closes, so
+ *   it names the Add button it hangs off. The earlier version read
+ *   `event.currentTarget` and was dead — no call site ever passed an event.
  */
-function openFolders(invoker = null) {
-  folderInvoker.value = invoker instanceof HTMLElement ? invoker : null;
+function openFolders(invoker) {
+  folderInvoker.value = invoker;
   foldersOpen.value = true;
 }
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -27,12 +27,14 @@
          header already says it and a second announcer double-speaks. -->
     <p class="visually-hidden" role="status">{{ sortAnnouncement }}</p>
 
-    <!-- The toolbar changes the VIEW. The two things on it that are not view
+    <!-- The toolbar changes the VIEW. The three things on it that are not view
          controls are the ones with no selection to hang on — Add, which makes a
-         row that does not exist yet, and the stack sweep, which proposes over
-         the whole shelf — so they sit together on the left, apart from the view
-         controls, and both open something before they write anything. Every
-         other verb lives on the row or in the selection pill (#904). -->
+         row that does not exist yet; the stack sweep, which proposes over the
+         whole shelf; and Model folders, which edits the registry the shelf
+         reads — so they sit together on the left, apart from the view controls.
+         The test the left group applies: it opens something, it writes nothing
+         on the press, and it has no selection to hang on. Every other verb
+         lives on the row or in the selection pill (#904). -->
     <div class="shelf-toolbar">
       <span class="shelf-title">Models</span>
       <span class="shelf-sub">{{ countLabel }}</span>
@@ -73,7 +75,7 @@
             class="shelf-mi"
             type="button"
             role="menuitem"
-            @click="openFolders()"
+            @click="openFolders(addBtnRef)"
           >
             <v-icon size="16">mdi-folder-plus-outline</v-icon>
             <span>Add folder…</span>
@@ -121,6 +123,33 @@
         @click="stacksOpen = true"
       >
         <v-icon size="19">mdi-layers-plus</v-icon>
+      </button>
+
+      <!-- The registry the shelf reads, and the only door to it once the empty
+           state is gone: Add ▾ spells this "Add folder…", which is the wrong
+           promise for rescan, relocate and forget.
+
+           No count badge: `bar-filter-badge` counts a deviation from a default
+           the reader set, and a folder count never returns to zero (the managed
+           store always exists), so a permanent number beside Show's identical
+           pill would mean something else entirely.
+
+           No `bar-btn--open` either, unlike Group/Sort/Show and unlike the
+           sweep beside it: that class is documented for a MENU activator, and
+           `AppDialog` sets `:scrim="true"`, so the highlight would be painted
+           under the scrim for the whole time it applies. It is a dialog, so
+           `aria-haspopup` says so and `aria-expanded` does not — focus moves
+           into the dialog rather than into anything this button owns. -->
+      <button
+        ref="foldersBtnRef"
+        class="bar-btn bar-btn--boxed"
+        type="button"
+        title="Model folders"
+        aria-label="Model folders"
+        aria-haspopup="dialog"
+        @click="openFolders()"
+      >
+        <v-icon size="19">mdi-folder-multiple-outline</v-icon>
       </button>
 
       <span class="shelf-spacer"></span>
@@ -1014,10 +1043,11 @@ const sortMenuOpen = ref(false);
 const foldersOpen = ref(false);
 const addMenuOpen = ref(false);
 const groupMenuOpen = ref(false);
-// One button behind every dialog the toolbar's left half opens, so focus has
-// one place to come back to however the reader got there. The menu item that
-// opened it is gone by then — it unmounts with the menu.
+// The toolbar buttons behind the dialogs its left half opens, so focus has a
+// place to come back to however the reader got there. A menu item cannot be
+// that place — it unmounts with the menu.
 const addBtnRef = ref(null);
+const foldersBtnRef = ref(null);
 const selBarRef = ref(null);
 /** Read once, dismissed for this visit; a refetch says it again. */
 const offlineDismissed = ref(false);
@@ -1775,9 +1805,15 @@ async function onFilePicked(path) {
 // making it reactive would deep-track an element tree for nothing.
 const folderInvoker = shallowRef(null);
 
-function openFolders(event) {
-  folderInvoker.value =
-    event?.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+/**
+ * @param {HTMLElement|null} invoker Control to hand focus back to on close.
+ *   The caller names it rather than the event supplying it, because the Add
+ *   menu's item is gone by the time the dialog closes and its durable stand-in
+ *   is the Add button behind it. Omit it and the toolbar's folder button is
+ *   used, which is what the empty-state button does — it unmounts too.
+ */
+function openFolders(invoker = null) {
+  folderInvoker.value = invoker instanceof HTMLElement ? invoker : null;
   foldersOpen.value = true;
 }
 
@@ -1787,8 +1823,9 @@ async function closeFolders() {
   folderInvoker.value = null;
   await nextTick();
   // The empty-state button unmounts the moment the first folder is scanned in,
-  // so fall back to the toolbar control rather than dropping focus to <body>.
-  (returnTo?.isConnected ? returnTo : addBtnRef.value)?.focus();
+  // so fall back to the toolbar's folder button — the one door that is always
+  // mounted — rather than dropping focus to <body>.
+  (returnTo?.isConnected ? returnTo : foldersBtnRef.value)?.focus();
 }
 
 // `missing` is a fact (the folder was readable, the file was not in it);


### PR DESCRIPTION
## What broke

The model shelf's toolbar used to carry an icon-only button that opened
`ModelFoldersDialog` — the registry surface where a folder is added, rescanned,
moved or forgotten. `fd7671e6` ("Bring the model shelf in line with the resolved
design", #934 / #904) consolidated the toolbar and dropped the whole right-hand
icon cluster. The sweep came back in that hunk as `mdi-layers-plus`; the folders
button did not.

Nothing was orphaned — the dialog, its store, its API layer and all six backend
endpoints are untouched, and `ModelShelf.vue` still renders the dialog. What was
lost was the door. Its replacement, an **Add folder…** item in the new `+ Add ▾`
menu, does not cover the same ground: it is labelled *Add*, under a menu whose
stated job is "the three ways a model gets onto the shelf", so a reader wanting
to rescan, relocate or forget a registered folder has no reason to look there.
The only other door — the empty state's "Add a model folder" — unmounts the
moment the first model is found, which is exactly when a populated shelf starts
needing the registry edited.

Nothing in the suite noticed the removal. That is fixed too.

## What this does

- Restores the button to the **left** group, after the stack sweep. The resolved
  design reserves that cluster for controls that open something before they
  write anything and have no selection to hang on; folders is one. Reuses
  `bar-btn bar-btn--boxed` verbatim — no new CSS, no new token, no hardcoded
  value.
- **One focus convention for all three doors.** `openFolders(invoker)` now takes
  the control to return focus to, and every door names the control that will
  still be mounted rather than the element pressed: the toolbar button and the
  empty-state button name themselves, the `Add folder…` item names the Add
  button behind it (the item unmounts with the menu). The fallback is the
  always-mounted toolbar button and exists for one case — the empty-state button
  disappearing underneath its own dialog when the first scan lands.
- **Fixes a focus bug on the way.** Previously `openFolders(event)` read
  `event.currentTarget`, but no call site ever passed an event, so
  `folderInvoker` was permanently `null` and the branch was dead. Closing the
  dialog from the empty state threw focus to a toolbar icon the reader never
  pressed (WCAG 2.4.3).
- **One ARIA convention for the bar's modal openers.** Both this button and the
  stack sweep get `aria-haspopup="dialog"` and neither gets `aria-expanded` —
  focus moves into the dialog rather than into anything the button owns.
- **Removes `bar-btn--open` from both.** `App.css` declares that class for "the
  toolbar button while its MENU is open"; both of these open an `AppDialog`,
  which sets `:scrim="true"`, so the highlight was painted under the scrim for
  exactly as long as it applied, and neither button has the chevron the rule
  rotates. Group/Sort/Show keep it — they really are menus.
- Three tests: the button exists and opens the dialog, and focus returns
  correctly from all three doors including the unmount fallback. Each was
  mutation-checked — deleting the button, the `folderInvoker` write, the
  `.focus()` call, or the `isConnected` guard each turns the suite red.

## Documentation

§9.1a had drifted from `fd7671e6` in five places, all now corrected: the
"toolbar changes the VIEW" rule (two non-view controls, now three), the toolbar
audit (which named `Model folders` and `Import from ai-toolkit` as buttons — the
latter has been an Add-menu item since #904 — and called the sweep by its old
name), the folder-registry section (one door, now three), the `Import from
ai-toolkit` hidden-not-disabled passage, and a "Both openers" line that
contradicted the same document 88 lines earlier.

`docs/design/toolbar-responsive-decisions.md` also still listed the shelf's left
group as ending at the sweep. Corrected, and while there: the shelf bar declares
`container-name: shelfbar toolbar` and writes no `@container` rule and has no
overflow menu, so Decision 2 is unimplemented for this bar. Recorded as open
work rather than invented here.

The audit is now counted in **focusable controls** (seven), not in visual
groupings — a tab stop is a stray-press target whatever it is grouped with, and
the previous count of six merged the Sort direction toggle in by judgement in a
paragraph that promised "a named set, not a judgement".

## Reviewer objections answered in advance

Two findings from the pre-push review are deliberately not acted on:

- **`UndoControl` writes on the press and sits in the same bar**, so the
  section's headline rule ("everything that changes a file lives on the row or
  in the selection bar, never in the toolbar") is not literally true. The change
  fences the app-wide tail out of the audited set rather than resolving it. The
  tail is genuinely a different thing — canonical across every view, documented
  separately, ruled off by a separator — and relocating Undo is not this card.
- **No `@container` fold on the shelf bar**, which now carries one more
  permanent control. Pre-existing: the bar has never had a ladder. Recorded in
  the design doc instead of designed here.

Neither the architecture doc nor the design record is parsed by any CI
guardrail, so the prose is unenforced and can rot again as it did in #904. The
three tests are the part that cannot.
