### PR TITLE
Stop the Duplicates toolbar overflowing its own bar

### DIFF
--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -365,8 +365,8 @@ mixed stacks waiting):
 |---|---|---|
 | — | everything on the bar | 1577px |
 | dqbar ≤1400 | qsub, the size value label | 1372px |
-| dqbar ≤1180 | the size control, Auto-stack's sentence → "Auto-stack N" | 1153px |
-| dqbar ≤1040 | the page toggles → ⋯, the tier label | 807px |
+| dqbar ≤1180 | the page toggles → ⋯, the tier label | 1026px † |
+| dqbar ≤1040 | the size control, Auto-stack's sentence → "Auto-stack N" | 807px |
 | dqbar ≤820 | Auto-stack → flash + count, the scope pill → icon + dismiss | 630px |
 | toolbar ≤480 | the undo chevron (shared, unchanged) | 598px |
 | toolbar ≤420 | redo (shared); the two runs' gaps → `--space-2` | 526px |
@@ -375,6 +375,27 @@ Between two rungs the count headline takes the difference: it ellipsizes from
 the right, so the number survives and "groups to review" is what goes. A
 `flex-shrink: 6` on it buys that order, because a clipped tail on a sentence
 reads better than "Mixed stac…" on a button.
+
+**Rung order: what has somewhere to go, goes first.** The toggles fold — they
+are still reachable, one click further away — while the size control has no
+destination and hiding it takes the control away outright, so the toggles must
+buy the width before the slider is asked to. They are also the bigger purchase
+(~346px against the slider's ~130px), which is why this order both keeps the
+slider ~140px of bar width longer *and* leaves more slack between every rung:
+the count has to absorb 103px less between 1180 and 1040 than the other order
+asked of it. A slider folded into the ⋯ as a row would keep it further still,
+and was left out: a drag target inside a menu that closes on click is a worse
+control than none, and the value survives the hide either way.
+
+† These two rungs were swapped after the first measurement pass, which had the
+slider going a rung before the toggles that could fold instead. The fold sets
+themselves did not change, so the middle figure is the harness's own measured
+savings re-applied in the new order (1372 − 346), and the floor is unchanged.
+What was re-measured is the shipped app rather than the harness: stepping the
+real Duplicates bar 1900 → 700px of window in 10px steps, the rungs fire at
+exactly 1180 and 1040 of container width, `scrollWidth === clientWidth` at
+every step, no left-group child reaches the tail (worst approach 11px), and the
+size slider is still on the bar down to 1045.
 
 Floor: `128 ⋯ │ [filter ▾] [scope ×] …gap… [⚡ 42] │ [undo] [Settings] [Stats]`.
 The two numbers in the last row are not in conflict: 526px is what the bar
@@ -390,12 +411,13 @@ container query styles descendants, never the container itself.)
 
 **Duplicates ranking, revised:** 1 Undo (never folds or hides) / 2 Settings +
 Stats (never fold; the whole point of this amendment) / 3 Tier gate (never
-folds, compresses at 1040) / 4 Count (never folds; ellipsizes between rungs,
+folds, compresses at 1180) / 4 Count (never folds; ellipsizes between rungs,
 the number never truncates) / 5 Scope pill (never folds while scoped,
-compresses at 820) / 6 Auto-stack (never folds, compresses at 1180 and 820) /
-7 Redo + chevron (shared 420/480) / 8 Decided + Mixed stacks (fold to ⋯ rows at
-1040, unless showing "Back to review") / 9 Size slider (hides at 1180) /
-10 qsub (hides at 1400).
+compresses at 820) / 6 Auto-stack (never folds, compresses at 1040 and 820) /
+7 Redo + chevron (shared 420/480) / 8 Size slider (hides at 1040; ranked above
+the toggles because hiding it removes a control, where folding them only moves
+one) / 9 Decided + Mixed stacks (fold to ⋯ rows at 1180, unless showing "Back
+to review") / 10 qsub (hides at 1400).
 
 **Acceptance, and it is arithmetic rather than judgement.** At every container
 width, with the worst content the bar can hold: the bar does not overflow its

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -3737,7 +3737,7 @@ view holds in the other (`docs/design/toolbar-responsive-decisions.md`). Both
 bars also share the `toolbar` container name and the ⋯ overflow's collapse
 ladder, so the shared chrome degrades identically at every width. The queue's
 own ⋯ sits at the end of its toggle run and holds the Decided and Mixed stacks
-toggles, which fold into it at ≤1040 — except while one of them reads "Back to
+toggles, which fold into it at ≤1180 — except while one of them reads "Back to
 review", when it is the visible way out of a sub-page and stays on the bar
 (amendment #4). Settings, the stats toggle and undo never fold at any width,
 and the bar's shrink chain makes that structural rather than a promise the

--- a/frontend/e2e/specs/dedup.spec.js
+++ b/frontend/e2e/specs/dedup.spec.js
@@ -196,12 +196,25 @@ test.describe.serial('duplicates queue (§21)', () => {
           .map((el) => el.getBoundingClientRect())
           .filter((b) => b.width > 0)
           .reduce((worst, b) => Math.max(worst, b.right - right.left), -Infinity)
+        const size = bar.querySelector('.dq-size')
+        // What the container query actually reads: the bar's CONTENT box, not
+        // the window and not its border box. The bar's own insets are ~19px,
+        // enough to put a rung boundary on the wrong side of a check.
+        const pad = getComputedStyle(bar)
+        const inline =
+          bar.clientWidth -
+          parseFloat(pad.paddingLeft) -
+          parseFloat(pad.paddingRight)
         return {
+          // The ladder's rungs are container widths, and the container is the
+          // bar rather than the window — the sidebar takes the difference.
+          bar: Math.round(inline),
           overflow: Math.round(bar.scrollWidth - bar.clientWidth),
           spill: Math.round(spill),
           settings: inside(bar.querySelector('button[title="Settings"]')),
           stats: inside(bar.querySelector('.tb-stats-btn')),
           undo: inside(bar.querySelector('.uc-btn--undo')),
+          size: Boolean(size) && size.getBoundingClientRect().width > 0,
         }
       })
 
@@ -210,6 +223,16 @@ test.describe.serial('duplicates queue (§21)', () => {
       expect(fit.settings, `Settings is off the bar at ${width}px`).toBe(true)
       expect(fit.stats, `the stats toggle is off the bar at ${width}px`).toBe(true)
       expect(fit.undo, `undo is off the bar at ${width}px`).toBe(true)
+      // The size slider is the one control on this bar that HIDES rather than
+      // folds, so it is the one the ladder must not spend early: above its
+      // rung it is still there. Asserted against the measured bar width, not
+      // the window's, because that is what the container query reads.
+      if (fit.bar > 1040) {
+        expect(
+          fit.size,
+          `the size slider is gone with ${fit.bar}px of bar (rung is 1040)`,
+        ).toBe(true)
+      }
     }
   })
 

--- a/frontend/src/components/panels/TbOverflowMenu.vue
+++ b/frontend/src/components/panels/TbOverflowMenu.vue
@@ -116,7 +116,7 @@ defineExpose({ close, isOpen });
 
 /* The trigger appears with the host's FIRST fold step, and the host owns that
    rule from its own ladder (`.tb-overflow` at selbar ≤700, `.dq-overflow` at
-   dqbar ≤1040): only the host knows when its first control folds. The rule
+   dqbar ≤1180): only the host knows when its first control folds. The rule
    lives there rather than here because the breakpoint differs per bar. */
 
 /* Mirrors `.bar-btn` from the hosts' bars (their scoped styles cannot cross

--- a/frontend/src/components/views/DuplicateQueue.test.js
+++ b/frontend/src/components/views/DuplicateQueue.test.js
@@ -996,7 +996,7 @@ describe("DuplicateQueue — the shell chrome", () => {
   });
 
   // Fold = CSS both ways: every control the ⋯ collapses exists as a bar
-  // button AND as a row, and the container query at ≤1040 flips which of the
+  // button AND as a row, and the container query at ≤1180 flips which of the
   // pair is visible. Nothing else may be in there — the tier gate, the scope
   // pill, the count and the app-wide tail all stay on the bar at every width.
   it("carries a row for each folded page toggle and nothing else", async () => {
@@ -1018,7 +1018,7 @@ describe("DuplicateQueue — the shell chrome", () => {
     // Each row's bar twin carries the fold class that hides it at the same
     // width, so exactly one of the pair is ever on screen.
     for (const toggle of wrapper.findAll(".dq-toolbar .qdecided")) {
-      expect(toggle.classes()).toContain("dq-fold-1040");
+      expect(toggle.classes()).toContain("dq-fold-1180");
     }
     wrapper.unmount();
   });
@@ -1059,26 +1059,26 @@ describe("DuplicateQueue — the shell chrome", () => {
 
     const back = wrapper.find(".dq-toolbar .qdecided");
     expect(back.attributes("aria-label")).toBe("Back to review");
-    expect(back.classes()).not.toContain("dq-fold-1040");
+    expect(back.classes()).not.toContain("dq-fold-1180");
     expect(wrapper.find(".dq-overflow").exists()).toBe(false);
     wrapper.unmount();
   });
 
   // The separator amendments: D-S1's left flank is populated at every width —
-  // by the toggles above 1040 and by the ⋯ that replaces them below it — so
+  // by the toggles above 1180 and by the ⋯ that replaces them below it — so
   // both rules render at all widths and neither carries a fold class.
   it("both separators render at all widths, neither carrying a fold class", async () => {
     const { wrapper } = await mountQueue([group("g1")]);
     const separators = wrapper.findAll(".dq-toolbar .dq-tb-sep");
     expect(separators).toHaveLength(2);
     for (const separator of separators) {
-      expect(separator.classes()).not.toContain("dq-fold-1040");
       expect(separator.classes()).not.toContain("dq-fold-1180");
+      expect(separator.classes()).not.toContain("dq-fold-1040");
     }
     wrapper.unmount();
   });
 
-  // The Decided toggle folds at ≤1040 and compresses to an arrow while it is
+  // The Decided toggle folds at ≤1180 and compresses to an arrow while it is
   // the way back, so it must carry its own accessible name and keep its
   // pressed state at every width.
   it("the Decided toggle exposes its label and keeps aria-pressed", async () => {
@@ -1106,7 +1106,7 @@ describe("DuplicateQueue — the shell chrome", () => {
   });
 
   // The tier trigger's label ellipsizes under pressure and hides entirely at
-  // ≤1040, so the button must carry its own accessible name at every width
+  // ≤1180, so the button must carry its own accessible name at every width
   // (WCAG 4.1.2 — a hidden span would leave it empty).
   it("the tier button exposes its label as title and aria-label", async () => {
     const { wrapper } = await mountQueue([group("g1")]);

--- a/frontend/src/components/views/DuplicateQueue.vue
+++ b/frontend/src/components/views/DuplicateQueue.vue
@@ -63,7 +63,7 @@
         >
         <!-- The flip side of the queue: review what was already decided and
              clear a decision. -->
-        <!-- Folds into the ⋯ at ≤1040 (amendment #4), where it keeps its label
+        <!-- Folds into the ⋯ at ≤1180 (amendment #4), where it keeps its label
              — icon-only, `mdi-history` says nothing on its own. The exception
              is the way BACK: while the Decided page is showing, this button is
              the visible exit from a sub-page, so it stays on the bar and
@@ -74,7 +74,7 @@
           class="qdecided"
           :class="{
             'qdecided--on': store.showingDecided,
-            'dq-fold-1040': pageTogglesFold,
+            'dq-fold-1180': pageTogglesFold,
           }"
           :title="decidedToggleLabel"
           :aria-label="decidedToggleLabel"
@@ -102,7 +102,7 @@
           class="qdecided"
           :class="{
             'qdecided--on': store.showingMixed,
-            'dq-fold-1040': pageTogglesFold,
+            'dq-fold-1180': pageTogglesFold,
           }"
           :title="mixedToggleTitle"
           :aria-label="mixedToggleTitle"
@@ -128,7 +128,7 @@
              toggles and nothing else — the tier gate, the scope pill, the
              count and the app-wide tail all stay on the bar at every width.
              Fold = CSS both ways: a row and its bar button carry the same
-             condition, and the container query at ≤1040 flips which of the
+             condition, and the container query at ≤1180 flips which of the
              pair
              is visible. The panel opens rightward (`align="start"`), because
              this trigger sits near the bar's left edge. -->
@@ -184,7 +184,7 @@
         </TbOverflowMenu>
 
         <!-- Separator D-S1: renders at ALL widths (amendment #2). Its left
-             flank is always populated — by the toggles above 1040, by the ⋯
+             flank is always populated — by the toggles above 1180, by the ⋯
              below it, and on an empty queue by whichever of the two is
              showing. The tail's D-S2 stays at every width too. -->
         <span class="dq-tb-sep" aria-hidden="true"></span>
@@ -197,7 +197,7 @@
           class="dq-tier-wrap"
           @keydown.esc.stop.prevent="closeTierMenu()"
         >
-          <!-- The label ellipsizes under pressure and hides at ≤1040 (the
+          <!-- The label ellipsizes under pressure and hides at ≤1180 (the
                compressed form is [filter icon][chevron], the grid Filter
                trigger's grammar), so the button carries its own accessible
                name at every width — without it the hidden span would leave
@@ -257,7 +257,7 @@
              so a size control there would be a control with nothing to buy. -->
         <div
           v-if="store.hasGroups && !store.showingMixed"
-          class="dq-size dq-fold-1180"
+          class="dq-size dq-fold-1040"
         >
           <v-icon size="16" aria-hidden="true"
             >mdi-image-size-select-large</v-icon
@@ -281,7 +281,7 @@
 
         <!-- Compresses with the bar rather than folding: a bulk action with
              an accent fill must stay a visible target. Full label → short
-             "Auto-stack N" (≤1180) → icon + count (≤820), the sentence
+             "Auto-stack N" (≤1040) → icon + count (≤820), the sentence
              surviving as tooltip and accessible name throughout. -->
         <button
           v-if="store.exactCount > 0 && !readOnly && !store.showingMixed"
@@ -312,7 +312,7 @@
              the app-wide tail never folds at any width. The queue's own ⋯
              lives in the left group, where the controls it collapses stood.
              Auto-stack compresses to an icon form and the size slider hides
-             at ≤1180, its value persisting in the store. -->
+             at ≤1040, its value persisting in the store. -->
         <UndoControl />
         <TbGlobalActions @open-settings="emit('open-settings')" />
       </div>
@@ -1166,7 +1166,7 @@ const maxSizeLevel = MAX_THUMBNAIL_SIZE_LEVEL;
 const sizeLabel = computed(() => sizeLabelForLevel(store.sizeLevel));
 
 /**
- * Whether the two page toggles are the kind that folds into the ⋯ at ≤1040.
+ * Whether the two page toggles are the kind that folds into the ⋯ at ≤1180.
  * They are, on the review queue, where both are forward navigation. On the
  * Decided and Mixed pages the surviving toggle reads "Back to review" and is
  * the visible way out of a sub-page, so it stays on the bar (amendment #4) —
@@ -1177,7 +1177,7 @@ const pageTogglesFold = computed(
 );
 
 /** What the Decided toggle says: the visible label on a wide bar, the
- * tooltip and accessible name at every width (folded into the ⋯ at ≤1040). */
+ * tooltip and accessible name at every width (folded into the ⋯ at ≤1180). */
 const decidedToggleLabel = computed(() =>
   store.showingDecided ? "Back to review" : "Decided",
 );
@@ -3484,7 +3484,7 @@ defineExpose({ windowedGroups, tierLabel });
 
 /* ── The collapse ladder (docs/design/toolbar-responsive-decisions.md,
    amendment #4, which measured what amendment #2 assumed). The ⋯ takes the
-   two page toggles at ≤1040; everything else compresses or hides in its own
+   two page toggles at ≤1180; everything else compresses or hides in its own
    group. Floor: count (ellipsizing), ⋯, separator, tier gate (icon +
    chevron), scope pill (compressed, if scoped), Auto-stack (icon + count, if
    present), separator, Undo, Settings, Stats — measured clean down to 320px
@@ -3520,29 +3520,15 @@ defineExpose({ windowedGroups, tierLabel });
   }
 }
 
-/* Rung 2. The size control goes entirely — no replacement row: the value
-   persists in the store and comes back with the width — and Auto-stack drops
-   its sentence for "Auto-stack N", the full one surviving as its tooltip and
-   accessible name. */
+/* Rung 2. What has somewhere to go, goes first: the page toggles fold into
+   the ⋯, which appears in their place, and that buys more bar (~346px) than
+   anything else on it. A toggle showing "Back to review" never carries the
+   fold class, so the way out of a sub-page stays on the bar and compresses to
+   its arrow. The tier trigger compresses to [filter icon][chevron] in the same
+   step, the grid Filter trigger's grammar; its title/aria-label carry the
+   name. */
 @container dqbar (max-width: 1180px) {
   .dq-fold-1180 {
-    display: none;
-  }
-  .dq-auto-full {
-    display: none;
-  }
-  .dq-auto-short {
-    display: inline;
-  }
-}
-
-/* Rung 3. The page toggles fold into the ⋯, which appears in their place; a
-   toggle showing "Back to review" never carries the fold class, so the way
-   out of a sub-page stays on the bar and compresses to its arrow. The tier
-   trigger compresses to [filter icon][chevron] in the same step, the grid
-   Filter trigger's grammar; its title/aria-label carry the name. */
-@container dqbar (max-width: 1040px) {
-  .dq-fold-1040 {
     display: none;
   }
   .dq-overflow {
@@ -3555,6 +3541,24 @@ defineExpose({ windowedGroups, tierLabel });
      says what it does without its label. */
   .qdecided-label {
     display: none;
+  }
+}
+
+/* Rung 3, and the size control is here rather than a rung earlier for a
+   reason: it has no fold destination, so hiding it costs the user the control
+   outright, while the toggles above only move. It goes when the folding has
+   run out — no replacement row, the value persists in the store and comes back
+   with the width — and Auto-stack drops its sentence for "Auto-stack N" in the
+   same step, the full one surviving as its tooltip and accessible name. */
+@container dqbar (max-width: 1040px) {
+  .dq-fold-1040 {
+    display: none;
+  }
+  .dq-auto-full {
+    display: none;
+  }
+  .dq-auto-short {
+    display: inline;
   }
 }
 


### PR DESCRIPTION
Closes #1009.

## What was wrong

The Duplicates toolbar has never fitted its own container at any width. Two causes, both structural:

1. **Nothing in the bar could shrink.** `.dq-tb-left` and `.dq-tb-right` were flex items at the default `min-width: auto` over `white-space: nowrap` content, so both kept their intrinsic width whatever the container did. The surplus left through the right edge, and the last children in DOM order are the ones that walk off it: Settings, then the stats toggle, then undo. They did not fold, they vanished, with no signifier that anything was missing.
2. **The ladder's rungs were above its own floor.** The shipped steps (860/720/600) were placed from an inventory rather than a measurement. After all of them the bar still measured ~690px at the 600px breakpoint, so it never converged.

Measured by rendering the shipped markup and `<style>` blocks in Chromium and stepping the container width:

| bar width | overflow | Settings | Stats |
|---|---|---|---|
| 1400 | 170px | clipped | clipped |
| 860 | 504px | clipped | clipped |
| 720 | 149px | clipped | clipped |
| 600 | 92px | clipped | clipped |

## What changed

**A shrink chain under the ladder, which is the actual guarantee.** The left group takes `min-width: 0; flex: 0 1 auto` and its text members ellipsize; the right group takes `flex: 0 0 auto`. The app-wide tail is then unreachable by any content the left group can hold, including a scope named by the user or a seven-digit count. Not `overflow: hidden` on the bar: the tier popover and the burger panel are absolutely positioned inside it and would be clipped away.

**The burger comes back, for the left group's page toggles only.** Amendment #2 dissolved it on principle ("a burger may only collapse controls from its own visual group"); the principle stands, its conclusion does not. The ⋯ sits at the end of the toggle run and holds Decided and Mixed stacks as labelled rows. That is both narrower than the icon-only pair and more legible: `mdi-history` and `mdi-alert-outline` unlabelled are mystery meat, and an alert glyph on a bare bar reads as an error rather than as a place to go. A toggle reading **"Back to review" never folds** — it is the visible way out of a sub-page (Nielsen #3), and it compresses to its arrow instead.

**Every rung re-placed where the measurement puts it**, with the worst content the bar can hold (scope in force, exact matches to auto-stack, mixed stacks waiting):

| rung | what gives | content after |
|---|---|---|
| — | everything on the bar | 1577px |
| ≤1400 | the session tally, the size value label | 1372px |
| ≤1180 | the size control, Auto-stack's sentence | 1153px |
| ≤1040 | the page toggles → ⋯, the tier label | 807px |
| ≤820 | Auto-stack → flash + count, the scope pill → icon + dismiss | 630px |
| ≤480 / ≤420 | shared undo chevron / redo; the runs' gaps tighten | 522px |

Between rungs the count headline takes the difference: it ellipsizes from the right, so the number survives and "groups to review" is what goes (`flex-shrink: 6` buys that order — a clipped tail on a sentence reads better than "Mixed stac…" on a button).

After: no overflow, no overlap, and Settings, Stats and undo inside the bar at **every width from 320 to 1600** with that same worst-case content.

Also here: the scope pill's label now *clips* rather than `display: none` at its rung, so the scope's name survives for a screen reader; `TbOverflowMenu` gained an `align` prop (a right-anchored 220px panel on a trigger this close to the left edge would open off-screen) and an `isOpen()` so the queue's keyboard can tell an open menu from a focused trigger.

Design decisions and the measurements are recorded as amendment #4 in `docs/design/toolbar-responsive-decisions.md`, which now also carries a "read as a log" header, since it had two contradictory ladders in it.

## Verification, and its boundary

- Full frontend suite green (2556 tests), eslint clean, build clean.
- New unit cases: the rows mirror their buttons and share their accessible names, the fold classes, the "Back to review" exception (and the ⋯ not mounting when it would be empty), the tail's order with the ⋯ in the left group, and the queue's keys ceding to an open menu but not to a closed trigger. Each was checked to fail with the logic inverted.
- New browser case in `e2e/specs/dedup.spec.js` asserting no overflow, no overlap and the tail inside the bar from 1600 down to 800px of window.
- **jsdom evaluates neither container queries nor layout, so no unit test can see this class of bug** — the suite passes unchanged with every rung inverted. That is stated in the design doc rather than left implied, and the rung table was measured in a real browser.

## Reviewer objections raised before pushing, and answered rather than obeyed

An adversarial pass over the diff found nineteen things; the substantive ones are fixed (a duplicated CSS block; a dead `@container` rule that tried to style its own container; the row's accessible name being reduced by name-from-content; the key guard firing on a closed trigger; `.dq-tb-sep` becoming shrinkable once the group shrank; stale breakpoints in comments; several doc claims that outran the code). Three I did not act on, deliberately:

- **The e2e case sits in a `test.describe.serial` block**, so a failure would skip the queue's later functional cases. Kept: the assertions are deterministic layout reads with no timing dependence, the file is serial precisely because every case shares mutable backend state, and a real failure here means the toolbar is broken. Moving it after the block would run it against an emptied queue and guard nothing.
- **The e2e case runs unscoped and stops at 800px of window**, so the scope pill's rung is not what CI exercises. That boundary is now written into the design doc. Below 800px the shell's sidebar does not respond to width, so a narrower window is a question about the sidebar, not this bar.
- **`TbOverflowMenu`'s panel is `role="menu"` with plain buttons in it** (no `menuitem`, no roving arrow keys). Pre-existing and shared with the grid bar, and the repo's own precedent (`UndoControl`'s popover is `role="dialog"` for exactly this reason) says the fix is to drop the `menu` claim, not to add `menuitem` roles. That is a change to the shared overflow pattern in both bars and wants its own review.

One thing the pass found that is real and **not** fixed here: the grid toolbar has the same latent defect (`.selection-bar-left` / `.selection-bar-right` are still `flex-shrink: 0` with no `min-width: 0`), so it will fail the same way once its content outgrows its ladder. It is out of scope for #1009 and needs its own measurement pass; `frontend_architecture.md` now records it as a known gap rather than claiming both bars are covered.