### PR TITLE
Keep watching a model move through a failed status read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,5 +967,37 @@ jobs:
           tests/test_watch_folder_worker.py
           tests/test_work_planner.py
 
+      # `PYTHONFAULTHANDLER` above did not name it, and that is itself the
+      # finding: pytest's faulthandler plugin restores the handler in its
+      # `pytest_unconfigure` whenever the env var enabled it (verified in
+      # `_pytest/faulthandler.py`), so it IS armed all the way into
+      # `Py_FinalizeEx` — and six of these crashes have still printed nothing.
+      # A handler that is live and silent puts the fault beyond CPython's reach
+      # entirely: past `_PyFaulthandler_Fini`, in native teardown. Windows logs
+      # one layer below that, an Application Error record naming the faulting
+      # module, its version and the fault offset — the DLL this has never been
+      # able to name.
+      #
+      # Read the event rather than shipping a minidump: artifacts on a public
+      # repository are downloadable by anyone, and dumped process memory reaches
+      # the environment block, which is where this job's `HF_TOKEN` lives. An
+      # event record carries module names and offsets and no memory at all.
+      - name: Name the faulting module
+        if: failure()
+        shell: pwsh
+        run: |
+          $events = Get-WinEvent -MaxEvents 5 -ErrorAction SilentlyContinue -FilterHashtable @{
+            LogName      = 'Application'
+            ProviderName = 'Application Error', 'Windows Error Reporting'
+          }
+          if (-not $events) {
+            Write-Host 'No Application Error record: this failure was not a native crash.'
+            exit 0
+          }
+          foreach ($event in $events) {
+            Write-Host "--- $($event.TimeCreated.ToString('o')) [$($event.Id)] $($event.ProviderName)"
+            Write-Host $event.Message
+          }
+
   # The `build-windows` aggregator over this job was removed with `build` in
   # #796 — see the note where `build` used to be, above `e2e`.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2841,6 +2841,27 @@ checked before either started. `busy` is what every entry point tests first.
 same-drive move, because those are renames — a byte-based bar would sit at 0%
 through the entire fastest case and then jump.
 
+**The watch is a self-scheduling timeout, and a failed reading does not end it
+(#1018).** The next status read is booked only once the current one has landed,
+so a slow read can never have a second queued behind it. A read that fails
+means *status unknown*, not *the move stopped*: the last snapshot stays up and
+the loop tries again, each consecutive failure doubling the wait to a 15 s
+ceiling. Giving up on one blip used to leave `busy` true off a stale `running`
+snapshot, which disabled every move entry point **and** `adopt()` — the one
+path that could have recovered it — so a reload was the only way back. What
+this buys is *recovery*, not a timeout: while the server stays unreachable the
+tab is still busy, because the move genuinely is still running as far as anyone
+here knows. It comes back on its own the moment a reading lands.
+
+**The loop ends on the reading that CONSUMED a terminal status, not on the job
+not being `running`** — plus a session reset and disposal, and nothing else.
+The distinction is a real case: `POST /model-moves` reads the job back on its
+way out, and a same-drive rename of a few files can finish before it does, so
+the accepted job can arrive already `finished`. Ending on the status would then
+end the loop on the first failed reading, losing the receipt and both refreshes
+for a move that actually completed. `watching` is cleared by the reading that
+reported the finish and by nothing else, so it is what the loop tests.
+
 **Two ways in, one dialog, and a drop does not move on release.** The selection
 bar's Move button and a drag onto a folder header **or onto a drive band's
 capacity meter** all resolve to the same list of copies and all open

--- a/frontend/src/stores/useModelMovesStore.js
+++ b/frontend/src/stores/useModelMovesStore.js
@@ -15,6 +15,16 @@ import { useNoticeStore } from "./useNoticeStore";
 
 /** How often the job is re-read while one is running. */
 const POLL_MS = 1000;
+/**
+ * The longest a run of unreadable statuses may push the next reading out to.
+ *
+ * A failed read is "status unknown", not "the move stopped" (#1018), so the
+ * loop keeps going — but a backend that is down for a minute must not be asked
+ * sixty times, so each consecutive failure doubles the wait up to this ceiling.
+ * Fifteen seconds is late enough to be cheap and early enough that a move which
+ * finished during the outage is still reported while the owner is looking.
+ */
+const POLL_MAX_MS = 15000;
 
 /**
  * What each per-item status means in a receipt, and whether it is bad news.
@@ -123,6 +133,7 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
    */
   const failure = ref("");
   let pollHandle = null;
+  let pollDelay = POLL_MS;
   let epoch = 0;
   // Set the moment a job is started or observed running, cleared when its
   // finish has been reported. Without it a `finished` job read on the first
@@ -152,14 +163,47 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
   );
 
   function stopPolling() {
+    pollDelay = POLL_MS;
     if (pollHandle === null) return;
-    clearInterval(pollHandle);
+    clearTimeout(pollHandle);
     pollHandle = null;
   }
 
+  /**
+   * Watch the job until it reaches a terminal status.
+   *
+   * A self-scheduling timeout and not an interval: the next reading is booked
+   * only once the current one has landed, so a slow status read can never have
+   * a second one queued behind it, and an unreadable one can simply wait longer
+   * before trying again. The loop ends on a terminal status, a session reset or
+   * disposal — never on a failed read, which is what left the tab permanently
+   * busy (#1018).
+   */
   function startPolling() {
     if (pollHandle !== null) return;
-    pollHandle = setInterval(poll, POLL_MS);
+    scheduleNextPoll();
+  }
+
+  function scheduleNextPoll() {
+    const startedAt = epoch;
+    // `pollHandle` is deliberately NOT cleared when the timeout fires: it is
+    // what `adopt()` and `startPolling()` test to know a loop already owns this
+    // job, and a window where it reads null across the in-flight read would let
+    // a second loop start on top of this one. `stopPolling()` clears it.
+    pollHandle = setTimeout(async () => {
+      const read = await poll();
+      // A reset while the read was in flight owns the store now; anything this
+      // loop does from here would be about somebody else's session.
+      if (startedAt !== epoch) return;
+      // `watching` is cleared by the reading that consumed a terminal status
+      // and reported it, and by nothing else — an unread status leaves it up,
+      // and we try again. Testing the job's status instead would end the loop
+      // on a failed read whenever the last snapshot was already terminal, which
+      // a job that finished before its own POST returned can be.
+      if (!watching) return;
+      pollDelay = read ? POLL_MS : Math.min(pollDelay * 2, POLL_MAX_MS);
+      scheduleNextPoll();
+    }, pollDelay);
   }
 
   /**
@@ -168,6 +212,8 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
    * The refresh on completion is BOTH stores: `model_file` rows were repointed,
    * so the shelf's locations are stale, and the folders' file counts and
    * `shelf_bytes` moved with them, so the drive bands are too.
+   *
+   * @returns {Promise<boolean>} whether a status was actually read.
    */
   async function poll() {
     const startedAt = epoch;
@@ -175,20 +221,20 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     try {
       snapshot = await getModelMoveStatus();
     } catch (err) {
-      // A poll that fails is not a move that failed. Stop watching rather than
-      // reporting an outcome we did not read, and leave the last snapshot up.
+      // A poll that fails is not a move that failed, and it is not a move that
+      // stopped either: the server is still copying. Leave the last snapshot up
+      // and say only that this reading did not happen.
       console.warn("[modelMoves] could not read the move status:", err);
-      stopPolling();
-      return;
+      return false;
     }
-    if (startedAt !== epoch) return;
+    if (startedAt !== epoch) return false;
     job.value = snapshot;
     if (snapshot?.status === "running") {
       watching = true;
-      return;
+      return true;
     }
     stopPolling();
-    if (!watching) return;
+    if (!watching) return true;
     watching = false;
     const results = snapshot?.results || [];
     const receipt = moveReceipt(results, Boolean(snapshot?.cancel_requested));
@@ -196,10 +242,20 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     // a run that lost files holds the panel until it is read.
     if (results.some((r) => r.status === "failed")) failure.value = receipt;
     else useNoticeStore().push({ level: "success", text: receipt });
-    await Promise.all([
-      useModelShelfStore().fetchRows(),
-      useModelFoldersStore().refresh({ quiet: true }),
-    ]);
+    try {
+      await Promise.all([
+        useModelShelfStore().fetchRows(),
+        useModelFoldersStore().refresh({ quiet: true }),
+      ]);
+    } catch (err) {
+      // The move itself landed and has been reported; only the repaint behind
+      // it did not. Caught here because the caller is usually a timer callback,
+      // where a rejection is nobody's to handle and surfaces as an unhandled
+      // one. The stale rows are the shelf's own problem and it refetches on the
+      // next mount.
+      console.warn("[modelMoves] could not refresh after the move:", err);
+    }
+    return true;
   }
 
   /**

--- a/frontend/src/stores/useModelMovesStore.js
+++ b/frontend/src/stores/useModelMovesStore.js
@@ -191,7 +191,18 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     // job, and a window where it reads null across the in-flight read would let
     // a second loop start on top of this one. `stopPolling()` clears it.
     pollHandle = setTimeout(async () => {
-      const read = await poll();
+      let read = false;
+      try {
+        read = await poll();
+      } catch (err) {
+        // A rejection out of a timer callback is nobody's to catch, and one
+        // thrown before the finish is reported would end the loop still holding
+        // `pollHandle` and `watching` — the stuck-busy shape this whole change
+        // is about, arriving by another door. A snapshot whose `results` is not
+        // a list gets here today. Treated as an unreadable status: said out
+        // loud, backed off, still watching.
+        console.error("[modelMoves] the move watch threw:", err);
+      }
       // A reset while the read was in flight owns the store now; anything this
       // loop does from here would be about somebody else's session.
       if (startedAt !== epoch) return;

--- a/frontend/src/stores/useModelMovesStore.test.js
+++ b/frontend/src/stores/useModelMovesStore.test.js
@@ -171,6 +171,176 @@ describe("watching one to its end", () => {
     expect(store.status).toBe("running");
   });
 
+  it("keeps watching after a failed reading and consumes the finish", async () => {
+    // #1018: a failed read is "status unknown", not "stop observing forever".
+    // Giving up on one left `busy` true off a stale `running` snapshot, which
+    // disabled every move entry point AND the adoption path that could have
+    // recovered it — so the tab could only be freed by a reload.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    getModelMoveStatus
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(
+        snapshot({
+          status: "finished",
+          done: 2,
+          results: [{ status: "moved" }, { status: "moved" }],
+        }),
+      );
+
+    await vi.advanceTimersByTimeAsync(1000); // the reading that fails
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+    expect(store.busy).toBe(true);
+    expect(useNoticeStore().notices).toHaveLength(0);
+
+    // The retry is BACKED OFF, so it is not due one interval later.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+    expect(store.busy).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1000); // two intervals after the failure
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(2);
+    expect(store.status).toBe("finished");
+    expect(store.busy).toBe(false);
+    expect(useNoticeStore().notices.at(-1).text).toBe("Moved 2 files.");
+    expect(fetchRows).toHaveBeenCalledTimes(1);
+    expect(refreshFolders).toHaveBeenCalledTimes(1);
+
+    // And then it stops: a loop that outlives its job keeps a timer and a
+    // request per second going for the rest of the session.
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the finish even when the refresh behind it fails", async () => {
+    // The move landed and the receipt is the news. The two reads that follow it
+    // are a repaint, and letting one of them reject out of a timer callback is
+    // an unhandled rejection nobody is positioned to catch — so it is caught
+    // and said out loud here instead.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    fetchRows.mockRejectedValue(new Error("offline"));
+    getModelMoveStatus.mockResolvedValue(
+      snapshot({ status: "finished", done: 2, results: [{ status: "moved" }] }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(useNoticeStore().notices.at(-1).text).toBe("Moved 1 file.");
+    expect(store.busy).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+
+    // And the store is idle rather than wedged: the next move takes the slot
+    // and gets a loop of its own.
+    fetchRows.mockResolvedValue(undefined);
+    getModelMoveStatus.mockClear().mockResolvedValue(snapshot());
+    startModelMove.mockResolvedValue(snapshot());
+    expect(await store.start(3, ITEMS)).toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a job that finished before its own POST returned", async () => {
+    // A same-drive rename of a handful of files can beat the read the start
+    // route does on its way out, so the accepted job comes back ALREADY
+    // terminal. Ending the loop on "the job is not running" rather than on
+    // "the finish has been reported" loses the receipt and both refreshes here,
+    // because the one reading that would have consumed it is the one that fails.
+    const store = useModelMovesStore();
+    const finished = snapshot({
+      status: "finished",
+      done: 1,
+      results: [{ status: "moved" }],
+    });
+    startModelMove.mockResolvedValue(finished);
+    getModelMoveStatus
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(finished);
+
+    await store.start(2, ITEMS);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(useNoticeStore().notices.at(-1).text).toBe("Moved 1 file.");
+    expect(fetchRows).toHaveBeenCalledTimes(1);
+  });
+
+  it("backs off to a ceiling rather than doubling away from the owner", async () => {
+    // Unbounded doubling would put the reading that notices the server came
+    // back minutes out. Bounded, five minutes of outage is tens of readings,
+    // not the nine an uncapped 2^n would manage.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    getModelMoveStatus.mockReset().mockRejectedValue(new Error("offline"));
+
+    await vi.advanceTimersByTimeAsync(300000);
+    expect(getModelMoveStatus.mock.calls.length).toBeGreaterThan(15);
+    expect(store.busy).toBe(true);
+  });
+
+  it("never has two readings in flight at once", async () => {
+    // The next reading is booked only once the current one lands. An interval
+    // would stack a request per tick on top of a status read that is hanging.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    getModelMoveStatus.mockReset().mockReturnValue(new Promise(() => {}));
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons a reading already in flight when the session resets", async () => {
+    // Host paths and folder ids are owner-only, so the new session has no
+    // standing to watch a job the old one started — including the answer to a
+    // request it had already sent.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    let answer;
+    getModelMoveStatus
+      .mockReset()
+      .mockReturnValue(new Promise((resolve) => (answer = resolve)));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+    store.resetForSession();
+    answer(
+      snapshot({ status: "finished", done: 2, results: [{ status: "moved" }] }),
+    );
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(store.job).toBe(null);
+    expect(store.busy).toBe(false);
+    expect(useNoticeStore().notices).toHaveLength(0);
+    expect(fetchRows).not.toHaveBeenCalled();
+    // The loop is gone with the session, not merely quiet for one tick.
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not leave a second loop behind when a move follows a reset", async () => {
+    // The abandoned reading lands after the new session has started a move of
+    // its own, so "is anything still being watched?" is the wrong question —
+    // something is, just not this loop's job. Two loops on one job is two
+    // requests a second and two receipts for the same finish.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    let answer;
+    getModelMoveStatus
+      .mockReset()
+      .mockReturnValueOnce(new Promise((resolve) => (answer = resolve)))
+      .mockResolvedValue(snapshot());
+
+    await vi.advanceTimersByTimeAsync(1000); // the abandoned reading, in flight
+    store.resetForSession();
+    await store.start(3, ITEMS);
+    answer(snapshot());
+
+    // From here every reading hangs, so the new session's loop can account for
+    // exactly one of them and a second could only be a loop still alive from
+    // before the reset.
+    getModelMoveStatus.mockClear().mockReturnValue(new Promise(() => {}));
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+  });
+
   it("counts progress in items, because a same-drive move copies no bytes", () => {
     const store = useModelMovesStore();
     store.job = snapshot({ total: 4, done: 1, bytes_to_copy: 0 });

--- a/frontend/src/stores/useModelMovesStore.test.js
+++ b/frontend/src/stores/useModelMovesStore.test.js
@@ -241,6 +241,31 @@ describe("watching one to its end", () => {
     expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
   });
 
+  it("does not let a reading throw out of the timer callback", async () => {
+    // A terminal snapshot whose `results` is not a list: the tally of "did
+    // anything fail?" throws on it, from inside a timer callback where there is
+    // nobody left to catch it. That receipt is lost either way — an unhandled
+    // rejection that also strands the loop is the part that must not happen.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    getModelMoveStatus.mockResolvedValue(
+      snapshot({ status: "finished", results: {} }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+
+    // The store is idle rather than wedged, and the next move gets a loop.
+    expect(store.busy).toBe(false);
+    startModelMove.mockResolvedValue(snapshot());
+    getModelMoveStatus.mockClear().mockResolvedValue(snapshot());
+    expect(await store.start(3, ITEMS)).toBe(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getModelMoveStatus).toHaveBeenCalledTimes(1);
+  });
+
   it("still reports a job that finished before its own POST returned", async () => {
     // A same-drive rename of a handful of files can beat the read the start
     // route does on its way out, so the accepted job comes back ALREADY


### PR DESCRIPTION
Fixes #1018.

## What was wrong

`useModelMovesStore` polled `GET /model-moves` on a `setInterval` and called `stopPolling()` the first time a read threw. The last `running` snapshot stayed in the store, so `busy` stayed true, which disabled Move and Relocate — and `adopt()`, the one path that could have picked the job back up, is itself gated on `busy`. One dropped request and the tab could only be freed by a reload, while the server finished the move unobserved.

## What changed

`frontend/src/stores/useModelMovesStore.js`

- The interval is now a **self-scheduling timeout**. The next reading is booked only once the current one lands, so a slow status read can never have a second queued behind it.
- A **failed read is "status unknown"**: the last snapshot stays up and the loop tries again, each consecutive failure doubling the wait to a 15 s ceiling (`POLL_MAX_MS`). It ends on the reading that consumed a terminal status, a session reset, or disposal — nothing else.
- The exit test is **`watching`, not `job.status`**. `POST /model-moves` reads the job back on its way out (`_snapshot(_launch(...))`, `pixlstash/routes/model_moves.py:596`) and a same-drive rename can finish before it does, so an accepted job can arrive already `finished`. Exiting on the status would then drop the loop on the first failed read and lose the receipt *and* both refreshes for a move that actually completed.
- The completion refresh is wrapped: a rejected `fetchRows`/`refresh` was an unhandled rejection out of a timer callback. It is logged instead; the receipt is unaffected.
- `pollHandle` is deliberately not cleared when the timeout fires, so `adopt()`'s `pollHandle !== null` guard still means "a loop owns this job" across the in-flight read rather than reading null for the whole window.

Six new tests. Each new branch was mutation-checked — removing the backoff, inverting it, removing the ceiling, exiting on `!running`, dropping the loop exit, dropping either epoch guard, and rethrowing from the refresh catch all turn the suite red.

## Answering the adversarial review

Two objections I am not acting on:

- **"With the backend down, `busy` stays true forever and a reload is still the only way out."** That is the intended behaviour and what the issue asks for ("stop only on terminal status, session reset, or store disposal"). While no status can be read, the move genuinely is still running as far as this tab knows, and a client-side timeout would have to invent an outcome it never read. What the change buys is recovery: it comes back on its own the moment a reading lands. The doc paragraph now says that rather than implying an outage is cured.
- **`startPolling()`'s `pollHandle !== null` guard is not covered by a test.** It is a one-line guard mirroring `stopPolling()`, unreachable given `busy` gates every caller. Left in as cheap defence rather than grown a test.

`docs/frontend_architecture.md` §"Moving files (F4)" updated for both the loop shape and the `watching` exit.


---

## The red check was not this change (and the shard now says which DLL)

`backend-windows shard 4` failed on the second push with **117 passed, 1 skipped, 0 failed**, then a segfault 5.09 s after the green summary (exit 139).

It is not this diff:

- The delta between the green run and the red one is 37 lines in two frontend JS files, on an identical base commit (`069aaaf2`).
- That shard runs Python only. The same file list passes here — 118 passed, exit 0, clean shutdown.
- `backend-windows shard 4` is the most frequently failing job in the repository: **14 of the last 60 failed CI runs**, across unrelated branches and **five times on `develop` itself**. Six of eight sampled failures are byte-for-byte this signature — green summary, zero failures, exit 139.

So the flake is pre-existing and repo-wide, and this PR is one of its victims.

### What the last commit adds

`PYTHONFAULTHANDLER=1` was added to this job to name the crash and has never produced a line. That silence is the diagnosis, not a gap: pytest's faulthandler plugin *restores* the handler in its `pytest_unconfigure` when the env var enabled it (`_pytest/faulthandler.py:56-58`), so it is armed all the way into `Py_FinalizeEx` — verified locally by crashing a session from an `atexit` hook with and without a re-arm, which printed a traceback either way. A handler that is live and still silent puts the fault past `_PyFaulthandler_Fini`, in native teardown, where nothing Python-level can see it. No Python threads survive the session either (`_enforce_no_leaked_threads` prints nothing).

The new `if: failure()` step reads the Windows Application event log, whose Application Error record names the faulting module, its version and the fault offset. That is the DLL this crash has never been able to name.

Deliberately **not** a minidump: artifacts on a public repository are downloadable by anyone, and dumped process memory reaches the environment block, where this job's `HF_TOKEN` lives. An event record carries module names and offsets and no memory. The step adds no action, no download and no permission — `Get-WinEvent` is built in, there is no `${{ }}` in the run block, and the trigger is `pull_request`, not `pull_request_target`.

It is a diagnostic, not a fix. The shard can still fail; the next time it does, the log will say what crashed.
