### PR TITLE
Stop downloading the spaCy model in the desktop runtime build

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -245,8 +245,6 @@ Background processing is **data-driven**: each task type has a *finder* that que
 | Inference runtime | **onnxruntime** ≥ 1.24 |
 | Face detection | **insightface** ≥ 0.7.3 |
 | Text embeddings | **sentence_transformers** ≥ 5.2 |
-| NLP | **spacy** ≥ 3.8 |
-| Tensor utils | **einops** ≥ 0.8 |
 
 #### ML import discipline — these libraries are imported *inside functions*
 

--- a/electron/src/backend/BackendManager.ts
+++ b/electron/src/backend/BackendManager.ts
@@ -132,8 +132,8 @@ export function buildOverlayPipArgs(
  *    torch 2.11.0+cu128). pip is free to put a satisfying setuptools in the
  *    overlay instead, which is the long-standing installed state anyway.
  * Constraints files also reject direct references (`pkg @ url` / local paths —
- * e.g. the pixlstash wheel and the spaCy model) and option/comment lines, so
- * only plain `name==version` pins survive.
+ * e.g. the pixlstash wheel) and option/comment lines, so only plain
+ * `name==version` pins survive.
  */
 export function filterConstraintsFreeze(frozen: string): string {
   const drop = /^(torch|torchvision|onnxruntime|onnxruntime-gpu|setuptools|pip|wheel)(==|@|\s|$)/i;

--- a/scripts/build_desktop_runtime.py
+++ b/scripts/build_desktop_runtime.py
@@ -219,10 +219,6 @@ def populate_env(py: Path, wheel: Path, accel: str, cache_dir: Path) -> None:
     # 3. The PixlStash wheel + remaining deps from PyPI.
     pip_install(py, [str(wheel)], cache_dir)
 
-    # 4. The spaCy English model used by the description pipeline.
-    log("downloading spaCy en_core_web_sm")
-    subprocess.run([str(py), "-m", "spacy", "download", "en_core_web_sm"], check=True)
-
 
 def installed_version(py: Path, dist: str) -> str:
     out = subprocess.run(


### PR DESCRIPTION
`scripts/build_desktop_runtime.py` ran `python -m spacy download en_core_web_sm` after installing the wheel. spacy was dropped from the install set in 44b1b3c9, so the electron build now fails with `No module named spacy` (v1.10.0-dev.3, Build Electron Desktop App).

Nothing under `pixlstash/` imports spacy — not before that commit either — so the model was downloaded and never loaded. Removing the step rather than restoring the dependency.

Also drops the stale spacy/einops rows from the ML stack table and the spaCy example from the constraints-filter comment.