### PR TITLE
Say so when copying a CLI command fails

### DIFF
--- a/frontend/src/components/settings/LibrariesSection.test.js
+++ b/frontend/src/components/settings/LibrariesSection.test.js
@@ -24,6 +24,7 @@ vi.mock("vuetify/components", () => ({
 import LibrariesSection from "./LibrariesSection.vue";
 import { listLibraries, setActiveLibrary } from "../../api/libraries";
 import { useLibrarySwitchStore } from "../../stores/useLibrariesStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
 import { copyText } from "../../utils/clipboard";
 
 vi.mock("../../api/libraries", () => ({
@@ -98,6 +99,7 @@ beforeEach(() => {
   listLibraries.mockResolvedValue(structuredClone(LOCAL_RESPONSE));
   confirmMock.mockResolvedValue(true);
   setActiveLibrary.mockResolvedValue({ status: "ok" });
+  copyText.mockResolvedValue(true);
 });
 
 describe("listing", () => {
@@ -409,6 +411,97 @@ describe("teaching the CLI", () => {
     );
     expect(rows[0].find(".libraries-cli__copy").exists()).toBe(true);
     expect(rows[2].find(".libraries-cli__copy").exists()).toBe(true);
+  });
+
+  it("confirms the copy only once the clipboard actually took it", async () => {
+    const wrapper = await settle(mountPane());
+
+    await wrapper.findAll(".libraries-cli")[0].find("button").trigger("click");
+    await nextTick();
+
+    expect(wrapper.findAll(".libraries-cli")[0].text()).toContain("Copied");
+    expect(wrapper.find('[role="status"]').text()).toContain(
+      "Copied pixlstash-cli libraries list",
+    );
+    expect(useNoticeStore().notices).toHaveLength(0);
+  });
+
+  // The clipboard refuses on an insecure context, and "Copied" then leaves the
+  // user pasting whatever was there before.
+  it("says how to copy by hand when the clipboard refuses", async () => {
+    copyText.mockResolvedValue(false);
+    const wrapper = await settle(mountPane());
+
+    await wrapper.findAll(".libraries-cli")[0].find("button").trigger("click");
+    await nextTick();
+
+    expect(wrapper.findAll(".libraries-cli")[0].text()).not.toContain("Copied");
+    expect(wrapper.find('[role="status"]').text()).toBe("");
+    const notice = useNoticeStore().notices.at(-1);
+    expect(notice.level).toBe("error");
+    // Actionable: it says what to do instead, on both platforms.
+    expect(notice.text).toContain("Ctrl+C");
+    expect(notice.text).toContain("Command-C");
+  });
+
+  // A failure landing late must not wipe a copy that has since succeeded — the
+  // same lie as the reported bug, pointing the other way.
+  it("leaves a later successful copy alone when an earlier one fails", async () => {
+    let failSlowCopy;
+    copyText.mockImplementationOnce(
+      () => new Promise((resolve) => (failSlowCopy = () => resolve(false))),
+    );
+    const wrapper = await settle(mountPane());
+    const rows = wrapper.findAll(".libraries-cli");
+
+    await rows[0].find("button").trigger("click");
+    await rows[1].find("button").trigger("click");
+    await nextTick();
+    expect(rows[1].text()).toContain("Copied");
+
+    failSlowCopy();
+    await nextTick();
+    await nextTick();
+
+    expect(rows[1].text()).toContain("Copied");
+    expect(wrapper.find('[role="status"]').text()).toContain(
+      "pixlstash-cli libraries create <folder>",
+    );
+  });
+
+  it("forgets the confirmation when the dialog closes", async () => {
+    const wrapper = await settle(mountPane());
+    // The stubbed dialog always renders its slot, so open it explicitly:
+    // otherwise closing is not a change and the watcher never runs.
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Show the commands")
+      .trigger("click");
+
+    await wrapper.findAll(".libraries-cli")[0].find("button").trigger("click");
+    await nextTick();
+    await wrapper.findAll(".libraries-cli-dialog__actions button")[0].trigger(
+      "click",
+    );
+    await nextTick();
+
+    expect(wrapper.find('[role="status"]').text()).toBe("");
+    expect(wrapper.findAll(".libraries-cli")[0].text()).not.toContain("Copied");
+  });
+
+  it("drops its feedback timer when the pane goes away", async () => {
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    const wrapper = await settle(mountPane());
+
+    await wrapper.findAll(".libraries-cli")[0].find("button").trigger("click");
+    await nextTick();
+    const timer = setTimeoutSpy.mock.results.at(-1).value;
+    wrapper.unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
   });
 
   it("only shows the one-library primer after a successful one-row response", async () => {

--- a/frontend/src/components/settings/LibrariesSection.vue
+++ b/frontend/src/components/settings/LibrariesSection.vue
@@ -12,7 +12,7 @@
  * reload rather than a store refresh: picture ids do not mean the same thing in
  * another library, and every open view describes the old one.
  */
-import { computed, ref, watch } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { VCard, VDialog, VProgressCircular } from "vuetify/components";
 
@@ -22,6 +22,7 @@ import {
   useLibrariesStore,
   useLibrarySwitchStore,
 } from "../../stores/useLibrariesStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
 import { copyText } from "../../utils/clipboard";
 import AppButton from "../widgets/AppButton.vue";
 import SettingsSection from "./SettingsSection.vue";
@@ -35,6 +36,7 @@ const props = defineProps({
 const { confirm } = useConfirm();
 const librariesStore = useLibrariesStore();
 const switchStore = useLibrarySwitchStore();
+const noticeStore = useNoticeStore();
 const {
   libraries,
   canManage,
@@ -47,6 +49,7 @@ const {
 } = storeToRefs(librariesStore);
 const { targetLibrary, overlayOpen } = storeToRefs(switchStore);
 const copiedCommand = ref("");
+let copyResetTimer = 0;
 // The four commands carry an absolute interpreter path each, so inline they
 // dominated a panel whose actual job is listing and switching libraries. They
 // are reference material consulted once, not part of that flow, so they live
@@ -132,12 +135,32 @@ function togglePath(libraryUuid) {
 }
 
 async function copyCommand(command) {
-  await copyText(command);
-  copiedCommand.value = command;
-  window.setTimeout(() => {
-    if (copiedCommand.value === command) copiedCommand.value = "";
-  }, 2000);
+  if (await copyText(command)) {
+    copiedCommand.value = command;
+    window.clearTimeout(copyResetTimer);
+    copyResetTimer = window.setTimeout(() => {
+      if (copiedCommand.value === command) copiedCommand.value = "";
+    }, 2000);
+    return;
+  }
+  // The clipboard refuses on an insecure context and the execCommand fallback
+  // can be denied too. Claiming "Copied" then leaves the user pasting whatever
+  // was on the clipboard before, and this command is the one thing on the
+  // screen nobody can retype from memory. The shared notice surface owns the
+  // failure, as it does for the identical copy in OverlayDescriptionPanel.
+  noticeStore.error(
+    "Couldn't copy the command. Select the text and press Ctrl+C, or Command-C on a Mac.",
+    { key: "libraries-cli-copy" },
+  );
 }
+
+// Reopening the dialog otherwise shows "Copied" — and announces it — for a
+// button nobody pressed this time.
+watch(commandsOpen, (isOpen) => {
+  if (!isOpen) copiedCommand.value = "";
+});
+
+onUnmounted(() => window.clearTimeout(copyResetTimer));
 </script>
 
 <template>


### PR DESCRIPTION
Closes #1013.

`copyCommand()` in `LibrariesSection.vue` awaited `copyText()` and threw the
result away, so a clipboard write the browser refused — insecure context, denied
permission, `execCommand` fallback intercepting nothing — still flipped the
button to "Copied" and announced "Copied …" in the live region. The CLI command
is the one thing on that screen nobody can retype from memory, so the false
success sends the user to paste whatever was on the clipboard before.

## What changed

- Success feedback (`copiedCommand`, the live-region announcement) is now set
  only when `copyText()` returns `true`.
- Failure goes to the shared notice surface — `noticeStore.error(...)`, keyed so
  repeats coalesce — rather than a new one-off element. That is the mechanism
  `docs/design/notice-surface.md` specifies, the one `OverlayDescriptionPanel`
  already uses for this exact event, and it is sticky per §6, so the instruction
  cannot expire before it is read. Its text says what to do instead:
  select the text and press Ctrl+C, or Command-C on a Mac.
- The reset timer is kept in a handle, cleared on a repeat click, and cleared in
  `onUnmounted`.
- Closing the commands dialog forgets `copiedCommand`. Reopening it otherwise
  showed and re-announced "Copied" for a button nobody pressed that time — the
  same false confirmation the issue is about.

## Tests

Five cases in `LibrariesSection.test.js`: success confirms and raises no notice;
refusal confirms nothing, announces nothing, and raises an actionable error
notice; a failure landing *after* a later successful copy leaves that success
intact (the old code had no such ordering guard, and the naive fix reintroduces
the lie pointing the other way); closing the dialog clears the confirmation;
unmount clears the timer. Each was checked by mutating the source and confirming
the suite goes red. Full frontend suite green (3478 tests), eslint clean.

## Reviewed and deliberately left alone

An adversarial pass flagged the sibling `copyText()` callers, and it is right
that they are not consistent: `AccountSection.copyToken()` and `copyShareLink()`
ignore the boolean silently (no feedback at all on failure) and leak unhandled
`setTimeout`s, `OverlayMetadataPanel` reports failure only to `console.warn`, and
`FolderEditor` does not clear its copy timer on unmount. None of those is the
false-success bug this issue reports, and fixing them means choosing new
user-facing copy on a screen this issue does not touch — worth its own card
rather than widening this diff.