### PR TITLE
Serve character and set thumbnails at 256, not 64

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2961,7 +2961,7 @@ The refusal is **`400`**, deliberately, and the three properties are asserted ra
 
 Relationship names that a *dedicated* GET route shadows never reach this handler and keep their own contract: `GET /pictures/{id}/faces`, `/detections`, `/tags`, `/tag_predictions`, `/{picture_id}/stack`, and `GET /characters/{id}/faces`.
 
-**Exactly one exception remains, and it is not a relationship.** `PICTURE_EXTRA_SERVABLE_FIELDS` is now **empty**; `CHARACTER_EXTRA_SERVABLE_FIELDS` holds only `thumbnail`, which is synthetic (the handler generates a 64x64 face crop and returns image bytes, it is not a `Character` column) and therefore discloses no related rows. It stays because the SPA calls it (`api/characters.js:193`) and the server hands out `/characters/{id}/thumbnail` URLs itself.
+**Exactly one exception remains, and it is not a relationship.** `PICTURE_EXTRA_SERVABLE_FIELDS` is now **empty**; `CHARACTER_EXTRA_SERVABLE_FIELDS` holds only `thumbnail`, which is synthetic (the handler generates a 256x256 face crop and returns image bytes, it is not a `Character` column) and therefore discloses no related rows. It stays because the SPA calls it (`api/characters.js:193`) and the server hands out `/characters/{id}/thumbnail` URLs itself.
 
 `faces` briefly sat in both sets, because the SPA's face-box overlay and `tests/utils.py::wait_for_faces` read it and no other route served it. **That is now the worked example of the right fix**: instead of keeping a relationship exception, `faces` got dedicated projected routes and the exception was emptied back out.
 

--- a/pixlstash/routes/characters.py
+++ b/pixlstash/routes/characters.py
@@ -1243,7 +1243,7 @@ def create_router(server) -> APIRouter:
         require_servable_field(Character, field, CHARACTER_EXTRA_SERVABLE_FIELDS)
 
         if field == "thumbnail":
-            thumbnail_cache_version = 6
+            thumbnail_cache_version = 7
             cache_dir = os.path.join(server.vault.image_root, "tmp", "face_thumbnails")
             os.makedirs(cache_dir, exist_ok=True)
             cache_path = resolve_path_within(cache_dir, f"character_{id}.png")
@@ -1424,7 +1424,11 @@ def create_router(server) -> APIRouter:
                     int(round(new_y2)),
                 )
             )
-            crop = crop.resize((64, 64), Image.LANCZOS)
+            # 256, not 64: the in-app consumer is a 24 px ModelMark, but this
+            # is the only character image the API serves, and a picker that
+            # renders it in a ~150 px HiDPI grid cell had nothing else to ask
+            # for. Bump ``thumbnail_cache_version`` above when this changes.
+            crop = crop.resize((256, 256), Image.LANCZOS)
             try:
                 crop.save(cache_path, format="PNG")
                 try:

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -945,7 +945,7 @@ def create_router(server) -> APIRouter:
         responses={200: {"content": {"image/png": {}}}},
     )
     def get_picture_set_thumbnail(id: int, request: Request):
-        thumbnail_cache_version = 16
+        thumbnail_cache_version = 17
         cache_dir = os.path.join(server.vault.image_root, "tmp", "set_thumbnails")
         os.makedirs(cache_dir, exist_ok=True)
         cache_path = resolve_path_within(cache_dir, f"picture_set_{id}.png")
@@ -1014,13 +1014,22 @@ def create_router(server) -> APIRouter:
         path_map = server.vault.db.run_immediate_read_task(
             fetch_picture_paths, picture_ids=top_ids
         )
-        target_size = 64
-        work_size = 256
+        # 256, not the 64 this fan was authored at: consumers outside the app
+        # render it far larger than the in-app card. Every pixel constant below
+        # is written as a multiple of `scale`, so the composite is *rendered*
+        # bigger rather than upscaled -- the old code fitted a ~90 px fan into
+        # 64 px, and simply raising the output size alone would have blown that
+        # up instead. `target_size` is derived from `scale` rather than the
+        # reverse because only whole multiples of the authored 64 reproduce the
+        # geometry. Bump `thumbnail_cache_version` above when this changes.
+        scale = 4
+        target_size = 64 * scale
+        work_size = 256 * scale
         card_height = int(target_size * 0.75)
         card_width = max(1, int(card_height * 0.7))
         card_size = (card_width, card_height)
         angles = [20, 5, -20]
-        offsets = [(0, 0), (0, 0), (0, -4)]
+        offsets = [(0, 0), (0, 0), (0, -4 * scale)]
         base = Image.new("RGBA", (work_size, work_size), (0, 0, 0, 0))
         pivot_x = work_size // 2
         pivot_y = work_size // 2
@@ -1035,15 +1044,15 @@ def create_router(server) -> APIRouter:
             mask = Image.new("L", card_size, 0)
             draw = ImageDraw.Draw(mask)
             draw.rounded_rectangle(
-                (0, 0, card_size[0], card_size[1]), radius=6, fill=255
+                (0, 0, card_size[0], card_size[1]), radius=6 * scale, fill=255
             )
             card.putalpha(mask)
             draw = ImageDraw.Draw(card)
             draw.rounded_rectangle(
-                (-2, -2, card_size[0] + 1, card_size[1] + 1),
-                radius=7,
+                (-2 * scale, -2 * scale, card_size[0] + scale, card_size[1] + scale),
+                radius=7 * scale,
                 outline=(170, 170, 170, 255),
-                width=2,
+                width=2 * scale,
             )
             return card
 
@@ -1107,7 +1116,7 @@ def create_router(server) -> APIRouter:
         shadow_layer = Image.new("RGBA", base.size, (0, 0, 0, 0))
         shadow_alpha = base.split()[-1]
         shadow_layer.putalpha(shadow_alpha)
-        shadow_layer = shadow_layer.filter(ImageFilter.GaussianBlur(radius=4))
+        shadow_layer = shadow_layer.filter(ImageFilter.GaussianBlur(radius=4 * scale))
         shadow_tint = Image.new("RGBA", base.size, (0, 0, 0, 90))
         shadow = Image.composite(
             shadow_tint,
@@ -1115,7 +1124,7 @@ def create_router(server) -> APIRouter:
             shadow_layer.split()[-1],
         )
         fan_with_shadow = Image.new("RGBA", base.size, (0, 0, 0, 0))
-        fan_with_shadow.alpha_composite(shadow, (2, 3))
+        fan_with_shadow.alpha_composite(shadow, (2 * scale, 3 * scale))
         fan_with_shadow.alpha_composite(base, (0, 0))
         base = fan_with_shadow
 

--- a/pixlstash/utils/field_allowlist.py
+++ b/pixlstash/utils/field_allowlist.py
@@ -79,7 +79,7 @@ logger = get_logger(__name__)
 PICTURE_EXTRA_SERVABLE_FIELDS: frozenset[str] = frozenset()
 
 #: ``thumbnail`` is not a ``Character`` column at all: the handler generates a
-#: 64x64 face crop and returns image bytes. It is a live frontend consumer
+#: 256x256 face crop and returns image bytes. It is a live frontend consumer
 #: (``frontend/src/api/characters.js::getCharacterThumbnail``, and the server
 #: hands the SPA ``/characters/{id}/thumbnail`` URLs itself), so it must stay
 #: servable. It is *synthetic*, not a relationship: it discloses no related

--- a/tests/test_thumbnail_cache_headers.py
+++ b/tests/test_thumbnail_cache_headers.py
@@ -17,12 +17,14 @@ request is actually answered with a 304 rather than the whole PNG again.
 """
 
 import gc
+import io
 import json
 import os
 import tempfile
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+from PIL import Image
 
 from pixlstash.db_models import Face
 from pixlstash.server import Server
@@ -148,6 +150,32 @@ def _import_one_picture(client):
     return import_resp["results"][0]["picture_id"]
 
 
+def _age_the_cached_thumbnail(server, subdir, stem, old_version):
+    """Rewind a just-written cache entry to a pre-256 PixlStash.
+
+    A fresh vault starts with an empty thumbnail cache, so the branch every
+    *existing* install takes -- read the cache, decide it is stale, regenerate
+    -- is unreachable without one on disk. This edits the metadata the route
+    itself just wrote and changes **only** the version, so a regeneration can
+    only be attributed to ``thumbnail_cache_version`` and not to a picture id
+    or hidden-tag key that happened not to match.
+    """
+    cache_dir = os.path.join(server.vault.image_root, "tmp", subdir)
+    meta_path = os.path.join(cache_dir, f"{stem}.json")
+    with open(meta_path, "r", encoding="utf-8") as handle:
+        meta = json.load(handle)
+    assert meta["version"] > old_version, (
+        f"{subdir} cache version was not bumped past {old_version}, so every "
+        "already-cached 64x64 thumbnail would go on being served forever"
+    )
+    meta["version"] = old_version
+    with open(meta_path, "w", encoding="utf-8") as handle:
+        json.dump(meta, handle)
+    Image.new("RGBA", (64, 64), (1, 2, 3, 255)).save(
+        os.path.join(cache_dir, f"{stem}.png"), format="PNG"
+    )
+
+
 def _link_face(server, pic_id, char_id):
     def _add(session):
         session.add(
@@ -177,6 +205,9 @@ def test_character_thumbnail_revalidates_instead_of_going_stale():
         first = client.get(f"/characters/{char_id}/thumbnail")
         assert first.status_code == 200, first.text
         assert first.headers["cache-control"] == REVALIDATE_CACHE_CONTROL
+        # Served at 256, not the 64 this route used to hardcode: the in-app
+        # consumer is a 24 px mark, but external pickers render it far larger.
+        assert Image.open(io.BytesIO(first.content)).size == (256, 256)
         etag = first.headers.get("etag")
         assert etag
 
@@ -192,6 +223,12 @@ def test_character_thumbnail_revalidates_instead_of_going_stale():
         )
         assert conditional.status_code == 304
         assert conditional.content == b""
+
+        # An install that already cached a 64x64 crop must not keep serving it.
+        _age_the_cached_thumbnail(server, "face_thumbnails", f"character_{char_id}", 6)
+        regenerated = client.get(f"/characters/{char_id}/thumbnail")
+        assert regenerated.status_code == 200
+        assert Image.open(io.BytesIO(regenerated.content)).size == (256, 256)
     finally:
         server.close()
         temp_dir.cleanup()
@@ -213,6 +250,10 @@ def test_picture_set_thumbnail_revalidates_instead_of_going_stale():
         assert first.status_code == 200, first.text
         assert first.headers["cache-control"] == REVALIDATE_CACHE_CONTROL
         assert first.headers.get("etag")
+        # Same size bump as the character route. This pins the served size
+        # only -- whether the fan was *rendered* at that size or upscaled from
+        # a smaller canvas is not something a PNG's dimensions can tell you.
+        assert Image.open(io.BytesIO(first.content)).size == (256, 256)
 
         conditional = client.get(
             f"/picture_sets/{set_id}/thumbnail",
@@ -220,6 +261,12 @@ def test_picture_set_thumbnail_revalidates_instead_of_going_stale():
         )
         assert conditional.status_code == 304
         assert conditional.content == b""
+
+        # Same stale-cache branch as the character route.
+        _age_the_cached_thumbnail(server, "set_thumbnails", f"picture_set_{set_id}", 16)
+        regenerated = client.get(f"/picture_sets/{set_id}/thumbnail")
+        assert regenerated.status_code == 200
+        assert Image.open(io.BytesIO(regenerated.content)).size == (256, 256)
     finally:
         server.close()
         temp_dir.cleanup()


### PR DESCRIPTION
`GET /characters/{id}/thumbnail` and `GET /picture_sets/{id}/thumbnail` served
64x64 PNGs, hardcoded in two places. That size is correct for the only in-app
consumer (`ModelMark`, a 24 px square — 2.6x oversampled, crisp on HiDPI), but
these are the *only* character and set images the API serves, so an external
consumer rendering one in a ~150 px HiDPI grid cell had nothing better to ask
for and got a 64 px image blown up. Both are now 256.

## What changed

- **`routes/characters.py`** — the face crop resizes to `(256, 256)`;
  `thumbnail_cache_version` 6 → 7.
- **`routes/picture_sets.py`** — the collage is now *rendered* at 256 rather
  than fitted down to 64. Its geometry was authored in 64 px units (cards on a
  256 px canvas, corner radii, outline width, shadow blur and offset), so
  raising the output size alone would have upscaled a ~90 px fan into 256.
  Everything is expressed against `scale = 4`, with `target_size = 64 * scale`
  — only whole multiples of the authored 64 reproduce the composition.
  `thumbnail_cache_version` 16 → 17, so existing caches regenerate.
- **Tests** — the two existing thumbnail tests now pin the served size, and
  each rewinds the metadata the route just wrote to its pre-bump version and
  re-fetches. That is the branch every existing install takes, and a fresh
  vault's empty cache never reaches it. Only the version field is edited, so a
  regeneration cannot be attributed to a picture id or hidden-tag key that
  happened not to match. Both mutants (7 → 6, 17 → 16) were confirmed to fail.
- **Docs** — `backend_architecture.md` and the `field_allowlist.py` docstring
  it paraphrases both said "64x64 face crop".

## Cost

Measured: the set collage composites on a 1024² canvas instead of 256², so its
generation goes ~15 ms → ~120 ms and peak PIL buffers ~0.75 MB → ~12 MB, once
per cache miss. Both routes are `Cache-Control: private, no-cache` with an
ETag, so the larger bytes (~55 KB character crop, ~76 KB collage) transfer on
regeneration and 304 thereafter — but the version bump does force one full
re-download of every mark on the shelf.

## Adversarial review — objections not taken, and why

An adversarial pass over the diff raised nine points; four were real and are
fixed above (the untested version bumps, the stale `field_allowlist.py`
docstring, a test comment claiming more than its assertion proved, and
`scale = max(1, target_size // 64)` being a constant dressed as a computation
that misbehaved off multiples of 64). Three I'd push back on:

- **"The character resize is an unconditional upscale for faces under 256 px."**
  True, and it was already true at 64 — the old code upscaled every crop
  smaller than that. Capping at the source's own side would save bytes but
  makes the served size vary per character, and no consumer can then rely on a
  square of known size. Worth revisiting alongside a `?size=` parameter.
- **"WebP would be 21x smaller than this PNG."** Also true, and probably the
  right follow-up, but it changes the declared `image/png` response contract of
  two documented routes. That is a separate change from a size bump.
- **"`ModelMark` renders both at 24 px and now pulls ~55 KB per row, with no
  `?size=` to opt out."** The honest trade: this fixes the shared route for
  every consumer at some cost to the smallest one. A `?size=` parameter (with
  the size in the cache key) is the answer if shelf load becomes a problem —
  it wasn't worth multiplying the on-disk cache pre-emptively.

Nothing in `secrets` or `privacy`.
