### PR TITLE
Say which folder a model is in on every grouping axis

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2010,6 +2010,57 @@ groups with `tier`, `icon`, `chip`, `drive`, `offline` and `nested`.
   accessible name and a hue has none either, so the header's `aria-label` states
   the tier, the drive and the offline state alongside the path and the count.
 
+#### Where the file is, on every axis
+
+A folder header is drawn only under `groupBy: 'folder'`. Group by base model, by
+feature, or not at all — the default — and the shelf stopped saying where
+anything was, which is the first question of anyone keeping the same adapter on
+two disks. `copyPathsTitle()` (pure, in `utils/modelShelf.js`) joins each
+`locations[]` entry into one full path and the **file line carries them as its
+tooltip**, one per line, on covers and on expanded stack members alike.
+
+- **Every copy, not the first.** A model registered in two folders is one row,
+  and naming one of its homes would read as naming its only one.
+- **Except under `folder`, where a draw stands for ONE copy** and the store
+  hands it exactly that one. `groups` narrows the drawn row's `locations` beside
+  the `locState` override it already made, and for the same reason: a row under
+  the `/media/…` header reading "file is not where it was" whose tooltip's first
+  line is a path under `/home/…`, where the file is present, is that override
+  undone one attribute at a time. Narrowing is safe because nothing else reads a
+  *drawn* row's locations — `selectedRows` and every verb read `visibleRows`,
+  which still carries all of them. That axis still gains the *subdirectory*
+  under the header, which no header states.
+- **Each line says what is at it.** A bare path is a claim that the file is
+  there, and three of the four states are the claim that it is not, so
+  `COPY_STATE_NOTE` appends "not where it was" / "out of reach" / "not
+  downloaded yet". `present` appends nothing, because that is what a path
+  already says. Rendering all four alike is the one place the section below
+  would be contradicted.
+- **No copies, no tooltip** rather than an empty one: the file line already says
+  "every registered copy forgotten" in words. A copy missing either half of its
+  path is skipped rather than half-named — both are NOT NULL on the wire, so
+  that is a broken row, and `a.st` alone answers "where is this file" with the
+  one thing that is not a location.
+- **The separator comes from the registered folder, and takes the relpath with
+  it.** The two halves come from different places — `model_folder.path` as
+  registered, `relpath` as the scanner wrote it — so a backslashed folder
+  rewrites the relpath's slashes and a POSIX one leaves them alone, where a
+  backslash is a legal filename character rather than a separator.
+
+A tooltip and not a column: the path is long, it is the same on most rows, and
+the shelf's columns are for what a reader *scans*. The words that must be
+scannable are already on the line (`LOC_NOTE`).
+
+**It is hover-only, and that is a floor rather than the finished answer.** A
+`title` on a non-focusable span reaches neither the keyboard nor touch, and the
+row is a single roving tab stop with nothing inside it to focus. The accessible
+shape already exists in this codebase (`HelpTip.vue`, `ScrapheapSection.vue` —
+`v-tooltip` with `open-on-focus`), and moving the file line onto it, or naming
+the folder in the row's accessible name, is the follow-up. It is not free: it
+adds a tab stop per row to a list whose keyboard model is deliberately one stop
+per row (§ the roving grid), which is a `ui-ux-expert` decision rather than a
+rendering one.
+
 #### The two kinds of absence (#898)
 
 `locationState()` reduces a row's copies to one word, and the shelf renders

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -576,6 +576,74 @@ describe("location state", () => {
     const rows = wrapper.findAll(".shelf-row");
     expect(rows[2].find(".shelf-row-loc").exists()).toBe(false);
   });
+
+  it("says where the file is on an axis that draws no folder header", async () => {
+    // Only `groupBy: 'folder'` puts the folder on screen. Every other axis —
+    // and `none`, the default this mounts with — left the reader with no way
+    // to tell a copy on the spare disk from one in the ComfyUI tree.
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          { state: "present", folder_path: "/home/me/models", relpath: "a.st" },
+          { state: "present", folder_path: "/media/me/spare", relpath: "a.st" },
+        ],
+      }),
+    ]);
+    expect(wrapper.find(".shelf-row-file").attributes("title")).toBe(
+      "/home/me/models/a.st\n/media/me/spare/a.st",
+    );
+  });
+
+  it("names THIS copy on a folder-grouped row, not the other folder's", async () => {
+    // The draw stands for one copy — that is why it already reports that
+    // copy's state rather than the merged one. A tooltip reading the merged
+    // array put a path where the file IS on the row that says it is gone.
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          { state: "present", folder_path: "/home/me/models", relpath: "a.st" },
+          { state: "missing", folder_path: "/media/me/spare", relpath: "a.st" },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder" });
+    await wrapper.vm.$nextTick();
+    const titles = wrapper
+      .findAll(".shelf-row-file")
+      .map((el) => el.attributes("title"));
+    expect(titles).toEqual([
+      "/home/me/models/a.st",
+      "/media/me/spare/a.st · not where it was",
+    ]);
+  });
+
+  it("says where each step of an expanded run is", async () => {
+    // A member is a shelf row drawn by a second binding, and a run's steps can
+    // sit in different folders from each other.
+    const wrapper = await mountShelf([
+      adapter({ id: 1, stack_id: 7, stack_position: 0 }),
+      adapter({
+        id: 2,
+        stack_id: 7,
+        stack_position: 1,
+        sha256: "b".repeat(64),
+        locations: [
+          { state: "present", folder_path: "/media/me/spare", relpath: "b.st" },
+        ],
+      }),
+    ]);
+    await wrapper.find(".shelf-row").trigger("keydown", { key: "ArrowRight" });
+    expect(
+      wrapper.find(".shelf-row--member .shelf-row-file").attributes("title"),
+    ).toBe("/media/me/spare/b.st");
+  });
+
+  it("offers no tooltip at all when every copy has been forgotten", async () => {
+    // An empty `title` is a tooltip that flashes and says nothing. The file
+    // line already carries the words for this state.
+    const wrapper = await mountShelf([adapter({ locations: [] })]);
+    expect(wrapper.find(".shelf-row-file").attributes("title")).toBeUndefined();
+  });
 });
 
 describe("empty states", () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -768,8 +768,14 @@
                        the file is actually called, which the name above it may
                        well not be, and it is the string the reader pastes into
                        a ComfyUI node — so it is monospaced and it is always
-                       there rather than living in a tooltip. -->
-                  <span class="shelf-row-file">
+                       there rather than living in a tooltip. What IS in the
+                       tooltip is the folder: the header names it only under
+                       `groupBy: 'folder'`, so on every other axis this line is
+                       the one place left that can say where the file is. -->
+                  <span
+                    class="shelf-row-file"
+                    :title="copyPathsTitle(row.locations) || undefined"
+                  >
                     {{ row.filename
                     }}<template v-if="LOC_NOTE[row.locState]">
                       · {{ LOC_NOTE[row.locState] }}</template
@@ -845,7 +851,11 @@
                     <span class="shelf-row-name">{{
                       memberLabel(member)
                     }}</span>
-                    <span class="shelf-row-file">{{ member.filename }}</span>
+                    <span
+                      class="shelf-row-file"
+                      :title="copyPathsTitle(member.locations) || undefined"
+                      >{{ member.filename }}</span
+                    >
                   </span>
                   <!-- A step of a run has no kind or base of its own — those
                        are the run's, one row up — but a grid row still owes a
@@ -982,6 +992,7 @@ import {
   bandProjection,
   bandUsage,
   capabilityLabel,
+  copyPathsTitle,
   deletableModels,
   trashName,
   withEmptyFolders,

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -1004,13 +1004,21 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
         //
         // Under `folder` a row also reports THAT copy's state rather than the
         // merged one, or a file present here and missing there would claim to
-        // be fine in the folder it is absent from.
+        // be fine in the folder it is absent from. `locations` is narrowed to
+        // the same one copy for the same reason: the draw stands for one copy,
+        // and the file line's path tooltip reading the merged array would
+        // answer "where is this file" with a path in the folder above.
+        //
+        // Narrowing here is safe because nothing else reads a DRAWN row's
+        // locations — `selectedRows` and the verbs all read `visibleRows`,
+        // which still carries every copy.
         bucket.rows.push(
           group.location
             ? {
                 ...row,
                 rowKey: `${row.id}:${group.key}`,
                 locState: locationState([group.location]),
+                locations: [group.location],
               }
             : { ...row, rowKey: `${row.id}:${group.key}` },
         );

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -830,6 +830,67 @@ export function locationState(locations) {
 }
 
 /**
+ * What a copy's own state adds to its path, per {@link copyPathsTitle}.
+ *
+ * A path with nothing after it is a claim that the file is THERE. Three of the
+ * four states are the claim that it is not, and the shelf spends a rail, a
+ * glyph and a word telling them apart on the row (#898) — a tooltip that
+ * rendered all four as bare identical lines would be the one place they read
+ * the same. `present` adds nothing, because that is what a path already says.
+ */
+const COPY_STATE_NOTE = {
+  missing: "not where it was",
+  unreachable: "out of reach",
+  not_downloaded: "not downloaded yet",
+};
+
+/**
+ * Where a row's copies sit, one path per line, each saying what is there.
+ *
+ * The folder is only on screen under `groupBy: 'folder'`, where the header
+ * names it. Group by base model or by feature — or not at all, which is the
+ * default — and the shelf stops saying where anything is, which is the first
+ * question of a reader with the same adapter on two disks. So the file line
+ * carries the answer as its tooltip on every axis, including `folder`, where
+ * the header names the folder but nothing names the SUBDIRECTORY under it.
+ *
+ * Every copy, not the first: a model registered in two folders is one row, and
+ * naming one of its homes would read as naming its only one. Under `folder` the
+ * store hands this ONE copy, because that draw stands for one copy.
+ *
+ * The separator is taken from the registered folder rather than assumed, and a
+ * Windows folder takes the relpath's separators with it: the two halves come
+ * from different places (`model_folder.path` as registered, `relpath` as the
+ * scanner wrote it), so joining them without a rule is how a path comes back
+ * half-slashed. A POSIX folder leaves the relpath alone, where a backslash is a
+ * legal character in a filename rather than a separator.
+ *
+ * A copy missing either half is skipped rather than half-named: both are
+ * NOT NULL on the wire, so this is a broken row, and `a.st` on its own answers
+ * "where is this file" with the one thing that is not a location.
+ *
+ * @param {Array<Object>} locations - the row's `locations` array.
+ * @returns {string} the paths, newline-separated, or `""` when there are none —
+ *   which the caller must bind as no tooltip at all rather than an empty one.
+ */
+export function copyPathsTitle(locations) {
+  return (Array.isArray(locations) ? locations : [])
+    .map((loc) => {
+      const folder = String(loc?.folder_path || "");
+      const relpath = String(loc?.relpath || "");
+      if (!folder || !relpath) return "";
+      const windows = folder.includes("\\") && !folder.includes("/");
+      const sep = windows ? "\\" : "/";
+      const tail = windows ? relpath.replace(/\//g, "\\") : relpath;
+      const path = `${folder.replace(/[/\\]+$/, "")}${sep}${tail.replace(/^[/\\]+/, "")}`;
+      const note = COPY_STATE_NOTE[loc?.state];
+      return note ? `${path} · ${note}` : path;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
  * The registered folders whose every copy is out of reach, and how many rows
  * each one takes with it.
  *

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -837,12 +837,33 @@ export function locationState(locations) {
  * glyph and a word telling them apart on the row (#898) — a tooltip that
  * rendered all four as bare identical lines would be the one place they read
  * the same. `present` adds nothing, because that is what a path already says.
+ *
+ * Read through `copyStateNote` and never indexed raw, for the reason
+ * `ADAPTER_KIND_LABELS` is not exported: `state` comes off the wire, and
+ * `constructor` indexes a FUNCTION off `Object.prototype` that is truthy and
+ * would be pasted into the tooltip.
  */
 const COPY_STATE_NOTE = {
   missing: "not where it was",
   unreachable: "out of reach",
   not_downloaded: "not downloaded yet",
 };
+
+/**
+ * What one copy's state adds to its path, or nothing.
+ *
+ * Unlike {@link labelFrom} an unknown state falls through to NOTHING rather
+ * than to itself: the fallthrough there shows a value a human chose, and this
+ * one is machine vocabulary that would read as a fault ("/x/a.st · sundered").
+ * A state this build has never seen is not a claim it may make.
+ *
+ * @param {string} state - a stored `model_file.state`.
+ * @returns {string} the note, or `""`.
+ */
+function copyStateNote(state) {
+  const key = String(state || "");
+  return Object.hasOwn(COPY_STATE_NOTE, key) ? COPY_STATE_NOTE[key] : "";
+}
 
 /**
  * Where a row's copies sit, one path per line, each saying what is there.
@@ -883,7 +904,7 @@ export function copyPathsTitle(locations) {
       const sep = windows ? "\\" : "/";
       const tail = windows ? relpath.replace(/\//g, "\\") : relpath;
       const path = `${folder.replace(/[/\\]+$/, "")}${sep}${tail.replace(/^[/\\]+/, "")}`;
-      const note = COPY_STATE_NOTE[loc?.state];
+      const note = copyStateNote(loc?.state);
       return note ? `${path} · ${note}` : path;
     })
     .filter(Boolean)

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -18,6 +18,7 @@ import {
   baseModelKey,
   capabilityLabel,
   collapseStacks,
+  copyPathsTitle,
   withEmptyFolders,
   cleanAssetName,
   deriveModelName,
@@ -191,6 +192,81 @@ describe("formatModelSize", () => {
   it("says nothing rather than zero when the size is unknown", () => {
     expect(formatModelSize(null)).toBe("");
     expect(formatModelSize(undefined)).toBe("");
+  });
+});
+
+describe("copyPathsTitle", () => {
+  it("names every folder a copy sits in, one line each", () => {
+    // The whole point: under `groupBy: 'base_model'` no header names a folder,
+    // so a model on two disks has to say both here or say neither anywhere.
+    expect(
+      copyPathsTitle([
+        {
+          folder_path: "/home/me/models/lora",
+          relpath: "sdxl/foo.safetensors",
+        },
+        { folder_path: "/media/me/spare/", relpath: "foo.safetensors" },
+      ]),
+    ).toBe(
+      "/home/me/models/lora/sdxl/foo.safetensors\n" +
+        "/media/me/spare/foo.safetensors",
+    );
+  });
+
+  it("keeps a Windows path a Windows path, both halves of it", () => {
+    // The two halves come from different places — the folder as registered, the
+    // relpath as the scanner wrote it — so a forward-slashed relpath under a
+    // backslashed folder is the case that comes back half-slashed.
+    expect(
+      copyPathsTitle([
+        {
+          folder_path: "C:\\Users\\me\\models",
+          relpath: "sdxl/foo.safetensors",
+        },
+      ]),
+    ).toBe("C:\\Users\\me\\models\\sdxl\\foo.safetensors");
+    // A POSIX folder leaves the relpath alone: a backslash there is a legal
+    // character in a filename, not a separator to rewrite.
+    expect(
+      copyPathsTitle([{ folder_path: "/home/me/models", relpath: "a\\b.st" }]),
+    ).toBe("/home/me/models/a\\b.st");
+  });
+
+  it("says what is at each path, so an absent copy is not drawn as a present one", () => {
+    // The row spends a rail, a glyph and a word telling the three absences
+    // apart (#898). Rendering four states as four identical lines is the one
+    // place they would read the same.
+    expect(
+      copyPathsTitle([
+        { folder_path: "/home/me/models", relpath: "a.st", state: "present" },
+        { folder_path: "/media/me/spare", relpath: "a.st", state: "missing" },
+        { folder_path: "/mnt/ext", relpath: "a.st", state: "unreachable" },
+      ]),
+    ).toBe(
+      "/home/me/models/a.st\n" +
+        "/media/me/spare/a.st · not where it was\n" +
+        "/mnt/ext/a.st · out of reach",
+    );
+  });
+
+  it("skips a copy missing either half rather than half-naming it", () => {
+    // Both are NOT NULL on the wire, so this is a broken row — and `a.st` on
+    // its own answers "where is this file" with the one thing that is not a
+    // location.
+    expect(
+      copyPathsTitle([
+        { relpath: "a.st" },
+        { folder_path: "/home/me/models" },
+        { folder_path: "/home/me/models", relpath: "b.st" },
+      ]),
+    ).toBe("/home/me/models/b.st");
+  });
+
+  it("says nothing when every copy has been forgotten", () => {
+    // The caller binds no tooltip at all rather than an empty one, and the
+    // file line already carries the words for this state.
+    expect(copyPathsTitle([])).toBe("");
+    expect(copyPathsTitle(undefined)).toBe("");
   });
 });
 

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -262,6 +262,24 @@ describe("copyPathsTitle", () => {
     ).toBe("/home/me/models/b.st");
   });
 
+  it("appends nothing for a state that names something on Object.prototype", () => {
+    // `state` comes off the wire, and a plain index answers `constructor` with
+    // a FUNCTION — truthy, so the note would be Object's constructor source
+    // pasted after the path. Same hole `labelFrom` closes for the two label
+    // tables. A state this build has simply never seen appends nothing either:
+    // machine vocabulary after a path reads as a fault.
+    expect(
+      copyPathsTitle([
+        {
+          folder_path: "/home/me/models",
+          relpath: "a.st",
+          state: "constructor",
+        },
+        { folder_path: "/home/me/models", relpath: "b.st", state: "sundered" },
+      ]),
+    ).toBe("/home/me/models/a.st\n/home/me/models/b.st");
+  });
+
   it("says nothing when every copy has been forgotten", () => {
     // The caller binds no tooltip at all rather than an empty one, and the
     // file line already carries the words for this state.


### PR DESCRIPTION
The model shelf draws a folder header only under `groupBy: 'folder'`. Group by
base model, by feature, or not at all — which is the default — and nothing on
screen says where a file is, so two copies of one adapter on two disks are
indistinguishable.

## What changed

`copyPathsTitle()` (pure, `utils/modelShelf.js`) turns a row's `locations[]`
into one full path per line, and the **file line carries them as its `title`** —
on covers and on expanded stack members. Everything it needs is already on the
payload, so there is no API change.

- **Each line says what is at it.** A bare path claims the file is there, and
  three of the four states claim it is not, so a copy appends "not where it
  was" / "out of reach" / "not downloaded yet". `present` appends nothing. This
  is the rule of "the two kinds of absence" (#898) applied to the tooltip.
- **Under `folder`, the tooltip names THIS copy.** That axis draws one row per
  copy and already overrides the row's state to that copy's; the drawn row's
  `locations` is now narrowed the same way, or a row reading "file is not where
  it was" would list a path in the other folder where the file is present.
  Narrowing is safe because nothing else reads a *drawn* row's locations —
  `selectedRows` and every verb read `visibleRows`, which still carries all of
  them. That axis still gains the subdirectory, which no header states.
- **A Windows folder takes the relpath's separators with it.** The two halves
  come from different places, so a forward-slashed relpath under a backslashed
  folder is exactly the case that came back half-slashed. A POSIX folder leaves
  the relpath alone, where a backslash is a filename character.
- **No copies, no tooltip**, rather than an empty one that flashes and says
  nothing; a copy missing either half of its path is skipped rather than
  half-named as `a.st`.

Tests: five in `modelShelf.test.js` for the helper, four in `ModelShelf.test.js`
for the two bindings and the folder axis. The folder-axis one was checked
against the mutation — dropping the store's `locations` narrowing turns it red.
`docs/frontend_architecture.md` §9.1a gains a section stating the rules above.

## Answering the adversarial pass

Two objections it raised are deliberately not fixed:

- **The tooltip is hover-only.** A `title` on a non-focusable span reaches
  neither the keyboard nor touch. The accessible shape exists here (`HelpTip`,
  `ScrapheapSection` use `v-tooltip` with `open-on-focus`) but it costs a tab
  stop per row in a list whose keyboard model is deliberately one stop per row.
  That is a UX decision rather than a rendering one; the brief asked for a
  tooltip "at least", so this ships the floor and the doc records the follow-up
  and its cost rather than pretending the gap is not there.
- **The helper returns `""` and both call sites write `|| undefined`.** Two
  sites, one explicit idiom, and the empty string keeps it consistent with the
  other pure helpers in that module. Returning `undefined` from a `@returns
  {string}` to save a token at the call site is the worse trade.
