### PR TITLE
Model shelf: sortable column headings and draggable column widths

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1734,23 +1734,88 @@ read-only: Assign stays the shelf's verb, so there is one writer of
 `PUT /adapters/{sha256}/attachments` and one place that holds the whole
 attachment set it replaces.
 
-**A row is flex, not a grid, and its columns are FIXED widths.** Grouping makes
+**A row is flex, not a grid, and its columns are STATED ONCE.** Grouping makes
 one `role="treegrid"` list per group, so `auto` tracks would be measured against
 that group's contents alone and the columns would step sideways from one folder
-to the next — which is the alignment #891 exists to hold. The widths
-(`--shelf-col-kind: 64px`, `--shelf-col-base: 84px`, `--shelf-col-size: 74px`)
-are the resolved design's own. The name takes the rest, and the FILENAME takes
-the whole of a second line under it in the mono face: it is what the file is
-actually called — which the name above it often is not — and it is the string
-that gets pasted into a ComfyUI node, so it is drawn rather than parked in a
-tooltip.
+to the next — which is the alignment #891 exists to hold. The three widths are
+custom properties (`--shelf-col-kind`, `--shelf-col-base`, `--shelf-col-size`),
+declared on `.shelf` at the resolved design's own 64/84/74px and **overridden on
+the element from `view.columnWidths`**, so the headings, the rows and a stack's
+member rows all resolve one declaration and cannot drift apart. The name takes
+the rest — it is the flexible track and therefore has no remembered width — and
+the FILENAME takes the whole of a second line under it in the mono face: it is
+what the file is actually called, which the name above it often is not, and it
+is the string that gets pasted into a ComfyUI node, so it is drawn rather than
+parked in a tooltip.
 
-**The column names are announced and never drawn.** Each grid carries a
-`visually-hidden` `role="row"` of `columnheader`s, because a `columnheader` heads
-the grid it is in and nothing else. The resolved design has no visible header
-strip: the kind is a chip, the base is a word and the size is right-aligned,
-which is what makes the columns readable without being named. Rows are **not**
-focus stops while they carry no verb:
+**One visible column strip for the view, and hidden `columnheader`s per grid.**
+`.shelf-head` is sticky at the top of the body scroller and the group headings
+stick under it at `--shelf-head-h`. It is deliberately **not** the grid's header
+row: a `columnheader` heads the grid it is in and nothing else, so a visible one
+would have to be repeated per group, which is eight identical bands of chrome
+down a grouped list. So the strip is a `role="group"` of controls —
+
+- **A heading is a button that sorts.** Pressing the sorted column flips the
+  direction; pressing another starts at that column's OWN end. `Kind` is a
+  heading and not a button: the API's `SortKey` has no member for it, and a
+  control that does nothing is worse than none. The toolbar's `Sort` panel
+  keeps the whole five-key vocabulary, including the two with no column
+  (`Date added`, `File date`).
+
+  **`defaultSortDirection` is applied in `setView`, not in either control.**
+  There are two writers of `view.sortKey` — the headings and `ShelfSortPanel`
+  — and the panel writes it *without* a direction. With the rule in one of
+  them, the panel carried `Newest first` onto `Name` and handed back Z-to-A
+  while the heading beside it gave A-to-Z. `setView` fills the direction in
+  only when the key actually changes and the caller named none, so the
+  direction toggle and a re-pick of the current key are both untouched.
+- **A grip is a `role="separator"` that resizes.** It sits on the column's right
+  edge — 24px of grab area for WCAG 2.5.8 around a 1px drawn hairline, which is
+  the only signal a column is resizable and is therefore a component-grade 0.4
+  alpha rather than the `divider` token (1.4.11 wants 3:1, and `divider` on this
+  canvas is ~1.2:1). It drags with pointer capture and answers the window-
+  splitter keys: Left/Right by 8px, Home/End to the bounds, **Enter to the
+  default** — with a double-click doing the same, because a width is remembered
+  for good once it is dragged and a reset is otherwise the reader's only way out
+  of a mis-drag. It sets no `preventDefault` on `pointerdown`: `.shelf` already
+  suppresses selection and the grip sets `touch-action: none`, and calling it
+  would suppress the compatibility mouse events that focus the grip and that
+  `dblclick` is built on. A `pointermove` arriving with `buttons === 0` ends the
+  drag, so a refused or lost capture cannot leave one live forever.
+
+  Widths are clamped to **48–200px**, and 200 is chosen so three columns at the
+  ceiling *cannot* overflow the panel sideways (~690px of chrome, which fits a
+  1024px window with the stats rail open). Past that the row scrolls
+  horizontally and the strip's background stops at the scrollport, so rows slide
+  through a transparent header. They are written into the same versioned view
+  blob **once per gesture, not per frame** — `rememberView` rebuilds the whole
+  blob synchronously, so `setColumnWidth(key, px, persist)` takes `false` during
+  a drag and is called once on pointerup — and read back per column through
+  `clampColumnWidth`, which takes a **finite number only**: `Number()` coercion
+  would turn a stored `null` into the 48px floor instead of falling through to
+  the default.
+
+  `DEFAULT_COLUMN_WIDTHS` in the store is the *only* declaration of the three
+  figures; `.shelf` deliberately carries no CSS fallback copy, which would be a
+  second literal with nothing keeping it equal.
+
+  Every heading is left-aligned, Size's included, though its figures are not:
+  the heading is a label and the figures are a magnitude, and a right-aligned
+  `SIZE` would sit under its own grip.
+
+— and the per-grid hidden header row stays, now carrying `aria-sort`, so the
+order is readable from inside the treegrid rather than only from the strip
+above it.
+
+The strip draws only where rows do: it lives inside the `v-else` that the
+loading, error, `nothingSelected` and both empty states branch away from, since
+a header for a list that is not there names nothing. It is opaque and pinned, so
+it takes its own rung inside the sticky stratum (`--shelf-head-z`) to stay above
+the group headings, and **`.shelf-dim` — the visible half of the move's `inert`
+— was raised above both**: an opaque band at full brightness over a dimmed list
+reads as usable when it is not, which is the failure the veil exists to prevent.
+
+**Rows are not focus stops while they carry no verb.**
 1,800 empty tab stops would be a trap, so the shelf root takes `tabindex="-1"`
 and receives focus on entry, and roving focus arrives with the first thing a
 focused row can do. The sidebar's Models entry is a real `<button>` with

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -935,6 +935,278 @@ describe("the Sort split-button", () => {
   });
 });
 
+describe("the column headings", () => {
+  /** The heading button for a column, by the width class on its wrapper. */
+  const headOf = (wrapper, key) =>
+    wrapper.find(`.shelf-head-col--${key} .shelf-head-cell`);
+  const gripOf = (wrapper, key) =>
+    wrapper.find(`.shelf-head-col--${key} .shelf-head-grip`);
+
+  it("sorts on the column pressed, at that column's own end", async () => {
+    // Not the direction the previous key was left at: arriving at Base from
+    // "Date added, newest first" would otherwise hand back Z to A.
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    expect(store.view.sortKey).toBe("added_at");
+    expect(store.view.sortDirection).toBe("desc");
+
+    await headOf(wrapper, "base").trigger("click");
+    expect(store.view.sortKey).toBe("base_model");
+    expect(store.view.sortDirection).toBe("asc");
+
+    // A size column starts at the big files, because that is what anyone
+    // sorting a shelf by size is looking for.
+    await headOf(wrapper, "size").trigger("click");
+    expect(store.view.sortKey).toBe("size");
+    expect(store.view.sortDirection).toBe("desc");
+
+    // Name is drawn on its own rather than from the column list — it is the
+    // flexible track, with no width and no grip — so it is asserted separately
+    // or the one heading written by hand is the one nothing covers.
+    await wrapper
+      .find(".shelf-head-col--label .shelf-head-cell")
+      .trigger("click");
+    expect(store.view.sortKey).toBe("name");
+    expect(store.view.sortDirection).toBe("asc");
+  });
+
+  it("flips the direction when the sorted column is pressed again", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    await headOf(wrapper, "size").trigger("click");
+    expect(store.view.sortDirection).toBe("desc");
+    await headOf(wrapper, "size").trigger("click");
+    expect(store.view.sortDirection).toBe("asc");
+    expect(store.view.sortKey).toBe("size");
+  });
+
+  it("names its own state and what pressing it would do", async () => {
+    // The heading is the sort control for a mouse user, so a screen-reader
+    // user has to hear the same three things the arrow and the ink say.
+    const wrapper = await mountShelf([adapter()]);
+    expect(headOf(wrapper, "size").attributes("aria-label")).toBe(
+      "Size, not sorted. Activate to sort Largest first.",
+    );
+    await headOf(wrapper, "size").trigger("click");
+    expect(headOf(wrapper, "size").attributes("aria-label")).toBe(
+      "Size, sorted Largest first. Activate to sort Smallest first.",
+    );
+  });
+
+  it("is absent from every state that draws no rows", async () => {
+    // A header for a list that is not there names nothing, and the three empty
+    // states are the ones a reader is meant to act on rather than read past.
+    // The positive control first, or every assertion below passes on a typo.
+    const shown = await mountShelf([adapter()]);
+    expect(shown.find(".shelf-head").exists()).toBe(true);
+
+    setActivePinia(createPinia());
+    const wrapper = await mountShelf([]);
+    const store = useModelShelfStore();
+    expect(wrapper.find(".shelf-head").exists()).toBe(false);
+
+    store.setFilters({ adapters: false, checkpoints: false });
+    store.setFilters({ engines: false, unclassified: false, support: false });
+    await wrapper.vm.$nextTick();
+    expect(store.nothingSelected).toBe(true);
+    expect(wrapper.find(".shelf-head").exists()).toBe(false);
+
+    store.error = "The shelf could not be read.";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".shelf-head").exists()).toBe(false);
+  });
+
+  it("leaves Kind a heading rather than a button, having no sort key", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    expect(headOf(wrapper, "kind").element.tagName).toBe("SPAN");
+    // And it is still resizable: the grip belongs to the column, not to the
+    // sort.
+    expect(gripOf(wrapper, "kind").exists()).toBe(true);
+  });
+
+  it("carries the order into the grid's own hidden headings", async () => {
+    // The visible strip is a control group outside the treegrid, so without
+    // this a reader inside the grid hears the columns and not the order.
+    const wrapper = await mountShelf([adapter()]);
+    await headOf(wrapper, "base").trigger("click");
+    const headers = wrapper.findAll('[role="columnheader"]');
+    expect(headers.map((h) => h.attributes("aria-sort"))).toEqual([
+      undefined,
+      "none",
+      undefined,
+      "ascending",
+      "none",
+    ]);
+  });
+});
+
+describe("resizing the columns", () => {
+  const gripOf = (wrapper, key) =>
+    wrapper.find(`.shelf-head-col--${key} .shelf-head-grip`);
+
+  // Dispatched rather than `trigger`ed: test-utils builds the event and then
+  // assigns the options onto it, and `clientX` is a getter on MouseEvent, so
+  // the coordinate the whole gesture is made of never arrives.
+  //
+  // `buttons` is part of the gesture and not decoration: a move that arrives
+  // with nothing held down is how the code recognises a release it never heard
+  // about, so a helper that left it at 0 would end every drag on its first
+  // frame. `pointerup` is the one event that genuinely carries 0.
+  const fire = async (wrapper, grip, type, clientX, buttons = 1) => {
+    grip.element.dispatchEvent(
+      new MouseEvent(type, { clientX, buttons, bubbles: true }),
+    );
+    await wrapper.vm.$nextTick();
+  };
+
+  const drag = async (wrapper, grip, from, to) => {
+    await fire(wrapper, grip, "pointerdown", from);
+    await fire(wrapper, grip, "pointermove", to);
+    await fire(wrapper, grip, "pointerup", to, 0);
+  };
+
+  it("widens the column the grip belongs to, and remembers it", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    expect(store.view.columnWidths.base).toBe(84);
+
+    await drag(wrapper, gripOf(wrapper, "base"), 200, 240);
+    expect(store.view.columnWidths.base).toBe(124);
+    // The variable the rows read, not a per-cell style: one declaration, so a
+    // heading and the cells under it cannot drift apart.
+    expect(
+      wrapper.find(".shelf").element.style.getPropertyValue("--shelf-col-base"),
+    ).toBe("124px");
+    expect(
+      JSON.parse(window.localStorage.getItem("pixlstash:modelShelfView"))
+        .columnWidths.base,
+    ).toBe(124);
+  });
+
+  it("holds a column at its floor rather than letting it vanish", async () => {
+    // A column dragged to nothing takes its own grip off the screen with it,
+    // and there is no way back.
+    const wrapper = await mountShelf([adapter()]);
+    await drag(wrapper, gripOf(wrapper, "size"), 400, 0);
+    expect(useModelShelfStore().view.columnWidths.size).toBe(48);
+  });
+
+  it("stops tracking once the pointer is released", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "kind");
+    await drag(wrapper, grip, 100, 120);
+    expect(store.view.columnWidths.kind).toBe(84);
+    await fire(wrapper, grip, "pointermove", 300, 0);
+    expect(store.view.columnWidths.kind).toBe(84);
+  });
+
+  it("gives up a drag whose release it never heard, rather than sticking", async () => {
+    // Pointer capture normally guarantees the pointerup, but a refused or lost
+    // capture would otherwise leave the drag live for good: the next hover over
+    // any grip would resume it from the original press and jump the column.
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "base");
+
+    await fire(wrapper, grip, "pointerdown", 200);
+    await fire(wrapper, grip, "pointermove", 220);
+    expect(store.view.columnWidths.base).toBe(104);
+
+    // The release happened somewhere else. The next move arrives with nothing
+    // held down, and that is the drag over.
+    await fire(wrapper, grip, "pointermove", 260, 0);
+    expect(store.view.columnWidths.base).toBe(104);
+    await fire(wrapper, grip, "pointermove", 400, 0);
+    expect(store.view.columnWidths.base).toBe(104);
+  });
+
+  it("refuses a secondary button on any device, a pen's barrel included", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "kind");
+    grip.element.dispatchEvent(
+      new MouseEvent("pointerdown", { clientX: 100, button: 2, bubbles: true }),
+    );
+    await wrapper.vm.$nextTick();
+    await fire(wrapper, grip, "pointermove", 200);
+    expect(store.view.columnWidths.kind).toBe(64);
+  });
+
+  it("moves the edge from the keyboard, which is why the grip is focusable", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "kind");
+    expect(grip.attributes("role")).toBe("separator");
+    expect(grip.attributes("tabindex")).toBe("0");
+    expect(grip.attributes("aria-valuenow")).toBe("64");
+
+    await grip.trigger("keydown", { key: "ArrowRight" });
+    expect(store.view.columnWidths.kind).toBe(72);
+    await grip.trigger("keydown", { key: "ArrowLeft" });
+    await grip.trigger("keydown", { key: "ArrowLeft" });
+    expect(store.view.columnWidths.kind).toBe(56);
+    expect(gripOf(wrapper, "kind").attributes("aria-valuenow")).toBe("56");
+    expect(gripOf(wrapper, "kind").attributes("aria-valuetext")).toBe(
+      "56 pixels",
+    );
+  });
+
+  it("takes Home and End to the two ends", async () => {
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "base");
+    await grip.trigger("keydown", { key: "End" });
+    expect(store.view.columnWidths.base).toBe(200);
+    await grip.trigger("keydown", { key: "Home" });
+    expect(store.view.columnWidths.base).toBe(48);
+  });
+
+  it("puts a column back, which is the only way out of a mis-drag", async () => {
+    // A width is remembered for good once it is dragged, so without a reset
+    // the reader's only recovery is clearing the browser's storage.
+    const wrapper = await mountShelf([adapter()]);
+    const store = useModelShelfStore();
+    const grip = gripOf(wrapper, "size");
+
+    await drag(wrapper, grip, 400, 500);
+    expect(store.view.columnWidths.size).toBe(174);
+    await grip.trigger("keydown", { key: "Enter" });
+    expect(store.view.columnWidths.size).toBe(74);
+
+    await drag(wrapper, grip, 400, 500);
+    await grip.trigger("dblclick");
+    expect(store.view.columnWidths.size).toBe(74);
+    expect(
+      JSON.parse(window.localStorage.getItem("pixlstash:modelShelfView"))
+        .columnWidths.size,
+    ).toBe(74);
+  });
+
+  it("writes the blob once the drag ends, not on every frame of it", async () => {
+    // `rememberView` rebuilds the whole blob and does a synchronous setItem;
+    // at one per pointermove that is ~120 main-thread writes a second.
+    const wrapper = await mountShelf([adapter()]);
+    const grip = gripOf(wrapper, "base");
+    const write = vi.spyOn(Storage.prototype, "setItem");
+
+    await fire(wrapper, grip, "pointerdown", 200);
+    await fire(wrapper, grip, "pointermove", 210);
+    await fire(wrapper, grip, "pointermove", 220);
+    await fire(wrapper, grip, "pointermove", 230);
+    expect(useModelShelfStore().view.columnWidths.base).toBe(114);
+    expect(write).not.toHaveBeenCalled();
+
+    await fire(wrapper, grip, "pointerup", 230, 0);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.parse(window.localStorage.getItem("pixlstash:modelShelfView"))
+        .columnWidths.base,
+    ).toBe(114);
+    write.mockRestore();
+  });
+});
+
 describe("selecting rows", () => {
   const rowAt = (wrapper, i) => wrapper.findAll(".shelf-row")[i];
 
@@ -2201,11 +2473,12 @@ describe("a run's disclosure", () => {
     );
   });
 
-  it("heads the columns once, and on every grid a reader may land in", async () => {
+  it("heads the columns on every grid a reader may land in, and draws the strip once", async () => {
     // The point of #891: a `columnheader` heads the grid it is in and nothing
     // else, and grouping makes one grid per group — so every group carries the
-    // row, and all but the first carry it visually-hidden so the eye sees one
-    // header line rather than one per folder.
+    // row, and every one of them is visually-hidden. What the eye sees is the
+    // single `.shelf-head` strip above the whole list, which is a control group
+    // and not the grid's header row precisely so it does not have to repeat.
     const wrapper = await mountShelf([
       adapter({
         id: 1,
@@ -2224,17 +2497,23 @@ describe("a run's disclosure", () => {
     useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
     await wrapper.vm.$nextTick();
 
-    // One strip per grid, and NONE of them drawn: a `columnheader` heads the
-    // grid it is in and nothing else, so grouping needs one per group — and
-    // the resolved design has no visible header strip, because the kind is a
-    // chip, the base is a word and the size is right-aligned, which is what
-    // makes the columns readable without being named. The names stay for the
-    // reader who cannot see that.
+    // One hidden header row per grid, because that is what the grid semantics
+    // want, and exactly ONE visible strip however many groups there are: eight
+    // identical bands of chrome down a grouped list is the thing the strip's
+    // whole design avoids.
     const heads = wrapper.findAll('[role="row"].visually-hidden');
     expect(heads).toHaveLength(2);
     expect(
       heads[0].findAll('[role="columnheader"]').map((cell) => cell.text()),
     ).toEqual(["Model", "Name", "Kind", "Base", "Size"]);
+    expect(wrapper.findAll(".shelf-head")).toHaveLength(1);
+    // And the widths reach a group's rows through the one root declaration, so
+    // the columns cannot step sideways from one folder to the next.
+    useModelShelfStore().setColumnWidth("kind", 120);
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper.find(".shelf").element.style.getPropertyValue("--shelf-col-kind"),
+    ).toBe("120px");
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -5,6 +5,7 @@
   <div
     ref="rootEl"
     class="shelf"
+    :style="columnStyle"
     role="region"
     tabindex="-1"
     aria-label="Model shelf"
@@ -13,13 +14,16 @@
     <p id="shelf-help" class="visually-hidden">
       Every adapter and checkpoint PixlStash has found on this machine. Group
       and Sort choose the order and whether the list is cut into groups; Show
-      chooses which kinds are listed and which base models. The bar ends in the
-      app-wide controls: Settings and the stats sidebar toggle. Nothing on this
-      screen can be undone. A ring around a model's mark says who it is assigned
-      to. A name in italics has not been given one. A row that stands for a
-      training run says how many files it holds; Right and Left open and close
-      it. Right-click a row for everything that can be done to it. Escape clears
-      the selection.
+      chooses which kinds are listed and which base models. Above the list, the
+      Name, Base and Size headings sort it too, and Kind, Base and Size each end
+      in a handle that resizes them: Left and Right move the edge, Home and End
+      take it to its narrowest and widest, Enter puts it back. The bar ends in
+      the app-wide controls: Settings and the stats sidebar toggle. Nothing on
+      this screen can be undone. A ring around a model's mark says who it is
+      assigned to. A name in italics has not been given one. A row that stands
+      for a training run says how many files it holds; Right and Left open and
+      close it. Right-click a row for everything that can be done to it. Escape
+      clears the selection.
     </p>
 
     <!-- One announcement for a resort, because the rows reorder silently: the
@@ -404,6 +408,105 @@
            menu rather than inside it. Group headers stay stops too, so Tab
            still moves group to group. -->
       <template v-else>
+        <!-- The column headings, drawn ONCE for the view and sticky above
+             everything under them. Once per group is what the grid semantics
+             want — a `columnheader` heads the grid it is in, which is why the
+             hidden header row below is repeated per `<ul>` — but a visible
+             strip repeated over eight folders would be eight identical bands
+             of chrome down a list, and the widths are shared anyway.
+
+             So this is a control group, not the grid's header: a `group` of
+             buttons that set the sort and separators that size the columns.
+             The grid keeps its own hidden headings, and those now carry
+             `aria-sort`, so a reader inside the treegrid hears the order
+             without this strip having to lie about being part of it. -->
+        <div
+          class="shelf-head"
+          role="group"
+          aria-label="Sort and size the columns"
+        >
+          <!-- Matches `.shelf-row-ident`, which holds the mark and the ring.
+               There is nothing to name: the mark IS the row's identity and the
+               hidden `Model` columnheader already says so. -->
+          <span class="shelf-head-ident" aria-hidden="true"></span>
+          <span class="shelf-head-col shelf-head-col--label">
+            <button
+              class="section-label shelf-head-cell"
+              :class="{
+                'shelf-head-cell--on': store.view.sortKey === NAME_COLUMN.sort,
+              }"
+              type="button"
+              :aria-label="columnSortLabel(NAME_COLUMN)"
+              :title="columnSortLabel(NAME_COLUMN)"
+              @click="sortByColumn(NAME_COLUMN.sort)"
+            >
+              <span class="shelf-head-text">{{ NAME_COLUMN.label }}</span>
+              <v-icon class="shelf-head-arrow" size="14" aria-hidden="true">{{
+                directionIcon
+              }}</v-icon>
+            </button>
+          </span>
+          <!-- The heading and its grip are one element wide, because the grip
+               is positioned against the heading's own right edge. Without the
+               wrapper it would either be a flex item of its own — widening
+               every column past what the rows draw — or clipped by the
+               heading's overflow. -->
+          <span
+            v-for="col in SHELF_COLUMNS"
+            :key="col.key"
+            class="shelf-head-col"
+            :class="`shelf-head-col--${col.key}`"
+          >
+            <button
+              v-if="col.sort"
+              class="section-label shelf-head-cell"
+              :class="{
+                'shelf-head-cell--on': store.view.sortKey === col.sort,
+              }"
+              type="button"
+              :aria-label="columnSortLabel(col)"
+              :title="columnSortLabel(col)"
+              @click="sortByColumn(col.sort)"
+            >
+              <span class="shelf-head-text">{{ col.label }}</span>
+              <v-icon class="shelf-head-arrow" size="14" aria-hidden="true">{{
+                directionIcon
+              }}</v-icon>
+            </button>
+            <span
+              v-else
+              class="section-label shelf-head-cell shelf-head-cell--static"
+            >
+              <span class="shelf-head-text">{{ col.label }}</span>
+            </span>
+            <!-- `separator` with a value, which is the window-splitter pattern
+                 and the only reason this is focusable: a grip that answered
+                 the pointer alone would put the column widths out of reach of
+                 anyone not using one. Left, Right, Home and End move the edge;
+                 Enter and a double-click put it back, which is the only way
+                 back from a mis-drag. -->
+            <span
+              class="shelf-head-grip"
+              :class="{ 'shelf-head-grip--on': resizing?.key === col.key }"
+              role="separator"
+              aria-orientation="vertical"
+              :aria-label="`Resize the ${col.label} column`"
+              :aria-valuenow="store.view.columnWidths[col.key]"
+              :aria-valuetext="`${store.view.columnWidths[col.key]} pixels`"
+              :aria-valuemin="MIN_COLUMN_WIDTH"
+              :aria-valuemax="MAX_COLUMN_WIDTH"
+              tabindex="0"
+              :title="`Drag to resize the ${col.label} column, double-click to reset it`"
+              @pointerdown="startResize(col.key, $event)"
+              @pointermove="onResizeMove"
+              @pointerup="endResize"
+              @pointercancel="endResize"
+              @lostpointercapture="endResize"
+              @dblclick="resetColumn(col.key)"
+              @keydown="onGripKeydown(col.key, $event)"
+            ></span>
+          </span>
+        </div>
         <!-- The key to the meters, said ONCE for the view rather than once per
              band: it is the same three segments every time, and repeating it
              down the list would cost more room than the meters themselves.
@@ -624,17 +727,26 @@
           >
             <!-- The column names, on every grid and drawn on none of them.
                  `columnheader`s head the grid they are in and nothing else, so
-                 grouping needs one strip per group — and the resolved design
-                 has no visible header strip, because the kind is a chip, the
-                 base is a word and the size is right-aligned, which is what
-                 makes the columns readable without being named. The names stay
-                 for the reader who cannot see that. -->
+                 grouping needs one strip per group, and eight identical
+                 visible bands down a grouped list is exactly what the header
+                 strip above the list exists to avoid. These stay hidden and
+                 carry the `aria-sort` for their own grid, so the order is
+                 readable from inside the treegrid rather than only from the
+                 control group above it. -->
             <li class="visually-hidden" role="row">
               <span role="columnheader">Model</span>
-              <span role="columnheader">Name</span>
+              <span role="columnheader" :aria-sort="columnSortState('name')"
+                >Name</span
+              >
               <span role="columnheader">Kind</span>
-              <span role="columnheader">Base</span>
-              <span role="columnheader">Size</span>
+              <span
+                role="columnheader"
+                :aria-sort="columnSortState('base_model')"
+                >Base</span
+              >
+              <span role="columnheader" :aria-sort="columnSortState('size')"
+                >Size</span
+              >
             </li>
             <!-- A row with one spanning cell, because a grid takes nothing but
                  rows: not selectable, because there is nothing here to select.
@@ -1008,7 +1120,12 @@ import { addModelFile } from "../../api/modelFiles";
 import { openModelLocation } from "../../api/modelShelf";
 import { createStack } from "../../api/modelStacks";
 import { useEntityListsStore } from "../../stores/useEntityListsStore";
-import { useModelShelfStore } from "../../stores/useModelShelfStore";
+import {
+  DEFAULT_COLUMN_WIDTHS,
+  MAX_COLUMN_WIDTH,
+  MIN_COLUMN_WIDTH,
+  useModelShelfStore,
+} from "../../stores/useModelShelfStore";
 import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
@@ -1026,6 +1143,7 @@ import {
   bandUsage,
   capabilityLabel,
   copyPathsTitle,
+  defaultSortDirection,
   deletableModels,
   trashName,
   withEmptyFolders,
@@ -2576,6 +2694,171 @@ function toggleDirection() {
   });
 }
 
+/* ── The header strip ──────────────────────────────────────────────────────
+   The three fixed data columns, in the order the rows draw them. `sort` is the
+   SORT_KEYS value the heading orders on, or null where the column answers no
+   sort key: `Kind` is a chip of whatever the row's capabilities happen to be
+   and the API's `SortKey` has no member for it, so its heading names the
+   column and offers a grip, but is not a button that would do nothing.
+
+   The Name column is not in this list. It is the flexible track — it takes
+   whatever the other three leave — so it has a heading and a sort but no width
+   to drag, and it is written out on its own in the template.
+
+   Every heading is LEFT-aligned, including Size's, whose figures are not: the
+   heading is a label naming the column and the figures are a magnitude being
+   compared, and the grip lives on the column's right edge — a right-aligned
+   `SIZE` would sit under it and be a resize target as much as a sort one. */
+const NAME_COLUMN = { key: "name", label: "Name", sort: "name" };
+
+const SHELF_COLUMNS = [
+  { key: "kind", label: "Kind", sort: null },
+  { key: "base", label: "Base", sort: "base_model" },
+  { key: "size", label: "Size", sort: "size" },
+];
+
+/** How far one arrow-key press moves a column edge. One --space-3. */
+const RESIZE_STEP = 8;
+
+/** The column drag in flight, or null. Never persisted. */
+const resizing = ref(null);
+
+/**
+ * The remembered widths, handed to the row rules as the custom properties they
+ * already read. Bound on the root rather than per cell so the headings, the
+ * rows and a stack's member rows cannot drift apart: there is one declaration
+ * of each width and every cell resolves the same variable.
+ */
+const columnStyle = computed(() =>
+  Object.fromEntries(
+    Object.entries(store.view.columnWidths).map(([key, px]) => [
+      `--shelf-col-${key}`,
+      `${px}px`,
+    ]),
+  ),
+);
+
+/** `"ascending"` / `"descending"` / `"none"`, for `aria-sort`. */
+function columnSortState(key) {
+  if (!key || store.view.sortKey !== key) return "none";
+  return store.view.sortDirection === "asc" ? "ascending" : "descending";
+}
+
+/**
+ * A heading's accessible name: what the column is, how it is sorted now, and
+ * what pressing it would do.
+ *
+ * The direction phrases keep their capitals for the reason `sortButtonTitle`
+ * does — "A to Z" lowercased reads as a typo — so the three parts are separate
+ * sentences rather than one clause.
+ */
+function columnSortLabel(column) {
+  const now = store.view.sortKey === column.sort;
+  const next = now
+    ? store.view.sortDirection === "asc"
+      ? "desc"
+      : "asc"
+    : defaultSortDirection(column.sort);
+  const state = now
+    ? `sorted ${sortDirectionLabel(column.sort, store.view.sortDirection)}`
+    : "not sorted";
+  return `${column.label}, ${state}. Activate to sort ${sortDirectionLabel(column.sort, next)}.`;
+}
+
+/**
+ * Sort on a column, or flip the direction if it is already the sorted one.
+ *
+ * A key the reader has just arrived at starts at its own end, and that is
+ * `setView`'s job rather than this one's: the Sort panel writes `sortKey` too,
+ * and a rule living in one of the two writers is a rule the other breaks.
+ */
+function sortByColumn(key) {
+  if (store.view.sortKey === key) toggleDirection();
+  else store.setView({ sortKey: key });
+}
+
+/**
+ * Start a column drag.
+ *
+ * Pointer capture rather than window listeners: the grip keeps receiving moves
+ * once the pointer has left it — which it does immediately, because dragging
+ * an edge is exactly moving away from where you pressed — and the browser
+ * releases the capture for us on pointerup, on cancel, and if the element goes
+ * away mid-drag.
+ *
+ * The primary button on ANY device, not just a mouse: a pen's barrel button
+ * reports `button: 2` with `pointerType: "pen"`, and a guard that only tested
+ * mice let it start a drag. Touch reports 0 and is unaffected.
+ *
+ * There is deliberately NO `preventDefault()` here. It is not needed — `.shelf`
+ * already sets `user-select: none` and the grip sets `touch-action: none`, so
+ * neither a text selection nor a touch scroll can start — and calling it
+ * suppresses the compatibility mouse events, which is what focuses the grip on
+ * click and what `dblclick` (the only pointer-side way back from a mis-drag)
+ * is built on.
+ */
+function startResize(key, event) {
+  if (event.button !== 0) return;
+  resizing.value = {
+    key,
+    startX: event.clientX,
+    startWidth: store.view.columnWidths[key],
+  };
+  event.currentTarget.setPointerCapture?.(event.pointerId);
+}
+
+// Not persisted per frame: see `setColumnWidth`. The end of the gesture is
+// what writes.
+function onResizeMove(event) {
+  if (!resizing.value) return;
+  // The pointer came back with nothing held down, so the release happened
+  // somewhere this grip never heard about — a refused or lost capture, or the
+  // strip re-rendering out from under the drag. Without this the drag is stuck
+  // for good and the next hover resumes it from the original press.
+  if (event.buttons === 0) {
+    endResize();
+    return;
+  }
+  const { key, startX, startWidth } = resizing.value;
+  store.setColumnWidth(key, startWidth + (event.clientX - startX), false);
+}
+
+function endResize() {
+  if (!resizing.value) return;
+  const { key } = resizing.value;
+  resizing.value = null;
+  store.setColumnWidth(key, store.view.columnWidths[key]);
+}
+
+/**
+ * The keyboard half of the same gesture, which is the whole reason the grip is
+ * a focusable `separator` rather than a decoration on the heading.
+ *
+ * Left/Right/Home/End are the window-splitter pattern's own keys. `Enter` is
+ * the pattern's "restore the default position", and here it is the ONLY way
+ * back: a width is remembered for good once it has been dragged, so without a
+ * reset a mis-drag is permanent short of clearing the browser's storage. A
+ * double-click on the grip does the same thing, which is the pointer-side
+ * convention every table with draggable columns already trains.
+ */
+function onGripKeydown(key, event) {
+  const width = {
+    ArrowLeft: () => store.view.columnWidths[key] - RESIZE_STEP,
+    ArrowRight: () => store.view.columnWidths[key] + RESIZE_STEP,
+    Home: () => MIN_COLUMN_WIDTH,
+    End: () => MAX_COLUMN_WIDTH,
+    Enter: () => DEFAULT_COLUMN_WIDTHS[key],
+  }[event.key];
+  if (!width) return;
+  // Home and End scroll the list, and the list is 1,800 rows long.
+  event.preventDefault();
+  store.setColumnWidth(key, width());
+}
+
+function resetColumn(key) {
+  store.setColumnWidth(key, DEFAULT_COLUMN_WIDTHS[key]);
+}
+
 /**
  * The always-present anchor of the metadata line, whatever else is null.
  *
@@ -2670,14 +2953,23 @@ watch(
   background: rgb(var(--v-theme-background));
   color: rgb(var(--v-theme-on-background));
   outline: none;
-  /* The three data columns, stated once. FIXED widths, not `auto`: grouping
-     makes one list per group, so `auto` tracks would be measured against that
-     group's contents alone and the columns would step sideways from one folder
-     to the next — which is the alignment #891 exists to hold. The figures are
-     the resolved design's own (ui_kits/app/model-shelf.html, row anatomy). */
-  --shelf-col-kind: 64px;
-  --shelf-col-base: 84px;
-  --shelf-col-size: 74px;
+  /* `--shelf-col-kind` / `--shelf-col-base` / `--shelf-col-size` are NOT
+     declared here. `columnStyle` writes all three onto this element from
+     `view.columnWidths`, whose defaults are the resolved design's own
+     (ui_kits/app/model-shelf.html, row anatomy) — and a fallback copy of those
+     figures here would be a second literal of the same three numbers with
+     nothing keeping them equal, which is how a "cannot disagree" comment
+     becomes false. One declaration, in the store.
+
+     FIXED widths, not `auto`: grouping makes one list per group, so `auto`
+     tracks would be measured against that group's contents alone and the
+     columns would step sideways from one folder to the next — the alignment
+     #891 exists to hold. */
+  /* What the header strip stands, so the group headings can stick UNDER it
+     rather than behind it. A fixed figure rather than a measured one: the
+     strip is one line of --text-2xs and never wraps, and 32px is already the
+     token for a horizontal band of exactly this kind. */
+  --shelf-head-h: var(--rule-h-seam);
   /* Picking rows is the gesture on this panel, and the browser's text selection
      rode along with it: Shift+click extends a text range from the last click and
      a fast double click word-selects, so a multi-select arrived with the list
@@ -3030,6 +3322,173 @@ watch(
   color: rgba(var(--v-theme-on-background), 0.7);
 }
 
+/* ── The column strip ──────────────────────────────────────────────────────
+   The same flex metrics as `.shelf-row`, restated rather than shared, because
+   the row's padding and gap are what a heading has to line up with and a
+   heading that computed its own would be one refactor from drifting. The
+   transparent rail is the rows' absence rail: without it every heading would
+   sit one rail-width left of the column it names.
+
+   Its own rung, named rather than an arithmetic `+1` at the use site: it is
+   INSIDE the sticky stratum and one step above the group headings, which are
+   later siblings in the same scroller and would otherwise win the tie on DOM
+   order and paint over it. OPAQUE for the same reason — the headings pass
+   under this one. */
+.shelf-head {
+  --shelf-head-z: calc(var(--z-sticky) + 5);
+  position: sticky;
+  top: 0;
+  z-index: var(--shelf-head-z);
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-4);
+  /* border-box, so the hairline is INSIDE the 32px the group headings offset
+     themselves by. There is no universal reset in this app, so a content-box
+     strip would stand 33px and leave a 1px sliver of row under it. */
+  box-sizing: border-box;
+  height: var(--shelf-head-h);
+  padding: 0 var(--space-4) 0 var(--space-6);
+  border-left: var(--rail-w) solid transparent;
+  border-bottom: 1px solid rgb(var(--v-theme-divider));
+  background: rgb(var(--v-theme-background));
+}
+
+.shelf-head-ident {
+  width: calc(var(--entity-thumb) + var(--space-4));
+  flex: none;
+}
+
+/* The wrapper that carries the column's width and anchors its grip. Its own
+   width classes rather than the rows' `.shelf-col--*`: those are the DATA
+   cells, several selectors reach for them by name, and a heading answering to
+   the same class is how `.shelf-col--base span` came to find a column name
+   instead of a base model. The variable is what the two share. */
+.shelf-head-col {
+  position: relative;
+  flex: none;
+}
+
+.shelf-head-col--label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.shelf-head-col--kind {
+  width: var(--shelf-col-kind);
+}
+
+.shelf-head-col--base {
+  width: var(--shelf-col-base);
+}
+
+.shelf-head-col--size {
+  width: var(--shelf-col-size);
+}
+
+/* The type, the weight, the tracking, the case and the 0.7 ink all come from
+   the global `.section-label`, which is what a column name IS — §3 says use it
+   rather than re-roll it, and its alpha in particular is a measured value that
+   has been wrong here once already. Only the layout is local. */
+.shelf-head-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  transition: color var(--dur-1) var(--ease-standard);
+}
+
+.shelf-head-cell--static {
+  cursor: default;
+}
+
+button.shelf-head-cell:hover {
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.shelf-head-cell:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
+}
+
+/* The sorted column is named in full ink with an arrow beside it. Both halves
+   on purpose: the arrow alone is a 14px glyph at the edge of a quiet strip,
+   and the ink alone does not say which way. */
+.shelf-head-cell--on {
+  color: rgb(var(--v-theme-on-surface));
+}
+
+/* Always present, only sometimes visible — the same rule as the row's absence
+   rail (§5.1): `v-if` would let the label shift 22px sideways at the instant
+   the reader clicks it, and ellipsize its own heading at the narrow end. */
+.shelf-head-arrow {
+  visibility: hidden;
+}
+
+.shelf-head-cell--on .shelf-head-arrow {
+  visibility: visible;
+}
+
+.shelf-head-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 24px wide and centred ON the column's right edge, so the grab area is the
+   visual seam rather than something beside it. 24 is WCAG 2.5.8's floor and
+   the grab area is decoupled from the drawn hairline by the pseudo-element
+   below, so it costs nothing to hit: the strip's 12px gap takes half of it and
+   the column's own last 12px take the other, which no heading's label reaches
+   (the widest is `BASE` at ~30px in an 84px column, and every heading is
+   left-aligned so none of them ends near the edge). The last column's grip
+   lands inside the row's right padding, which is why the strip does not clip
+   and why it stops exactly where the next column begins. */
+.shelf-head-grip {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: calc(var(--space-6) / -2);
+  width: var(--space-6);
+  cursor: col-resize;
+  touch-action: none;
+}
+
+/* The hairline the reader actually sees, and the ONLY signal that a column can
+   be resized — so it is a component-grade 0.4 rather than the `divider` token,
+   which measures ~1.2:1 on this canvas and fails 1.4.11's 3:1. Same floor and
+   the same reasoning as §11's scrollbar thumb. */
+.shelf-head-grip::after {
+  content: "";
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  left: 50%;
+  width: 1px;
+  background: rgba(var(--v-theme-on-background), 0.4);
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+/* Colour only, never width: the hairline is `left: 50%` on the seam, so
+   growing it would slide the line sideways under the pointer at the moment
+   the reader is aiming at it. */
+.shelf-head-grip:hover::after,
+.shelf-head-grip--on::after,
+.shelf-head-grip:focus-visible::after {
+  background: rgb(var(--v-theme-primary));
+}
+
+.shelf-head-grip:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
+}
+
 /* The key, once for the view. Wraps rather than scrolls: four short pairs at a
    narrow width belong on two lines, not behind a scrollbar. */
 .shelf-keys {
@@ -3081,7 +3540,10 @@ watch(
    header that gains one does not move a pixel. */
 .shelf-group-btn {
   position: sticky;
-  top: 0;
+  /* Under the column strip, not behind it: both are sticky in the same
+     scroller, and a heading pinned at 0 would be covered by the strip exactly
+     when the reader needs to know which folder they are scrolling through. */
+  top: var(--shelf-head-h);
   z-index: var(--z-sticky);
   display: flex;
   align-items: center;
@@ -3553,11 +4015,18 @@ watch(
 }
 
 /* The visible half of `inert`. A veil over the LIST, never over the app: the
-   toolbar keeps answering while files are in flight. */
+   toolbar keeps answering while files are in flight.
+
+   ABOVE everything sticky in this scroller, including the column strip and the
+   group headings. Both are opaque, so at or below the veil's rung they stay at
+   full brightness over a dimmed list and read as usable when they are not —
+   which is the failure the veil exists to prevent. The strip in particular is
+   pinned and spans the width, so it is the one that makes the veil look like a
+   bug. */
 .shelf-dim {
   position: absolute;
   inset: 0;
-  z-index: var(--z-sticky);
+  z-index: calc(var(--z-sticky) + 10);
   background: rgba(var(--v-theme-background), 0.55);
 }
 </style>

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -22,6 +22,7 @@ import {
   capabilityIcon,
   capabilityLabel,
   compareGroups,
+  defaultSortDirection,
   locationState,
   trashName,
   modelName,
@@ -83,6 +84,55 @@ export const GROUP_BY_KEYS = ["none", "base_model", "folder", "feature"];
  * and is why the absence of real sorting went unnoticed for so long.
  */
 export const FOLDER_LAYOUTS = ["drive", "alpha"];
+
+/**
+ * The three data columns the reader can resize, and what each starts at.
+ *
+ * The figures are the resolved design's own (ui_kits/app/model-shelf.html, row
+ * anatomy) and were fixed widths in the stylesheet until the header strip gave
+ * them a grip. The Name column is deliberately absent: it is the flexible
+ * track that takes whatever the other three leave, so it has no width of its
+ * own to remember.
+ */
+export const COLUMN_KEYS = ["kind", "base", "size"];
+
+/** @type {Record<string, number>} */
+export const DEFAULT_COLUMN_WIDTHS = { kind: 64, base: 84, size: 74 };
+
+/**
+ * The bounds a dragged column is held inside.
+ *
+ * The floor is what keeps a column from being dragged to nothing and then
+ * being unfindable to drag back.
+ *
+ * The ceiling is set so that three columns at it CANNOT overflow the panel
+ * sideways: 3 x 200 plus the rail, the identity slot, four gaps and the row's
+ * padding is ~690px, which fits the shelf on a 1024px window with the stats
+ * rail open. Past that the row would scroll horizontally, and the strip's
+ * background and hairline stop at the scrollport — rows sliding through a
+ * transparent header. The name is still the flexible track and still carries
+ * `min-width: 0`, so a genuinely narrow window squeezes it; what this bound
+ * rules out is the reader doing it to themselves with the new grips.
+ */
+export const MIN_COLUMN_WIDTH = 48;
+export const MAX_COLUMN_WIDTH = 200;
+
+/**
+ * Hold a width inside its bounds, or reject it.
+ *
+ * A finite NUMBER and nothing else. `Number()` coercion would take `null`,
+ * `""`, `[]` and `false` as 0 and hand back the floor, so a stored blob
+ * carrying `{"size": null}` would silently come back as a 48px column instead
+ * of falling through to the default — which is the one thing the read-back
+ * loop exists to prevent.
+ *
+ * @returns {number|null} the clamped width, or null if `px` is not one.
+ */
+export function clampColumnWidth(px) {
+  if (typeof px !== "number" || !Number.isFinite(px)) return null;
+  const n = Math.round(px);
+  return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, n));
+}
 
 /**
  * The five ruled sort keys, mirroring `SortKey` in `routes/model_shelf.py`.
@@ -355,6 +405,7 @@ function defaultView() {
     sortKey: "added_at",
     sortDirection: "desc",
     folderLayout: "drive",
+    columnWidths: { ...DEFAULT_COLUMN_WIDTHS },
   };
 }
 
@@ -470,6 +521,14 @@ function storedView() {
   if (SORT_KEYS.includes(parsed.sortKey)) view.sortKey = parsed.sortKey;
   if (parsed.sortDirection === "asc" || parsed.sortDirection === "desc") {
     view.sortDirection = parsed.sortDirection;
+  }
+  // Per column and clamped on the way in, for the reason the fields above are
+  // read one at a time: a blob written before the columns could be dragged is
+  // still a valid remembered sort, and a width edited by hand in devtools is
+  // not a reason to hand back a shelf whose Size column is 4,000px wide.
+  for (const key of COLUMN_KEYS) {
+    const width = clampColumnWidth(parsed.columnWidths?.[key]);
+    if (width !== null) view.columnWidths[key] = width;
   }
   return view;
 }
@@ -1117,8 +1176,49 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
    *   `sortDirection`.
    */
   function setView(patch) {
+    // A NEW sort key arrives at its own end unless the caller named one. Here
+    // rather than in the caller, because there are two writers of `sortKey` —
+    // the column headings and the Sort panel — and putting it in one of them
+    // is how the two came to disagree: the panel carried "Newest first" over
+    // onto Name and handed back Z to A, which is exactly what
+    // `defaultSortDirection` exists to stop.
+    if (
+      patch.sortKey !== undefined &&
+      patch.sortKey !== view.sortKey &&
+      patch.sortDirection === undefined
+    ) {
+      patch = { ...patch, sortDirection: defaultSortDirection(patch.sortKey) };
+    }
     Object.assign(view, patch);
     rememberView();
+  }
+
+  /**
+   * Resize one data column, in pixels.
+   *
+   * `persist` is off for the frames of a drag and on for the end of it: a
+   * `pointermove` arrives every frame, and `rememberView` rebuilds the whole
+   * blob, walks four collapsed sets and does a synchronous `setItem`, so
+   * writing per move is ~120 storage writes a second on the main thread for a
+   * value that only matters once the pointer is up. A press of the arrow keys
+   * IS the end of its own gesture and persists.
+   *
+   * Persisting is not conditional on the width having changed: the last frame
+   * of a drag usually sets the same pixel the frame before did, and skipping
+   * the write there would throw the whole drag away.
+   *
+   * @param {string} key - one of {@link COLUMN_KEYS}.
+   * @param {number} px - the requested width, clamped to the bounds.
+   * @param {boolean} [persist=true] - whether to write the view blob.
+   */
+  function setColumnWidth(key, px, persist = true) {
+    if (!COLUMN_KEYS.includes(key)) return;
+    const width = clampColumnWidth(px);
+    if (width === null) return;
+    if (width !== view.columnWidths[key]) {
+      view.columnWidths = { ...view.columnWidths, [key]: width };
+    }
+    if (persist) rememberView();
   }
 
   /**
@@ -1705,5 +1805,6 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     resetForSession,
     setFilters,
     setView,
+    setColumnWidth,
   };
 });

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -392,9 +392,7 @@ describe("the support block", () => {
     // block is two requests, and a reader deciding what to keep sees one list.
     const store = useModelShelfStore();
     listSupport
-      .mockResolvedValueOnce([
-        adapter({ id: 1, file_kind: "vae", kind: null }),
-      ])
+      .mockResolvedValueOnce([adapter({ id: 1, file_kind: "vae", kind: null })])
       .mockResolvedValueOnce([
         adapter({ id: 2, file_kind: "text_encoder", kind: null }),
       ]);
@@ -531,6 +529,40 @@ describe("persistence", () => {
 // sorts last in BOTH directions, and collapse is namespaced per axis.
 
 describe("sorting", () => {
+  it("starts a NEW key at its own end, whichever control asked", () => {
+    // The rule lives in `setView` rather than in the column headings, because
+    // the Sort panel writes `sortKey` too and writes it WITHOUT a direction
+    // (`ShelfSortPanel.vue`). With the rule in the heading, the panel carried
+    // "Newest first" onto Name and handed back Z to A while the heading beside
+    // it gave A to Z.
+    const store = useModelShelfStore();
+    expect(store.view.sortKey).toBe("added_at");
+    expect(store.view.sortDirection).toBe("desc");
+
+    store.setView({ sortKey: "name" });
+    expect(store.view.sortDirection).toBe("asc");
+    store.setView({ sortKey: "size" });
+    expect(store.view.sortDirection).toBe("desc");
+    store.setView({ sortKey: "base_model" });
+    expect(store.view.sortDirection).toBe("asc");
+  });
+
+  it("leaves the direction alone when the key is unchanged or given", () => {
+    // Otherwise the direction toggle could never reach the non-default end,
+    // and re-picking the key you are already on would silently reset it.
+    const store = useModelShelfStore();
+    store.setView({ sortKey: "name" });
+    store.setView({ sortDirection: "desc" });
+    expect(store.view.sortDirection).toBe("desc");
+    store.setView({ sortKey: "name" });
+    expect(store.view.sortDirection).toBe("desc");
+    store.setView({ sortKey: "size", sortDirection: "asc" });
+    expect(store.view.sortDirection).toBe("asc");
+    // And a patch that is about something else entirely does not touch it.
+    store.setView({ groupBy: "folder" });
+    expect(store.view.sortDirection).toBe("asc");
+  });
+
   it("never refetches: every sort field is already on the row", async () => {
     // `fetchRows` merges up to three parallel requests, so a server-sorted list
     // per block would be destroyed by the concatenation anyway. Sorting client
@@ -844,6 +876,77 @@ describe("the view is remembered", () => {
     const store = useModelShelfStore();
     expect(store.view.groupBy).toBe("none");
     expect(store.view.sortKey).toBe("added_at");
+  });
+});
+
+describe("the column widths", () => {
+  it("clamps a width to the bounds rather than taking what it is given", () => {
+    const store = useModelShelfStore();
+    store.setColumnWidth("size", 4000);
+    expect(store.view.columnWidths.size).toBe(200);
+    store.setColumnWidth("size", -20);
+    expect(store.view.columnWidths.size).toBe(48);
+  });
+
+  it("ignores a column it does not have and a width that is not one", () => {
+    // Every one of these coerces to 0 through `Number()` and would come back
+    // as the 48px FLOOR rather than being refused — `null` in particular is a
+    // value JSON can carry, so a stored blob would silently hand back a
+    // 48px column where the read-back loop is meant to fall through to the
+    // default.
+    const store = useModelShelfStore();
+    store.setColumnWidth("name", 120);
+    for (const bad of ["wide", null, undefined, "", "64", [], {}, true, NaN]) {
+      store.setColumnWidth("kind", bad);
+    }
+    expect(store.view.columnWidths).toEqual({ kind: 64, base: 84, size: 74 });
+  });
+
+  it("falls through to the default for a stored width that is not a number", () => {
+    window.localStorage.setItem(
+      "pixlstash:modelShelfView",
+      JSON.stringify({
+        v: 1,
+        columnWidths: { kind: null, base: "84", size: 90 },
+      }),
+    );
+    const store = useModelShelfStore();
+    expect(store.view.columnWidths).toEqual({ kind: 64, base: 84, size: 90 });
+  });
+
+  it("restores what was dragged, and clamps that too", () => {
+    // A blob edited by hand — or written by a build with different bounds —
+    // must not hand back a shelf whose Size column is 4,000px wide.
+    const store = useModelShelfStore();
+    store.setColumnWidth("base", 150);
+    const blob = JSON.parse(
+      window.localStorage.getItem("pixlstash:modelShelfView"),
+    );
+    expect(blob.columnWidths).toEqual({ kind: 64, base: 150, size: 74 });
+
+    window.localStorage.setItem(
+      "pixlstash:modelShelfView",
+      JSON.stringify({ ...blob, columnWidths: { base: 150, size: 9000 } }),
+    );
+    setActivePinia(createPinia());
+    const restored = useModelShelfStore();
+    expect(restored.view.columnWidths).toEqual({
+      kind: 64,
+      base: 150,
+      size: 200,
+    });
+  });
+
+  it("takes the defaults from a blob written before columns could be dragged", () => {
+    // Per field rather than behind a schema bump, for the reason the folder
+    // layout is: that blob is still a perfectly good remembered sort.
+    window.localStorage.setItem(
+      "pixlstash:modelShelfView",
+      JSON.stringify({ v: 1, sortKey: "name", sortDirection: "asc" }),
+    );
+    const store = useModelShelfStore();
+    expect(store.view.sortKey).toBe("name");
+    expect(store.view.columnWidths).toEqual({ kind: 64, base: 84, size: 74 });
   });
 });
 

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -130,6 +130,23 @@ export function sortDirectionLabel(key, direction) {
   return direction === "asc" ? words[0] : words[1];
 }
 
+/**
+ * Which end a key starts at when the reader first sorts on it.
+ *
+ * Carrying the previous key's direction over is what a plain toggle would do,
+ * and it is wrong at the moment it matters most: arriving at Name from "Date
+ * added, newest first" would hand back Z to A, which nobody asked for and
+ * reads as a broken sort. A name starts at A, a size starts at the big files —
+ * the reason anyone sorts a shelf by size is to find what is eating the disk —
+ * and a date starts at the newest, which is the shelf's own default.
+ *
+ * @param {string} key - a `SORT_LABELS` key.
+ * @returns {"asc"|"desc"}
+ */
+export function defaultSortDirection(key) {
+  return key === "name" || key === "base_model" ? "asc" : "desc";
+}
+
 /** What each grouping axis is called, and the glyph that stands for it. */
 export const GROUP_BY_LABELS = {
   none: { label: "None", icon: "mdi-format-list-bulleted" },


### PR DESCRIPTION
The model shelf's columns were named only to a screen reader — a
`visually-hidden` `columnheader` row per grid — and the only way to reorder the
list was the toolbar's Sort split-button. This adds the visible strip.

## What's here

**A sticky column strip above the list.** Headings for Name, Kind, Base and
Size, with the group headings sticking under it rather than behind it.

**Headings sort.** Press the sorted column to flip its direction; press another
to sort on it. A new key arrives at its own end — names ascend, sizes and dates
start at the big and the new — rather than inheriting the previous key's
direction, which is what made "Date added, newest first" → Name hand back Z-to-A.

Kind is a heading and not a button: the API's `SortKey` has no member for it,
and a control that does nothing is worse than none.

**Columns resize.** A `role="separator"` grip on each fixed column's right edge:
drag it, or use Left/Right (8px), Home/End (the bounds) and Enter (back to the
default). Double-click does the same as Enter. Widths are clamped to 48–200px
and remembered in the shelf's existing versioned view blob, read back per column
so a blob written before this existed keeps the defaults.

## Two things worth a reviewer's eye

**The default-direction rule went into `setView`, not into the headings.** There
are two writers of `view.sortKey` — the new headings and `ShelfSortPanel`, which
writes it *without* a direction. With the rule in the headings only, the panel
and the strip beside it would have disagreed about what "Name" means. `setView`
fills a direction in only when the key actually changes and the caller named
none, so the direction toggle and a re-pick of the current key are untouched.
Covered by two new store tests.

**`.shelf-dim` was raised above the sticky layers.** It is the visible half of
the `inert` veil during a model move. The new strip is opaque and pinned, so at
or below the veil's rung it would have stayed at full brightness over a dimmed
list — reading as usable when it is not, which is the failure the veil exists to
prevent. The group headings already leaked the same way at equal z on DOM order;
this fixes both.

## Design and review

Went past `lead-designer` and `ui-ux-expert` before the adversarial pass, and
their findings are applied: the grip's hairline is a component-grade 0.4 alpha
rather than the `divider` token (which measures ~1.2:1 on this canvas and fails
1.4.11), the grab area is 24px for WCAG 2.5.8, focus is `--focus-ring` rather
than a hand-rolled outline, the type comes from the global `.section-label`
rather than being re-rolled, and the rail and strip height use `--rail-w` and
`--rule-h-seam`.

The direction arrow is always rendered and toggled with `visibility`, so sorting
a column cannot shift its own label — the same rule as the row's absence rail.

`DEFAULT_COLUMN_WIDTHS` in the store is now the only declaration of the three
figures; the CSS fallback copy is gone rather than left as a second literal with
nothing keeping it equal.

## Objections I did not act on

- **Six new tab stops ahead of an 1,800-row list.** The grips are focusable
  deliberately — a pointer-only resize puts column widths out of reach of anyone
  not using a mouse, which `ui-ux-expert` raised as a blocker. Keeping them.
- **Size's heading is left-aligned over right-aligned figures.** The heading is
  a label and the figures are a magnitude, and a right-aligned `SIZE` in a 74px
  column would sit under its own grip and be a resize target as much as a sort
  one. Finder and Explorer both do this.
- **The default sort (`Date added`) has no column, so the strip opens with no
  arrow anywhere.** Adding a fourth column for it is a bigger decision than this
  issue; every heading carries a `title` stating whether it is sorted, and the
  toolbar still shows the truth.

## Not verified in a browser

The suite is jsdom, which has no `setPointerCapture` and no compatibility
mouse-event mapping. Pointer capture itself, and whether `dblclick` survives on
the grip, are the two things no test here can see — the code avoids
`preventDefault` on `pointerdown` precisely so they should, but that wants a
real browser.

Heads-up: another branch is adding a date column to this shelf. It will need one
more entry in `SHELF_COLUMNS` and in `COLUMN_KEYS`/`DEFAULT_COLUMN_WIDTHS`;
nothing else about the strip should need touching.
