### PR TITLE
Drop undo, redo and History from the model shelf

### DIFF
--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -23,11 +23,11 @@ container queries today**):
 `shelfbar toolbar`) — added 2026-08-15, after this record was written:
 
 - Left: title → count → Add (accent) → stack sweep
-- Right: Group → Sort split-button → Show → separator → **UndoControl** →
-  TbGlobalActions
+- Right: Group → Sort split-button → Show → separator → TbGlobalActions
+  (no UndoControl — see Amendment #4)
 
 It was shipped without the tail at all, so both app-wide controls simply
-vanished on `/models`; it now follows Decision 1 as written rather than
+vanished on `/models`; it then followed Decision 1 as written rather than
 inventing a third arrangement.
 
 So undo/redo sits mid-left in the grid and right-adjacent-to-TbGlobalActions in
@@ -281,3 +281,51 @@ S stacks it. K keeps it separate. Down moves on without deciding."
   a marginal taxonomy gain.
 - **A separator-less tail**: proximity alone cannot separate identical 32px
   icon buttons; the boundary needs the rule.
+
+## Amendment #4 (2026-08-16): the model shelf carries no undo
+
+**The finding:** Decision 1 gave every toolbar the same tail, and the shelf bar
+took it whole. But the shelf writes nothing to the operation log — adapters,
+model folders, model stacks and model moves are not operations — so on
+`/models` the pair sat permanently at "Nothing to undo", and the one time it
+did not, the step it offered to revert was a library edit made on a screen the
+reader had since left. Meanwhile the shelf's own destructive verbs say "There
+is no undo for this" in as many words, two icons away from an undo button. An
+affordance that never answers for what is in front of it teaches the wrong
+thing about the actions beside it, and it is worse when the actions beside it
+are the unrecoverable ones.
+
+**The change:** `ModelShelf.vue` drops `UndoControl`; its tail is
+`[separator] [TbGlobalActions]`. The separator stays — the rejected-options
+list above still holds, the boundary between this view's controls and the
+app's needs the rule. The shelf has no ⋯ overflow, so there is no "History…"
+row to remove, and undo stays exactly where Decision 1 put it in the grid and
+Duplicates bars, which do write the log.
+
+**And the chord goes with the button**, which is the part it would have been
+easy to skip. `useGlobalKeydown` is route-agnostic, so `Ctrl+Z` on `/models`
+kept calling `operationStore.undo()` — and the shelf mounts no `ActionReceipt`
+either, while `UndoControl` is the app's ONLY renderer of the "Changed
+elsewhere" warning. Removing the display and leaving the action reachable is
+the one combination worse than either alternative: a library mutation with no
+button, no state, no history, no receipt and no warning. The handler already
+declines behind a modal scrim for exactly this reason ("every undo raises a
+receipt"), so the shelf joins that guard on the same kind of DOM signal the
+lightbox check uses. What is gone is not only the claim that this screen has
+something to take back, but the silent way it had of taking it.
+
+**And it declines out loud.** A chord that does nothing at all teaches nothing,
+and the reader's next move is to press it again or go hunting for the buttons.
+The notice surface is app-wide and already renders over the shelf, so the
+answer costs no new chrome: one `info` notice, one sentence — "Model shelf
+changes aren't undoable — undo and redo apply to library actions in the grid."
+No action button; it would offer to navigate away mid-task. The push carries a
+fixed coalescing key, so a repeated press updates one card rather than building
+a wall (notice spec §9.1).
+
+**Rejected: hiding the control but keeping it inert**, the read-only pattern
+(`aria-disabled` + an explaining title, "show-but-disable, never hide"). That
+rule exists so a demo can see a feature it may not use — the feature is real,
+the session is not entitled to it. Here the feature does not exist on this
+screen at all, and a permanently inert undo two icons from verbs that say
+"There is no undo for this" teaches the opposite of what is true.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -756,7 +756,7 @@ The transient undo pill, built to the owner's "Undo / Redo System" design. One i
 **The second sentence.** The server's `summary` says what an operation *did*; an action that deliberately left something alone can add one sentence about what it did **not** do, by calling `useOperationStore.noteNextReceipt(opType, note)` immediately before the `refresh()` that will narrate it. `useActionReceipt` appends it to `text` (and therefore to the announcement) on both surfaces, and drops it once the pill flips to "Undone", where it would describe work that has just been taken back. The note is armed for one op type and consumed by the **first** receipt built afterwards, matching or not, so it can never drift onto an unrelated action. This exists so a skip belongs on the same pill as the move it qualifies: split across a pill and a notice, the half that needed a decision gets dismissed along with the half that did not. First and only consumer: `stack.keep_cover_only`'s skipped stacks.
 
 #### `UndoControl.vue` (`panels/`)
-The toolbar undo/redo pair plus a chevron opening the History popover. Mounted in the **right-side app-wide cluster of every toolbar** — the canonical tail `[separator] [UndoControl] [TbGlobalActions]`, identical in the grid bar and the Duplicates bar (see `docs/design/toolbar-responsive-decisions.md`), and the same position in the Electron shell and in the browser, which is why it is not in the breadcrumb. Under the shared `toolbar` container it collapses in steps: ≤480px the chevron hides (the hosts' ⋯ overflow "History…" row calls the exposed `openHistory()` instead), ≤420px redo hides; **undo itself never folds or hides** — the recovery control stays a single visible target, which also keeps the "Changed elsewhere" warning surfaced. Buttons use `aria-disabled` + a guarded handler rather than the native `disabled`, so they stay tabbable and keep naming the step ("Nothing to undo"), and carry `aria-keyshortcuts`. The popover reuses the shared `.tbm*` menu chrome and is labelled `role="dialog"` (not `menu`): it is a list of ordinary tab-order buttons with no roving arrow-key navigation, so claiming a menu would promise a contract it does not honour. Rows are newest-first, undone steps struck through and inert; hovering **or focusing** a row previews how far back you would go (`--active-wash` + an `--active-bar` inset rail across the whole range), and activating it walks the stack via `undoTo`. Enter is handled explicitly because Vuetify's menu `preventDefault`s it. Focus returns to the chevron on a programmatic close. Exposes `openHistory()`.
+The toolbar undo/redo pair plus a chevron opening the History popover. Mounted in the **right-side app-wide cluster of every toolbar that writes the operation log** — the canonical tail `[separator] [UndoControl] [TbGlobalActions]`, identical in the grid bar and the Duplicates bar (see `docs/design/toolbar-responsive-decisions.md`; the model shelf is the one documented exception and mounts no undo), and the same position in the Electron shell and in the browser, which is why it is not in the breadcrumb. Under the shared `toolbar` container it collapses in steps: ≤480px the chevron hides (the hosts' ⋯ overflow "History…" row calls the exposed `openHistory()` instead), ≤420px redo hides; **undo itself never folds or hides in a host that mounts it** — the recovery control stays a single visible target at every width, which also keeps the "Changed elsewhere" warning surfaced. (Whether a host mounts it at all is a separate question, answered per view: the model shelf does not, and `useGlobalKeydown` declines the chord there for the same reason.) Buttons use `aria-disabled` + a guarded handler rather than the native `disabled`, so they stay tabbable and keep naming the step ("Nothing to undo"), and carry `aria-keyshortcuts`. The popover reuses the shared `.tbm*` menu chrome and is labelled `role="dialog"` (not `menu`): it is a list of ordinary tab-order buttons with no roving arrow-key navigation, so claiming a menu would promise a contract it does not honour. Rows are newest-first, undone steps struck through and inert; hovering **or focusing** a row previews how far back you would go (`--active-wash` + an `--active-bar` inset rail across the whole range), and activating it walks the stack via `undoTo`. Enter is handled explicitly because Vuetify's menu `preventDefault`s it. Focus returns to the chevron on a programmatic close. Exposes `openHistory()`.
 
 #### `OverlayActionReceipt.vue` (`widgets/`)
 The lightbox's own narration of the same single receipt, mounted by `ImageOverlay` as the last child of `.overlay-main`. The owner ruled that undo must work in the lightbox and that the affordance may be fitted differently there, because the lightbox has its own GUI — so this is not the grid pill promoted above the modal layer. Everything the receipt *means* comes from the shared `useActionReceipt` composable, so the two surfaces cannot drift; only the chrome differs: `dark-surface`/`on-dark-surface` at 0.9 (the exact fill `.overlay-topbar` and `.overlay-rail` carry), `--elevation-4` (the rung `visual-language.md` §7 names for lightbox chrome, and the reason the grid pill takes -3), a `0.2` border matching `.overlay-nav`, and its own 64px transient-status lane inset by `--filmstrip-rail-width` / `--sidebar-width` so it centres on the visible image. Three deliberate differences beyond the material: **no live region** (the grid's still speaks from underneath, so a second one would double-speak); **no History popover** (choosing a step is a browsing task whose preview has no referent on a surface showing one picture); and a **scope clause** above one target ("Across 2,700 pictures, not just this one"), derived from the count alone so navigating to the next picture cannot falsify it. Nothing on this surface ever says "this picture". Exposes `containsFocus()` / `dismiss()` for the overlay's Escape guard.
@@ -1532,15 +1532,26 @@ express that. Like Duplicates it is excluded from `selectionOwnsHighlight` in
 destination in the rail.
 
 **And like Duplicates its bar carries the shell chrome.** Replacing the grid
-also replaces the grid's toolbar, so `.shelf-toolbar` ends in the canonical tail
-whole — `[separator] [UndoControl] [TbGlobalActions]`, the same components the
-grid and the queue mount, with `TbGlobalActions` emitting `open-settings` up to
-`App.vue`. The shelf writes nothing to the operation log itself, but
-`useOperationStore` is a read model over the backend's app-wide log, so undo
-here is live for whatever library work preceded the visit — which is the point
-of a recovery control that survives a change of destination. `.shelf-toolbar`
-declares `container-name: shelfbar toolbar` for the same reason both other
-hosts do: the shared chrome's scoped `@container toolbar` rules must reach it.
+also replaces the grid's toolbar, so `.shelf-toolbar` ends in
+`[separator] [TbGlobalActions]`, with `TbGlobalActions` emitting `open-settings`
+up to `App.vue`. **`UndoControl` is the documented exception to the canonical
+tail** (`docs/design/toolbar-responsive-decisions.md`): nothing the shelf does
+is an operation-log entry, so every step its History popover listed belonged to
+a screen the reader was not on, and the pair sat permanently at "Nothing to
+undo" or else offered to revert a library edit made elsewhere — a recovery
+control that never answers for what is in front of it, next to shelf actions
+that say in as many words that they cannot be undone. **`Ctrl+Z` declines here
+too** (`useGlobalKeydown`, the `.shelf` check beside the existing modal guard):
+the shelf mounts no `ActionReceipt` either, and `UndoControl` is the app's only
+renderer of the "Changed elsewhere" warning, so the chord would otherwise
+revert a library action with nothing on screen to say it happened — the same
+"every undo raises a receipt" invariant the modal guard protects. It declines
+*out loud*: one `info` notice under the coalescing key `SHELF_NO_UNDO_KEY`, so
+a held or repeated chord updates a single card instead of stacking (notice spec
+§9.1). A silent no-op would leave the reader pressing it again. `.shelf-toolbar`
+still declares `container-name: shelfbar toolbar` — the convention both other
+hosts follow, so a shared control mounted here degrades by the same scoped
+rules — though after this change nothing queries either name on this bar.
 
 These rules come from measurement against real adapter folders and are easy to
 undo by accident:

--- a/frontend/src/components/panels/Toolbar.test.js
+++ b/frontend/src/components/panels/Toolbar.test.js
@@ -254,9 +254,11 @@ describe("Toolbar — Recently changed stacks", () => {
 });
 
 describe("Toolbar — the canonical app-wide tail", () => {
-  // The decision record: EVERY toolbar ends [separator][UndoControl]
-  // [TbGlobalActions]; the ⋯ (amendment #2) is NOT part of the tail — a
-  // burger stands at the end of the group it collapses, the left action run.
+  // The decision record: every toolbar that writes the operation log ends
+  // [separator][UndoControl][TbGlobalActions] (the model shelf does not write
+  // it and carries no undo, amendment #4); the ⋯ (amendment #2) is NOT part of
+  // the tail — a burger stands at the end of the group it collapses, the left
+  // action run.
   it("orders the tail separator → UndoControl → TbGlobalActions", () => {
     const wrapper = mountToolbar();
     const undo = wrapper.findComponent({ name: "UndoControl" }).element;

--- a/frontend/src/components/panels/Toolbar.vue
+++ b/frontend/src/components/panels/Toolbar.vue
@@ -210,8 +210,9 @@
         </v-menu>
         <!-- Undo/redo moved to the right-side app-wide tail (see below): the
              canonical [separator][UndoControl][TbGlobalActions] cluster is
-             identical in every view, so the position learned here holds in
-             Duplicates too. -->
+             identical in every view that writes the operation log, so the
+             position learned here holds in Duplicates too. (The model shelf
+             writes none and carries no undo — amendment #4.) -->
         <!-- ── Filter button ──────────────────────────────────────── -->
         <v-menu
           v-model="gbFilterMenuOpen"
@@ -600,7 +601,8 @@
           <v-icon size="20">mdi-tag-check-outline</v-icon>
         </button>
         <!-- ── Separator G-S4: view-local actions | app-wide chrome ─────
-             The canonical toolbar tail, identical in every view:
+             The canonical toolbar tail, identical in every view that writes
+             the operation log (not the model shelf, amendment #4):
              [separator] [UndoControl] [TbGlobalActions]. The rule is
              required AND stays at every width (it mirrors the Duplicates
              bar's D-S2): proximity alone cannot separate identical 32px
@@ -1114,9 +1116,9 @@ const gbCollapseAllStacksDisabled = computed(
   align-items: center;
   container-type: inline-size;
   /* Two names on one container: `selbar` for this bar's own ladder, and the
-     shared `toolbar` name that UndoControl, TbGlobalActions and the overflow
-     write their scoped @container rules against — so the shared chrome
-     degrades identically here and in the Duplicates bar (`dqbar toolbar`). */
+     shared `toolbar` name that UndoControl and the overflow write their
+     scoped @container rules against — so the shared chrome degrades
+     identically here and in the Duplicates bar (`dqbar toolbar`). */
   container-name: selbar toolbar;
 }
 .selection-bar-content {

--- a/frontend/src/components/views/DuplicateQueue.test.js
+++ b/frontend/src/components/views/DuplicateQueue.test.js
@@ -928,7 +928,8 @@ describe("DuplicateQueue — the shell chrome", () => {
     wrapper.unmount();
   });
 
-  // The decision record's canonical tail, identical in every view:
+  // The decision record's canonical tail, identical in every view that writes
+  // the operation log (the model shelf does not, and mounts no undo):
   // [separator] [UndoControl] [TbGlobalActions]. No ⋯ anywhere in this bar
   // (amendment #2): every foldable here compresses or hides in its own group.
   it("orders the tail separator → UndoControl → TbGlobalActions, no burger", async () => {

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -719,6 +719,18 @@ describe("the shelf's own accessible name", () => {
     expect(root.attributes("aria-describedby")).toBe("shelf-help");
     expect(wrapper.find("#shelf-help").exists()).toBe(true);
   });
+
+  it("describes the tail that is actually there", async () => {
+    // The description is the only account of the bar a screen-reader user
+    // gets, so it is the one place a removed control can go on existing for
+    // them alone. It named Undo and Redo until the shelf stopped mounting
+    // them.
+    const wrapper = await mountShelf([adapter()]);
+    const help = wrapper.find("#shelf-help").text();
+    expect(help).toContain("Settings and the stats sidebar toggle");
+    expect(help).toMatch(/nothing on this screen can be undone/i);
+    expect(help).not.toMatch(/undo and redo/i);
+  });
 });
 
 // ── F2: group headers and the Sort split-button ────────────────────────────

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -2757,8 +2757,9 @@ describe("a long move, in the panel that is running it", () => {
 });
 
 // #938-follow-up: the shelf is a destination like Duplicates, so it carries the
-// app-wide tail — undo, Settings and the stats toggle — rather than dropping all
-// three the moment the grid unmounts.
+// app-wide tail — Settings and the stats toggle — rather than dropping both the
+// moment the grid unmounts. Undo is the exception: nothing on this screen writes
+// to the operation log, so there is nothing here for it to take back.
 describe("the app-wide toolbar tail", () => {
   it("asks App.vue for Settings and toggles the stats sidebar itself", async () => {
     const wrapper = await mountShelf([adapter({ id: 1 })]);
@@ -2777,16 +2778,16 @@ describe("the app-wide toolbar tail", () => {
     expect(sidebar.statsOpen).toBe(false);
   });
 
-  it("orders the tail separator → UndoControl → TbGlobalActions, last in the bar", async () => {
-    // The documented canonical tail
+  it("orders the tail separator → TbGlobalActions, last in the bar", async () => {
+    // The documented tail minus undo
     // (docs/design/toolbar-responsive-decisions.md). Asserted as PLACEMENT and
-    // not merely as presence: the whole point of the rule is that the pair sits
-    // after the view controls, ruled off from them, at the end of the bar.
+    // not merely as presence: the whole point of the rule is that the app-wide
+    // chrome sits after the view controls, ruled off from them, at the end.
     const wrapper = await mountShelf([adapter({ id: 1 })]);
     const cluster = wrapper.find(".shelf-bar-cluster").element;
-    const undo = wrapper.findComponent({ name: "UndoControl" }).element;
     // TbGlobalActions is multi-root; its Settings button is a stable anchor.
     const settings = wrapper.find("button[title='Settings']").element;
+    const separator = wrapper.find(".shelf-bar-cluster .bar-separator").element;
     // The Show menu — the LAST of this view's own controls, and the one the
     // tail has to come after. (`.bar-btn--boxed` alone would find the stack
     // sweep, which sits outside the cluster and proves nothing.)
@@ -2796,16 +2797,22 @@ describe("the app-wide toolbar tail", () => {
     const follows = (a, b) =>
       Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
 
-    expect(
-      undo.previousElementSibling.classList.contains("bar-separator"),
-    ).toBe(true);
-    expect(follows(showBtn, undo)).toBe(true);
-    expect(follows(undo, settings)).toBe(true);
-    // Nothing of this view's own follows the app-wide pair. TbGlobalActions is
-    // multi-root, so its stats button IS the bar's last element.
+    expect(follows(showBtn, separator)).toBe(true);
+    // Adjacency, not merely order: the rule marks the boundary, so nothing may
+    // slip between it and the chrome it rules off.
+    expect(separator.nextElementSibling).toBe(settings);
+    // Nothing of this view's own follows the app-wide chrome. TbGlobalActions
+    // is multi-root, so its stats button IS the bar's last element.
     expect(cluster.lastElementChild.classList.contains("tb-stats-btn")).toBe(
       true,
     );
+  });
+
+  // The shelf writes nothing to the operation log, so undo/redo and the
+  // History popover are not offered here at all.
+  it("mounts no undo control", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    expect(wrapper.findComponent({ name: "UndoControl" }).exists()).toBe(false);
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -248,18 +248,15 @@
           <ShelfShowPanel />
         </v-menu>
 
-        <!-- The canonical tail, whole and in the documented order:
-             [separator] [UndoControl] [TbGlobalActions]
-             (docs/design/toolbar-responsive-decisions.md). The shelf replaces
-             the grid, and with it the grid's toolbar, so it owes the same
-             app-wide chrome the duplicates queue does — including undo, which
-             is about RECOVERY: the shelf writes nothing to the operation log
-             itself, but a library action undone from here is one the reader
-             does not have to navigate back to reach. The separator is required
-             at every width: proximity alone cannot separate identical icon
-             buttons into "this view's controls" and "the app's". -->
+        <!-- The tail, minus undo: [separator] [TbGlobalActions]
+             (docs/design/toolbar-responsive-decisions.md). The shelf records
+             nothing in the operation log, so every step the History popover
+             could offer here belongs to a screen the reader is not on — an
+             undo control that never answers for anything in front of you is
+             worse than no control. The separator is still required: proximity
+             alone cannot separate identical icon buttons into "this view's
+             controls" and "the app's". -->
         <span class="bar-separator" aria-hidden="true"></span>
-        <UndoControl />
         <TbGlobalActions @open-settings="emit('open-settings')" />
       </div>
     </div>
@@ -956,7 +953,6 @@ import ModelFoldersDialog from "../panels/ModelFoldersDialog.vue";
 import ModelImportDialog from "../panels/ModelImportDialog.vue";
 import ShelfStackProposalsDialog from "../panels/ShelfStackProposalsDialog.vue";
 import TbGlobalActions from "../panels/TbGlobalActions.vue";
-import UndoControl from "../panels/UndoControl.vue";
 import FolderBrowser from "../editors/FolderBrowser.vue";
 import ModelMark from "../widgets/ModelMark.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
@@ -2599,9 +2595,15 @@ watch(
   align-items: center;
   gap: var(--space-4);
   /* `shelfbar` for this bar's own ladder, and the shared `toolbar` name the
-     app-wide chrome (UndoControl, TbGlobalActions) writes its scoped
-     @container rules against — so it degrades here exactly as it does in the
-     grid bar (`selbar toolbar`) and the queue's (`dqbar toolbar`). */
+     app-wide chrome writes its scoped @container rules against — the same
+     pair the grid bar (`selbar toolbar`) and the queue's (`dqbar toolbar`)
+     declare, so a shared control mounted here degrades exactly as it does
+     there. Nothing queries either name on this bar today: the shelf has no
+     ladder of its own yet, and dropping UndoControl took the one control that
+     wrote `@container toolbar` rules with it. The declaration stays because
+     the convention is what makes the next shared control work without a
+     second look — and `container-type: inline-size` is also what keeps the
+     bar's width independent of its contents. */
   container-type: inline-size;
   container-name: shelfbar toolbar;
   height: var(--bar-height);

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -14,11 +14,12 @@
       Every adapter and checkpoint PixlStash has found on this machine. Group
       and Sort choose the order and whether the list is cut into groups; Show
       chooses which kinds are listed and which base models. The bar ends in the
-      app-wide controls: Undo and Redo, Settings, and the stats sidebar toggle.
-      A ring around a model's mark says who it is assigned to. A name in italics
-      has not been given one. A row that stands for a training run says how many
-      files it holds; Right and Left open and close it. Right-click a row for
-      everything that can be done to it. Escape clears the selection.
+      app-wide controls: Settings and the stats sidebar toggle. Nothing on this
+      screen can be undone. A ring around a model's mark says who it is assigned
+      to. A name in italics has not been given one. A row that stands for a
+      training run says how many files it holds; Right and Left open and close
+      it. Right-click a row for everything that can be done to it. Escape clears
+      the selection.
     </p>
 
     <!-- One announcement for a resort, because the rows reorder silently: the

--- a/frontend/src/composables/useGlobalKeydown.js
+++ b/frontend/src/composables/useGlobalKeydown.js
@@ -1,6 +1,7 @@
 import { onMounted, onUnmounted } from "vue";
 import { isReadOnly } from "../utils/apiClient";
 import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
+import { useNoticeStore } from "../stores/useNoticeStore";
 import { useOperationStore } from "../stores/useOperationStore";
 import { useSearchStore } from "../stores/useSearchStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
@@ -20,12 +21,19 @@ import { isTypingTarget } from "../utils/dom.js";
  * @param {import("vue").Ref} deps.shortcutsDialogOpen - the keyboard-help
  *   dialog, which its own shortcut toggles.
  */
+/**
+ * Coalescing key for the shelf's "no undo here" answer, so holding the chord
+ * updates one card instead of stacking them (notice spec §9.1).
+ */
+export const SHELF_NO_UNDO_KEY = "shelf-no-undo";
+
 export function useGlobalKeydown({
   gridContainer,
   sidebarRef,
   shortcutsDialogOpen,
 }) {
   const reviewSessionsStore = useReviewSessionsStore();
+  const noticeStore = useNoticeStore();
   const operationStore = useOperationStore();
   const searchStore = useSearchStore();
   const sidebarStore = useSidebarStore();
@@ -43,6 +51,21 @@ export function useGlobalKeydown({
     return (
       document.querySelector(".v-overlay--active .v-overlay__scrim") != null
     );
+  }
+
+  /**
+   * Is the model shelf the mounted destination?
+   *
+   * The shelf replaces the grid, and it is the one destination that neither
+   * writes the operation log nor mounts an `ActionReceipt` — and since it also
+   * dropped `UndoControl`, nothing on that screen can narrate an undo or carry
+   * the "Changed elsewhere" warning. Read off the same kind of DOM signal the
+   * lightbox check above uses, for the same reason: there is no shared
+   * which-view-is-up flag, and `.shelf` is v-if'd on the route.
+   */
+  function isModelShelfOpen() {
+    if (typeof document === "undefined") return false;
+    return document.querySelector(".shelf") != null;
   }
 
   function handleGlobalKeydown(e) {
@@ -91,7 +114,7 @@ export function useGlobalKeydown({
     // and Meta are both accepted (the HINT is platform-specific, the binding is
     // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
     //
-    // Four guards, each for its own reason:
+    // Five guards, each for its own reason:
     //   * typing: a text field keeps its own native undo stack;
     //   * read-only: the endpoints are owner-only anyway;
     //   * auto-repeat: a HELD Ctrl+Z must not walk the whole stack;
@@ -100,6 +123,17 @@ export function useGlobalKeydown({
     //     library with no visible narration. That breaks the design's own "every
     //     undo raises a receipt" invariant, so the shortcut declines rather than
     //     acting blind.
+    //
+    // The MODEL SHELF declines rather than acts, for the same invariant
+    // arrived at from the other side: it mounts no receipt and (deliberately)
+    // no UndoControl, so the chord there would revert a library action taken
+    // on a screen the reader has left, with nothing on this one to say it
+    // happened — not even the "Changed elsewhere" warning, whose only renderer
+    // is the control the shelf does not have. It declines OUT LOUD: a chord
+    // that does nothing at all teaches nothing, and the next thing a reader
+    // does is press it again. The notice surface is app-wide and already
+    // renders over the shelf, so this costs no new chrome; the coalescing key
+    // is what keeps a repeated press one card rather than a wall.
     //
     // The lightbox is NOT covered by that last guard and never was:
     // `isModalOverlayOpen()` looks for a Vuetify scrim, and `.image-overlay`
@@ -117,12 +151,21 @@ export function useGlobalKeydown({
       !isModalOverlayOpen()
     ) {
       const key = e.key?.toLowerCase();
-      if (key === "z" && !e.shiftKey) {
+      const wantsUndo = key === "z" && !e.shiftKey;
+      const wantsRedo = key === "y" || (key === "z" && e.shiftKey);
+      if (wantsUndo || wantsRedo) {
         e.preventDefault();
-        operationStore.undo();
-      } else if (key === "y" || (key === "z" && e.shiftKey)) {
-        e.preventDefault();
-        operationStore.redo();
+        if (isModelShelfOpen()) {
+          noticeStore.push({
+            level: "info",
+            key: SHELF_NO_UNDO_KEY,
+            text: "Model shelf changes aren't undoable — undo and redo apply to library actions in the grid.",
+          });
+        } else if (wantsUndo) {
+          operationStore.undo();
+        } else {
+          operationStore.redo();
+        }
       }
     }
 

--- a/frontend/src/composables/useGlobalKeydown.test.js
+++ b/frontend/src/composables/useGlobalKeydown.test.js
@@ -1,0 +1,111 @@
+// useGlobalKeydown — where the undo chord is allowed to act.
+//
+// The handler's own invariant is that every undo raises a receipt, which is why
+// it already declines behind a modal scrim. The model shelf is the same rule
+// reached from the other side: it mounts no `ActionReceipt` and no
+// `UndoControl`, so an undo fired there would revert a library action taken on
+// a screen the reader has left, with nothing on this one to say so. These tests
+// pin the positive control beside the negative — over-declining would be its
+// own regression.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+import { SHELF_NO_UNDO_KEY, useGlobalKeydown } from "./useGlobalKeydown";
+import { useNoticeStore } from "../stores/useNoticeStore";
+import { useOperationStore } from "../stores/useOperationStore";
+
+/** A host component whose only job is to install the listener. */
+const Host = {
+  setup() {
+    useGlobalKeydown({
+      gridContainer: ref(null),
+      sidebarRef: ref(null),
+      shortcutsDialogOpen: ref(false),
+    });
+    return () => null;
+  },
+};
+
+let wrapper;
+let store;
+let notices;
+
+function press(key, init = {}) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key,
+      ctrlKey: true,
+      bubbles: true,
+      ...init,
+    }),
+  );
+}
+
+/** Mount the shelf's root signal — the class `ModelShelf.vue` renders. */
+function mountShelfMarker() {
+  const el = document.createElement("div");
+  el.className = "shelf";
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  store = useOperationStore();
+  notices = useNoticeStore();
+  vi.spyOn(store, "undo").mockResolvedValue(undefined);
+  vi.spyOn(store, "redo").mockResolvedValue(undefined);
+  wrapper = mount(Host, { attachTo: document.body });
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("the undo chord", () => {
+  it("undoes and redoes from a narrating view, silently", () => {
+    press("z");
+    expect(store.undo).toHaveBeenCalledTimes(1);
+    press("y");
+    expect(store.redo).toHaveBeenCalledTimes(1);
+    press("z", { shiftKey: true });
+    expect(store.redo).toHaveBeenCalledTimes(2);
+    // The receipt narrates a real undo; a notice here would be a second voice.
+    expect(notices.notices).toHaveLength(0);
+  });
+
+  it("declines while the model shelf is the mounted destination", () => {
+    mountShelfMarker();
+    press("z");
+    press("y");
+    press("z", { shiftKey: true });
+    expect(store.undo).not.toHaveBeenCalled();
+    expect(store.redo).not.toHaveBeenCalled();
+  });
+
+  it("says why, once, however many times the chord is pressed", () => {
+    mountShelfMarker();
+    press("z");
+    press("z");
+    press("y");
+    // One card, not three: the coalescing key is what makes a repeated press
+    // an update rather than a wall (notice spec §9.1).
+    expect(notices.notices).toHaveLength(1);
+    expect(notices.notices[0].key).toBe(SHELF_NO_UNDO_KEY);
+    expect(notices.notices[0].text).toContain("aren't undoable");
+  });
+
+  it("acts again once the shelf unmounts", () => {
+    const el = mountShelfMarker();
+    press("z");
+    expect(store.undo).not.toHaveBeenCalled();
+    el.remove();
+    press("z");
+    expect(store.undo).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The model shelf has no undo/redo features, so the toolbar no longer offers them.

## What changed

**`ModelShelf.vue` drops `UndoControl`** — the undo button, the redo button and
the History popover. Its tail is now `[separator] [TbGlobalActions]`. The
separator stays: it still divides this view's controls from the app's, and
proximity alone cannot separate identical 32px icon buttons.

**`Ctrl+Z` / `Ctrl+Y` decline on `/models` too**, which is the half that would
have been easy to skip. `useGlobalKeydown` is route-agnostic, so hiding the
button alone would have left the chord silently reverting a library action
taken on a screen the reader has left — with no button, no state, no History,
no receipt (`ActionReceipt` mounts only in the grid and the queue) and not even
the "Changed elsewhere" warning, whose sole renderer is the control the shelf
no longer has. The handler already declines behind a modal scrim for exactly
this reason ("every undo raises a receipt"); the shelf joins that guard on the
same kind of DOM signal the lightbox check uses.

It declines **out loud**: one `info` notice, one sentence, under a fixed
coalescing key so a repeated press updates one card instead of building a wall.
A silent no-op leaves the reader pressing the chord again.

## Why

Nothing the shelf does is an operation-log entry — `pixlstash/routes/model_shelf.py`
says so outright, and none of the model routes call `record_operation_in_session`.
So every step the History popover listed came from somewhere else, undo/redo sat
permanently at "Nothing to undo", and the one time they did not, they offered to
revert something invisible from here. Two icons away, the shelf's own destructive
verbs display "There is no undo for this." A recovery control that never answers
for what is in front of it contradicts the warning that is doing real work.

Not the read-only "show-but-disable, never hide" pattern: that rule is about
*entitlement* — the feature works, this session may not use it, so the demo
should still see it. Here the feature does not apply to anything on the screen.

## Tests and docs

- New `useGlobalKeydown.test.js`: the positive control (undo/redo still fire,
  silently, from a narrating view) beside the negative (declined on the shelf,
  one notice however many presses, and acting again once the shelf unmounts).
  Verified it can fail — inverting the guard reds two of the four.
- `ModelShelf.test.js`: the tail test drops undo and gains an adjacency
  assertion on the separator; a new test pins that no undo control mounts.
- `docs/design/toolbar-responsive-decisions.md` gains Amendment #4 (the
  exception to Decision 1, the chord, the rejected alternative);
  `docs/frontend_architecture.md` §`UndoControl` and the shelf section follow.
- Stale "identical in every view" comments corrected in `Toolbar.vue`,
  `Toolbar.test.js` and `DuplicateQueue.test.js`.

Full frontend suite green (3306 tests).

## Reviewer objections raised early, and answered

An adversarial pass over the diff before pushing produced eight findings; the
Ctrl+Z hole, the self-contradicting doc paragraph, the stale tail comments and
the weakened adjacency assertion are all fixed above. Three I disagreed with or
left:

- **"`ShortcutsDialog` still teaches Ctrl+Z on that screen."** It doesn't: those
  rows live under the dialog's **Grid view** heading, along with every other key
  that does nothing on `/models`. No change.
- **"`.shelf-toolbar` keeps a `container-name` with no consumers."** True after
  this change, and now stated in the comment rather than papered over. Kept
  deliberately: it is the convention both other bars follow, so the next shared
  control mounted there degrades without a second look, and `container-type:
  inline-size` also keeps the bar's width independent of its contents.
- **"`TbGlobalActions` has an unused `separator` prop rendering the same span."**
  Real dead code, but pre-existing and not this change's: the grid and Duplicates
  bars hand-roll the separator too, so the shelf matches house style. Worth a
  follow-up to delete the prop.

Finally: the published design-system spec (`ui_kits/app/model-shelf`,
`ui_kits/app/undo-redo`) still draws the old tail and should be updated there —
I can't edit it from here. The two design calls (decline the chord rather than
no-op silently; remove rather than show-but-disable) went past `ui-ux-expert`,
which endorsed both and asked for the notice that is now in the diff.
