### PR TITLE
Widen the shelf Group by menu so Base model fits

### DIFF
--- a/frontend/src/components/panels/ShelfSortPanel.vue
+++ b/frontend/src/components/panels/ShelfSortPanel.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="tbm shelf-sort-panel">
+  <div
+    class="tbm shelf-sort-panel"
+    :class="{ 'shelf-sort-panel--wide': showsGroup }"
+  >
     <span class="tbm-caret tbm-caret--end"></span>
     <div class="tbm-header">
       <v-icon size="18" class="tbm-header-icon">{{ headerIcon }}</v-icon>
@@ -154,5 +157,15 @@ function toggleDirection() {
 .shelf-sort-panel {
   width: 320px;
   max-width: 94vw;
+}
+
+/* Only the Group section needs the extra room: its three columns left ~51px of
+   label at 320px, so "Base model" — the middle one — ellipsized, and it wants
+   ~76px at --text-sm. 420px gives ~126px tracks, ~84px of label, clearing it
+   on a wide fallback font too. Sort stays 320px, matching the Show popover
+   beside it in the same bar. Below ~447px of viewport the 94vw cap wins and
+   the label ellipsizes again, as everything in this bar already does. */
+.shelf-sort-panel--wide {
+  width: 420px;
 }
 </style>


### PR DESCRIPTION
## What

`ShelfSortPanel` is 320px. Its Group section lays four keys out in `.tbm-grid-3`, so each track is ~93px; a toggle spends 42px of that on icon, gap and padding, leaving ~51px of label. "Base model" needs ~76px at `--text-sm`, so the middle column ellipsized.

The Group section now renders at 420px (`.shelf-sort-panel--wide`, applied when the group section is shown): ~126px tracks, ~84px of label, which clears "Base model" even on a wide fallback font. 420px is already used by `TbTagPanel` and the toolbar's search panel, so it is not a new number.

## Why the width is scoped to Group

Sort keeps 320px. Its five keys sit in `.tbm-grid-2`, where "Base model" already had ~99px of label — widening it would buy nothing and would leave the shelf bar with two 420px popovers next to a 320px Show popover.

## Reviewer objections raised pre-push and not taken

An adversarial pass argued the root cause is the grid, not the width — four keys in a three-column grid — and that `.tbm-grid-2` would fix the truncation at 320px and tidy the ragged second row ("Feature" alone). That is a real alternative and worth doing in the design pass that owns these panels, but the change asked for here is the width, and the three-across layout is what puts Base model in the middle column. Flagging it rather than silently dropping it.

Same pass noted there is no automated coverage: reverting the width leaves every panel and shelf test green, because jsdom does no layout and no e2e spec opens this menu. The check is visual.