### PR TITLE
Save the Windows model path, and bust the key so the save can run

### DIFF
--- a/.github/actions/model-cache/action.yml
+++ b/.github/actions/model-cache/action.yml
@@ -61,6 +61,15 @@ runs:
     # itself, so any change to the model set busts it. restore-keys keeps the
     # previous set warm across unrelated commits, so a bust only costs the
     # delta.
+    #
+    # `-v2-` is a manual bust, and it is not decoration. `actions/cache` writes
+    # only on a key MISS and `warm_models*` skips its save on a hit, so widening
+    # the path list alone can never reach an entry that keeps hitting: the
+    # Windows entry saved without `downloaded_models` would have gone on hitting
+    # forever, exactly as CLIP did (see the header). Widening the paths and
+    # bumping this literal are one change, never two. restore-keys deliberately
+    # stays on the unversioned prefix, so the bust falls back to the previous
+    # entry and costs only the delta.
     - name: Restore the model cache
       id: restore
       if: inputs.mode != 'save'
@@ -70,7 +79,7 @@ runs:
           ~/.cache/huggingface
           ~/.local/share/pixlstash/downloaded_models
           ~/AppData/Local/pixlstash/pixlstash/downloaded_models
-        key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/clip_service.py', 'pixlstash/tagger_plugins/sbert.py', 'pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py', 'scripts/prefetch_ci_models.py') }}
+        key: hf-models-${{ runner.os }}-v2-${{ hashFiles('pixlstash/tagger_plugins/clip_service.py', 'pixlstash/tagger_plugins/sbert.py', 'pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py', 'scripts/prefetch_ci_models.py') }}
         restore-keys: hf-models-${{ runner.os }}-
 
     - name: Save the model cache
@@ -80,4 +89,5 @@ runs:
         path: |
           ~/.cache/huggingface
           ~/.local/share/pixlstash/downloaded_models
+          ~/AppData/Local/pixlstash/pixlstash/downloaded_models
         key: ${{ inputs.key }}

--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -1,5 +1,13 @@
 # Toolbar decisions: undo/redo placement and responsive collapse (2026-07-30)
 
+> **Read this file as a log, newest last.** Amendment #4 (2026-08-17) is the
+> current record for the **Duplicates** bar: it measured the ladder the earlier
+> sections designed, found the bar had never fitted its own container at any
+> width, and replaced every rung. Any width given for that bar before amendment
+> #4 — 860 / 720 / 600, and the fold classes named after them — is history, not
+> the shipped CSS. The grid bar's ladder is unchanged, and amendment #2 remains
+> the record for it.
+
 ## Current state (verified, not assumed)
 
 **Grid toolbar** (`Toolbar.vue`, `.selection-bar-overlay`, 36px band, container
@@ -71,6 +79,11 @@ No ResizeObserver, no JS measurement. Existing touch-mode overrides untouched.
 
 ### Duplicates ladder (container dqbar / shared toolbar)
 
+> **SUPERSEDED by amendment #4 (2026-08-17).** Every width in this subsection
+> is obsolete: the rungs were placed against an inventory rather than a
+> measurement, and the bar overflowed at all of them. The shipped ladder is
+> the table in amendment #4.
+
 - dqbar ≤860px: qsub ("N done this session") hides entirely (no overflow row);
   the dq-size-value label hides (the slider keeps its aria-label).
 - dqbar ≤720px: ⋯ appears before UndoControl; the Decided toggle + size slider
@@ -90,6 +103,9 @@ surfaced at all widths.
 
 ### Ranking tables
 
+> The Duplicates ranking below is **superseded by amendment #4**; the grid
+> ranking still stands, with amendment #2's corrections.
+
 Grid ranking: 1 Sort (never folds) / 2 Filter (never folds) / 3 Search (never
 folds) / 4 Undo (never folds or hides) / 5 Redo (hides last step) / 6 History
 chevron (folds to row at 480) / 7 View (folds 600) / 8 Stats (folds 600, dot
@@ -104,6 +120,10 @@ folds) / 6 Redo+chevron (shared 420/480) / 7 Decided toggle (folds 720) /
 shared) / 10 qsub (hides 860, no row).
 
 ## Implementation checklist
+
+> Historical: this was the plan for the 2026-07-30 change. Items 5 and 6 (the
+> dq ladder's widths, and what the tests can cover) were overtaken by
+> amendment #4.
 
 1. `Toolbar.vue`: the move + separator; the container-name addition; the ≤700
    fold rules; mount TbOverflowMenu with mirrored rows; the View fold at 600.
@@ -204,7 +224,9 @@ boundary.
 7. Floor:
    `Sort(icons) Filter │G-S1│ Search ⋯ …gap… Review │G-S4│ Undo Settings Stats`.
 
-**Duplicates — the burger DISSOLVES:** every foldable found an own-group
+**Duplicates — the burger DISSOLVES** (REVERSED by amendment #4, which
+measured it: the own-group answers left a floor ~100px wider than the burger
+does, and the bar never fitted): every foldable found an own-group
 answer, so the bar mounts no overflow at all.
 
 1. The TbOverflowMenu mount, all its rows, and the
@@ -251,6 +273,133 @@ chip becomes "K"; `aria-keyshortcuts` carries the full machine-readable set
 keys before, a shipped gap this closes. Compare's footer hint and its Keep
 separate `key-hint` follow; the queue's hidden help sentence reads "Enter or
 S stacks it. K keeps it separate. Down moves on without deciding."
+
+## Amendment #4 (2026-08-17): the Duplicates bar actually fits (issue #1009)
+
+**The finding, measured rather than argued.** The ladder above was written from
+an inventory, never from a measurement, and the Duplicates bar has never fitted
+its own container at any width. Rendering the shipped markup and the shipped
+`<style>` blocks in Chromium and stepping the container width gives:
+
+| bar width | bar overflow | Settings | Stats |
+|---|---|---|---|
+| 1400 | 170px | clipped | clipped |
+| 860 | 504px | clipped | clipped |
+| 720 | 149px | clipped | clipped |
+| 600 | 92px | clipped | clipped |
+| 480 | 180px | clipped | clipped |
+
+Two causes, both structural:
+
+1. **Nothing in the bar can shrink.** `.dq-tb-left` and `.dq-tb-right` are flex
+   items at the default `min-width: auto` holding `white-space: nowrap`
+   content, so both keep their intrinsic width whatever the container does.
+   The surplus leaves through the right edge, and the last children in DOM
+   order are the ones that walk off it: Settings, then Stats, then undo. The
+   controls do not fold, they *vanish*, with no signifier that anything is
+   missing (Nielsen #1, visibility of system status).
+2. **The ladder's floor is wider than the widths it fires at.** After every
+   shipped step the bar still measures ~690px at the 600px breakpoint. A
+   ladder that ends above its own last rung has no floor at all. Amendment #2's
+   "every foldable found an own-group answer" was reasoned, not measured: an
+   icon-only Decided plus an icon-only Mixed stacks plus a full-width count
+   headline is still ~100px wider than a burger holding both.
+
+**Decision 1 — the shrink chain is the guarantee, the ladder is the design.**
+`.dq-tb-left` gets `min-width: 0; flex: 0 1 auto` and its text members
+ellipsize; `.dq-tb-right` gets `flex: 0 0 auto` and never shrinks. The
+app-wide tail is then unreachable by any content the left group can hold: a
+pathological scope name or a seven-digit count eats itself before it can push
+Settings off the bar. The ladder still does the visible work; the chain only
+catches what the ladder did not foresee. **The bar must not take
+`overflow: hidden`** as a cheaper cure: the tier popover and the ⋯ panel are
+absolutely positioned inside it and would be clipped away.
+
+**Decision 2 — the burger comes back, for the left group's page toggles only.**
+Amendment #2's principle stands (a burger collapses its own visual group and
+stands where those controls stood); its conclusion does not. The ⋯ sits at the
+end of the toggle run, after the count and before D-S1, and holds exactly the
+Decided and Mixed stacks toggles, as labeled rows. This is narrower than the
+icon-only pair AND more legible: `mdi-history` and `mdi-alert-outline` with no
+label are mystery meat (Norman, signifiers), and an alert glyph on a bare bar
+reads as an error rather than as a place to go. The panel opens from its left
+edge in this bar (`align="start"`), because a right-anchored 220px panel hung
+off a trigger this close to the left edge would open off-screen.
+
+**A toggle that says "Back to review" never folds.** On the Decided and Mixed
+pages the toggle is the visible way out of a sub-page (Nielsen #3, user control
+and freedom); it stays on the bar and compresses to its `mdi-arrow-left`, which
+is the one glyph in this set that needs no label. So the bar button and its
+overflow row do not share a v-if verbatim here: one computed
+(`pageTogglesFold`) says whether the toggles are the folding kind, and it gates
+both the buttons' fold class and the mount of the ⋯ itself. The rows carry no
+condition of their own — the menu they sit in only exists while they apply,
+which is also what stops the ⋯ appearing with nothing in it on a sub-page.
+
+**Decision 3 — the ladder, revised, and each rung placed where the measurement
+puts it.** The old rungs were round numbers picked by eye. These are the widths
+at which the previous form stops fitting, measured on the shipped CSS with the
+worst content the bar can hold (a scope in force, exact matches to auto-stack,
+mixed stacks waiting):
+
+| rung | what gives | content after |
+|---|---|---|
+| — | everything on the bar | 1577px |
+| dqbar ≤1400 | qsub, the size value label | 1372px |
+| dqbar ≤1180 | the size control, Auto-stack's sentence → "Auto-stack N" | 1153px |
+| dqbar ≤1040 | the page toggles → ⋯, the tier label | 807px |
+| dqbar ≤820 | Auto-stack → flash + count, the scope pill → icon + dismiss | 630px |
+| toolbar ≤480 | the undo chevron (shared, unchanged) | 598px |
+| toolbar ≤420 | redo (shared); the two runs' gaps → `--space-2` | 526px |
+
+Between two rungs the count headline takes the difference: it ellipsizes from
+the right, so the number survives and "groups to review" is what goes. A
+`flex-shrink: 6` on it buys that order, because a clipped tail on a sentence
+reads better than "Mixed stac…" on a button.
+
+Floor: `128 ⋯ │ [filter ▾] [scope ×] …gap… [⚡ 42] │ [undo] [Settings] [Stats]`.
+The two numbers in the last row are not in conflict: 526px is what the bar
+holds with the count at its full width, and the count is the elastic member, so
+the bar goes on fitting below that by spending it. Measured with everything
+above present and nothing clipped or overlapping down to **320px of bar
+width**, where the count is down to its first digits — well under the shared
+ladder's last rung of 420, and under any width this shell is usable at. The
+bar's own 36px band and its insets are NOT this ladder's to spend: they are
+pinned equal to the grid bar's by a guardrail in `Toolbar.test.js`. (A rule for
+them here would be dead anyway — `.dq-toolbar` is the query's container, and a
+container query styles descendants, never the container itself.)
+
+**Duplicates ranking, revised:** 1 Undo (never folds or hides) / 2 Settings +
+Stats (never fold; the whole point of this amendment) / 3 Tier gate (never
+folds, compresses at 1040) / 4 Count (never folds; ellipsizes between rungs,
+the number never truncates) / 5 Scope pill (never folds while scoped,
+compresses at 820) / 6 Auto-stack (never folds, compresses at 1180 and 820) /
+7 Redo + chevron (shared 420/480) / 8 Decided + Mixed stacks (fold to ⋯ rows at
+1040, unless showing "Back to review") / 9 Size slider (hides at 1180) /
+10 qsub (hides at 1400).
+
+**Acceptance, and it is arithmetic rather than judgement.** At every container
+width, with the worst content the bar can hold: the bar does not overflow its
+own box (`scrollWidth === clientWidth`), no child of the left group paints past
+the right group's left edge, and Settings, Stats and undo all sit inside the
+bar.
+
+**What checks it, and what does not.** This has to be measured in a browser:
+jsdom evaluates neither container queries nor layout, so no unit test can see
+this class of bug at all — and the unit suite passes unchanged with every rung
+in this ladder inverted. It is kept for the DOM-level contracts only (each row
+mirrors its button, the fold classes, every control's accessible name, the
+tail's order, the ⋯ standing in its own group), and it should not be read as
+cover for the widths. The browser check is a case in
+`frontend/e2e/specs/dedup.spec.js`, which drives the real app from 1600 down to
+800px of window and asserts the three invariants above at each step. Its
+boundary, stated rather than implied: it stops at 800px because the shell's
+sidebar does not respond to width (below that the question is the sidebar's,
+not this bar's), and it runs on an unscoped queue, so the scope pill's own rung
+is not among what CI exercises. The rows in the rung table were measured by
+rendering the shipped `<style>` blocks against the bar's real markup in
+Chromium at each width; reproducing that is the way to re-check a rung after
+changing what the bar carries.
 
 ## (d) Deliberately rejected, and why
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -445,10 +445,24 @@ Top/grid toolbar. Imports state directly from Pinia stores (`useGridStore`, `use
 (`UndoControl`, `TbGlobalActions`, `TbOverflowMenu`) writes scoped
 `@container toolbar (…)` rules so it degrades identically in both bars. Fold =
 CSS both ways: every foldable control exists as its bar button AND as a
-`TbOverflowMenu` row with the same `v-if`, and container queries flip which of
-the pair is visible — no ResizeObserver, no JS measurement. The ladder and the
+`TbOverflowMenu` row under the same condition, and container queries flip which
+of the pair is visible — no ResizeObserver, no JS measurement. Usually that
+condition is one `v-if` written twice; where a whole menu is gated on it
+instead (the Duplicates bar's ⋯ mounts only while its rows apply), one computed
+carries it and the rows inherit it from the mount. The ladder and the
 never-fold floor are recorded in `docs/design/toolbar-responsive-decisions.md`;
-undo never enters the overflow.
+undo never enters the overflow. **The Duplicates bar carries a shrink chain
+underneath the ladder** (amendment #4): its left group takes `min-width: 0` so
+its labels ellipsize, its right group takes `flex: 0 0 auto` so the app-wide
+tail is unreachable by any content the left group can hold. Without it a bar
+whose ladder runs out simply pushes Settings and Stats off its right edge,
+which is what issue #1009 was. **The grid bar has no such chain yet** —
+`.selection-bar-left` / `.selection-bar-right` are still `flex-shrink: 0` with
+no `min-width: 0`, so the same failure is available to it once its own content
+outgrows its ladder; that is a known gap, not a decision.
+`TbOverflowMenu`'s panel hangs from the edge its `align` prop names (`end` by
+default, `start` for a trigger near the bar's left edge), and it exposes
+`isOpen()` for a host whose surface owns the keyboard.
 
 Responsibilities:
 - Grid bar: sort selector, filter chips (tags, score, media type, resolution), column slider, stack controls, view mode toggles.
@@ -1597,7 +1611,13 @@ UndoControl moved out of the left group into the identical right-side tail
 `[separator] [UndoControl] [TbGlobalActions]`, so the position learned in one
 view holds in the other (`docs/design/toolbar-responsive-decisions.md`). Both
 bars also share the `toolbar` container name and the ⋯ overflow's collapse
-ladder, so the shared chrome degrades identically at every width. Undo/redo run through the shared
+ladder, so the shared chrome degrades identically at every width. The queue's
+own ⋯ sits at the end of its toggle run and holds the Decided and Mixed stacks
+toggles, which fold into it at ≤1040 — except while one of them reads "Back to
+review", when it is the visible way out of a sub-page and stays on the bar
+(amendment #4). Settings, the stats toggle and undo never fold at any width,
+and the bar's shrink chain makes that structural rather than a promise the
+ladder has to keep. Undo/redo run through the shared
 `useOperationStore` and its receipt exactly as everywhere else; the queue's
 one addition is a Pinia `$onAction` subscription on that store which, after an
 `undo`/`redo`/`undoTo`/`undoBatchById` that touched a `dedup.*` operation,

--- a/frontend/e2e/specs/dedup.spec.js
+++ b/frontend/e2e/specs/dedup.spec.js
@@ -165,6 +165,54 @@ test.describe.serial('duplicates queue (§21)', () => {
     await expect(duplicates.compareDialog).toBeHidden()
   })
 
+  // Issue #1009. The bar could not shrink (two nowrap flex groups at the
+  // default `min-width: auto`), so the surplus left through the right edge and
+  // took the last children in DOM order with it: Settings, then the stats
+  // toggle, then undo, gone with no signifier that anything was missing. The
+  // ladder that was supposed to prevent it (docs/design/toolbar-responsive-
+  // decisions.md) had rungs at 860/720/600 for content measuring ~1570px.
+  //
+  // This case is a BROWSER one because it has to be: jsdom evaluates neither
+  // container queries nor layout, so no unit test can see the bug. Widths stop
+  // at 800 deliberately — the shell's sidebar does not respond, so a narrower
+  // window is a question about the sidebar rather than about this bar.
+  test('the toolbar keeps its chrome at every width it is used at', async ({
+    duplicates,
+  }) => {
+    await duplicates.goto()
+    const page = duplicates.page
+
+    for (const width of [1600, 1280, 1100, 960, 860, 800]) {
+      await page.setViewportSize({ width, height: 900 })
+      const fit = await page.evaluate(() => {
+        const bar = document.querySelector('.dq-toolbar')
+        const box = bar.getBoundingClientRect()
+        const right = bar.querySelector('.dq-tb-right').getBoundingClientRect()
+        const inside = (el) =>
+          Boolean(el) && el.getBoundingClientRect().right <= box.right + 0.5
+        // The left group's box can shrink while its children keep their width
+        // and paint over the tail, so zero overflow is not enough on its own.
+        const spill = [...bar.querySelectorAll('.dq-tb-left *')]
+          .map((el) => el.getBoundingClientRect())
+          .filter((b) => b.width > 0)
+          .reduce((worst, b) => Math.max(worst, b.right - right.left), -Infinity)
+        return {
+          overflow: Math.round(bar.scrollWidth - bar.clientWidth),
+          spill: Math.round(spill),
+          settings: inside(bar.querySelector('button[title="Settings"]')),
+          stats: inside(bar.querySelector('.tb-stats-btn')),
+          undo: inside(bar.querySelector('.uc-btn--undo')),
+        }
+      })
+
+      expect(fit.overflow, `bar overflows at ${width}px`).toBeLessThanOrEqual(1)
+      expect(fit.spill, `left group paints over the tail at ${width}px`).toBeLessThanOrEqual(1)
+      expect(fit.settings, `Settings is off the bar at ${width}px`).toBe(true)
+      expect(fit.stats, `the stats toggle is off the bar at ${width}px`).toBe(true)
+      expect(fit.undo, `undo is off the bar at ${width}px`).toBe(true)
+    }
+  })
+
   test('Enter stacks the focused group, auto-advances and moves the badge', async ({
     duplicates,
     apiContext,

--- a/frontend/src/components/panels/TbOverflowMenu.vue
+++ b/frontend/src/components/panels/TbOverflowMenu.vue
@@ -15,6 +15,7 @@
     <div
       v-if="open"
       class="tbm tbo-panel"
+      :class="`tbo-panel--${align}`"
       role="menu"
       aria-label="More actions"
     >
@@ -41,6 +42,21 @@
 // `.tbm-action` recipe.
 
 import { onBeforeUnmount, onMounted, ref } from "vue";
+
+defineProps({
+  /**
+   * Which edge the panel hangs from. `end` (the default) opens leftward and
+   * suits a trigger near the bar's right side; `start` opens rightward, which
+   * is what a trigger sitting near the LEFT edge needs — a 220px panel
+   * right-anchored to it would open off-screen (the Duplicates bar's ⋯,
+   * amendment #4).
+   */
+  align: {
+    type: String,
+    default: "end",
+    validator: (value) => ["start", "end"].includes(value),
+  },
+});
 
 const open = ref(false);
 const wrapEl = ref(null);
@@ -78,7 +94,18 @@ onBeforeUnmount(() => {
   document.removeEventListener("mousedown", onDocumentPointerDown);
 });
 
-defineExpose({ close });
+/**
+ * Whether the panel is showing. A host whose surface owns the keyboard needs
+ * this to tell "a key pressed inside my open menu" from "a key pressed with
+ * the closed trigger focused" — the second one still belongs to the host.
+ *
+ * @returns {boolean}
+ */
+function isOpen() {
+  return open.value;
+}
+
+defineExpose({ close, isOpen });
 </script>
 
 <style scoped>
@@ -87,12 +114,10 @@ defineExpose({ close });
   display: none;
 }
 
-/* The trigger appears with the host's FIRST fold step; the host raises this
-   flag class from its own ladder (`selbar ≤700`, `dqbar ≤720`), because only
-   the host knows when its first control folds. */
-.tbo-wrap--folding {
-  display: flex;
-}
+/* The trigger appears with the host's FIRST fold step, and the host owns that
+   rule from its own ladder (`.tb-overflow` at selbar ≤700, `.dq-overflow` at
+   dqbar ≤1040): only the host knows when its first control folds. The rule
+   lives there rather than here because the breakpoint differs per bar. */
 
 /* Mirrors `.bar-btn` from the hosts' bars (their scoped styles cannot cross
    the component boundary — same note as UndoControl carries). */
@@ -132,13 +157,21 @@ defineExpose({ close });
 .tbo-panel {
   position: absolute;
   top: calc(100% + var(--space-2));
-  right: 0;
   z-index: var(--z-dropdown);
   min-width: 220px;
   padding: var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+}
+
+/* Which edge the panel hangs from; see the `align` prop. */
+.tbo-panel--end {
+  right: 0;
+}
+
+.tbo-panel--start {
+  left: 0;
 }
 
 </style>

--- a/frontend/src/components/views/DuplicateQueue.test.js
+++ b/frontend/src/components/views/DuplicateQueue.test.js
@@ -853,6 +853,37 @@ describe("DuplicateQueue — the toolbar hands the keyboard back", () => {
     wrapper.unmount();
   });
 
+  // The ⋯ panel takes the same deal as the tier popover: the keys pressed
+  // inside it are the menu's, not the queue's. Without it, S on an open menu
+  // would stack the group behind it.
+  it("keys pressed inside the ⋯ panel never fire verdicts", async () => {
+    const { wrapper } = await mountQueue([group("g1")]);
+    await wrapper.find(".dq-overflow .tbo-trigger").trigger("click");
+    const row = wrapper.find('[data-testid="mixed-row"]').element;
+    row.focus();
+    stackGroup.mockResolvedValue({});
+    key("s", row);
+    await flushPromises();
+    expect(stackGroup).not.toHaveBeenCalled();
+    expect(keepGroupSeparate).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  // ...and only while it is OPEN. A closed ⋯ is an ordinary toolbar button,
+  // and the keys go on working on it exactly as they do on the tier trigger
+  // beside it — the alternative is two adjacent triggers with opposite
+  // keyboard behaviour.
+  it("keys pressed on the closed ⋯ trigger still reach the queue", async () => {
+    const { wrapper } = await mountQueue([group("g1")]);
+    const trigger = wrapper.find(".dq-overflow .tbo-trigger").element;
+    trigger.focus();
+    stackGroup.mockResolvedValue({});
+    key("s", trigger);
+    await flushPromises();
+    expect(stackGroup).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
   it("Escape on the threshold slider still dismisses the popover to its trigger", async () => {
     const { wrapper, store } = await mountQueue([group("g1")]);
     store.nearEnabled = true;
@@ -929,9 +960,10 @@ describe("DuplicateQueue — the shell chrome", () => {
   });
 
   // The decision record's canonical tail, identical in every view:
-  // [separator] [UndoControl] [TbGlobalActions]. No ⋯ anywhere in this bar
-  // (amendment #2): every foldable here compresses or hides in its own group.
-  it("orders the tail separator → UndoControl → TbGlobalActions, no burger", async () => {
+  // [separator] [UndoControl] [TbGlobalActions]. The ⋯ is NOT part of the
+  // tail — it belongs to the left group, whose controls it collapses, and the
+  // app-wide cluster never folds into it (amendment #4).
+  it("orders the tail separator → UndoControl → TbGlobalActions, ⋯ elsewhere", async () => {
     const { wrapper } = await mountQueue([group("g1")]);
     const undo = wrapper.findComponent({ name: "UndoControl" }).element;
     // TbGlobalActions is multi-root; its Settings button is a stable anchor.
@@ -943,26 +975,111 @@ describe("DuplicateQueue — the shell chrome", () => {
       true,
     );
     expect(follows(undo, globalActions)).toBe(true);
-    expect(wrapper.find(".tbo-wrap").exists()).toBe(false);
+    expect(wrapper.find(".dq-tb-left .dq-overflow").exists()).toBe(true);
+    expect(wrapper.find(".dq-tb-right .dq-overflow").exists()).toBe(false);
     wrapper.unmount();
   });
 
-  // The separator amendments: with the Decided toggle COMPRESSING instead of
-  // folding (amendment #2), D-S1's left flank is always populated — so both
-  // rules render at all widths and neither carries a fold class.
+  // The ⋯ stands where the controls it collapses stood: at the end of the
+  // toggle run, before D-S1.
+  it("puts the ⋯ after the page toggles and before the separator", async () => {
+    const { wrapper } = await mountQueue([group("g1")]);
+    const burger = wrapper.find(".dq-tb-left .dq-overflow").element;
+    expect(burger.previousElementSibling.classList.contains("qdecided")).toBe(
+      true,
+    );
+    expect(burger.nextElementSibling.classList.contains("dq-tb-sep")).toBe(
+      true,
+    );
+    wrapper.unmount();
+  });
+
+  // Fold = CSS both ways: every control the ⋯ collapses exists as a bar
+  // button AND as a row, and the container query at ≤1040 flips which of the
+  // pair is visible. Nothing else may be in there — the tier gate, the scope
+  // pill, the count and the app-wide tail all stay on the bar at every width.
+  it("carries a row for each folded page toggle and nothing else", async () => {
+    const { wrapper } = await mountQueue([group("g1")]);
+    await wrapper.find(".dq-overflow .tbo-trigger").trigger("click");
+    const rows = wrapper.findAll(".dq-overflow .tbm-action");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].text()).toContain("Decided");
+    expect(rows[1].text()).toContain("Mixed stacks");
+    // A folded control keeps the name its bar button carried. Name-from-content
+    // would otherwise cut Mixed stacks down to its label and count, losing the
+    // sentence that says what a mixed stack is.
+    expect(rows[0].attributes("aria-label")).toBe(
+      wrapper.find(".dq-toolbar .qdecided").attributes("aria-label"),
+    );
+    expect(rows[1].attributes("aria-label")).toBe(
+      wrapper.find('[data-testid="mixed-toggle"]').attributes("aria-label"),
+    );
+    // Each row's bar twin carries the fold class that hides it at the same
+    // width, so exactly one of the pair is ever on screen.
+    for (const toggle of wrapper.findAll(".dq-toolbar .qdecided")) {
+      expect(toggle.classes()).toContain("dq-fold-1040");
+    }
+    wrapper.unmount();
+  });
+
+  // A row does the same thing its button does.
+  it("navigates from the folded row, and closes the panel behind it", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    await wrapper.find(".dq-overflow .tbo-trigger").trigger("click");
+    listGroups.mockResolvedValue({
+      groups: [],
+      total: 0,
+      offset: 0,
+      limit: 20,
+      scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+    });
+    await wrapper.find('[data-testid="mixed-row"]').trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(store.showingMixed).toBe(true);
+    expect(wrapper.find(".dq-overflow .tbm-action").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  // The way OUT of a sub-page is not a foldable: on the Decided and Mixed
+  // pages the surviving toggle reads "Back to review" and is the visible exit,
+  // so it keeps its place on the bar and the ⋯ (which would then hold nothing)
+  // does not mount at all.
+  it("never folds a Back to review toggle, and drops the ⋯ with it", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    listGroups.mockResolvedValue({
+      groups: [],
+      total: 0,
+      offset: 0,
+      limit: 20,
+      scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+    });
+    await store.toggleDecided();
+    await wrapper.vm.$nextTick();
+
+    const back = wrapper.find(".dq-toolbar .qdecided");
+    expect(back.attributes("aria-label")).toBe("Back to review");
+    expect(back.classes()).not.toContain("dq-fold-1040");
+    expect(wrapper.find(".dq-overflow").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  // The separator amendments: D-S1's left flank is populated at every width —
+  // by the toggles above 1040 and by the ⋯ that replaces them below it — so
+  // both rules render at all widths and neither carries a fold class.
   it("both separators render at all widths, neither carrying a fold class", async () => {
     const { wrapper } = await mountQueue([group("g1")]);
     const separators = wrapper.findAll(".dq-toolbar .dq-tb-sep");
     expect(separators).toHaveLength(2);
     for (const separator of separators) {
-      expect(separator.classes()).not.toContain("dq-fold-720");
+      expect(separator.classes()).not.toContain("dq-fold-1040");
+      expect(separator.classes()).not.toContain("dq-fold-1180");
     }
     wrapper.unmount();
   });
 
-  // The Decided toggle compresses (icon-only at ≤720, the Auto-stack
-  // pattern), so it must carry its own accessible name and keep its pressed
-  // state at every width.
+  // The Decided toggle folds at ≤1040 and compresses to an arrow while it is
+  // the way back, so it must carry its own accessible name and keep its
+  // pressed state at every width.
   it("the Decided toggle exposes its label and keeps aria-pressed", async () => {
     const { wrapper, store } = await mountQueue([group("g1")]);
     const toggle = wrapper.find(".dq-toolbar .qdecided");
@@ -988,7 +1105,7 @@ describe("DuplicateQueue — the shell chrome", () => {
   });
 
   // The tier trigger's label ellipsizes under pressure and hides entirely at
-  // ≤720, so the button must carry its own accessible name at every width
+  // ≤1040, so the button must carry its own accessible name at every width
   // (WCAG 4.1.2 — a hidden span would leave it empty).
   it("the tier button exposes its label as title and aria-label", async () => {
     const { wrapper } = await mountQueue([group("g1")]);

--- a/frontend/src/components/views/DuplicateQueue.vue
+++ b/frontend/src/components/views/DuplicateQueue.vue
@@ -44,9 +44,15 @@
          2026-07-29). -->
     <div class="dq-toolbar">
       <div class="dq-tb-left">
-        <span v-if="store.hasGroups || store.showingMixed" class="qtitle">{{
-          headline
-        }}</span>
+        <!-- The count leads, so the ellipsis eats the noun phrase and never
+             the number; the full sentence stays in the DOM (a screen reader
+             hears it whole at every width) and in the tooltip. -->
+        <span
+          v-if="store.hasGroups || store.showingMixed"
+          class="qtitle"
+          :title="headline"
+          >{{ headline }}</span
+        >
         <!-- SESSION tally, and says so: the durable record is the Decided
              page, which spans every session. -->
         <span
@@ -56,15 +62,19 @@
         >
         <!-- The flip side of the queue: review what was already decided and
              clear a decision. -->
-        <!-- Compresses, never folds (amendment #2): at ≤720 the label span
-             hides and the icon-only form remains — the same pattern as
-             Auto-stack — so the button carries its own accessible name at
-             every width. -->
+        <!-- Folds into the ⋯ at ≤1040 (amendment #4), where it keeps its label
+             — icon-only, `mdi-history` says nothing on its own. The exception
+             is the way BACK: while the Decided page is showing, this button is
+             the visible exit from a sub-page, so it stays on the bar and
+             compresses to its arrow, which needs no label. -->
         <button
           v-if="!store.showingMixed"
           type="button"
           class="qdecided"
-          :class="{ 'qdecided--on': store.showingDecided }"
+          :class="{
+            'qdecided--on': store.showingDecided,
+            'dq-fold-1040': pageTogglesFold,
+          }"
           :title="decidedToggleLabel"
           :aria-label="decidedToggleLabel"
           :aria-pressed="store.showingDecided ? 'true' : 'false'"
@@ -89,7 +99,10 @@
           v-if="!store.showingDecided"
           type="button"
           class="qdecided"
-          :class="{ 'qdecided--on': store.showingMixed }"
+          :class="{
+            'qdecided--on': store.showingMixed,
+            'dq-fold-1040': pageTogglesFold,
+          }"
           :title="mixedToggleTitle"
           :aria-label="mixedToggleTitle"
           :aria-pressed="store.showingMixed ? 'true' : 'false'"
@@ -108,11 +121,71 @@
           >
         </button>
 
-        <!-- Separator D-S1: renders at ALL widths (amendment #2). With the
-             Decided toggle compressing instead of folding, its left flank is
-             always populated — including on an empty queue, where the
-             headline is v-if'd away but the toggle remains. The tail's D-S2
-             stays at every width too. -->
+        <!-- The ⋯, and it stands where the controls it collapses stood: at the
+             end of the toggle run, inside the group it serves (amendment #2's
+             principle, amendment #4's measurement). It holds the two page
+             toggles and nothing else — the tier gate, the scope pill, the
+             count and the app-wide tail all stay on the bar at every width.
+             Fold = CSS both ways: a row and its bar button carry the same
+             condition, and the container query at ≤1040 flips which of the
+             pair
+             is visible. The panel opens rightward (`align="start"`), because
+             this trigger sits near the bar's left edge. -->
+        <TbOverflowMenu
+          v-if="pageTogglesFold"
+          ref="overflowEl"
+          class="dq-overflow"
+          align="start"
+        >
+          <!-- Each row carries the same accessible name its bar button
+               carries, spelled out rather than left to the visible text:
+               name-from-content would otherwise reduce Mixed stacks to its
+               label and count, and the sentence saying what a mixed stack IS
+               is the whole reason that button has a tooltip. The count is
+               aria-hidden on both forms for the same reason — it is already
+               in the sentence. -->
+          <template #default="{ close }">
+            <button
+              type="button"
+              class="tbm-action"
+              :title="decidedToggleLabel"
+              :aria-label="decidedToggleLabel"
+              data-testid="decided-row"
+              @click="
+                onToggleDecided();
+                close();
+              "
+            >
+              <v-icon size="18">mdi-history</v-icon>
+              <span>{{ decidedToggleLabel }}</span>
+            </button>
+            <button
+              type="button"
+              class="tbm-action"
+              :title="mixedToggleTitle"
+              :aria-label="mixedToggleTitle"
+              data-testid="mixed-row"
+              @click="
+                onToggleMixed();
+                close();
+              "
+            >
+              <v-icon size="18">mdi-alert-outline</v-icon>
+              <span>{{ mixedToggleLabel }}</span>
+              <span
+                v-if="store.mixedTotal"
+                class="qmixed-count"
+                aria-hidden="true"
+                >{{ store.mixedTotal.toLocaleString() }}</span
+              >
+            </button>
+          </template>
+        </TbOverflowMenu>
+
+        <!-- Separator D-S1: renders at ALL widths (amendment #2). Its left
+             flank is always populated — by the toggles above 1040, by the ⋯
+             below it, and on an empty queue by whichever of the two is
+             showing. The tail's D-S2 stays at every width too. -->
         <span class="dq-tb-sep" aria-hidden="true"></span>
 
         <!-- Escape inside the popover (including on its threshold slider,
@@ -123,7 +196,7 @@
           class="dq-tier-wrap"
           @keydown.esc.stop.prevent="closeTierMenu()"
         >
-          <!-- The label ellipsizes under pressure and hides at ≤720 (the
+          <!-- The label ellipsizes under pressure and hides at ≤1040 (the
                compressed form is [filter icon][chevron], the grid Filter
                trigger's grammar), so the button carries its own accessible
                name at every width — without it the hidden span would leave
@@ -183,7 +256,7 @@
              so a size control there would be a control with nothing to buy. -->
         <div
           v-if="store.hasGroups && !store.showingMixed"
-          class="dq-size dq-fold-720"
+          class="dq-size dq-fold-1180"
         >
           <v-icon size="16" aria-hidden="true"
             >mdi-image-size-select-large</v-icon
@@ -207,7 +280,7 @@
 
         <!-- Compresses with the bar rather than folding: a bulk action with
              an accent fill must stay a visible target. Full label → short
-             "Auto-stack N" (≤720) → icon + count (≤600), the sentence
+             "Auto-stack N" (≤1180) → icon + count (≤820), the sentence
              surviving as tooltip and accessible name throughout. -->
         <button
           v-if="store.exactCount > 0 && !readOnly && !store.showingMixed"
@@ -233,11 +306,12 @@
              they must not vanish with it. One separator divides the queue's
              own controls from the app-wide cluster. -->
         <span class="dq-tb-sep" aria-hidden="true"></span>
-        <!-- No burger in this bar (amendment #2): a burger may only collapse
-             controls from its own visual group, and every foldable here
-             found a better answer — Decided and Auto-stack compress to
-             icon forms, the size slider simply hides at ≤720 (the value
-             persists in the store), and the app-wide tail never folds. -->
+        <!-- No burger in THIS group (amendment #2's principle, kept): a
+             burger may only collapse controls from its own visual group, and
+             the app-wide tail never folds at any width. The queue's own ⋯
+             lives in the left group, where the controls it collapses stood.
+             Auto-stack compresses to an icon form and the size slider hides
+             at ≤1180, its value persisting in the store. -->
         <UndoControl />
         <TbGlobalActions @open-settings="emit('open-settings')" />
       </div>
@@ -723,6 +797,7 @@ import {
 } from "../../utils/thumbnailSizes";
 import { pictureThumbnailUrl } from "../../api/pictures";
 import TbGlobalActions from "../panels/TbGlobalActions.vue";
+import TbOverflowMenu from "../panels/TbOverflowMenu.vue";
 import UndoControl from "../panels/UndoControl.vue";
 import DedupGroupRow from "../widgets/DedupGroupRow.vue";
 import MixedQueueRow from "../widgets/MixedQueueRow.vue";
@@ -998,6 +1073,7 @@ const listEl = ref(null);
 const mixedListEl = ref(null);
 const tierWrapEl = ref(null);
 const tierButtonEl = ref(null);
+const overflowEl = ref(null);
 const tierMenuOpen = ref(false);
 const compareOpen = ref(false);
 const autoStackOpen = ref(false);
@@ -1085,8 +1161,19 @@ function announceExpansion(group, stackId, open) {
 const maxSizeLevel = MAX_THUMBNAIL_SIZE_LEVEL;
 const sizeLabel = computed(() => sizeLabelForLevel(store.sizeLevel));
 
+/**
+ * Whether the two page toggles are the kind that folds into the ⋯ at ≤1040.
+ * They are, on the review queue, where both are forward navigation. On the
+ * Decided and Mixed pages the surviving toggle reads "Back to review" and is
+ * the visible way out of a sub-page, so it stays on the bar (amendment #4) —
+ * and the ⋯ would then hold nothing, which is why the same flag mounts it.
+ */
+const pageTogglesFold = computed(
+  () => !store.showingDecided && !store.showingMixed,
+);
+
 /** What the Decided toggle says: the visible label on a wide bar, the
- * tooltip and accessible name at every width (the span hides at ≤720). */
+ * tooltip and accessible name at every width (folded into the ⋯ at ≤1040). */
 const decidedToggleLabel = computed(() =>
   store.showingDecided ? "Back to review" : "Decided",
 );
@@ -1980,6 +2067,22 @@ function tierMenuOwnsEvent(event) {
 }
 
 /**
+ * The same rule for the ⋯ overflow, and the same shape: only an OPEN panel
+ * owns the keys pressed inside it. With the panel closed the trigger is an
+ * ordinary toolbar button, so the queue's keys keep working while it holds
+ * focus — exactly as they do on the tier trigger beside it. Escape never
+ * reaches here: the menu stops it on its own wrap and closes back to the
+ * trigger.
+ *
+ * @param {KeyboardEvent} [event]
+ * @returns {boolean}
+ */
+function overflowOwnsEvent(event) {
+  if (!overflowEl.value?.isOpen?.()) return false;
+  return Boolean(overflowEl.value?.$el?.contains?.(event?.target));
+}
+
+/**
  * What `Escape` means in the queue.
  *
  * A popover first, because that is the thing on top. Otherwise it hands the
@@ -2539,7 +2642,8 @@ const handleKeydown = createDedupKeyHandler({
   isBlocked: (event) =>
     autoStackOpen.value ||
     store.showingMixed ||
-    (tierMenuOpen.value && tierMenuOwnsEvent(event)),
+    (tierMenuOpen.value && tierMenuOwnsEvent(event)) ||
+    overflowOwnsEvent(event),
   // One row less than the viewport holds, so a page move keeps the row the
   // user was reading on screen as the anchor for the next one.
   pageRows: () => Math.max(1, viewportRows.value - 1),
@@ -2633,7 +2737,9 @@ const handleMixedKeydown = createDedupKeyHandler({
   undo: () => operationStore.undo(),
   isReadOnly: () => readOnly.value,
   isBlocked: (event) =>
-    autoStackOpen.value || (tierMenuOpen.value && tierMenuOwnsEvent(event)),
+    autoStackOpen.value ||
+    (tierMenuOpen.value && tierMenuOwnsEvent(event)) ||
+    overflowOwnsEvent(event),
   pageRows: () => Math.max(1, viewportRows.value - 1),
   onEscape,
   // `E` opens a deck in the review queue. Here every member is already on
@@ -2927,8 +3033,25 @@ defineExpose({ windowedGroups, tierLabel });
   gap: var(--space-3);
 }
 
+/* The shrink chain, and it is the GUARANTEE behind the ladder below
+   (amendment #4). Both groups used to sit at the flex default
+   (`min-width: auto`) over `white-space: nowrap` content, so neither could
+   shrink: the surplus left through the right edge and took the last children
+   in DOM order with it, which is exactly Settings and Stats. The left group
+   yields first and its text members ellipsize; the right group never shrinks,
+   so no content the left group can hold — a scope named by the user, a
+   seven-digit count — can push the app-wide tail off the bar.
+
+   NOT `overflow: hidden` on the bar: the tier popover and the ⋯ panel are
+   absolutely positioned inside it and would be clipped away. */
+.dq-tb-left {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
 .dq-tb-right {
   margin-left: auto;
+  flex: 0 0 auto;
 }
 
 /* Divides the queue's identity (what it holds, which side is showing) from the
@@ -2936,6 +3059,10 @@ defineExpose({ windowedGroups, tierLabel });
 .dq-tb-sep {
   width: 1px;
   height: 18px;
+  /* A 1px flex item is a shrinkable one: once the left group started yielding
+     (amendment #4) the rule would give up its single pixel and disappear
+     before any label did. */
+  flex-shrink: 0;
   background: rgb(var(--v-theme-divider));
 }
 
@@ -2975,7 +3102,11 @@ defineExpose({ windowedGroups, tierLabel });
 .dq-tier-wrap {
   position: relative;
   /* Part of the tier button's shrink chain: without this the flex default
-     (min-width: auto) refuses to shrink and the label wraps instead. */
+     (min-width: auto) refuses to shrink and the label wraps instead.
+     `display: flex` is the other half — as a block the wrap could shrink to
+     nothing while the inline-flex button inside kept its full width and drew
+     straight over its neighbours (amendment #4). */
+  display: flex;
   min-width: 0;
 }
 
@@ -3046,8 +3177,16 @@ defineExpose({ windowedGroups, tierLabel });
   font-size: var(--text-md);
   font-weight: var(--weight-semibold);
   white-space: nowrap;
-  /* The to-do count is the queue's one number; it never truncates. */
-  flex-shrink: 0;
+  /* The FIRST thing to give between two rungs, and it gives from the RIGHT:
+     the count leads the string, so the ellipsis eats "groups to review" and
+     never the number (amendment #4). The full sentence stays in the DOM for a
+     screen reader and in the tooltip. The weight buys the order — the give is
+     shared out in proportion to `flex-shrink × width`, and a clipped tail on a
+     sentence reads better than "Mixed stac…" on a button. */
+  min-width: 0;
+  flex-shrink: 6;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .qsub {
@@ -3062,6 +3201,10 @@ defineExpose({ windowedGroups, tierLabel });
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
+  /* Same shrink chain as the tier button: between two rungs the label
+     ellipsizes on one line rather than the button overlapping its
+     neighbour. The glyph and the count never feed the ellipsis. */
+  min-width: 0;
   padding: var(--space-1) var(--space-3);
   border: 1px solid rgb(var(--v-theme-border));
   border-radius: var(--radius-md);
@@ -3072,6 +3215,16 @@ defineExpose({ windowedGroups, tierLabel });
   white-space: nowrap;
   cursor: pointer;
   transition: background var(--dur-1) var(--ease-standard);
+}
+
+.qdecided .v-icon {
+  flex-shrink: 0;
+}
+
+.qdecided-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .qdecided:hover {
@@ -3095,6 +3248,7 @@ defineExpose({ windowedGroups, tierLabel });
 .qmixed-count {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
   min-width: var(--badge-size);
   min-height: var(--badge-size);
   padding: 0 var(--space-2);
@@ -3316,12 +3470,20 @@ defineExpose({ windowedGroups, tierLabel });
 }
 
 /* ── The collapse ladder (docs/design/toolbar-responsive-decisions.md,
-   amendment #2 — this bar has NO burger: every foldable compresses or
-   hides within its own group instead). Floor: count, Decided (icon), Tier
-   gate (icon+chevron), scope pill (compressed, if scoped), Auto-stack
-   (compressed, if present), separator, Undo, Settings, Stats. ──────────── */
+   amendment #4, which measured what amendment #2 assumed). The ⋯ takes the
+   two page toggles at ≤1040; everything else compresses or hides in its own
+   group. Floor: count (ellipsizing), ⋯, separator, tier gate (icon +
+   chevron), scope pill (compressed, if scoped), Auto-stack (icon + count, if
+   present), separator, Undo, Settings, Stats — measured clean down to 320px
+   of bar width with every one of those present. ───────────────────────── */
 .dq-auto-short,
 .dq-auto-count {
+  display: none;
+}
+
+/* The ⋯ trigger appears with the first control that folds into it, and only
+   this bar knows that width (the component's own default is hidden). */
+.dq-overflow {
   display: none;
 }
 
@@ -3332,7 +3494,11 @@ defineExpose({ windowedGroups, tierLabel });
   text-overflow: ellipsis;
 }
 
-@container dqbar (max-width: 860px) {
+/* Rung 1. The two readouts that report rather than control: the session tally
+   (the durable record is the Decided page) and the slider's word for a
+   position the slider already shows. Measured: the full bar wants 1570px, so
+   this is where the first thing has to give. */
+@container dqbar (max-width: 1400px) {
   .qsub {
     display: none;
   }
@@ -3341,10 +3507,12 @@ defineExpose({ windowedGroups, tierLabel });
   }
 }
 
-@container dqbar (max-width: 720px) {
-  /* The size control hides outright — no replacement row: the value
-     persists in the store and comes back with the width. */
-  .dq-fold-720 {
+/* Rung 2. The size control goes entirely — no replacement row: the value
+   persists in the store and comes back with the width — and Auto-stack drops
+   its sentence for "Auto-stack N", the full one surviving as its tooltip and
+   accessible name. */
+@container dqbar (max-width: 1180px) {
+  .dq-fold-1180 {
     display: none;
   }
   .dq-auto-full {
@@ -3353,24 +3521,56 @@ defineExpose({ windowedGroups, tierLabel });
   .dq-auto-short {
     display: inline;
   }
-  /* The tier trigger compresses to [filter icon][chevron] — the grid Filter
-     trigger's grammar; the button's own title/aria-label carry the name. */
+}
+
+/* Rung 3. The page toggles fold into the ⋯, which appears in their place; a
+   toggle showing "Back to review" never carries the fold class, so the way
+   out of a sub-page stays on the bar and compresses to its arrow. The tier
+   trigger compresses to [filter icon][chevron] in the same step, the grid
+   Filter trigger's grammar; its title/aria-label carry the name. */
+@container dqbar (max-width: 1040px) {
+  .dq-fold-1040 {
+    display: none;
+  }
+  .dq-overflow {
+    display: flex;
+  }
   .dq-tier-label {
     display: none;
   }
-  /* The Decided toggle compresses to its icon, the Auto-stack pattern; its
-     title/aria-label carry the name. */
+  /* All that can be left on the bar now is a "Back to review" arrow, which
+     says what it does without its label. */
   .qdecided-label {
     display: none;
   }
 }
 
-@container toolbar (max-width: 600px) {
+/* Rung 4. Auto-stack keeps its flash and its count and drops the verb; the
+   scope pill compresses to [kind icon][dismiss] in the same step (its own
+   `@container toolbar` rule, in DedupScopePill.vue). */
+@container dqbar (max-width: 820px) {
   .dq-auto-short {
     display: none;
   }
   .dq-auto-count {
     display: inline;
+  }
+}
+
+/* The floor's density step. Below the shared ladder's last rung the bar buys
+   its remaining width from the runs' own gaps rather than from another
+   control, so the worst case (a scope in force AND exact matches to
+   auto-stack) still fits with nothing leaving the bar.
+
+   The groups only: `.dq-toolbar` IS the query's container, and a container
+   query styles a container's DESCENDANTS, never the container itself — a rule
+   for the bar's own gap or inset here would be dead. Its 36px band and its
+   insets are pinned to the grid bar's anyway (guardrail in Toolbar.test.js),
+   so they are not this ladder's to spend. */
+@container toolbar (max-width: 420px) {
+  .dq-tb-left,
+  .dq-tb-right {
+    gap: var(--space-2);
   }
 }
 </style>

--- a/frontend/src/components/widgets/DedupScopePill.vue
+++ b/frontend/src/components/widgets/DedupScopePill.vue
@@ -61,6 +61,9 @@ const countText = computed(() =>
   line-height: var(--leading-snug);
   color: rgb(var(--v-theme-on-surface));
   max-width: 100%;
+  /* The containing block for the clipped label at the narrow end (below),
+     which would otherwise anchor to whatever positioned ancestor it found. */
+  position: relative;
 }
 
 .scope-pill__ico {
@@ -107,11 +110,22 @@ const countText = computed(() =>
    The pill never folds while a scope is active — a filtered list that does
    not say it is filtered is the bug this pill exists to prevent — so on a
    narrow bar it compresses to the kind icon + dismiss, the full label
-   surviving as the pill's tooltip. ─────────────────────────────────────── */
-@container toolbar (max-width: 600px) {
+   surviving as the pill's tooltip.
+
+   CLIPPED, not `display: none` (amendment #4): a tooltip reaches neither a
+   screen reader nor a touch user, and the scope's name is the whole point of
+   the pill. Clipping keeps the name in the accessibility tree at every
+   width. ──────────────────────────────────────────────────────────────── */
+@container toolbar (max-width: 820px) {
   .scope-pill__label,
   .scope-pill__count {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 }
 </style>

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -439,6 +439,49 @@ def test_electron_apple_signing_requires_validated_release_tag():
     )
 
 
+def test_model_cache_saves_every_path_it_restores():
+    """A path only the restore step lists is warmed on every run and never kept.
+
+    The Windows ``downloaded_models`` directory was in the restore list and
+    absent from the save list, so ``warm_models_windows`` downloaded the WD14
+    and PixlStash taggers and saved an entry without them. That entry then went
+    on hitting its primary key, so the save step (`hit != 'true'`) never ran
+    again and could never repair it — every Windows shard re-fetched the
+    taggers, which is the HuggingFace stampede the warm job exists to prevent.
+    """
+    action = yaml.safe_load(
+        (REPO_ROOT / ".github" / "actions" / "model-cache" / "action.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    steps = {}
+    for step in action["runs"]["steps"]:
+        uses = step.get("uses", "")
+        for mode in ("restore", "save"):
+            if f"/cache/{mode}@" in uses:
+                assert mode not in steps, f"Two {mode} steps in one path list"
+                steps[mode] = step
+
+    assert steps.keys() == {"restore", "save"}
+    # Both are guarded on `mode`, or one of them runs in the wrong direction.
+    assert steps["restore"]["if"] == "inputs.mode != 'save'"
+    assert steps["save"]["if"] == "inputs.mode == 'save'"
+
+    # One path per line, not `.split()`: a Windows path can contain a space.
+    paths = {
+        mode: {
+            line.strip() for line in step["with"]["path"].splitlines() if line.strip()
+        }
+        for mode, step in steps.items()
+    }
+    assert paths["restore"] == paths["save"], (
+        "Restore and save must cover the same model paths on every platform; "
+        f"restore-only: {sorted(paths['restore'] - paths['save'])}, "
+        f"save-only: {sorted(paths['save'] - paths['restore'])}"
+    )
+    assert "~/AppData/Local/pixlstash/pixlstash/downloaded_models" in paths["save"]
+
+
 def _shard_matrix(job: dict) -> list:
     """Return the ``shard`` matrix values declared by *job*."""
     matrix = job.get("strategy", {}).get("matrix", {})

--- a/website/upgrade.html
+++ b/website/upgrade.html
@@ -109,6 +109,14 @@
         margin: 0;
       }
 
+      /* The one upgrade step that is not "download and restart". It is shown
+         statically because the changelog panel that carries the same warning as
+         1.9.0's lead note only renders when ?v= tells us the old version; when
+         that panel does render, the static copy is hidden as a duplicate. */
+      .upgrade-notice {
+        margin: 0 0 24px;
+      }
+
       .whatsnew-banner {
         display: grid;
         grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.25fr);
@@ -388,22 +396,31 @@
         <div id="changes-since-list"></div>
       </div>
 
+      <div id="upgrade-notice" class="method-warning upgrade-notice">
+        ⚠️ <strong>Coming from 1.8.0 or earlier?</strong> Updating clears every
+        API token, as it did in 1.8.1. Create replacements from Settings, share
+        your links again with their new values, and enter your public URL and
+        ComfyUI URL again. If you already updated to 1.8.1 or later this has
+        happened and your current tokens are left alone.
+      </div>
+
       <a class="whatsnew-banner" href="whatsnew.html">
         <div>
-          <span class="whatsnew-kicker">New in 1.8</span>
+          <span class="whatsnew-kicker">New in 1.9</span>
           <h2 class="whatsnew-title">
             Explore what changed before you upgrade
           </h2>
           <p class="whatsnew-copy">
-            Try the new justified grid layout, background imports, Scrapheap delete and auto-empty, the
-            Agreement chart.
+            Undo and redo across your library, the new Duplicates view, Keep
+            cover only for clearing out stacks, characters and sets in several
+            projects at once, and a new Privacy pane.
           </p>
           <span class="whatsnew-cta">Open the What's New page →</span>
         </div>
         <div class="whatsnew-media">
           <img
-            src="assets/ScreenshotsJustified.jpg"
-            alt="PixlStash 1.8: the justified grid layout"
+            src="assets/ScreenshotDuplicates.jpg"
+            alt="PixlStash 1.9: the Duplicates view grouping likely copies for review"
           />
         </div>
       </a>
@@ -838,6 +855,9 @@
           })
           .join("");
         document.getElementById("changes-since").style.display = "block";
+        // The rendered entries carry each version's own lead note, including the
+        // token-clearing warning, so the static callout above would repeat it.
+        document.getElementById("upgrade-notice").style.display = "none";
       }
 
       function fetchText(url) {


### PR DESCRIPTION
Closes #1011.

## The reported bug

`.github/actions/model-cache/action.yml` restored three paths and saved two: the Windows `~/AppData/Local/pixlstash/pixlstash/downloaded_models` entry was missing from the save step's `path:`. `warm_models_windows` therefore downloaded the WD14 and PixlStash taggers and saved an entry without them, so every Windows shard re-fetched them — the HuggingFace stampede warming exists to prevent.

## Why the one-line fix was not enough

Adding the path alone would have been inert. `actions/cache` writes only on a key **miss**, and `warm_models_windows` gates its save on `steps.models.outputs.hit != 'true'`. The existing Windows entry is non-empty (it holds `~/.cache/huggingface` — CLIP, SBert, Florence), so it keeps hitting its primary key, the save step never runs, and the widened path list never reaches it. That is the exact failure this action's own header records for CLIP.

So the key carries a `-v2-` literal now. The two changes are one change: widening the paths without bumping the key fixes nothing. `restore-keys` deliberately stays on the unversioned `hf-models-<os>-` prefix, so the bust falls back to the previous entry and the warm job pays only the delta — on Linux, effectively nothing.

## Test

`tests/test_ci_shards.py::test_model_cache_saves_every_path_it_restores` compares the restore and save path sets and asserts the two steps' `mode` gating. Mutation-tested both ways: removing the save path fails it, inverting the `if:` on either step fails it.

A structural test cannot see server-side cache state, so it proves the declaration and not the entry. Acceptance-criteria items 3 and 4 — a fresh-key Windows push, then a second run restoring without redownloading — need two consecutive live runs on `develop` after merge, and are not verifiable from this branch.
