### PR TITLE
Add plugins available: list and search the published plugin catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [Unreleased]
 
+- `pixlstash-cli plugins available` lists what the plugins repository publishes,
+  with each plugin's name, title, one-line summary and, where declared, its
+  author and licence; `*` marks one you already have installed. Add a word to
+  search across all of those fields. Until now the only way to learn a plugin's
+  name was to guess one wrong and read the error.
 - The desktop app can now run the PixlStash CLI: `PixlStash.AppImage cli
   libraries list` works whether or not the app is open, and targets the desktop
   app's own library registry. Turn on Settings → Backend → Desktop → Shell

--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ PixlStash supports built-in plugins and user-created plugins.
 ### With the CLI (recommended)
 
 ```bash
+pixlstash-cli plugins available                     # what is published
+pixlstash-cli plugins available caption             # ...matching a word
 pixlstash-cli plugins install hello_world_stamp     # from the plugins repository
 pixlstash-cli plugins install ./my_captioner.zip    # a zip of a plugin folder
 pixlstash-cli plugins install ./my_captioner/       # an extracted folder
@@ -463,6 +465,14 @@ pixlstash-cli plugins test ./my_captioner.py       # does it load and render?
 pixlstash-cli plugins list
 pixlstash-cli plugins remove my_captioner
 ```
+
+`plugins available` lists what
+[PixlStash-plugins](https://github.com/Pikselkroken/PixlStash-plugins) publishes,
+with each plugin's name, title, one-line summary and (where declared) author and
+licence; `*` marks one you already have. Add a word to search, and it matches
+any of those fields, so anything you can see in the listing you can search for.
+It downloads the same archive `install` does and reads it without importing
+anything, so it needs no token and runs no published code.
 
 The destination differs by kind (captioning plugin or image filter) and by
 shape, so `install` works it out from the source instead of asking you to type

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -313,7 +313,7 @@ Modules **off** the server import path (`tagger_plugins/wd14.py`, `tagger_plugin
 | [pixlstash/stacking.py](../pixlstash/stacking.py) | Picture stacking (duplicates / variants). |
 | [pixlstash/image_loading_dataset_prepper.py](../pixlstash/image_loading_dataset_prepper.py) | Dataset preparation utilities for offline training scripts. |
 | [pixlstash/cli.py](../pixlstash/cli.py) | CLI entry point (`pixlstash-cli`). Two verb groups: `libraries` (list/create/attach/detach/relocate/backup/prepare-legacy-identity/rename) and `plugins` (install/test/list/remove). Only the `libraries` group opens the hub — see §8.1. |
-| [pixlstash/plugin_install.py](../pixlstash/plugin_install.py) | Backs `pixlstash-cli plugins install/list/remove`. Classifies a plugin source with `ast` (never by importing it), resolves the destination, and copies it. See §8.1. |
+| [pixlstash/plugin_install.py](../pixlstash/plugin_install.py) | Backs `pixlstash-cli plugins available/install/list/remove`. Classifies a plugin source with `ast` (never by importing it), resolves the destination, and copies it; also lists what the plugins repository publishes. See §8.1. |
 | [pixlstash/plugin_check.py](../pixlstash/plugin_check.py) | Backs `pixlstash-cli plugins test`. The one plugin verb that *does* import, through the server's own loader, and the only place the parameter schema is checked against what the UI renders. See §8.1. |
 
 ---
@@ -906,7 +906,7 @@ User-supplied image plugins are loaded from `user_data_dir("pixlstash")/image-pl
 
 ### 8.1 Installing and checking plugins from the CLI (issue #958)
 
-`pixlstash-cli plugins install|list|remove` ([pixlstash/plugin_install.py](../pixlstash/plugin_install.py))
+`pixlstash-cli plugins available|install|list|remove` ([pixlstash/plugin_install.py](../pixlstash/plugin_install.py))
 puts a plugin in the right directory instead of asking the user to. The
 destination differs by kind *and* by shape, and getting it wrong fails silently:
 a folder in the image directory is skipped without a message, and a single
@@ -975,6 +975,34 @@ dot segments before sending, so an unchecked ref (`../../../someone/evil/zip/mai
 walks out of `PLUGINS_REPO` entirely and installs code this CLI then runs
 unsandboxed in the server process. `_REF_RE` plus an explicit `..` component
 check is what keeps "a named plugin from one repository" true.
+
+**`plugins available` lists that repository, and shares its download.** Until it
+existed, `install <name>` was the only thing that knew what `PLUGINS_REPO`
+contained, and the catalogue leaked out only on the failure path — the
+`Available: ...` line of the "no plugin called X" refusal. Guessing a name wrong
+was the documented way to discover the right one. The listing reuses that same
+archive rather than adding a second source: `_download_repository` and
+`_published_dirs` were split out of `_fetch_from_repository`, so the layout
+(`plugins/<kind>/<slug>`) and the `--ref` validation above have one definition
+each, and a listing can never show a set that installing cannot reach. It needs
+no API token and no second host, because codeload serves the zip unauthenticated.
+
+Two properties carry over from §8.1 and one is new:
+
+- **Still nothing is imported.** This reads plugin source that has just come off
+  the network, so the ast-only rule is not a preference here but the whole of the
+  safety story; `test_the_catalogue_never_imports_a_published_plugin` fails the
+  build if `importlib` is reached at all.
+- **One broken published plugin does not empty the listing.** `_catalogue_entry`
+  records the problem on the entry rather than raising, because the reader is
+  choosing between the others and a refusal naming none of them is useless. This
+  is the same shape as `_describe` for installed plugins.
+- **The summary comes from the README's first *sentence*, not its first line.**
+  The published READMEs hard-wrap their opening paragraph, so a line-wise read
+  prints a fragment ("...so it runs"). `_summary` joins the paragraph before
+  splitting the sentence. `author` and `license` (issue #961) are read as class
+  literals through the existing `_string_attribute`, and shown only where the
+  plugin declares them — every plugin published so far predates the header.
 
 **`plugins test` is the exception to "nothing is imported", and the reason the
 rest of the group can stay static** ([pixlstash/plugin_check.py](../pixlstash/plugin_check.py),

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -300,8 +300,8 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
     install_parser.add_argument(
         "source",
         help=(
-            "A plugin name from the plugins repository, or a path to a .zip, "
-            "a folder, or a single .py file."
+            "A plugin name from the plugins repository (`plugins available` "
+            "lists them), or a path to a .zip, a folder, or a single .py file."
         ),
     )
     install_parser.add_argument(
@@ -382,6 +382,35 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
         ),
     )
     test_parser.set_defaults(handler=_cmd_plugins_test)
+
+    available_parser = commands.add_parser(
+        "available",
+        help="Show the plugins published in the plugins repository.",
+        description=(
+            "List what the plugins repository publishes, so you can find a "
+            "plugin's name before installing it. Give a word to search: it "
+            "matches the name, title, summary, author and licence, so anything "
+            "you can see in the listing you can also search for. `*` marks a "
+            "plugin you already have installed. This downloads the same "
+            "archive `plugins install <name>` does; nothing is imported or run."
+        ),
+    )
+    available_parser.add_argument(
+        "query",
+        nargs="?",
+        default="",
+        metavar="WORD",
+        help="Only show plugins matching this word (case-insensitive).",
+    )
+    available_parser.add_argument(
+        "--ref",
+        default=plugin_install.DEFAULT_REF,
+        help=(
+            "Branch, tag or commit in the plugins repository "
+            f"(default: {plugin_install.DEFAULT_REF})."
+        ),
+    )
+    available_parser.set_defaults(handler=_cmd_plugins_available)
 
     list_parser = commands.add_parser(
         "list",
@@ -758,6 +787,49 @@ def _print_parameters(parameters: object) -> None:
         )
 
 
+def _cmd_plugins_available(args: argparse.Namespace) -> int:
+    """Print the published catalogue, optionally filtered by a search word."""
+    entries = plugin_install.catalogue(args.ref)
+    matched = [entry for entry in entries if plugin_install.matches(entry, args.query)]
+
+    if not matched:
+        # The two empty results mean different things, and telling them apart is
+        # the difference between "try another word" and "something is wrong".
+        if args.query and entries:
+            print(f"No published plugin matches {args.query!r}.")
+            print(f"Drop the word to see all {len(entries)}.")
+        else:
+            print(f"{plugin_install.PLUGINS_REPO} publishes no plugins at this ref.")
+        return EXIT_OK
+
+    seen_installed = False
+    for kind in (plugin_install.CAPTIONING, plugin_install.IMAGE):
+        of_kind = [entry for entry in matched if entry.kind == kind]
+        if not of_kind:
+            continue
+        print(f"\n{plugin_install.KIND_LABELS[kind]}")
+        width = max(len(entry.name) for entry in of_kind)
+        for entry in of_kind:
+            marker = "  "
+            if entry.installed:
+                marker, seen_installed = "* ", True
+            print(f"  {marker}{entry.name:<{width}}  {entry.display_name}")
+            detail = entry.problem or entry.summary
+            if detail:
+                print(f"      {' ' * width}{detail}")
+            # Only shown once declared: every published plugin predates the
+            # header, so printing "author: -" on all of them would be noise.
+            credit = "  ".join(part for part in (entry.author, entry.license) if part)
+            if credit:
+                print(f"      {' ' * width}{credit}")
+
+    print()
+    if seen_installed:
+        print("* already installed")
+    print(f"Install one with:  {invoked_as()} plugins install <name>")
+    return EXIT_OK
+
+
 def _cmd_plugins_list(_args: argparse.Namespace) -> int:
     """Print both plugin directories, grouped by kind, with a marker legend."""
     listing = plugin_install.list_installed()
@@ -767,7 +839,8 @@ def _cmd_plugins_list(_args: argparse.Namespace) -> int:
             print(
                 f"  {plugin_install.KIND_LABELS[kind]}: {plugin_install.user_dir(kind)}"
             )
-        print(f"Add one with:  {invoked_as()} plugins install hello_world_stamp")
+        print(f"See what is published:  {invoked_as()} plugins available")
+        print(f"Add one with:           {invoked_as()} plugins install <name>")
         return EXIT_OK
 
     notes = {

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -91,6 +91,11 @@ class PluginClass:
     kind: str
     file: Path
     warnings: list[str] = field(default_factory=list)
+    # Declared on the base classes (issue #961). Read here as literals rather
+    # than off an instance, because everything in this module has to work on a
+    # plugin it has deliberately not imported.
+    author: str = ""
+    license: str = ""
 
 
 @dataclass
@@ -360,6 +365,8 @@ def _analyse(source: str, path: Path, *, strict: bool) -> list[PluginClass]:
                 f"{class_name} sets neither supports_tags nor "
                 "supports_descriptions, so it appears in no table."
             )
+        _, author = _string_attribute(node, "author")
+        _, license_id = _string_attribute(node, "license")
         found.append(
             PluginClass(
                 name=name,
@@ -368,6 +375,8 @@ def _analyse(source: str, path: Path, *, strict: bool) -> list[PluginClass]:
                 kind=kind,
                 file=path,
                 warnings=warnings,
+                author=author or "",
+                license=license_id or "",
             )
         )
 
@@ -462,8 +471,8 @@ def _extract_zip(archive: Path, target: Path) -> Path:
     return root
 
 
-def _fetch_from_repository(slug: str, ref: str, workdir: Path) -> Path:
-    """Download *slug* from the plugins repository and return its folder."""
+def _download_repository(ref: str, workdir: Path) -> Path:
+    """Download the plugins repository at *ref* and return the extracted root."""
     # The ref goes into a URL path, and requests collapses dot segments before
     # sending: an unchecked `--ref ../../../someone-else/evil/zip/main` walks
     # straight out of PLUGINS_REPO and installs code that this CLI then runs
@@ -488,11 +497,24 @@ def _fetch_from_repository(slug: str, ref: str, workdir: Path) -> Path:
 
     archive = workdir / "repository.zip"
     archive.write_bytes(response.content)
-    root = _extract_zip(archive, workdir / "repository")
+    return _extract_zip(archive, workdir / "repository")
 
-    candidates = sorted(
-        path for path in (root / "plugins").glob("*/*") if path.is_dir()
-    )
+
+def _published_dirs(root: Path) -> list[Path]:
+    """Return every published plugin folder in an extracted repository.
+
+    The repository lays them out as ``plugins/<kind>/<slug>``, so the parent
+    directory names the kind and the directory itself names the slug. One
+    definition of that layout, shared by installing a named plugin and by
+    listing the catalogue, so the two cannot come to disagree about what the
+    repository contains.
+    """
+    return sorted(path for path in (root / "plugins").glob("*/*") if path.is_dir())
+
+
+def _fetch_from_repository(slug: str, ref: str, workdir: Path) -> Path:
+    """Download *slug* from the plugins repository and return its folder."""
+    candidates = _published_dirs(_download_repository(ref, workdir))
     for candidate in candidates:
         if candidate.name == slug:
             return candidate
@@ -793,6 +815,134 @@ def _describe(kind: str, path: Path, builtins: set[str]) -> InstalledPlugin:
         problem=problem,
         shadows_builtin=primary.name in builtins,
     )
+
+
+# ----------------------------------------------------------------------
+# The published catalogue
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class CataloguePlugin:
+    """One plugin published in the repository, as ``plugins available`` shows it."""
+
+    kind: str
+    name: str
+    display_name: str
+    summary: str = ""
+    author: str = ""
+    license: str = ""
+    installed: bool = False
+    problem: str | None = None
+
+
+def _summary(folder: Path) -> str:
+    """Return the one-line summary from a published plugin's README.
+
+    The repository writes each README as a title, a blank line, then a paragraph
+    saying what the plugin does. That paragraph is *hard-wrapped*, so the first
+    line of it is a fragment ("...so it runs") rather than a sentence: the lines
+    are joined back up before the first sentence is taken. A plugin without a
+    README, or with a shape this does not fit, simply has no summary — guessing
+    harder would put the wrong sentence in a listing people read to choose what
+    to install.
+    """
+    try:
+        text = (folder / "README.md").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return ""
+
+    paragraph: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("#", "<!--", "![", "[!")):
+            continue
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        paragraph.append(stripped)
+    if not paragraph:
+        return ""
+
+    joined = " ".join(paragraph)
+    sentence = re.split(r"(?<=[.!?])\s", joined, maxsplit=1)[0]
+    # ponytail: a plain length clamp, not word-aware wrapping. A README whose
+    # first sentence runs past this is already unusual; wrap properly if the
+    # catalogue ever grows entries that genuinely need it.
+    return sentence if len(sentence) <= 200 else sentence[:197] + "..."
+
+
+def _catalogue_entry(folder: Path, installed: set[str]) -> CataloguePlugin:
+    """Read one published plugin folder, recording problems rather than raising.
+
+    One unparseable plugin in the repository must not empty the whole listing:
+    the reader is choosing between the others, and a refusal that names none of
+    them is useless. Nothing here imports the plugin — this is the same ast-only
+    read the installer does, on code that has just come off the network.
+    """
+    kind = CAPTIONING if folder.parent.name == "captioning" else IMAGE
+    try:
+        found: list[PluginClass] = []
+        for source in _python_files(folder):
+            found.extend(_analyse(read_source(source), source, strict=False))
+    except (PluginError, OSError) as exc:
+        return CataloguePlugin(
+            kind=kind,
+            name=folder.name,
+            display_name="-",
+            installed=folder.name in installed,
+            problem=str(exc),
+        )
+    if not found:
+        return CataloguePlugin(
+            kind=kind,
+            name=folder.name,
+            display_name="-",
+            installed=folder.name in installed,
+            problem="no plugin class found",
+        )
+    primary = found[0]
+    return CataloguePlugin(
+        kind=primary.kind,
+        name=primary.name,
+        display_name=primary.display_name,
+        summary=_summary(folder),
+        author=primary.author,
+        license=primary.license,
+        installed=primary.name in installed,
+    )
+
+
+def catalogue(ref: str = DEFAULT_REF) -> list[CataloguePlugin]:
+    """Return every plugin published in the repository at *ref*.
+
+    One download of the same archive ``plugins install <name>`` uses, so
+    listing needs no API token, no second host and no rate-limited endpoint —
+    and shows exactly the set that installing can reach.
+    """
+    installed = {
+        entry.name for entries in list_installed().values() for entry in entries
+    }
+    with TemporaryDirectory(prefix="pixlstash-catalogue-") as scratch:
+        root = _download_repository(ref, Path(scratch))
+        return [_catalogue_entry(folder, installed) for folder in _published_dirs(root)]
+
+
+def matches(entry: CataloguePlugin, query: str) -> bool:
+    """Return whether *entry* matches a case-insensitive *query*.
+
+    Searched across everything the listing shows — name, display name, summary,
+    author and licence — because a reader who can see a word in the output will
+    expect to be able to search for it. An empty query matches everything.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return True
+    haystack = " ".join(
+        (entry.name, entry.display_name, entry.summary, entry.author, entry.license)
+    )
+    return needle in haystack.lower()
 
 
 def resolve_removal(name: str, kind: str | None = None) -> tuple[str, Path]:

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -52,8 +52,9 @@ def test_the_walk_reaches_every_command():
     walked = {path for path, _parser in _all_parsers()}
     assert "pixlstash-cli libraries backup" in walked
     assert "pixlstash-server" in walked
-    # 2 roots + 2 groups + 8 library verbs + 3 plugin verbs, at least.
-    assert len(walked) >= 15, walked
+    assert "pixlstash-cli plugins available" in walked
+    # 2 roots + 2 groups + 8 library verbs + 5 plugin verbs, at least.
+    assert len(walked) >= 17, walked
 
 
 def test_entry_points_are_named_as_they_are_installed():

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -427,6 +427,30 @@ class _FakeResponse:
         pass
 
 
+# A published plugin as the repository actually ships one: a header declaring
+# author and licence (issue #961) and a README whose first prose line says what
+# it does. `plugins available` reads both, so the fixture has to carry both.
+CREDITED_FILTER = IMAGE_PLUGIN.replace(
+    'display_name = "My Filter"',
+    'display_name = "My Filter"\n'
+    '    author = "Ada <ada@example.com>"\n'
+    '    license = "MIT"',
+)
+
+# Hard-wrapped exactly as the published READMEs are: the first *line* of the
+# summary paragraph is a fragment, so anything reading line-by-line prints
+# "...so it" and stops. The summary is the first sentence of the joined
+# paragraph, never the first line.
+FILTER_README = """\
+# My Filter
+
+Stamps every picture with a magenta watermark, so it
+needs no model. Second sentence nobody needs.
+
+A longer explanation nobody needs in a listing.
+"""
+
+
 @pytest.fixture
 def fake_repository(monkeypatch, tmp_path):
     """Serve a zip shaped like a codeload download of the plugins repository."""
@@ -435,7 +459,11 @@ def fake_repository(monkeypatch, tmp_path):
     with zipfile.ZipFile(archive, "w") as bundle:
         bundle.writestr("PixlStash-plugins-main/README.md", "hi")
         bundle.writestr(
-            "PixlStash-plugins-main/plugins/image/my_filter/my_filter.py", IMAGE_PLUGIN
+            "PixlStash-plugins-main/plugins/image/my_filter/my_filter.py",
+            CREDITED_FILTER,
+        )
+        bundle.writestr(
+            "PixlStash-plugins-main/plugins/image/my_filter/README.md", FILTER_README
         )
         bundle.writestr(
             "PixlStash-plugins-main/plugins/captioning/my_captioner/__init__.py",
@@ -500,6 +528,147 @@ def test_a_ref_cannot_steer_the_download_at_another_repository(
     assert _install("my_filter", "--ref", ref) == cli.EXIT_REFUSED
     assert "url" not in fake_repository
     assert not (plugin_root / "image-plugins").exists()
+
+
+# ----------------------------------------------------------------------
+# The published catalogue: `plugins available`
+# ----------------------------------------------------------------------
+
+
+def _available(*extra: str) -> int:
+    return cli.main(["plugins", "available", *extra])
+
+
+def test_available_lists_both_kinds_with_what_the_repository_declares(
+    plugin_root, fake_repository, capsys
+):
+    assert _available() == cli.EXIT_OK
+    out = capsys.readouterr().out
+
+    assert "my_filter" in out and "my_captioner" in out
+    assert "My Filter" in out
+    # The first sentence of the joined paragraph: not the title, not the
+    # hard-wrapped first line, not the second sentence, not the next paragraph.
+    assert "Stamps every picture with a magenta watermark, so it needs no model." in out
+    assert "Second sentence" not in out
+    assert "A longer explanation" not in out
+    assert "Ada <ada@example.com>" in out and "MIT" in out
+    # It downloads the same archive `install` does, at the same default ref.
+    assert fake_repository["url"].endswith("/zip/main")
+
+
+def test_available_takes_the_same_ref_as_install(plugin_root, fake_repository):
+    assert _available("--ref", "v1.2.3") == cli.EXIT_OK
+    assert fake_repository["url"].endswith("/zip/v1.2.3")
+
+
+@pytest.mark.parametrize("ref", ["../../../someone-else/evil/zip/main", ".."])
+def test_available_refuses_a_ref_that_steers_the_download(
+    plugin_root, fake_repository, ref
+):
+    """Listing shares the installer's download, so it shares its one guard."""
+    assert _available("--ref", ref) == cli.EXIT_REFUSED
+    assert "url" not in fake_repository
+
+
+def test_a_search_word_matches_the_summary_not_just_the_name(
+    plugin_root, fake_repository, capsys
+):
+    """A reader searches for the word they can see, wherever it appeared."""
+    assert _available("watermark") == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "my_filter" in out
+    assert "my_captioner" not in out
+
+
+def test_a_search_word_matches_the_author(plugin_root, fake_repository, capsys):
+    assert _available("ada") == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "my_filter" in out and "my_captioner" not in out
+
+
+def test_a_word_matching_nothing_says_so_and_says_how_many_there_are(
+    plugin_root, fake_repository, capsys
+):
+    """Distinct from an empty repository: one is "try again", one is "broken"."""
+    assert _available("nosuchthing") == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "nosuchthing" in out
+    assert "all 2" in out
+
+
+def test_an_empty_repository_is_not_reported_as_a_failed_search(
+    plugin_root, monkeypatch, capsys
+):
+    monkeypatch.setattr(plugin_install, "catalogue", lambda _ref: [])
+    assert _available("anything") == cli.EXIT_OK
+    assert "publishes no plugins" in capsys.readouterr().out
+
+
+def test_available_marks_what_is_already_installed(
+    plugin_root, fake_repository, capsys
+):
+    assert _install("my_filter") == cli.EXIT_OK
+    capsys.readouterr()
+
+    assert _available() == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "* my_filter" in out
+    assert "already installed" in out
+    assert "* my_captioner" not in out
+
+
+def test_one_broken_published_plugin_does_not_empty_the_listing(
+    plugin_root, monkeypatch, capsys
+):
+    """The reader is choosing between the others; naming none of them is useless."""
+    broken = plugin_install.CataloguePlugin(
+        kind=plugin_install.IMAGE,
+        name="bad_one",
+        display_name="-",
+        problem="no plugin class found",
+    )
+    good = plugin_install.CataloguePlugin(
+        kind=plugin_install.IMAGE, name="good_one", display_name="Good One"
+    )
+    monkeypatch.setattr(plugin_install, "catalogue", lambda _ref: [broken, good])
+
+    assert _available() == cli.EXIT_OK
+    out = capsys.readouterr().out
+    assert "good_one" in out
+    assert "bad_one" in out and "no plugin class found" in out
+
+
+def test_the_catalogue_never_imports_a_published_plugin(
+    plugin_root, fake_repository, monkeypatch
+):
+    """It reads code straight off the network, so ast is the whole safety story."""
+    import importlib
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("plugins available must not import anything published")
+
+    monkeypatch.setattr(importlib.util, "module_from_spec", explode)
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", explode)
+
+    assert _available() == cli.EXIT_OK
+
+
+def test_matches_searches_every_field_the_listing_shows(plugin_root):
+    entry = plugin_install.CataloguePlugin(
+        kind=plugin_install.IMAGE,
+        name="stamper",
+        display_name="The Stamper",
+        summary="Draws a mark",
+        author="Ada",
+        license="MIT",
+    )
+    for word in ("stamp", "STAMPER", "the stamper", "mark", "ada", "mit"):
+        assert plugin_install.matches(entry, word), word
+    assert not plugin_install.matches(entry, "captioning")
+    # An empty query is a listing, not a search that matches nothing.
+    assert plugin_install.matches(entry, "")
+    assert plugin_install.matches(entry, "   ")
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Closes the discovery gap under `plugins install <name>`: you had to already know
the name.

## Why

`PLUGINS_REPO` was known to the CLI, but only to `install`. The catalogue leaked
out on the failure path only — the `Available: ...` line of the "no plugin called
X" refusal — so guessing a name wrong was the documented way to find the right
one:

```
$ pixlstash-cli plugins install nope
error: Pikselkroken/PixlStash-plugins at ref 'main' has no plugin called 'nope'. Available: ...
```

And `plugins list`, the verb whose name suggests it would answer, lists only
what is installed.

## What it looks like

```
$ pixlstash-cli plugins available

Captioning plugins
    hello_world_captioner  Hello World Captioner
                           Writes a short description from a template instead of from a model, so it runs anywhere and uses no GPU.
    hello_world_tagger     Hello World Tagger
                           Applies a fixed list of tags, `hello world` by default, to every image.

Image filters
  * hello_world_stamp      Hello World Stamp
                           Draws "Hello World" onto every picture, in magenta.

* already installed
Install one with:  pixlstash-cli plugins install <name>
```

`plugins available <word>` filters. It searches the name, title, summary, author
and licence — everything the listing shows — so a word you can see is a word you
can search for. Verified against the live repository: `magenta` (README prose)
finds `hello_world_stamp`, `tagger` finds `hello_world_tagger`.

## Design notes

**It shares the installer's download, it does not add a source.**
`_download_repository` and `_published_dirs` are split out of
`_fetch_from_repository`, so the `plugins/<kind>/<slug>` layout has one
definition and the `--ref` validation (the guard that stops a ref steering the
download at another repository — `#958`) covers listing for free. A listing can
therefore never show a set that installing cannot reach. Codeload serves the zip
unauthenticated, so no API token and no second host.

**Nothing is imported.** Inherited from the rest of the group, but load-bearing
differently here: this reads plugin source that has just come off the network,
so `ast` is the whole safety story rather than a preference.
`test_the_catalogue_never_imports_a_published_plugin` fails the build if
`importlib` is reached at all.

**One broken published plugin does not empty the listing.** `_catalogue_entry`
records the problem on that row and carries on, the same shape `_describe` uses
for installed plugins — the reader is choosing between the others, and a refusal
naming none of them is useless.

**The summary is the first sentence, not the first line.** I had this wrong
first time and caught it running against the real repository: those READMEs
hard-wrap their opening paragraph, so a line-wise read printed
`"...from a model, so it runs"` and stopped. `_summary` joins the paragraph, then
takes the sentence. The fixture is now hard-wrapped the same way so the
regression is caught in the suite rather than by eye.

**`author` / `license`** (#961, merged in #983) are read as class literals via the
existing `_string_attribute` and shown only where declared — every plugin
published so far predates the header, so unconditional `author: -` rows would be
pure noise.

## Tests

159 passing across the three affected files. New: catalogue listing and its
fields, `--ref` passthrough, `--ref` refusal (parameterised, shared with
install's guard), search by summary and by author, the two distinct empty
results ("no match, drop the word to see all N" vs "the repository publishes
none"), the installed marker, one-broken-entry survival, the no-import guard,
and `matches()` as a unit.

I also raised the floor in `test_the_walk_reaches_every_command` from 15 to 17
and added an explicit assertion for the new verb — its comment said "3 plugin
verbs" and there are now five, so the floor had gone slack.

## Not done

No caching of the download: every invocation fetches the archive (a few hundred
KB). Worth adding if the catalogue grows or people run this in a loop; not worth
a cache-invalidation story today.
