### PR TITLE
Give VAEs and text encoders kinds of their own

### DIFF
--- a/frontend/src/api/modelShelf.js
+++ b/frontend/src/api/modelShelf.js
@@ -22,8 +22,9 @@ export const BASE_MODEL_UNASSIGNED = "UNASSIGNED";
  * List adapters (or the unclassified files) on the shelf.
  *
  * @param {Object} [options]
- * @param {string} [options.fileKind="adapter"] - `adapter` or `unknown`.
- *   Checkpoints have their own route; anything else is a 400.
+ * @param {string} [options.fileKind="adapter"] - `adapter`, `unknown`, `vae`,
+ *   `text_encoder` or `engine`. Checkpoints have their own route; anything
+ *   else is a 400.
  * @param {string} [options.baseModel] - exact match, or `UNASSIGNED` for the
  *   rows that record none. Omit for all.
  * @param {string} [options.kind] - adapter algorithm, e.g. `lora` or `lokr`.

--- a/frontend/src/components/panels/ShelfEditDialog.vue
+++ b/frontend/src/components/panels/ShelfEditDialog.vue
@@ -116,9 +116,14 @@ const emit = defineEmits(["close"]);
 
 const store = useModelShelfStore();
 
+// The support kinds are correctable like the rest, and are the two most likely
+// to need it: they are read off the folder the file sits in, so one kept outside
+// the usual layout gets whatever that folder says.
 const FILE_KINDS = [
   { value: "adapter", label: "Adapter (LoRA and friends)" },
   { value: "checkpoint", label: "Checkpoint (a base model)" },
+  { value: "vae", label: "VAE" },
+  { value: "text_encoder", label: "Text encoder" },
   { value: "unknown", label: "Unclassified" },
 ];
 

--- a/frontend/src/components/panels/ShelfShowPanel.vue
+++ b/frontend/src/components/panels/ShelfShowPanel.vue
@@ -81,6 +81,30 @@
         />
         Checkpoints
       </label>
+      <!-- Support files: the VAEs and text encoders a graph loads beside a
+           checkpoint. One box for two `file_kind`s, because they are one
+           question to someone deciding what to keep. On by default, and the
+           box matters more than the others: before these kinds existed the
+           large encoders were counted as checkpoints, so `Checkpoints` was
+           answering with a list mostly made of them. -->
+      <label
+        class="tbm-check"
+        title="VAEs and text encoders — the files a generation graph loads beside a checkpoint"
+      >
+        <input
+          type="checkbox"
+          :checked="filters.support"
+          @change="
+            store.setFilters(
+              { support: $event.target.checked },
+              {
+                refetch: true,
+              },
+            )
+          "
+        />
+        Support files
+      </label>
       <!-- `unknown` is a first-class stored value, never promoted to
            checkpoint and never folded into adapters. It gets its own box and
            its own word, and it is ON by default: the leftovers in PixlStash's

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -19,6 +19,10 @@ const listEngines = vi.fn();
 // And the unclassified block, for the same reason, now that it is on by
 // default (#927): one route, one more result set, its own double.
 const listUnclassified = vi.fn();
+// And the support block: two `file_kind`s behind one checkbox, so one double
+// answers both requests. Same reason again — without it every
+// `listAdapters.mockResolvedValue` here would answer them with adapter rows.
+const listSupport = vi.fn();
 const deleteModels = vi.fn();
 
 vi.mock("../../api/modelShelf", () => ({
@@ -26,6 +30,9 @@ vi.mock("../../api/modelShelf", () => ({
   listAdapters: (...args) => {
     if (args[0]?.fileKind === "engine") return listEngines(...args);
     if (args[0]?.fileKind === "unknown") return listUnclassified(...args);
+    if (args[0]?.fileKind === "vae" || args[0]?.fileKind === "text_encoder") {
+      return listSupport(...args);
+    }
     return listAdapters(...args);
   },
   listCheckpoints: (...args) => listCheckpoints(...args),
@@ -162,6 +169,7 @@ async function mountShelf(
   listCheckpoints.mockResolvedValue(checkpoints);
   listEngines.mockResolvedValue([]);
   listUnclassified.mockResolvedValue(unclassified);
+  listSupport.mockResolvedValue([]);
   const wrapper = mount(ModelShelf, { ...globalOpts, ...extra });
   await new Promise((resolve) => setTimeout(resolve, 0));
   await wrapper.vm.$nextTick();
@@ -180,6 +188,7 @@ beforeEach(() => {
   listCheckpoints.mockReset();
   listEngines.mockReset().mockResolvedValue([]);
   listUnclassified.mockReset().mockResolvedValue([]);
+  listSupport.mockReset().mockResolvedValue([]);
   listModelFolderDevices.mockReset();
   listModelFolderDevices.mockResolvedValue([]);
   listModelFolders.mockReset();
@@ -672,6 +681,7 @@ describe("empty states", () => {
       checkpoints: false,
       unclassified: false,
       engines: false,
+      support: false,
     });
     await wrapper.vm.$nextTick();
     expect(textOf(wrapper.find(".shelf-state"))).toContain(

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -2589,6 +2589,10 @@ function toggleDirection() {
 function kindLabel(row) {
   if (row.file_kind === "checkpoint") return "Checkpoint";
   if (row.file_kind === "unknown") return "Unclassified";
+  // Named as roles rather than as file types, because the reader deciding what
+  // to keep is asking what the file DOES beside a checkpoint.
+  if (row.file_kind === "vae") return "VAE";
+  if (row.file_kind === "text_encoder") return "Text encoder";
   const capabilities = Array.isArray(row.capabilities) ? row.capabilities : [];
   if (capabilities.length) return capabilities.map(capabilityLabel).join(", ");
   // One vocabulary with the `feature` group axis, though not always the same

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -375,6 +375,11 @@ function defaultFilters() {
     // (#927). The box is still there to turn it off.
     unclassified: true,
     engines: true,
+    // The VAEs and text encoders a generation graph loads beside a checkpoint.
+    // On for the same reason as the two above and rather more urgently: until
+    // they had kinds of their own the big ones were counted as checkpoints, so
+    // "what are my base models" answered with a list mostly made of encoders.
+    support: true,
     baseModels: [],
     capabilities: [],
   };
@@ -416,7 +421,9 @@ function storedFilters() {
   // default forward forever.
   if (!parsed || parsed.v !== FILTERS_SCHEMA_VERSION) return null;
   const filters = defaultFilters();
-  for (const key of ["adapters", "checkpoints", "unclassified", "engines"]) {
+  // `support` is absent from every blob an earlier build wrote, which needs no
+  // schema bump: the key simply misses this loop and keeps its default of on.
+  for (const key of BLOCKS) {
     if (typeof parsed[key] === "boolean") filters[key] = parsed[key];
   }
   for (const key of ["adapterKinds", "baseModels", "capabilities"]) {
@@ -591,14 +598,30 @@ function groupsOf(row, axis) {
   }));
 }
 
-/** The four top-level type checkboxes, each one request and one row bucket. */
-const BLOCKS = ["adapters", "checkpoints", "unclassified", "engines"];
+/** The top-level type checkboxes, each one row bucket. */
+const BLOCKS = [
+  "adapters",
+  "checkpoints",
+  "unclassified",
+  "engines",
+  "support",
+];
 
-/** Which block a row came from, so a fetch only replaces what it asked for. */
+/**
+ * Which block a row came from, so a fetch only replaces what it asked for.
+ *
+ * `support` is the one block that is two kinds. A VAE and a text encoder are
+ * separate answers to "what is this file" and one answer to "what does the
+ * shelf show", so they are separate `file_kind`s and one checkbox — the alt
+ * being two boxes nobody wants to tick separately.
+ */
 function blockOf(row) {
   if (row.file_kind === "checkpoint") return "checkpoints";
   if (row.file_kind === "unknown") return "unclassified";
   if (row.file_kind === "engine") return "engines";
+  if (row.file_kind === "vae" || row.file_kind === "text_encoder") {
+    return "support";
+  }
   return "adapters";
 }
 
@@ -685,6 +708,12 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
       // InsightFace packs and every HuggingFace repo in the cache. Same
       // route, same shape, one more `file_kind`.
       if (filters.engines) requests.push(listAdapters({ fileKind: "engine" }));
+      // Two requests for one checkbox: the route takes a single `file_kind`,
+      // and these two kinds are one thing to a reader deciding what to keep.
+      if (filters.support) {
+        requests.push(listAdapters({ fileKind: "vae" }));
+        requests.push(listAdapters({ fileKind: "text_encoder" }));
+      }
       const results = await Promise.all(requests);
       if (startedAt !== epoch) return;
       const refreshed = new Set(BLOCKS.filter((block) => filters[block]));

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -20,6 +20,10 @@ const listEngines = vi.fn();
 // would answer the unclassified request with adapter rows and make every list
 // here look duplicated.
 const listUnclassified = vi.fn();
+// Same split again, for the two support kinds. One double serves both: they are
+// one checkbox and one row bucket, so a test that wants support rows wants them
+// without caring which of the two requests carried them.
+const listSupport = vi.fn();
 
 const editModels = vi.fn();
 const listBaseModelCompletions = vi.fn();
@@ -34,6 +38,9 @@ vi.mock("../api/modelShelf", () => ({
   listAdapters: (...args) => {
     if (args[0]?.fileKind === "engine") return listEngines(...args);
     if (args[0]?.fileKind === "unknown") return listUnclassified(...args);
+    if (args[0]?.fileKind === "vae" || args[0]?.fileKind === "text_encoder") {
+      return listSupport(...args);
+    }
     return listAdapters(...args);
   },
   listCheckpoints: (...args) => listCheckpoints(...args),
@@ -83,6 +90,7 @@ beforeEach(() => {
   listCheckpoints.mockReset().mockResolvedValue([]);
   listEngines.mockReset().mockResolvedValue([]);
   listUnclassified.mockReset().mockResolvedValue([]);
+  listSupport.mockReset().mockResolvedValue([]);
   listBaseModelCompletions.mockReset().mockResolvedValue([]);
 });
 
@@ -370,6 +378,58 @@ describe("the badge", () => {
     await store.setFilters({ engines: false }, { refetch: true });
     expect(store.activeCount).toBe(1);
   });
+
+  it("counts turning support files off, for the same reason", async () => {
+    const store = useModelShelfStore();
+    await store.setFilters({ support: false }, { refetch: true });
+    expect(store.activeCount).toBe(1);
+  });
+});
+
+describe("the support block", () => {
+  it("puts both kinds in one bucket from two requests", async () => {
+    // One checkbox, two `file_kind`s. The route takes a single kind, so the
+    // block is two requests, and a reader deciding what to keep sees one list.
+    const store = useModelShelfStore();
+    listSupport
+      .mockResolvedValueOnce([
+        adapter({ id: 1, file_kind: "vae", kind: null }),
+      ])
+      .mockResolvedValueOnce([
+        adapter({ id: 2, file_kind: "text_encoder", kind: null }),
+      ]);
+
+    await store.fetchRows();
+
+    expect(store.rows.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it("replaces only its own rows when it refetches", async () => {
+    // `blockOf` has to map BOTH kinds to `support`, or a refetch leaves the
+    // kind it forgot about behind as a duplicate.
+    const store = useModelShelfStore();
+    listSupport
+      .mockResolvedValueOnce([adapter({ id: 1, file_kind: "vae", kind: null })])
+      .mockResolvedValueOnce([
+        adapter({ id: 2, file_kind: "text_encoder", kind: null }),
+      ]);
+    await store.fetchRows();
+
+    listSupport
+      .mockResolvedValueOnce([adapter({ id: 3, file_kind: "vae", kind: null })])
+      .mockResolvedValueOnce([
+        adapter({ id: 4, file_kind: "text_encoder", kind: null }),
+      ]);
+    await store.fetchRows();
+
+    expect(store.rows.map((r) => r.id)).toEqual([3, 4]);
+  });
+
+  it("asks for nothing when the box is off", async () => {
+    const store = useModelShelfStore();
+    await store.setFilters({ support: false }, { refetch: true });
+    expect(listSupport).not.toHaveBeenCalled();
+  });
 });
 
 describe("empty states", () => {
@@ -382,6 +442,7 @@ describe("empty states", () => {
         checkpoints: false,
         unclassified: false,
         engines: false,
+        support: false,
       },
       { refetch: true },
     );

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -64,6 +64,13 @@ CURRENT_SCHEMA_VERSION = 2
 # build ignores it entirely.
 CURRENT_DATA_VERSION = 1
 
+# `model_file.state` for a copy the last scan actually looked at, spelled out
+# rather than imported from `services.model_folder_scanner`. That module imports
+# `hub.db`, which imports this one, so the import would be a cycle. Kept beside
+# the version counters so the duplication is visible rather than buried at its
+# one use in `_backfill_component_roles`.
+_BACKFILL_LIVE_STATE = "present"
+
 
 # Identity plus the per-user preference and machine/deployment columns that move
 # out of the vault's ``user`` table (multi-library plan §5).
@@ -712,6 +719,14 @@ def _backfill_component_roles(conn: sqlite3.Connection) -> int:
     are not evidence, so the row is left alone rather than resolved by picking
     a side.
 
+    **``present`` copies decide it when there are any.** ``model_file`` is also
+    the tombstone: a copy deleted months ago leaves its row behind with
+    ``state = 'missing'``, and a dead path in a differently-named folder would
+    otherwise manufacture a disagreement and veto a re-filing that every live
+    copy agrees on. A model with *no* present copy — every location on a drive
+    that is not plugged in — still falls back to the paths it has, because this
+    runs once and skipping it there would mislabel that drive permanently.
+
     Runs exactly once per hub (see :data:`CURRENT_DATA_VERSION`), because
     ``file_kind`` is owner-correctable and a backfill that re-ran would undo the
     correction on the next restart.
@@ -726,7 +741,7 @@ def _backfill_component_roles(conn: sqlite3.Connection) -> int:
     # `apply_migrations`, which a test may hand a bare `sqlite3.connect` with no
     # `row_factory` set.
     rows = conn.execute(
-        "SELECT m.id, f.path, mf.relpath "
+        "SELECT m.id, f.path, mf.relpath, mf.state "
         "FROM model m "
         "JOIN model_file mf ON mf.model_id = m.id "
         "JOIN model_folder f ON f.id = mf.model_folder_id "
@@ -734,11 +749,21 @@ def _backfill_component_roles(conn: sqlite3.Connection) -> int:
         (FILE_UNKNOWN, FILE_CHECKPOINT),
     ).fetchall()
 
-    roles_by_model: dict[int, set] = {}
-    for model_id, folder_path, relpath in rows:
-        roles_by_model.setdefault(model_id, set()).add(
-            role_from_folder(f"{folder_path}/{relpath}")
-        )
+    # Gathered per state so the present copies can be preferred whole. Taking
+    # the union and then dropping tombstones would be the same thing written
+    # so that a later reader cannot see the rule.
+    live_roles: dict[int, set] = {}
+    any_roles: dict[int, set] = {}
+    for model_id, folder_path, relpath, state in rows:
+        role = role_from_folder(f"{folder_path}/{relpath}")
+        any_roles.setdefault(model_id, set()).add(role)
+        if state == _BACKFILL_LIVE_STATE:
+            live_roles.setdefault(model_id, set()).add(role)
+
+    roles_by_model = {
+        model_id: live_roles.get(model_id) or roles
+        for model_id, roles in any_roles.items()
+    }
 
     refiled = 0
     for model_id, roles in roles_by_model.items():

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -29,6 +29,11 @@ import secrets
 import sqlite3
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.adapter_header import (
+    FILE_CHECKPOINT,
+    FILE_UNKNOWN,
+    role_from_folder,
+)
 
 logger = get_logger(__name__)
 
@@ -37,6 +42,27 @@ logger = get_logger(__name__)
 # was written by a newer PixlStash: refuse it rather than migrate it downward
 # (see :func:`apply_migrations`).
 CURRENT_SCHEMA_VERSION = 2
+
+# How many one-shot DATA backfills have been applied, kept in SQLite's own
+# ``PRAGMA user_version`` slot.
+#
+# This is deliberately a second counter and not a schema version. The two answer
+# different questions and must not share one number:
+#
+# * ``schema_version`` is the SHAPE, and its steps are re-runnable by design —
+#   ``_apply_v2`` is re-applied on every open so a developer hub picks up newly
+#   added v2 tables. A step that rewrites a user-correctable *value* cannot live
+#   there: re-running it would undo the correction, silently, on every restart.
+# * this counter is applied strictly once per hub, which is what a backfill over
+#   owner-editable data needs.
+#
+# It also cannot be a third schema version. A build shipped before this change
+# has ``CURRENT_SCHEMA_VERSION = 2`` and would refuse a v3 hub outright with
+# ``HubSchemaTooNewError``, locking that user out of a downgrade — the same
+# reasoning the model-shelf tables were amended into v2 for. ``user_version`` is
+# free (nothing in PixlStash has ever written it), costs no DDL, and an older
+# build ignores it entirely.
+CURRENT_DATA_VERSION = 1
 
 
 # Identity plus the per-user preference and machine/deployment columns that move
@@ -667,6 +693,71 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
         )
 
 
+def _backfill_component_roles(conn: sqlite3.Connection) -> int:
+    """Re-file VAEs and text encoders that were registered before they had kinds.
+
+    Every row on an existing shelf was classified by tensor markers and a
+    parameter count alone, and those two cannot see a support file: a VAE and a
+    CLIP fall below ``_CHECKPOINT_MIN_PARAMS`` and were stored as ``unknown``,
+    while a T5-class encoder clears it and was stored as ``checkpoint``. The
+    directory each file sits in says which it is, and the directory is already
+    in the hub — so this needs no rescan and reads no bytes.
+
+    Only ``unknown`` and ``checkpoint`` rows are considered. An ``adapter`` was
+    asserted from markers the file cannot strip, and an ``engine`` was declared
+    by us rather than derived, so neither is a guess this can improve on.
+
+    **A model with several copies must agree with itself.** Two locations that
+    name different roles — one under ``vae/``, one loose in a mixed folder —
+    are not evidence, so the row is left alone rather than resolved by picking
+    a side.
+
+    Runs exactly once per hub (see :data:`CURRENT_DATA_VERSION`), because
+    ``file_kind`` is owner-correctable and a backfill that re-ran would undo the
+    correction on the next restart.
+
+    Args:
+        conn: An open hub connection, inside the caller's transaction.
+
+    Returns:
+        How many rows were re-filed.
+    """
+    # Indexed positionally rather than by name: this runs from
+    # `apply_migrations`, which a test may hand a bare `sqlite3.connect` with no
+    # `row_factory` set.
+    rows = conn.execute(
+        "SELECT m.id, f.path, mf.relpath "
+        "FROM model m "
+        "JOIN model_file mf ON mf.model_id = m.id "
+        "JOIN model_folder f ON f.id = mf.model_folder_id "
+        "WHERE m.file_kind IN (?, ?)",
+        (FILE_UNKNOWN, FILE_CHECKPOINT),
+    ).fetchall()
+
+    roles_by_model: dict[int, set] = {}
+    for model_id, folder_path, relpath in rows:
+        roles_by_model.setdefault(model_id, set()).add(
+            role_from_folder(f"{folder_path}/{relpath}")
+        )
+
+    refiled = 0
+    for model_id, roles in roles_by_model.items():
+        if len(roles) != 1:
+            continue
+        (role,) = roles
+        if role is None:
+            continue
+        conn.execute("UPDATE model SET file_kind = ? WHERE id = ?", (role, model_id))
+        refiled += 1
+    if refiled:
+        logger.info(
+            "Re-filed %d model rows as VAEs or text encoders from the folder "
+            "they sit in; they were registered before those kinds existed.",
+            refiled,
+        )
+    return refiled
+
+
 class HubSchemaTooNewError(RuntimeError):
     """The hub file was written by a newer PixlStash than this build.
 
@@ -750,6 +841,30 @@ def apply_migrations(conn: sqlite3.Connection) -> int:
             logger.error(
                 "Hub v2 shape reconciliation failed, hub stays on version %d: %s",
                 version,
+                exc,
+            )
+            raise
+
+    # Data backfills, after the shape is settled and each applied exactly once.
+    # BEGIN IMMEDIATE and the version write share the transaction for the same
+    # reason the schema steps do: an interrupted backfill must leave the counter
+    # where it was, so the next open retries it rather than skipping it.
+    data_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if data_version < CURRENT_DATA_VERSION:
+        try:
+            with conn:
+                conn.execute("BEGIN IMMEDIATE")
+                if data_version < 1:
+                    _backfill_component_roles(conn)
+                # No placeholder: PRAGMA takes no parameters, and the value is
+                # this module's own constant rather than anything from outside.
+                conn.execute(f"PRAGMA user_version = {CURRENT_DATA_VERSION:d}")
+        except sqlite3.Error as exc:
+            logger.error(
+                "Hub data backfill to version %d failed, hub stays on data "
+                "version %d: %s",
+                CURRENT_DATA_VERSION,
+                data_version,
                 exc,
             )
             raise

--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -27,6 +27,15 @@ default. It surfaces on the *adapters* block under an explicit
 is therefore hash-addressable exactly as an adapter is. ``/checkpoints`` never
 returns one.
 
+**Nor is a support file.** ``vae`` and ``text_encoder`` are the two kinds a
+generation graph loads *beside* a checkpoint, and they reach the same block the
+same way (``?file_kind=vae``). Before they existed the classifier had only tensor
+markers and a parameter count to go on, and neither can see a support file: a
+VAE and a CLIP sit below the checkpoint threshold and were stored as ``unknown``,
+a T5-class encoder sits above it and was stored as ``checkpoint``. So
+``/checkpoints`` was answering "what base models do I have" with a list mostly
+made of text encoders, and *"which of these can I delete"* had no answer at all.
+
 **Folding happens on the way out, not in the database.** Every row carries
 ``base_model_folded`` beside its raw ``base_model``. That is where the fold
 belongs: ``base_model`` is free text by rule, and the shelf sorts, filters,
@@ -114,7 +123,9 @@ from pixlstash.utils.adapter_header import (
     FILE_ADAPTER,
     FILE_CHECKPOINT,
     FILE_ENGINE,
+    FILE_TEXT_ENCODER,
     FILE_UNKNOWN,
+    FILE_VAE,
 )
 from pixlstash.utils.host_open import open_in_file_manager
 from pixlstash.utils.known_base_models import completions, fold
@@ -129,7 +140,20 @@ logger = get_logger(__name__)
 # ``engine`` rides here rather than gaining a fourth route: PixlStash's own
 # taggers and scorers are a *filter* over the same table, not a different shape,
 # and this block already serves a kind that is not an adapter.
-ADAPTER_BLOCK_FILE_KINDS = (FILE_ADAPTER, FILE_UNKNOWN, FILE_ENGINE)
+#
+# ``vae`` and ``text_encoder`` ride here for the same reason plus one of their
+# own: they are hashed by the scanner unless they are large, so they are
+# hash-addressable exactly as an adapter and an ``unknown`` are, which is the
+# property this block's routes are built on. They are emphatically NOT folded
+# into ``/checkpoints`` — filing a text encoder as a base model is the defect
+# this whole kind exists to end.
+ADAPTER_BLOCK_FILE_KINDS = (
+    FILE_ADAPTER,
+    FILE_UNKNOWN,
+    FILE_ENGINE,
+    FILE_VAE,
+    FILE_TEXT_ENCODER,
+)
 
 # Constrained here rather than validated in the handler, so an unknown key is a
 # 422 from FastAPI and never reaches the SQL builder. The values are the five
@@ -654,10 +678,12 @@ def create_router(server) -> APIRouter:
         description=(
             "Every adapter registered on this machine, with each copy's location "
             "and the characters/sets in the active library that use it. "
-            "`file_kind=unknown` returns the unclassified files instead — they "
-            "are hashed and addressable exactly as adapters are, and they are "
-            "never folded into /checkpoints. `base_model=UNASSIGNED` selects the "
-            "rows that record no base model."
+            "`file_kind` swaps in the other hash-addressable kinds instead: "
+            "`unknown` for the unclassified files, `vae` and `text_encoder` for "
+            "the support files a generation graph loads beside a checkpoint, "
+            "`engine` for the models PixlStash downloads for itself. None of "
+            "them is ever folded into /checkpoints. `base_model=UNASSIGNED` "
+            "selects the rows that record no base model."
         ),
         tags=["model_shelf"],
         response_model=AdapterListResponse,
@@ -666,7 +692,10 @@ def create_router(server) -> APIRouter:
         request: Request,
         file_kind: str = Query(
             FILE_ADAPTER,
-            description="`adapter` (default) or `unknown`. Checkpoints have their own route.",
+            description=(
+                "`adapter` (default), `unknown`, `vae`, `text_encoder` or "
+                "`engine`. Checkpoints have their own route."
+            ),
         ),
         base_model: Optional[str] = Query(
             None,

--- a/pixlstash/services/model_folder_scanner.py
+++ b/pixlstash/services/model_folder_scanner.py
@@ -82,6 +82,20 @@ PROVENANCE_EXTERNAL = "external"
 
 _HASH_CHUNK_BYTES = 1024 * 1024
 
+# Above this, a file is hashed later by MissingCheckpointHashFinder instead of
+# during the scan.
+#
+# The question was always about SIZE — "it may be 24 GB and the shelf must not
+# stall behind it" — and `file_kind == 'checkpoint'` was a usable proxy for it
+# only while `checkpoint` was the one large kind. It stopped being one the
+# moment text encoders got a kind of their own: a 23 GB T5 is precisely the read
+# the finder exists to defer, and it would have gone back to being paid inline.
+#
+# 2 GiB sits above every VAE and CLIP measured on a real shelf (the largest a
+# 5 GB video VAE, the typical 0.3 GB) and below every base model and large
+# encoder, so the split lands where the stall does.
+_DEFER_HASH_BYTES = 2 * 1024**3
+
 # Files per write transaction. The hub's multi-process contract is "short
 # transactions only", and this also means an interrupted scan keeps the rows it
 # already wrote instead of discarding the whole folder.
@@ -518,36 +532,49 @@ class ModelFolderScanner:
             param_count=info.param_count,
         )
 
+        # Hash now, or leave it for MissingCheckpointHashFinder.
+        #
+        # An adapter is always hashed here whatever its size: `CHECK (file_kind
+        # <> 'adapter' OR sha256 IS NOT NULL)` is an invariant, so a deferred one
+        # could not be registered at all. A checkpoint is always deferred: it may
+        # be 24 GB and the shelf must not stall behind it.
+        #
+        # Every other kind defers on SIZE, which is what the question was always
+        # about. `file_kind == 'checkpoint'` was a usable proxy for "large" only
+        # while `checkpoint` was the one large kind, and it stopped being one the
+        # moment text encoders got a kind of their own. The finder queries on
+        # `sha256 IS NULL` rather than on a kind, so it picks these up whatever
+        # they are.
+        #
+        # A digest the caller already has is used either way: that only happens
+        # when it just copied these bytes through a hash, so the read the finder
+        # exists to defer has already been paid for, and deferring anyway would
+        # schedule a second one for nothing.
+        if known_digest is not None:
+            digest = known_digest
+        elif info.file_kind != FILE_ADAPTER and (
+            info.file_kind == FILE_CHECKPOINT or size >= _DEFER_HASH_BYTES
+        ):
+            digest = None
+        else:
+            try:
+                digest = sha256_file(abs_path)
+            except OSError as exc:
+                logger.warning(
+                    "Model scan could not hash %s (%d bytes): %s. Leaving it "
+                    "unregistered; a partial hash would be a wrong identity.",
+                    abs_path,
+                    size,
+                    exc,
+                )
+                result.unreadable += 1
+                return None
+
         if info.file_kind == FILE_CHECKPOINT:
             result.checkpoints += 1
-            # No hash: it may be 24 GB. MissingCheckpointHashFinder supplies it.
-            # Unless the caller already has one, which only happens when it just
-            # copied these bytes through a hash — then the read the finder exists
-            # to defer has already been paid for, and deferring anyway would
-            # schedule a second one for nothing.
-            if known_digest is None:
-                return record
-            return record._replace(digest=known_digest)
-
-        if known_digest is not None:
+        else:
             result.adapters += 1
-            return record._replace(digest=known_digest)
-
-        try:
-            digest = sha256_file(abs_path)
-        except OSError as exc:
-            logger.warning(
-                "Model scan could not hash %s (%d bytes): %s. Leaving it "
-                "unregistered; a partial hash would be a wrong identity.",
-                abs_path,
-                size,
-                exc,
-            )
-            result.unreadable += 1
-            return None
-
-        result.adapters += 1
-        return record._replace(digest=digest)
+        return record if digest is None else record._replace(digest=digest)
 
     # -- hub reads --------------------------------------------------------
 

--- a/pixlstash/services/model_folder_scanner.py
+++ b/pixlstash/services/model_folder_scanner.py
@@ -91,9 +91,12 @@ _HASH_CHUNK_BYTES = 1024 * 1024
 # moment text encoders got a kind of their own: a 23 GB T5 is precisely the read
 # the finder exists to defer, and it would have gone back to being paid inline.
 #
-# 2 GiB sits above every VAE and CLIP measured on a real shelf (the largest a
-# 5 GB video VAE, the typical 0.3 GB) and below every base model and large
-# encoder, so the split lands where the stall does.
+# 2 GiB is where the stall starts to be worth deferring, not a boundary between
+# kinds — nothing here needs one, because this is only ever asked about the
+# non-adapter kinds. An image VAE and a CLIP measure a few hundred MB and are
+# hashed inline; a base model, a large text encoder and a multi-gigabyte video
+# VAE all sit above it and are left to the finder, which is right for each of
+# them for the same reason: they are a long read, whatever they are.
 _DEFER_HASH_BYTES = 2 * 1024**3
 
 # Files per write transaction. The hub's multi-process contract is "short

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -44,7 +44,9 @@ from pixlstash.utils.adapter_header import (
     FILE_ADAPTER,
     FILE_CHECKPOINT,
     FILE_ENGINE,
+    FILE_TEXT_ENCODER,
     FILE_UNKNOWN,
+    FILE_VAE,
 )
 
 logger = get_logger(__name__)
@@ -468,7 +470,17 @@ CURATABLE_FIELDS = ("display_name", "base_model", "kind", "file_kind")
 # What a file may be corrected to. Closed, and checked before the UPDATE rather
 # than left to the CHECK constraint: a violation would surface as a 500 naming
 # a constraint, which tells the owner nothing about the file they picked.
-FILE_KINDS = (FILE_ADAPTER, FILE_CHECKPOINT, FILE_UNKNOWN)
+#
+# `vae` and `text_encoder` are correctable like the rest, and they are the two
+# most likely to need it: their kind is read off the folder the file sits in, so
+# a support file kept outside the layout gets the answer the layout gives.
+FILE_KINDS = (
+    FILE_ADAPTER,
+    FILE_CHECKPOINT,
+    FILE_VAE,
+    FILE_TEXT_ENCODER,
+    FILE_UNKNOWN,
+)
 
 # A location state that means the bytes are still out there somewhere, so the
 # row is NOT a candidate for Forget. `unreachable` is in here deliberately: it

--- a/pixlstash/utils/adapter_header.py
+++ b/pixlstash/utils/adapter_header.py
@@ -373,7 +373,7 @@ def role_from_folder(path: str) -> Optional[str]:
 
 
 def classify_model_file(tensor_names, param_count: int, path: str = "") -> str:
-    """Return what a file *is*, from its tensor names, size and location.
+    """Return what a file *is*, from its tensor names, parameter count and location.
 
     The rule is deliberately asymmetric, and the order below is the ranking of
     how much each signal can be trusted:

--- a/pixlstash/utils/adapter_header.py
+++ b/pixlstash/utils/adapter_header.py
@@ -29,6 +29,7 @@ metadata: it is the only signal present on every file regardless of provenance.
 from __future__ import annotations
 
 import json
+import os
 import re
 import struct
 from dataclasses import dataclass, field
@@ -83,6 +84,47 @@ FILE_UNKNOWN = "unknown"
 # already holds free text, so this vocabulary stays four values wide.
 FILE_ENGINE = "engine"
 
+# The two support roles a generation graph loads beside a diffusion model. They
+# are not checkpoints and they are not adapters, and until they had names of
+# their own the shelf had nowhere to put them: measured against a real shelf,
+# every VAE and CLIP fell below `_CHECKPOINT_MIN_PARAMS` and read as `unknown`,
+# while every T5/UMT5/Qwen/Gemma text encoder cleared it and read as
+# `checkpoint`. That is 131 GB of encoders counted as base models on one
+# machine, and it is why "what can I delete" had no answer.
+FILE_VAE = "vae"
+FILE_TEXT_ENCODER = "text_encoder"
+
+# What a directory NAMES the files inside it, normalised by `_normalise_folder`.
+#
+# ComfyUI files models by role (`models/vae`, `models/text_encoders`,
+# `models/clip`) and the launchers that front it mirror the layout, so the role
+# is sitting in the path of nearly every file on a real shelf. That is a better
+# signal than anything the header carries here: a VAE and a text encoder are
+# ordinary tensor bundles with no marker to find, and their parameter counts
+# straddle the checkpoint threshold from both sides.
+#
+# Only genuinely different words belong here — the normaliser already folds
+# spacing and case, so a `text_encoders` entry covers `TextEncoders` too.
+#
+# Deliberately absent, each for its own reason:
+#
+# * `loras` / `lora` — an adapter is asserted from tensor markers, which is
+#   positive evidence no directory can improve on. Trusting the folder here
+#   would actively break the case that already works: an all-in-one checkpoint
+#   dropped in a LoRA folder is caught today by its parameter count.
+# * `approxvae` — TAESD previews and latent interposers. They live beside real
+#   autoencoders and are not one, so treating them as VAEs would offer the wrong
+#   file as a companion.
+# * `clipvision` — an image encoder. It shares a prefix with `clip` and does a
+#   different job, which is exactly the confusion worth not shipping.
+_ROLE_FOLDERS: dict[str, str] = {
+    "vae": FILE_VAE,
+    "vaes": FILE_VAE,
+    "clip": FILE_TEXT_ENCODER,
+    "textencoder": FILE_TEXT_ENCODER,
+    "textencoders": FILE_TEXT_ENCODER,
+}
+
 # Parameter count above which a marker-free file is a base checkpoint rather
 # than an adapter we failed to recognise.
 #
@@ -116,9 +158,10 @@ class AdapterInfo:
             from names the file cannot strip without breaking, so an
             unrecognised LyCORIS variant reads as "an adapter whose kind we do
             not know" rather than being mistaken for a checkpoint.
-        file_kind: What the file is: ``"adapter"``, ``"checkpoint"`` or
-            ``"unknown"``. Never guesses checkpoint from the absence of
-            markers alone; see :func:`classify_model_file`.
+        file_kind: What the file is: ``"adapter"``, ``"vae"``,
+            ``"text_encoder"``, ``"checkpoint"`` or ``"unknown"``. Never
+            guesses checkpoint from the absence of markers alone; see
+            :func:`classify_model_file`.
         param_count: Total parameters, summed from the tensor shapes already in
             the header. Exact and free, unlike file size which quantisation and
             rank both confound.
@@ -297,28 +340,79 @@ def count_parameters(header: dict) -> int:
     return total
 
 
-def classify_model_file(tensor_names, param_count: int) -> str:
-    """Return what a file *is*, given its tensor names and parameter count.
+def _normalise_folder(name: str) -> str:
+    """Fold a directory name to its letters and digits, lowercased.
 
-    The rule is deliberately asymmetric. Adapter is asserted on **positive**
-    evidence (markers the file cannot strip). Checkpoint is also asserted on
-    positive evidence (a parameter count no adapter reaches). Everything else
-    is ``"unknown"``, which the shelf shows as unknown and lets the user
-    correct.
+    ``TextEncoders``, ``text_encoders`` and ``text-encoders`` are one layout
+    spelled three ways, so :data:`_ROLE_FOLDERS` carries the word once.
+    """
+    return re.sub(r"[^a-z0-9]", "", name.lower())
 
-    ``unknown`` must never be rendered or stored as checkpoint. A marker-free
-    file is only a checkpoint when it is big enough to be one; otherwise it is
-    most likely an adapter format we have not met yet.
+
+def role_from_folder(path: str) -> Optional[str]:
+    """Return the component role the file's own directory names, or ``None``.
+
+    Only the directory the file sits in is consulted, never an ancestor: a
+    registered folder may itself be called ``vae`` (someone can register
+    ``ComfyUI/models/vae`` directly) and it may equally be a whole models tree
+    with ``vae/`` inside it. Both cases put the role one level up from the file,
+    and nothing else in the path is evidence about a particular file.
+
+    Args:
+        path: Path to the model file. May be relative or absolute.
+
+    Returns:
+        ``"vae"``, ``"text_encoder"``, or ``None`` when the directory names no
+        role we recognise — which is the answer for a flat folder of mixed
+        downloads and must never be read as "not a VAE".
+    """
+    folder = os.path.basename(os.path.dirname(path))
+    if not folder:
+        return None
+    return _ROLE_FOLDERS.get(_normalise_folder(folder))
+
+
+def classify_model_file(tensor_names, param_count: int, path: str = "") -> str:
+    """Return what a file *is*, from its tensor names, size and location.
+
+    The rule is deliberately asymmetric, and the order below is the ranking of
+    how much each signal can be trusted:
+
+    1. **Adapter markers**, when present, settle it. They are positive evidence
+       the file cannot strip without breaking, so nothing overrides them — not
+       a parameter count and not a directory. This is what keeps an all-in-one
+       checkpoint dropped in someone's ``Lora/`` folder from being filed as a
+       LoRA.
+    2. **The directory**, when it names a role. A VAE and a text encoder carry
+       no marker to find, so the layout the user (or their launcher) already
+       maintains is the best evidence there is. It outranks the parameter count
+       because the parameter count is *wrong* for both: they sit either side of
+       a threshold that was only ever meant to separate adapters from base
+       models.
+    3. **The parameter count**, for a marker-free file in a folder that says
+       nothing. A count no adapter reaches asserts checkpoint.
+
+    Everything else is ``"unknown"``, which the shelf shows as unknown and lets
+    the user correct. ``unknown`` must never be rendered or stored as
+    checkpoint: a marker-free file too small to be a base model is most likely
+    an adapter format we have not met yet.
 
     Args:
         tensor_names: Iterable of tensor keys from the header.
         param_count: Total parameters, from :func:`count_parameters`.
+        path: Where the file lives. Optional — omitting it drops rule 2 and
+            leaves the pre-existing behaviour, which is what a caller holding
+            only a header should get.
 
     Returns:
-        ``"adapter"``, ``"checkpoint"`` or ``"unknown"``.
+        ``"adapter"``, ``"vae"``, ``"text_encoder"``, ``"checkpoint"`` or
+        ``"unknown"``.
     """
     if has_adapter_markers(tensor_names):
         return FILE_ADAPTER
+    role = role_from_folder(path) if path else None
+    if role is not None:
+        return role
     if param_count >= _CHECKPOINT_MIN_PARAMS:
         return FILE_CHECKPOINT
     return FILE_UNKNOWN
@@ -438,7 +532,7 @@ def describe_adapter(path: str) -> Optional[AdapterInfo]:
         kind=detect_adapter_kind(tensor_names),
         tensor_count=len(tensor_names),
         is_adapter=has_adapter_markers(tensor_names),
-        file_kind=classify_model_file(tensor_names, param_count),
+        file_kind=classify_model_file(tensor_names, param_count, path),
         param_count=param_count,
         base_model=str(base_model) if base_model else None,
         trigger_words=_trigger_words_from_tag_frequency(

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -25,6 +25,7 @@ import time
 import pytest
 
 from pixlstash.hub.schema import (
+    CURRENT_DATA_VERSION,
     CURRENT_SCHEMA_VERSION,
     _V2_MODEL,
     _V2_MODEL_FILE,
@@ -554,6 +555,117 @@ class TestUnknownIsFirstClass:
         assert hub.execute(
             "SELECT COUNT(*) FROM model_file WHERE model_id = ?", (model_id,)
         ).fetchone() == (2,)
+
+
+class TestComponentRoleBackfill:
+    """Re-filing support files that were registered before they had kinds.
+
+    Every row on an existing shelf was classified by tensor markers and a
+    parameter count, and neither can see a VAE or a text encoder. The folder
+    each file sits in can, and it is already in the hub — so this is a data
+    backfill over stored columns, not a rescan.
+
+    It runs exactly once per hub, tracked in ``PRAGMA user_version`` rather than
+    in ``schema_version``: the schema steps are re-applied on every open by
+    design, and a step that rewrote an owner-correctable value on every restart
+    would undo the correction each time.
+    """
+
+    def test_a_small_vae_stored_as_unknown_is_refiled(self, hub):
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="unknown", sha256="v", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/models"), "VAE/sdxl_vae.safetensors")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("vae",)
+
+    def test_a_large_text_encoder_stored_as_checkpoint_is_refiled(self, hub):
+        # The 131 GB case: a T5-class encoder clears the checkpoint threshold,
+        # so it was filed as a base model and counted as one.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="checkpoint", sha256="t", kind=None)
+        add_file(
+            hub,
+            model_id,
+            add_folder(hub, "/models"),
+            "TextEncoders/t5xxl_fp16.safetensors",
+        )
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("text_encoder",)
+
+    def test_an_adapter_is_never_touched(self, hub):
+        # Markers are positive evidence. A LoRA kept beside the VAEs is a
+        # misfiled LoRA, and the backfill must not "fix" it into a VAE.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="adapter", sha256="a", kind="lora")
+        add_file(hub, model_id, add_folder(hub, "/models"), "VAE/mislaid.safetensors")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("adapter",)
+
+    def test_copies_that_disagree_leave_the_row_alone(self, hub):
+        # One copy under `VAE/` and one loose in a mixed folder is not evidence.
+        # Resolving it by picking a side would be a guess wearing a fact's face.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="unknown", sha256="d", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/a"), "VAE/thing.safetensors")
+        add_file(hub, model_id, add_folder(hub, "/b"), "Downloads/thing.safetensors")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("unknown",)
+
+    def test_it_runs_once_and_never_undoes_a_correction(self, hub):
+        # The reason this is not a schema step. `_apply_v2` re-runs on every
+        # open; if this did too, an owner who corrected a row would find it
+        # reverted on their next restart, silently, forever.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="unknown", sha256="c", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/models"), "VAE/odd.safetensors")
+        hub.commit()
+
+        apply_migrations(hub)
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("vae",)
+
+        # The owner disagrees: it is really a checkpoint someone filed oddly.
+        hub.execute(
+            "UPDATE model SET file_kind = 'checkpoint' WHERE id = ?", (model_id,)
+        )
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("checkpoint",)
+
+    def test_a_fresh_hub_records_the_backfill_as_done(self, hub):
+        apply_migrations(hub)
+
+        assert hub.execute("PRAGMA user_version").fetchone()[0] == CURRENT_DATA_VERSION
 
 
 class TestTombstone:

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -635,6 +635,67 @@ class TestComponentRoleBackfill:
             "SELECT file_kind FROM model WHERE id = ?", (model_id,)
         ).fetchone() == ("unknown",)
 
+    def test_a_tombstone_cannot_veto_what_the_live_copies_agree_on(self, hub):
+        # `model_file` is also the tombstone, so a copy deleted months ago leaves
+        # its row behind. Counting that dead path as a dissenting voice would
+        # block the re-filing every present copy agrees on.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="unknown", sha256="t", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/a"), "VAE/thing.safetensors")
+        add_file(
+            hub,
+            model_id,
+            add_folder(hub, "/b"),
+            "Downloads/thing.safetensors",
+            state="missing",
+        )
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("vae",)
+
+    def test_present_copies_that_disagree_still_veto(self, hub):
+        # Preferring the live copies is not the same as ignoring disagreement:
+        # two folders we can currently see, naming different roles, is exactly
+        # the case that must be left alone.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="unknown", sha256="p", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/a"), "VAE/thing.safetensors")
+        add_file(hub, model_id, add_folder(hub, "/b"), "Downloads/thing.safetensors")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("unknown",)
+
+    def test_a_model_with_no_present_copy_is_still_refiled(self, hub):
+        # An unplugged drive. This runs once, so skipping it here would leave
+        # that drive's support files mislabelled for good.
+        apply_migrations(hub)
+        hub.execute("PRAGMA user_version = 0")
+        model_id = add_model(hub, file_kind="checkpoint", sha256="o", kind=None)
+        add_file(
+            hub,
+            model_id,
+            add_folder(hub, "/detached"),
+            "TextEncoders/t5xxl.safetensors",
+            state="unreachable",
+        )
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE id = ?", (model_id,)
+        ).fetchone() == ("text_encoder",)
+
     def test_it_runs_once_and_never_undoes_a_correction(self, hub):
         # The reason this is not a schema step. `_apply_v2` re-runs on every
         # open; if this did too, an owner who corrected a row would find it

--- a/tests/test_model_file_classification.py
+++ b/tests/test_model_file_classification.py
@@ -19,7 +19,9 @@ import pytest
 from pixlstash.utils.adapter_header import (
     FILE_ADAPTER,
     FILE_CHECKPOINT,
+    FILE_TEXT_ENCODER,
     FILE_UNKNOWN,
+    FILE_VAE,
     KIND_UNKNOWN,
     classify_model_file,
     count_parameters,
@@ -113,6 +115,138 @@ class TestFileClassification:
 
     def test_an_empty_file_is_unknown(self):
         assert classify_model_file([], param_count=0) == FILE_UNKNOWN
+
+
+class TestTheFolderNamesTheRole:
+    """The support kinds, which no header signal can assert.
+
+    A VAE and a text encoder carry no marker, and their parameter counts land on
+    both sides of the checkpoint threshold — a CLIP-L below it, a T5-XXL well
+    above. The directory is what actually knows, because ComfyUI and the
+    launchers that front it file models by role.
+    """
+
+    def test_a_vae_folder_names_a_vae_however_small(self):
+        # Below the checkpoint threshold, and previously stored as `unknown`.
+        assert (
+            classify_model_file(
+                ["decoder.conv_in.weight"],
+                param_count=83_000_000,
+                path="/models/VAE/sdxl_vae.safetensors",
+            )
+            == FILE_VAE
+        )
+
+    def test_a_text_encoder_folder_beats_the_checkpoint_threshold(self):
+        # The regression that motivated the kind: a T5-XXL is 4.9 B parameters,
+        # clears `_CHECKPOINT_MIN_PARAMS`, and was filed as a base model.
+        assert (
+            classify_model_file(
+                ["encoder.block.0.layer.0.SelfAttention.q.weight"],
+                param_count=4_890_000_000,
+                path="/models/TextEncoders/t5xxl_fp16.safetensors",
+            )
+            == FILE_TEXT_ENCODER
+        )
+
+    @pytest.mark.parametrize(
+        "folder", ["text_encoders", "TextEncoders", "text-encoders", "TEXTENCODERS"]
+    )
+    def test_spelling_and_case_of_one_folder_are_one_folder(self, folder):
+        assert (
+            classify_model_file(
+                ["encoder.block.0.weight"],
+                param_count=123_000_000,
+                path=f"/models/{folder}/clip_l.safetensors",
+            )
+            == FILE_TEXT_ENCODER
+        )
+
+    def test_comfyui_spells_its_text_encoders_clip_too(self):
+        assert (
+            classify_model_file(
+                ["text_model.encoder.layers.0.weight"],
+                param_count=123_000_000,
+                path="/ComfyUI/models/clip/clip_l.safetensors",
+            )
+            == FILE_TEXT_ENCODER
+        )
+
+    def test_markers_still_win_over_the_folder(self):
+        # Positive evidence outranks a directory. Someone keeping a LoRA beside
+        # their VAEs has a misfiled LoRA, not a VAE.
+        assert (
+            classify_model_file(
+                ["x.lora_A.weight"],
+                param_count=40_000_000,
+                path="/models/VAE/mislaid.safetensors",
+            )
+            == FILE_ADAPTER
+        )
+
+    def test_a_lora_folder_names_nothing_so_a_big_file_is_still_a_checkpoint(self):
+        # `loras` is deliberately absent from the table. All-in-one checkpoints
+        # get dropped in LoRA folders, and the parameter count already catches
+        # them — trusting the folder here would BREAK that.
+        assert (
+            classify_model_file(
+                ["model.weight"],
+                param_count=10_260_000_000,
+                path="/models/Lora/everything_aio.safetensors",
+            )
+            == FILE_CHECKPOINT
+        )
+
+    @pytest.mark.parametrize("folder", ["ApproxVAE", "clip_vision", "Downloads"])
+    def test_a_folder_that_names_no_role_leaves_the_answer_where_it_was(self, folder):
+        # TAESD previews are not VAEs and a CLIP-Vision is not a text encoder,
+        # despite sharing a word with one. Not recognising a folder must read as
+        # "no evidence", never as "not a VAE".
+        assert (
+            classify_model_file(
+                ["some.unrecognised.weight"],
+                param_count=40_000_000,
+                path=f"/models/{folder}/thing.safetensors",
+            )
+            == FILE_UNKNOWN
+        )
+
+    def test_no_path_at_all_leaves_the_old_behaviour_intact(self):
+        assert (
+            classify_model_file(["model.weight"], param_count=2_600_000_000)
+            == FILE_CHECKPOINT
+        )
+
+    def test_a_bare_filename_has_no_folder_and_asserts_nothing(self):
+        assert (
+            classify_model_file(
+                ["model.weight"], param_count=40_000_000, path="vae.safetensors"
+            )
+            == FILE_UNKNOWN
+        )
+
+    def test_only_the_files_own_folder_counts_not_an_ancestor(self):
+        # A registered root called `vae` says nothing about a subdirectory of
+        # checkpoints inside it.
+        assert (
+            classify_model_file(
+                ["model.weight"],
+                param_count=2_600_000_000,
+                path="/models/vae/checkpoints/big.safetensors",
+            )
+            == FILE_CHECKPOINT
+        )
+
+    def test_describe_adapter_files_a_real_file_by_its_folder(self, tmp_path):
+        folder = tmp_path / "TextEncoders"
+        folder.mkdir()
+        path = _write_safetensors(
+            folder / "t5xxl_fp16.safetensors",
+            {"encoder.block.0.weight": _tensor([4096, 4096])},
+        )
+        info = describe_adapter(str(path))
+        assert info is not None
+        assert info.file_kind == FILE_TEXT_ENCODER
 
 
 class TestDescribeAdapterCarriesTheNewFields:


### PR DESCRIPTION
## The defect

`classify_model_file` had two signals: adapter tensor markers, and a parameter
count above which a marker-free file is a base model. Neither can see a support
file. A VAE (~80 M parameters) and a CLIP-L (~120 M) fall below the checkpoint
threshold and stored as `unknown`; a T5-class text encoder (~4.9 B) clears it and
stored as `checkpoint`.

So `GET /checkpoints` answered "what base models do I have" with a list
substantially made of text encoders, and "which support files can I delete" had
nowhere to be asked at all.

## The fix

The folder knows. ComfyUI files models by role (`models/vae`,
`models/text_encoders`, `models/clip`) and the launchers that front it mirror the
layout, so the role is sitting in the path of nearly every file on a shelf.

`file_kind` gains `vae` and `text_encoder`, and `classify_model_file` now ranks
three signals:

1. **Adapter markers** — positive evidence the file cannot strip without
   breaking. Nothing overrides them.
2. **The file's own folder**, when it names a role. Outranks the parameter count
   because the count is wrong for both support kinds, from opposite sides.
3. **The parameter count**, for a marker-free file in a folder that says nothing.

`loras/` is deliberately absent from the folder table: an all-in-one checkpoint
dropped in a LoRA folder is already caught by its parameter count, and trusting
the folder there would break the case that works today. So are `ApproxVAE`
(TAESD previews and latent interposers, which are not autoencoders) and
`clip_vision` (an image encoder sharing a prefix with a text one).

Only the file's own directory is consulted, never an ancestor: a registered root
may itself be called `vae`, and it says nothing about a subdirectory inside it.

## Backfill

Rows registered before these kinds existed are re-filed from the paths already in
the hub — no rescan, and no bytes read.

It runs **exactly once per hub**, tracked in `PRAGMA user_version` rather than in
`schema_version`. The schema steps are re-applied on every open by design
(`_apply_v2` is how a developer hub picks up newly added tables), and a step that
rewrote an owner-correctable value would silently undo the correction on every
restart. A third schema version was not an option either — a build shipped before
this change would refuse the hub outright with `HubSchemaTooNewError` and lock
that user out of a downgrade, the same reasoning the shelf tables were amended
into v2 for. `user_version` is free, costs no DDL, and an older build ignores it.

A model whose copies disagree — one under `vae/`, one loose in a mixed folder —
is left alone. Two locations naming different roles are not evidence, and
resolving it by picking a side would be a guess wearing a fact's face.

## A regression this would otherwise have introduced

The scanner deferred hashing on `file_kind == 'checkpoint'`. That was a proxy for
"large", and a usable one only while `checkpoint` was the one large kind — a
multi-gigabyte text encoder would have gone straight back to being hashed inline
during the scan, which is precisely the read `MissingCheckpointHashFinder` exists
to defer.

Deferral now keys on size. Adapters are always hashed (the
`CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)` invariant leaves no
choice) and checkpoints are always deferred. The finder queries on
`sha256 IS NULL` rather than on a kind, so it picks the new kinds up unchanged.

## Surfaces

- `GET /adapters` accepts `file_kind=vae` and `text_encoder`, the same way it
  already accepts `unknown` and `engine` — they are hashed unless large and so
  are hash-addressable exactly as an adapter is. Neither is ever folded into
  `/checkpoints`.
- Both are correctable through `PATCH /models`, and are the two most likely to
  need it: their kind is read off a folder, so one kept outside the usual layout
  gets whatever that folder says.
- The shelf gains a **Support files** checkbox — one box, two kinds, on by
  default. Two requests behind it, because the route takes a single `file_kind`
  and these two are one question to someone deciding what to keep.

## Tests

- **Classification**: the folder naming a role in every spelling and case, markers
  still winning over it, the LoRA-folder case, unmapped folders asserting nothing
  rather than "not a VAE", an ancestor folder not counting, and end to end through
  `describe_adapter`.
- **Hub**: both backfill directions, adapters never touched, disagreeing copies
  left alone, a fresh hub recording the backfill as done, and — the one the
  mechanism exists for — an owner's correction surviving the next open.
- **Frontend**: the support block's two requests landing in one bucket, and a
  refetch replacing only its own rows.

Backfill coverage verified by mutation: neutering the call turns three of those
tests red.

## Follow-on

Phase 0 of the model-companions work. The family/quant/weights-identity columns,
the layered usage evidence, and the orphan check in front of a delete are
specced separately and land as their own PRs.
