### PR TITLE
Install a plugin by the name the catalogue prints

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1003,6 +1003,24 @@ Two properties carry over from §8.1 and one is new:
   splitting the sentence. `author` and `license` (issue #961) are read as class
   literals through the existing `_string_attribute`, and shown only where the
   plugin declares them — every plugin published so far predates the header.
+- **`install <name>` takes the name the listing printed, which is the plugin's
+  *declared* name, not the repository's directory slug.** The two differ in the
+  published repository — `plugins/captioning/moondream2_captioner` declares
+  `moondream2` — and matching only on the directory left `plugins available`
+  advertising `moondream2` while `plugins install moondream2` refused it. The
+  declared name is the identity everywhere else too: it is what the plugin
+  installs under, what `plugins list` shows and what `plugins remove` takes. So
+  `_fetch_from_repository` matches the declared name first and the directory
+  name second (that one still works, and was the only one accepted before), and
+  its `Available:` refusal lists declared names, falling back to the directory
+  name only for a folder too broken to read one out of. **Both passes run over
+  the whole set**, not per folder in `sorted()` order: otherwise a declared name
+  would beat only the directory names that happen to sort after it, and which
+  plugin `install` fetched would depend on the kind directory it sat in. **Two
+  folders answering to one name are refused, naming both** — the shape
+  `resolve_removal` already uses for an ambiguous name. Picking one silently
+  would let a string inside downloaded code, which the listing does not show,
+  decide what gets installed.
 
 **`plugins test` is the exception to "nothing is imported", and the reason the
 rest of the group can stay static** ([pixlstash/plugin_check.py](../pixlstash/plugin_check.py),

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -512,15 +512,65 @@ def _published_dirs(root: Path) -> list[Path]:
     return sorted(path for path in (root / "plugins").glob("*/*") if path.is_dir())
 
 
-def _fetch_from_repository(slug: str, ref: str, workdir: Path) -> Path:
-    """Download *slug* from the plugins repository and return its folder."""
+def _declared_name(folder: Path) -> str | None:
+    """Return the name a published plugin folder declares, or None if unreadable.
+
+    The same ast-only read the catalogue and the installer do — nothing here
+    imports code that has just come off the network. A folder that will not
+    parse, or declares no plugin, is not an error at this point: it is one entry
+    the reader cannot be offered, and the others still have to work.
+    """
+    try:
+        for source in _python_files(folder):
+            found = _analyse(read_source(source), source, strict=False)
+            if found:
+                return found[0].name
+    except (PluginError, OSError):
+        return None
+    return None
+
+
+def _fetch_from_repository(name: str, ref: str, workdir: Path) -> Path:
+    """Download the plugin called *name* and return its folder.
+
+    Matched on the plugin's **declared** name first — that is what ``plugins
+    available`` prints, what it lands under once installed, what ``plugins
+    list`` shows and what ``plugins remove`` takes — and on the repository's
+    directory name second, because that is a real name too and was the only one
+    accepted before. Accepting only the directory name meant the catalogue
+    advertised `moondream2` and installing it failed.
+
+    Both passes look at the **whole** set before choosing, so a declared name
+    always beats a directory name rather than merely beating the ones that
+    happen to sort after it, and two folders answering to the same name are
+    refused rather than resolved alphabetically — the shape `resolve_removal`
+    already uses for an ambiguous name. Silently picking one would mean the
+    plugin a reader installs is decided by a string inside downloaded code that
+    nothing in the listing shows them.
+    """
     candidates = _published_dirs(_download_repository(ref, workdir))
-    for candidate in candidates:
-        if candidate.name == slug:
-            return candidate
-    available = ", ".join(sorted(path.name for path in candidates)) or "(none)"
+    declared = {folder: _declared_name(folder) for folder in candidates}
+
+    matched = [folder for folder in candidates if declared[folder] == name] or [
+        folder for folder in candidates if folder.name == name
+    ]
+    if len(matched) > 1:
+        where = ", ".join(f"{folder.parent.name}/{folder.name}" for folder in matched)
+        raise PluginError(
+            f"{PLUGINS_REPO} at ref {ref!r} publishes {len(matched)} plugins "
+            f"called {name!r} ({where}), so the name does not say which one you "
+            "mean. That is a fault in the repository; until it is fixed, "
+            "install from a local copy of the folder you want."
+        )
+    if matched:
+        return matched[0]
+
+    available = (
+        ", ".join(sorted(declared[folder] or folder.name for folder in candidates))
+        or "(none)"
+    )
     raise PluginError(
-        f"{PLUGINS_REPO} at ref {ref!r} has no plugin called {slug!r}. "
+        f"{PLUGINS_REPO} at ref {ref!r} has no plugin called {name!r}. "
         f"Available: {available}"
     )
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -465,8 +465,12 @@ def fake_repository(monkeypatch, tmp_path):
         bundle.writestr(
             "PixlStash-plugins-main/plugins/image/my_filter/README.md", FILTER_README
         )
+        # Folder slug deliberately unlike the declared name, as the published
+        # repository actually ships them (`moondream2_captioner` holding
+        # `moondream2`): the catalogue prints the declared name, so installing
+        # has to accept it.
         bundle.writestr(
-            "PixlStash-plugins-main/plugins/captioning/my_captioner/__init__.py",
+            "PixlStash-plugins-main/plugins/captioning/my_captioner_plugin/__init__.py",
             CAPTIONER,
         )
 
@@ -478,6 +482,32 @@ def fake_repository(monkeypatch, tmp_path):
 
     monkeypatch.setattr(requests, "get", fake_get)
     return requested
+
+
+@pytest.fixture
+def published(monkeypatch):
+    """Serve a codeload zip holding exactly the files one test names.
+
+    The shared `fake_repository` is the repository as it really is; this is for
+    the shapes it cannot hold at once — a name collision, a folder that will not
+    parse — without changing what every other test in the module sees.
+    """
+
+    def serve(files: dict[str, str]) -> None:
+        archive = io.BytesIO()
+        with zipfile.ZipFile(archive, "w") as bundle:
+            for path, content in files.items():
+                bundle.writestr(f"PixlStash-plugins-main/{path}", content)
+
+        import requests
+
+        monkeypatch.setattr(
+            requests,
+            "get",
+            lambda url, timeout=None: _FakeResponse(archive.getvalue()),
+        )
+
+    return serve
 
 
 def test_installing_a_named_plugin_from_the_repository(plugin_root, fake_repository):
@@ -492,7 +522,16 @@ def test_installing_a_named_plugin_from_the_repository(plugin_root, fake_reposit
 def test_a_repository_folder_captioner_installs_as_a_folder(
     plugin_root, fake_repository
 ):
+    """The declared name, which is what `plugins available` printed."""
     assert _install("my_captioner") == cli.EXIT_OK
+    assert (
+        plugin_root / "tagger-plugins" / "user" / "my_captioner" / "__init__.py"
+    ).is_file()
+
+
+def test_the_repository_folder_slug_still_installs(plugin_root, fake_repository):
+    """The directory name was the only name accepted before; keep it working."""
+    assert _install("my_captioner_plugin") == cli.EXIT_OK
     assert (
         plugin_root / "tagger-plugins" / "user" / "my_captioner" / "__init__.py"
     ).is_file()
@@ -501,9 +540,59 @@ def test_a_repository_folder_captioner_installs_as_a_folder(
 def test_an_unknown_plugin_name_lists_what_the_repository_has(
     plugin_root, fake_repository, capsys
 ):
+    """Listed under the names install takes, not the repository's own slugs."""
     assert _install("nosuch") == cli.EXIT_REFUSED
     error = capsys.readouterr().err
-    assert "my_filter" in error and "my_captioner" in error
+    # Exact, not a substring apiece: "my_captioner" is a prefix of the folder
+    # slug, so `in error` would pass on a listing that still printed slugs.
+    assert "Available: my_captioner, my_filter" in error
+
+
+def test_a_declared_name_beats_another_plugin_s_folder_slug(plugin_root, published):
+    """Whole-set precedence, not first-match: the slug owner sorts first here."""
+    published(
+        {
+            "plugins/captioning/my_filter/__init__.py": CAPTIONER,
+            "plugins/image/some_filter/my_filter.py": IMAGE_PLUGIN,
+        }
+    )
+    assert _install("my_filter") == cli.EXIT_OK
+    assert (plugin_root / "image-plugins" / "user" / "my_filter.py").is_file()
+    assert not (plugin_root / "tagger-plugins" / "user" / "my_filter").exists()
+
+
+def test_two_plugins_declaring_one_name_are_refused_not_chosen_between(
+    plugin_root, published, capsys
+):
+    """Alphabetical order must not decide which downloaded code gets installed."""
+    published(
+        {
+            "plugins/captioning/first/__init__.py": CAPTIONER,
+            "plugins/captioning/second/__init__.py": CAPTIONER,
+        }
+    )
+    assert _install("my_captioner") == cli.EXIT_REFUSED
+    error = capsys.readouterr().err
+    assert "captioning/first" in error and "captioning/second" in error
+    assert not (plugin_root / "tagger-plugins" / "user").exists()
+
+
+def test_a_published_folder_that_will_not_parse_blocks_nothing(
+    plugin_root, published, capsys
+):
+    """It is one entry the reader cannot be offered; the rest still install."""
+    published(
+        {
+            "plugins/image/broken/broken.py": "class Nope(:",
+            "plugins/image/my_filter/my_filter.py": IMAGE_PLUGIN,
+        }
+    )
+    assert _install("my_filter") == cli.EXIT_OK
+    assert (plugin_root / "image-plugins" / "user" / "my_filter.py").is_file()
+
+    # And it is still listed, under the only name it has left: its folder's.
+    assert _install("nosuch") == cli.EXIT_REFUSED
+    assert "broken" in capsys.readouterr().err
 
 
 def test_a_ref_may_choose_a_branch(plugin_root, fake_repository):


### PR DESCRIPTION
## What was wrong

`plugins available` prints a plugin's **declared** name; `plugins install` only ever
resolved names against the published repository's **directory** name. Those differ:

```
plugins/captioning/moondream2_captioner/   declares   name = "moondream2"
```

So the catalogue advertised `moondream2` and installing it refused, listing a set of
names no other command uses. The declared name is the identity everywhere else — it is
what the plugin lands under, what `plugins list` shows and what `plugins remove` takes —
so it is the one `install` should take.

## What changed

`_fetch_from_repository` now resolves the declared name first and the directory name
second. The directory name still works; it was the only accepted name before. The
`Available:` refusal now lists the same names the catalogue prints, falling back to the
directory name only for a folder too broken to read one out of.

Both passes run over the whole set rather than per folder in `sorted()` order, so a
declared name beats *every* directory name and not merely the ones sorting after it, and
two folders answering to one name are refused naming both — the shape `resolve_removal`
already uses for an ambiguous name. Silently picking one would let a string inside
downloaded code, which the listing does not show, decide what gets installed.

Nothing is imported; this is the same ast-only read the catalogue does.

## Tests

`tests/test_plugin_install.py`: the shared fixture's captioner folder is now named
unlike its declared name, as the real repository ships them, so the whole file exercises
the mismatch. Added: install by declared name, install by folder slug, declared-name
precedence over another folder's slug (fails if the precedence is per-folder — verified
by mutation), a collision refused rather than resolved, and a folder that will not parse
blocking neither installs nor the listing.

## From an adversarial review pass

The findings on precedence, collisions and the substring assertion are fixed above. Two
were left deliberately:

- *Identity moves from a directory path to a string in downloaded code, weakening review
  of the plugins repo.* The declaration was already the identity — it decides the install
  destination, and shadowing a built-in is checked against it. This makes `install` agree
  with the rest of the CLI; the ambiguity refusal is what closes the hijack.
- *`_catalogue_entry` was the wrong helper.* Agreed and changed: a small `_declared_name`
  keeps README parsing out of the install path.
