### PR TITLE
Match the model shelf toolbar to the grid's band

### DIFF
--- a/docs/design/design-system-handoff.md
+++ b/docs/design/design-system-handoff.md
@@ -101,8 +101,10 @@ fourth distinct occurrence of that bug in this codebase.
   want `dark-surface-error` (4.12:1). Pre-existing, mechanical, large enough to want its
   own eyeball pass.
 - **`SelectionBar`'s `6px` block padding** stays off-grid until the action-bar height
-  reconciliation (34 / 40 / 48 / 56px → `--bar-height`), which is UI/UX-gated because it
-  moves pixels on the app's most-used control.
+  reconciliation (34 / 36 / 40 / 48 / 56px → `--bar-height`), which is UI/UX-gated
+  because it moves pixels on the app's most-used control. The three **view toolbars**
+  are out of that list: they were reconciled with each other at 36px rather than onto
+  the token (`toolbar-responsive-decisions.md` Amendment #5).
 - **The 40+ raw z-index call sites.** The ladder is shipped; retrofitting is
   opportunistic (touch a rule, move it onto the ladder). The ladder's own values and the
   migration of the remaining squatters are owned by the concurrent layering lane — read

--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -19,8 +19,9 @@ container queries today**):
 - Right: size slider + label → Auto-stack button (conditional, accent) →
   separator → **UndoControl** → TbGlobalActions
 
-**Model shelf toolbar** (`ModelShelf.vue`, `.shelf-toolbar`, container
-`shelfbar toolbar`) — added 2026-08-15, after this record was written:
+**Model shelf toolbar** (`ModelShelf.vue`, `.shelf-toolbar`, 36px band since
+Amendment #5, container `shelfbar toolbar`) — added 2026-08-15, after this
+record was written:
 
 - Left: title → count → Add (accent) → stack sweep → Model folders
 - Right: Group → Sort split-button → Show → separator → TbGlobalActions
@@ -342,3 +343,94 @@ rule exists so a demo can see a feature it may not use — the feature is real,
 the session is not entitled to it. Here the feature does not exist on this
 screen at all, and a permanently inert undo two icons from verbs that say
 "There is no undo for this" teaches the opposite of what is true.
+
+## Amendment #5 (2026-08-16): one band, one tail anchor (fine pointers)
+
+**The finding:** Decision 1 unified what the three bars *hold*, and nothing
+unified what they *are*. Switching to `/models` moved the whole content area
+down 12px and back, because `.shelf-toolbar` shipped at `--bar-height` (48px)
+while the grid and Duplicates bars are 36px. The strip was also unpainted, so
+`.shelf`'s `background` showed through it — a different hue and value from the
+`toolbar` token in both themes — which made the shelf bar read as page rather
+than chrome. And its uniform `--space-5` inset put Settings and Stats 8px
+further left than in the other two views, so the one pair of controls that
+means the same thing everywhere jumped diagonally on every view switch. Three
+independent differences, all of them read at once as "this is a different app",
+which is exactly the reading a view switch must not produce.
+
+**The change:** `.shelf-toolbar` takes the grid bar's box recipe whole —
+`height: 36px` + `box-sizing: border-box` + zero vertical padding — paints
+`rgb(var(--v-theme-toolbar))` with `rgb(var(--v-theme-toolbar-text))` ink, and
+adopts the queue's split inset, `padding: 0 var(--space-3) 0 var(--space-5)`.
+The right token is the one that matters and is now identical in all three:
+the app-wide tail is a stable anchor only if it lands at the same distance from
+the edge in every view. The left stays at the view's own content gutter, which
+on the shelf is `--space-5` (`.shelf-group-btn` and the rows), the same
+reasoning the queue's inset already carried. `.shelf-title` drops from
+`--text-xl` to `--text-md`, the queue's `.qtitle`: 22px is a view heading, it
+does not sit in a 36px band, and the two bars that lead with an identity now
+lead with it at one size. `.shelf-sub` re-bases its ink on `toolbar-text` at
+the queue's `.qsub` alpha (0.6, not the 0.7 it carried on `on-background`) — at
+the old alpha the change would have invented a third strength for one role in a
+record whose whole premise is that these bars agree.
+
+`.shelf-viewseg` drops to `height: 30px` in the same pass. It is the only
+control on any of the three bars wrapped in a bordered track, so at `.bar-btn`'s
+32px the switch measured 34 against every neighbour's 32. The old 48px band hid
+that as mere misalignment; a 36px band (35px of content box) also left it 0.5px
+of slack, so a focused segment's 3px `--focus-ring` painted onto the first list
+row. 30 + 2×1px border is 32, which is what every other control in every bar
+already is.
+
+**Not `--bar-height`.** 36px is the shipped majority and the one the grid bar
+defines; migrating the whole app's 34/40/48/56 onto the 48px token is the
+separate UI/UX-gated item in `visual-language.md` §5, and a bar that jumped
+there alone would be drift in the other direction. What this amendment fixes is
+the *disagreement between views*, not the token question.
+
+**Kept different, deliberately:** the grid bar paints `rgba(…, 0.95)` rather
+than `rgb(…)`. It is the only one of the three that is absolutely positioned
+over scrolling content; the other two are flex children of their shells. The
+guardrail accepts either form of the same token.
+
+**The guardrail grew a third bar.** `Toolbar.test.js` now reads the CSS block of
+all three selectors and asserts the shared recipe, the equal right inset, that
+each declares exactly one `background` and that it paints `--v-theme-toolbar`,
+and that `.shelf-title`/`.shelf-sub` carry the same size and ink as the queue's
+`.qtitle`/`.qsub`. jsdom computes no layout, so the coupling is what gets
+pinned, not the rendered pixels. The "exactly one" is the load-bearing part: an
+earlier draft asserted only that *a* `background` matched the token, which an
+adversarial pass showed still passed with `background: transparent` appended on
+the next line — that is, on a reproduction of the very defect being fixed.
+
+### Still open after this amendment
+
+Two things this record should not be read as having settled.
+
+**Coarse pointers are NOT unified, and the gap widened.** `Toolbar.vue` carries
+a `@media (hover: none) and (pointer: coarse)` block taking `.selection-bar-
+overlay` to 56px with `--space-2` insets and its controls to 46px targets.
+Neither the queue nor the shelf has an equivalent, so on touch the three bars
+measure 56 / 36 / 36px with 4 / 8 / 8px right insets — every claim above holds
+for fine pointers only. The shelf was already wrong here (48px band, 32px
+targets: the coarse `.bar-btn { min-height: 46px }` rule is inside
+`Toolbar.vue`'s `<style scoped>` and so has never reached any bar but the
+grid's, the exact trap `App.css` documents at the `.bar-*` family), and 32px
+targets are under the 44px WCAG 2.5.5 floor on all three. The fix is the one
+`App.css` already made for the rest of the family — lift the coarse `.bar-*`
+rules out of the scoped block, then give the other two bars the band — but it
+moves pixels on touch hardware nobody has verified this on, so it is its own
+change with its own device pass, not a rider on this one. **The guardrail
+cannot see it**: `blockOf` takes the first matching block, so a media-query
+override is structurally invisible to it.
+
+**`.bar-btn--open` is a weak affordance and this made it marginally weaker on
+the shelf.** The open trigger paints `panel` fill inside a `border` outline;
+against `toolbar` that measures 1.01:1 (light) and 1.17:1 (dark) for the fill,
+1.28:1 for the outline — under the 3:1 non-text floor (WCAG 1.4.11). The shelf
+previously sat on `background`, where the same pairings measure 1.05 / 1.30 /
+1.42:1: still failing, slightly less so. This is not a shelf problem — it is how
+the open state reads on the grid and queue bars already, and the shelf has now
+converged onto it rather than away. Fixing `.bar-btn--open` app-wide (an accent
+border, the treatment `.bar-btn--icon.bar-btn--open` already uses) is a
+lead-designer item across all three bars.

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -465,9 +465,13 @@ header, toolbar, and stats header to one horizontal band and you respect that ba
 everywhere. The band height is `--bar-height` (48px) in the browser; the desktop
 Electron shell compresses the top strip (title bar `--titlebar-h` 34px, sidebar
 header 36px) so the custom title bar and controls fit — see the overrides in
-`style.css`. (Heads-up: the per-component action-bar heights still drift — 34 / 40 /
-48 / 56px across `ImageGrid`, `ImageOverlay`, and the selection bar. Unifying them
-onto `--bar-height` is an open reconciliation item; it moves pixels, so it needs
+`style.css`. (Heads-up: the per-component action-bar heights still drift — 34 / 36 /
+40 / 48 / 56px across `ImageGrid`, `ImageOverlay`, and the selection bar. The **three
+view toolbars are the one settled group**: the grid, Duplicates and model-shelf bars
+all sit at 36px, pinned to each other by a guardrail rather than to this token
+(`toolbar-responsive-decisions.md` Amendment #5) — so no view toolbar honours
+`--bar-height` today, deliberately. Unifying the rest onto `--bar-height` is an open
+reconciliation item; it moves pixels, so it needs
 UI/UX sign-off — see §13.)
 
 ### 5.1 The row grid (how a list row shares a left edge)
@@ -863,8 +867,11 @@ bar** — is one pattern. It reuses the grid; only the bar changes.
   and **always behind a confirm** — deletion is irreversible and must never be a
   single mis-click. Secondary actions are quiet (text/`cancel-button`).
 - **One band.** Action bars share `--bar-height` so they line up with the shell's
-  top strip (§5). The current per-component heights (34 / 40 / 48 / 56px) are drift
-  to migrate onto this token; because it moves pixels it is UI/UX-gated.
+  top strip (§5). The current per-component heights (34 / 36 / 40 / 48 / 56px) are
+  drift to migrate onto this token; because it moves pixels it is UI/UX-gated. The
+  36px group is the exception that is already settled: the three **view toolbars**
+  agree with each other at 36px and are guarded there, so they migrate together or
+  not at all.
 - **Empty & the Trash view.** Trash is the picture grid reused with the restore/purge
   bar. Its empty state uses the existing `EmptyTrash.png` art (§9) with a
   `--text-2xl` Tiny5 headline and a `--text-sm` line of guidance.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1619,6 +1619,28 @@ still declares `container-name: shelfbar toolbar` — the convention both other
 hosts follow, so a shared control mounted here degrades by the same scoped
 rules — though after this change nothing queries either name on this bar.
 
+**And the band itself is the grid bar's, not its own** (Amendment #5). What the
+three bars hold was unified before what they *are* was: the shelf strip shipped
+at `--bar-height` (48px) against the other two at 36px, unpainted so `.shelf`'s
+`background` showed through where the others paint `toolbar`, and inset
+`--space-5` on both sides so Settings and Stats sat 8px further left than
+everywhere else. Switching to `/models` therefore stepped the content area 12px
+and moved the one pair of controls that means the same thing in every view.
+`.shelf-toolbar` now copies `.selection-bar-overlay`'s box recipe (`height:
+36px`, `box-sizing: border-box`, no vertical padding), paints
+`rgb(var(--v-theme-toolbar))` with `toolbar-text` ink, and takes the queue's
+split inset `0 var(--space-3) 0 var(--space-5)` — right pinned to the grid's so
+the app-wide tail is a fixed anchor, left at the shelf's own content gutter.
+`.shelf-title` sits at `--text-md` (the queue's `.qtitle`) rather than
+`--text-xl`, `.shelf-sub` at the queue's `.qsub` alpha, and `.shelf-viewseg`
+drops to 30px so the bordered segmented track measures 32px like every other
+control on every bar. `Toolbar.test.js` reads the CSS block of all three
+selectors and asserts the shared recipe, the equal right inset, exactly one
+`background` declaration painting `toolbar`, and the identity type matching the
+queue's; jsdom computes no layout, so the coupling is what is pinned. **Fine
+pointers only** — the coarse-pointer band is still 56/36/36px across the three
+bars and is recorded as open work in Amendment #5.
+
 These rules come from measurement against real adapter folders and are easy to
 undo by accident:
 

--- a/frontend/src/components/panels/Toolbar.test.js
+++ b/frontend/src/components/panels/Toolbar.test.js
@@ -15,8 +15,8 @@ import { mount } from "@vue/test-utils";
 vi.mock("../../utils/apiClient", async () => {
   const { ref } = await import("vue");
   return {
-  onSessionReset: () => () => {},
-  sessionContext: { value: null },
+    onSessionReset: () => () => {},
+    sessionContext: { value: null },
     apiClient: {
       get: vi.fn().mockResolvedValue({ data: {} }),
       post: vi.fn().mockResolvedValue({ data: {} }),
@@ -151,13 +151,15 @@ beforeEach(() => {
 describe("Toolbar — the shell band's one box recipe", () => {
   // jsdom computes no layout, so rendered heights cannot be asserted; what
   // CAN be pinned is the coupling itself. `.selection-bar-overlay` is the
-  // point of truth for the 36px band recipe and `.dq-toolbar` copies it —
-  // the drift this guards against: the dq bar shipped with `min-height` +
-  // vertical padding on a content-box, which rendered 41px next to the
-  // grid's exact 36px once the 32px app-wide tail buttons landed.
+  // point of truth for the 36px band recipe and `.dq-toolbar` and
+  // `.shelf-toolbar` copy it — the drift this guards against: the dq bar
+  // shipped with `min-height` + vertical padding on a content-box, which
+  // rendered 41px next to the grid's exact 36px once the 32px app-wide tail
+  // buttons landed, and the shelf bar shipped at `--bar-height` (48px), which
+  // stepped the whole content area 12px on every switch to /models.
   // (Tokenising the shipped 36px is a recorded lead-designer follow-up;
   // until then this test is the shared source of truth.)
-  it("both bars declare the identical height-determining recipe", async () => {
+  it("every view bar declares the identical height-determining recipe", async () => {
     const { readFileSync } = await import("node:fs");
     // Vitest serves modules from a virtual scheme, so the SFC sources are
     // read relative to the frontend/ working directory instead.
@@ -181,26 +183,72 @@ describe("Toolbar — the shell band's one box recipe", () => {
       "src/components/views/DuplicateQueue.vue",
       ".dq-toolbar",
     );
+    const shelf = blockOf(
+      "src/components/views/ModelShelf.vue",
+      ".shelf-toolbar",
+    );
 
-    for (const block of [grid, dq]) {
+    for (const block of [grid, dq, shelf]) {
       expect(block).toContain("height: 36px");
       expect(block).toContain("box-sizing: border-box");
       // min-height + vertical padding is exactly the recipe that drifted.
       expect(block).not.toContain("min-height");
       expect(block).toMatch(/padding: 0 var\(--space-\d\)/);
+      // And every bar paints the chrome surface, not the page. The shelf bar
+      // painted nothing, so `.shelf`'s `background` showed through and the
+      // strip read as page rather than chrome. (The grid bar's `rgba(…, .95)`
+      // is allowed: it is absolutely positioned over the scrolling grid.)
+      //
+      // EVERY background declaration in the block is checked, not merely that
+      // one of them matches: a `toMatch` alone passes on a block that paints
+      // the token and then overrides it with `transparent` on the next line,
+      // which is the shipped defect itself.
+      const paints = block.match(/background:[^;]*/g) ?? [];
+      expect(paints).toHaveLength(1);
+      expect(paints[0]).toMatch(/rgba?\(var\(--v-theme-toolbar\)/);
     }
 
     // The RIGHT insets must be the same token: the app-wide tail is a stable
     // anchor only if its icons land at the identical distance from the edge
-    // in every view. (The dq bar's LEFT inset may differ — it aligns with the
-    // queue's own content gutter.) Shorthand forms accepted: `0 X` (right =
-    // X) and `0 R 0 L` (right = first var).
+    // in every view. (The dq and shelf bars' LEFT insets may differ — each
+    // aligns with its own view's content gutter.) Shorthand forms accepted:
+    // `0 X` (right = X) and `0 R 0 L` (right = first var).
     const rightInset = (block) => {
       const match = block.match(/padding:\s*0\s+var\((--space-\d)\)/);
       expect(match).toBeTruthy();
       return match[1];
     };
     expect(rightInset(dq)).toBe(rightInset(grid));
+    expect(rightInset(shelf)).toBe(rightInset(grid));
+
+    // Two of the three bars LEAD with an identity (the queue's count, the
+    // shelf's title) and each carries a quieter count beneath it. They read as
+    // one bar in two contexts only if that pair is one size and one ink: the
+    // shelf shipped its title at --text-xl, a 22px view heading that does not
+    // sit in a 36px band, and its count at a third alpha.
+    const decl = (block, property) => {
+      const match = block.match(new RegExp(`${property}:\\s*([^;]+);`));
+      expect(match, `${property} in ${block.slice(0, 24)}`).toBeTruthy();
+      return match[1].trim();
+    };
+    const qtitle = blockOf(
+      "src/components/views/DuplicateQueue.vue",
+      ".qtitle",
+    );
+    const qsub = blockOf("src/components/views/DuplicateQueue.vue", ".qsub");
+    const shelfTitle = blockOf(
+      "src/components/views/ModelShelf.vue",
+      ".shelf-title",
+    );
+    const shelfSub = blockOf(
+      "src/components/views/ModelShelf.vue",
+      ".shelf-sub",
+    );
+
+    expect(decl(shelfTitle, "font-size")).toBe(decl(qtitle, "font-size"));
+    expect(decl(shelfTitle, "font-weight")).toBe(decl(qtitle, "font-weight"));
+    expect(decl(shelfSub, "font-size")).toBe(decl(qsub, "font-size"));
+    expect(decl(shelfSub, "color")).toBe(decl(qsub, "color"));
   });
 });
 
@@ -303,9 +351,9 @@ describe("Toolbar — the canonical app-wide tail", () => {
     expect(wrapper.find(".bar-separator--gap-guard").exists()).toBe(false);
     // No rule leads the right group: its first element child is a control.
     const right = wrapper.find(".selection-bar-right").element;
-    expect(
-      right.firstElementChild.classList.contains("bar-separator"),
-    ).toBe(false);
+    expect(right.firstElementChild.classList.contains("bar-separator")).toBe(
+      false,
+    );
   });
 
   it("mounts UndoControl exactly once — the left-group copy is gone", () => {
@@ -428,13 +476,11 @@ describe("Toolbar — the ⋯ overflow mirrors its controls", () => {
   // The controls the amendment pinned OUT of the burger stay first-class.
   it("keeps Review and the global pair as visible controls", () => {
     const wrapper = mountToolbar();
+    expect(wrapper.find('button[title="Review and fix tags"]').exists()).toBe(
+      true,
+    );
     expect(
-      wrapper.find('button[title="Review and fix tags"]').exists(),
-    ).toBe(true);
-    expect(
-      wrapper
-        .find('button[title="Review and fix tags"]')
-        .classes(),
+      wrapper.find('button[title="Review and fix tags"]').classes(),
     ).not.toContain("tb-fold-700");
     expect(wrapper.findComponent({ name: "TbGlobalActions" }).exists()).toBe(
       true,

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -3513,20 +3513,54 @@ watch(
      bar's width independent of its contents. */
   container-type: inline-size;
   container-name: shelfbar toolbar;
-  height: var(--bar-height);
-  padding: 0 var(--space-5);
+  /* The shell's top band, copied from the GRID toolbar
+     (`.selection-bar-overlay` in Toolbar.vue), which is the point of truth for
+     the box recipe: `height: 36px` + `box-sizing: border-box` (the 1px bottom
+     border sits INSIDE the 36) + zero vertical padding, `align-items: center`
+     doing the vertical work. This bar shipped at `--bar-height` (48px), so
+     switching to /models moved the whole content area down 12px and back —
+     which reads as a different app, not a different context. NOT
+     `--bar-height`: unifying the shipped 34/36/40/48/56 onto that token is the
+     separate, UI/UX-gated item in visual-language.md §5, and a bar that jumped
+     there alone would be drift in the other direction. Guardrail:
+     Toolbar.test.js asserts all three bars carry the same recipe. */
+  height: 36px;
+  box-sizing: border-box;
+  /* Split inset, same as the queue's and for the same reason. RIGHT is
+     --space-3, the grid bar's inset: the app-wide tail ([separator]
+     [TbGlobalActions]) is a stable anchor only if Settings and Stats land at
+     the identical distance from the edge in every view — a uniform --space-5
+     here put them 8px further left than the grid's, so the pair jumped
+     sideways on every view switch. LEFT stays --space-5, the shelf's own
+     content gutter (`.shelf-group-btn` and the rows inset by --space-5), so
+     the title sits flush over the list. */
+  padding: 0 var(--space-3) 0 var(--space-5);
+  /* Paint the chrome surface the other two bars paint. Unpainted, this strip
+     showed `.shelf`'s `background` through it, which is a different hue and
+     value from `toolbar` in both themes — the bar read as page, not chrome.
+     `toolbar-text` is what `.bar-btn` already uses, so the title and the count
+     now inherit the same ink as the buttons beside them. */
+  background: rgb(var(--v-theme-toolbar));
+  color: rgb(var(--v-theme-toolbar-text));
   border-bottom: 1px solid rgb(var(--v-theme-divider));
   flex-shrink: 0;
 }
 
+/* --text-md, the queue's `.qtitle`, not --text-xl: 22px is a view heading and
+   does not sit in a 36px band. The two bars that lead with an identity now
+   lead with it at one size. */
 .shelf-title {
-  font-size: var(--text-xl);
+  font-size: var(--text-md);
   font-weight: var(--weight-semibold);
 }
 
+/* 0.6, the queue's `.qsub` alpha exactly. It was 0.7 on `on-background`, and
+   re-basing it on `toolbar-text` at the old alpha would have invented a third
+   strength for the one role in a change whose premise is that these bars
+   agree. */
 .shelf-sub {
   font-size: var(--text-xs);
-  color: rgba(var(--v-theme-on-background), 0.7);
+  color: rgba(var(--v-theme-toolbar-text), 0.6);
   font-variant-numeric: tabular-nums;
 }
 
@@ -3641,8 +3675,15 @@ watch(
   border-radius: var(--radius-pill);
 }
 
+/* 30px, not `.bar-btn`'s 32: this is the one control on any of the three bars
+   that wraps its buttons in a bordered track, so 32px segments made the switch
+   34px against every neighbour's 32. In the old 48px band that only misaligned
+   it; in the 36px band it also left 0.5px between the switch and the band edge,
+   so a focused segment's 3px ring painted over the first list row. 30 + 2×1px
+   border = 32, the height every other control in every bar already is. */
 .shelf-viewseg {
   border-radius: 0;
+  height: 30px;
   color: rgba(var(--v-theme-on-panel), 0.7);
 }
 


### PR DESCRIPTION
Switching views changed more than the context. The app has three view toolbars — the grid's `.selection-bar-overlay`, the queue's `.dq-toolbar` and the shelf's `.shelf-toolbar` — and only the first two agreed. The grid bar is the model here; nothing about it changes.

## What the shelf bar was doing

Three independent differences, all read at once:

- **48px band** (`--bar-height`) against the other two at 36px, so `/models` stepped the whole content area down 12px and back.
- **Unpainted**, so `.shelf`'s `background` showed through where the other two paint `toolbar` — a different hue *and* value in both themes. The strip read as page, not chrome.
- **`--space-5` on both sides**, putting Settings and Stats 8px further from the right edge than everywhere else. The one pair of controls that means the same thing in every view jumped sideways on every switch.

Plus a `--text-xl` (22px) title, which is a view heading and does not sit in a 36px band.

## The change

`.shelf-toolbar` takes the grid bar's box recipe whole — `height: 36px` + `box-sizing: border-box` + zero vertical padding — paints `rgb(var(--v-theme-toolbar))` with `toolbar-text` ink, and adopts the queue's split inset `0 var(--space-3) 0 var(--space-5)`. The right token is the one that matters and is now identical in all three; the left stays on the shelf's own content gutter so the title still sits flush over the rows. `.shelf-title` drops to `--text-md` and `.shelf-sub` to the queue's `.qsub` alpha, so the two bars that lead with an identity lead with it at one size and one ink. `.shelf-viewseg` drops to 30px: it is the only control on any bar wrapped in a bordered track, so at 32px the switch measured 34 against every neighbour's 32, and in a 36px band that also left a focused segment's 3px ring painting onto the first list row.

**Not `--bar-height`.** Migrating the app's 34/36/40/48/56 onto the 48px token is the separate UI/UX-gated item in `visual-language.md` §5; a bar that jumped there alone would be drift in the other direction. What this fixes is the disagreement *between views*. Both design docs are updated to say so rather than continuing to claim the token is honoured.

## Guardrail

`Toolbar.test.js` already read the CSS blocks of the grid and queue bars and asserted the shared recipe and equal right inset; it now covers the shelf too, and adds the paint and the identity type. Each new assertion was proved load-bearing by mutation — reverting the height, the paint, the title size or the count alpha each turns it red.

## Answering the adversarial review

A pre-merge pass argued for rejection. Four of its findings are fixed above (the `.qsub` alpha, the segmented-control height, the stale design manual, the untested title/ink). Three I disagree with, and say so here rather than silently:

- **"The `background` assertion is decorative."** It was — the reviewer proved it passed with `background: transparent` appended after the good one, i.e. on a reproduction of the defect itself. Fixed properly: the guard now requires *exactly one* background declaration and checks that one. The reviewer's mutation is part of the mutation set above.
- **"A 2px content step remains"** (`--selbar-height: 34px` vs the 36px bar). No: `ImageGrid.css` sets 34 deliberately so grid tiles tuck *under* the absolutely-positioned bar with no dark seam — the bar paints over those 2px. Visible content begins at 36px in all three views.
- **"The `--open` state's contrast degrades"** (fill 1.05 → 1.01:1). Real numbers, wrong conclusion for this PR: that is how `.bar-btn--open` already reads on the grid and queue bars, both of which paint `toolbar`. The shelf was the odd one out that happened to read marginally better, and matching is the ask. Recorded as a lead-designer item across all three bars instead.

## Known-open, deliberately not in this PR

**Coarse pointers are not unified.** `Toolbar.vue` has a scoped `@media (pointer: coarse)` block taking the grid bar to 56px with 46px targets; neither other bar has one, so on touch the three measure 56/36/36px. The shelf was already wrong here (its 32px targets are under the WCAG 2.5.5 floor, and the coarse `.bar-btn { min-height: 46px }` rule is inside a `<style scoped>` block so it has never reached any bar but the grid's). The fix is the one `App.css` already made for the rest of the `.bar-*` family, but it moves pixels on touch hardware I could not verify against, so it wants its own change and its own device pass. Written up in Amendment #5 with the numbers, including the note that the guardrail is structurally blind to media-query overrides.

Full frontend suite green: 181 files, 3448 tests.
