### PR TITLE
Name the library-switch alert dialog

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -562,6 +562,16 @@ Enter/Escape through `AppDialog`, restores invoking focus on cancel, and names
 outgoing live share links before any switch request is sent. After acceptance,
 `LibrarySwitchOverlay.vue` owns the persistent assertive switching/failure
 surface above Settings; it deliberately has no Escape or outside-click exit.
+Because Escape is blocked, being unnamed is worse here than elsewhere, so the
+`role="alertdialog"`, `aria-labelledby` and `aria-describedby` sit on the
+`<v-dialog>` rather than on the panel inside it: Vuetify's `VDialog` authors
+`role="dialog"` + `aria-modal` onto the `.v-overlay` root, and attributes on
+`<v-dialog>` fall through to that same element, so the naming lands on the one
+authoritative dialog instead of creating a second, nested one. The ids come
+from `useId()` and the heading/description ids are re-used by both phases (only
+one renders at a time), so the name tracks the phase. `LibrarySwitchOverlay.a11y.test.js`
+mounts the real Vuetify and asserts the resolved name and description in both
+phases — it is the guard on that fall-through if Vuetify's markup ever moves.
 
 Emits: `update:public-url`
 

--- a/frontend/src/components/settings/LibrarySwitchOverlay.a11y.test.js
+++ b/frontend/src/components/settings/LibrarySwitchOverlay.a11y.test.js
@@ -1,0 +1,115 @@
+// The accessible name of the library-switch overlay (#1016).
+//
+// LibrarySwitchOverlay.test.js mocks `vuetify/components` away, which is fine
+// for the behaviour it covers but useless here: the whole question is which
+// element Vuetify's real VDialog puts `role`/`aria-modal` on and whether our
+// naming attributes land on that same element. `vi.mock` is file-scoped, so
+// this check needs its own file with the real components mounted.
+//
+// Escape is deliberately suppressed on this dialog, so an unnamed one strands
+// a screen-reader user in a modal that also refuses the standard way out.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createVuetify } from "vuetify";
+import * as vuetifyComponents from "vuetify/components";
+import * as vuetifyDirectives from "vuetify/directives";
+import { nextTick } from "vue";
+
+vi.mock("../../api/libraries", () => ({ setActiveLibrary: vi.fn() }));
+vi.mock("../../utils/reloadPage", () => ({ reloadPage: vi.fn() }));
+
+import LibrarySwitchOverlay from "./LibrarySwitchOverlay.vue";
+import { setActiveLibrary } from "../../api/libraries";
+import { useLibrarySwitchStore } from "../../stores/useLibrariesStore";
+
+const vuetify = createVuetify({
+  components: vuetifyComponents,
+  directives: vuetifyDirectives,
+});
+
+let pinia;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pinia = createPinia();
+  setActivePinia(pinia);
+});
+
+/** Resolve an element's name/description the way an AT would: join the text of
+ * every id in the IDREF list, in order. */
+function fromIdRefs(element, attribute) {
+  const refs = element.getAttribute(attribute);
+  expect(refs, `${attribute} is missing`).toBeTruthy();
+  return refs
+    .split(/\s+/)
+    .map((id) => {
+      const target = document.getElementById(id);
+      expect(target, `${attribute} points at missing id "${id}"`).toBeTruthy();
+      return target.textContent.trim().replace(/\s+/g, " ");
+    })
+    .join(" ");
+}
+
+function findDialog() {
+  const dialogs = document.querySelectorAll('[role="alertdialog"]');
+  expect(dialogs).toHaveLength(1);
+  // The authoritative role is Vuetify's, overridden in place. A second nested
+  // dialog element would announce as a dialog inside a dialog.
+  expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(0);
+  return dialogs[0];
+}
+
+describe("LibrarySwitchOverlay accessible name", () => {
+  it("names and describes the switching phase", async () => {
+    setActiveLibrary.mockReturnValue(new Promise(() => {}));
+    const wrapper = mount(LibrarySwitchOverlay, {
+      attachTo: document.body,
+      global: { plugins: [pinia, vuetify] },
+    });
+    const store = useLibrarySwitchStore();
+    store.begin({ uuid: "b", name: "Client work" }, { uuid: "a", name: "Family Photos" }, null);
+    await nextTick();
+    await nextTick();
+
+    const dialog = findDialog();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(fromIdRefs(dialog, "aria-labelledby")).toBe(
+      "Switching to Client work…",
+    );
+    expect(fromIdRefs(dialog, "aria-describedby")).toContain(
+      "PixlStash is finishing or cancelling work",
+    );
+
+    wrapper.unmount();
+  });
+
+  it("names the failed phase and describes it with the error", async () => {
+    setActiveLibrary.mockRejectedValue({
+      response: { data: { detail: "Drive went away" } },
+    });
+    const wrapper = mount(LibrarySwitchOverlay, {
+      attachTo: document.body,
+      global: { plugins: [pinia, vuetify] },
+    });
+    const store = useLibrarySwitchStore();
+
+    await store.begin(
+      { uuid: "b", name: "Client work" },
+      { uuid: "a", name: "Family Photos" },
+      null,
+    );
+    await nextTick();
+
+    const dialog = findDialog();
+    expect(fromIdRefs(dialog, "aria-labelledby")).toBe(
+      "Could not switch to Client work",
+    );
+    const description = fromIdRefs(dialog, "aria-describedby");
+    expect(description).toContain("PixlStash is still using Family Photos");
+    expect(description).toContain("Drive went away");
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/settings/LibrarySwitchOverlay.test.js
+++ b/frontend/src/components/settings/LibrarySwitchOverlay.test.js
@@ -43,10 +43,10 @@ describe("LibrarySwitchOverlay", () => {
     await nextTick();
     await nextTick();
 
-    const dialog = wrapper.find('[role="alertdialog"]');
-    expect(dialog.attributes("aria-live")).toBe("assertive");
+    const panel = wrapper.find(".library-switch-overlay");
+    expect(panel.attributes("aria-live")).toBe("assertive");
     expect(wrapper.text()).toContain("Switching to Client work");
-    await dialog.trigger("keydown", { key: "Escape" });
+    await panel.trigger("keydown", { key: "Escape" });
     expect(store.phase).toBe("switching");
 
     rejectSwitch({ response: { data: { detail: "Drive went away" } } });

--- a/frontend/src/components/settings/LibrarySwitchOverlay.vue
+++ b/frontend/src/components/settings/LibrarySwitchOverlay.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, useId, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { VDialog, VIcon, VProgressCircular } from "vuetify/components";
 
@@ -15,6 +15,19 @@ const { phase, targetLibrary, currentLibrary, error, overlayOpen } =
 const panel = ref(null);
 const stayButton = ref(null);
 let restoreOverlayInertness = null;
+
+// Only one phase renders at a time, so a single heading id is always resolvable
+// and the accessible name follows the phase instead of going stale in one of
+// them. The error paragraph exists in the failed phase only; naming it while it
+// is absent would leave a dangling IDREF.
+const titleId = useId();
+const descriptionId = useId();
+const errorId = useId();
+const describedBy = computed(() =>
+  phase.value === "failed"
+    ? `${descriptionId} ${errorId}`
+    : descriptionId,
+);
 
 watch(
   [overlayOpen, phase],
@@ -49,13 +62,19 @@ function blockEscape(event) {
     persistent
     :scrim="true"
     :max-width="520"
+    role="alertdialog"
+    :aria-labelledby="titleId"
+    :aria-describedby="describedBy"
     @keydown="blockEscape"
   >
+    <!--
+      Vuetify's overlay root already carries the dialog role and aria-modal, so
+      the naming goes there (the attrs above fall through to it) rather than on
+      a second, nested dialog element here.
+    -->
     <section
       ref="panel"
       class="library-switch-overlay"
-      role="alertdialog"
-      aria-modal="true"
       aria-live="assertive"
       aria-atomic="true"
       tabindex="-1"
@@ -63,8 +82,10 @@ function blockEscape(event) {
       <template v-if="phase === 'switching'">
         <v-progress-circular indeterminate size="32" width="3" />
         <div>
-          <h2>Switching to {{ targetLibrary?.name }}…</h2>
-          <p>
+          <h2 :id="titleId">
+            Switching to {{ targetLibrary?.name }}…
+          </h2>
+          <p :id="descriptionId">
             PixlStash is finishing or cancelling work, then it will reload this
             window. Keep it open.
           </p>
@@ -76,12 +97,16 @@ function blockEscape(event) {
           mdi-alert-circle-outline
         </v-icon>
         <div class="library-switch-overlay__failure">
-          <h2>Could not switch to {{ targetLibrary?.name }}</h2>
-          <p>
+          <h2 :id="titleId">
+            Could not switch to {{ targetLibrary?.name }}
+          </h2>
+          <p :id="descriptionId">
             PixlStash is still using
             <strong>{{ currentLibrary?.name ?? "the current library" }}</strong>.
           </p>
-          <p class="library-switch-overlay__detail">{{ error }}</p>
+          <p :id="errorId" class="library-switch-overlay__detail">
+            {{ error }}
+          </p>
           <div class="library-switch-overlay__actions">
             <AppButton
               ref="stayButton"


### PR DESCRIPTION
Closes #1016.

## What changed

`LibrarySwitchOverlay.vue`'s panel carried `role="alertdialog"` with no
`aria-label` or `aria-labelledby`. `aria-live` is not a name, so a screen-reader
user entered an unnamed modal — and this is the one dialog in the app that
deliberately swallows Escape, so there was no standard way back out either.

- `role="alertdialog"`, `aria-labelledby` and `aria-describedby` now sit on the
  `<v-dialog>`. Vuetify's `VDialog` authors `role="dialog"` + `aria-modal="true"`
  onto the `.v-overlay` root, and attributes on `<v-dialog>` fall through to that
  same element — so the naming lands on the dialog Vuetify already owns instead
  of nesting a second one inside it. The panel's own `role`/`aria-modal` are
  gone; it keeps `aria-live`/`aria-atomic`/`tabindex`.
- Each phase's `<h2>` and explanatory `<p>` share one `useId()` pair, so the name
  and description track the phase rather than going stale in one of them. The
  failure phase adds the error paragraph to `aria-describedby`; it is left out
  while switching so the IDREF never dangles.
- New `LibrarySwitchOverlay.a11y.test.js` mounts the **real** Vuetify (the
  existing test file mocks it away, and `vi.mock` is file-scoped) and asserts, for
  both phases, that exactly one `[role="alertdialog"]` exists, that no
  `[role="dialog"]` is left over, and that the IDREFs resolve to the expected
  name and description text. Mutation-checked four ways — dropping the role,
  breaking either IDREF, or re-adding the nested role all go red.
- `docs/frontend_architecture.md` records the fall-through, since it is a
  surprising cross-library mechanism.

Whole frontend suite green (3475 tests); `npm run lint` clean.

## Answers to the adversarial review

An adversarial pass ran before the push. No secrets or private information. Of
its other findings, two were worth acting on and are already in the diff: the
hardcoded ids became `useId()` (the house pattern in eight other components,
and it removes the duplicate-id hazard if a second instance ever mounts), and
the docs got the paragraph above. The rest, with reasons:

- **"A one-line `:aria-label` on the `<section>` would close the issue with no
  Vuetify coupling."** It would, but it leaves the nested dialog-in-dialog the
  issue explicitly asked to avoid — an unnamed outer dialog announced before the
  named inner one — and a static label goes stale across the two phases, which
  is the failure mode the issue comment named. Rejected deliberately.
- **"The fall-through is version-fragile."** Fair, and that is exactly what the
  new test is for: a Vuetify bump that moves the role turns it red, which is the
  correct outcome for such a bump rather than a nuisance.
- **"The boundary is now the full-viewport `.v-overlay`, which contains the
  scrim."** True of the DOM, but the scrim contributes nothing to the
  accessibility tree, so the announced contents are the panel either way.
- **"`aria-live` on the panel is now orphaned."** Intentional: `alertdialog`
  announces on open only, so the live region is the only thing that announces
  the switching → failed transition. Removing it would lose that.
- **Not fixed here, on purpose:** six sibling dialogs (`RetentionReductionDialog`,
  `DeleteForeverDialog`, `ImageImporter`, `NewReviewDialog`, `ReviewRail`,
  `UndoControl`) still nest a role inside a `v-dialog`. Sweeping them is a
  repo-wide change, not this card. Also latent: `ModelShelf.vue`'s
  `closest(".ate, [role='dialog']")` no longer matches this overlay, currently
  masked by a class-based guard above it.
