### PR TITLE
Validate Electron popup URLs by parsed origin (#1020)

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -16,13 +16,13 @@ import { cp, mkdir, rename, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:net';
 import { networkInterfaces } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { randomUUID } from 'node:crypto';
 import { detectHardware, gpuUpgrades, Hardware } from './backend/HardwareDetector';
 import { BackendManager, OVERLAY_ACCELS, launchWithOverlayFallback } from './backend/BackendManager';
 import { uniqueDownloadPath } from './downloads';
 import { ipcBytes, pngClipboardPayload, safeMediaFilename } from './mediaIpc';
+import { isAllowedNavigation, redactUrl } from './urlPolicy';
 import { ServerProcess, devInterpreter } from './backend/ServerProcess';
 import {
   Accel,
@@ -140,57 +140,9 @@ function sendPhase(payload: Record<string, unknown>): void {
   mainWindow?.webContents.send('app:phase', payload);
 }
 
-/**
- * Decide whether the window may navigate (top-level) to `target`. The privileged
- * `pixlstashDesktop` preload bridge stays injected across same-window navigation,
- * so any off-origin page that loaded here could call high-impact IPC
- * (setServerSettings, commitSetup, installAccelerator, …). We therefore allow
- * ONLY the content we load ourselves and block everything else (deny-by-default):
- *
- *  - `file://` — ONLY files inside our own packaged renderer directory
- *    (renderer/index.html splash, renderer/setup.html, their assets). A blanket
- *    `file:` allow would let a navigated page load any local HTML under the
- *    privileged preload, so we resolve the target path and require it to live
- *    under RENDERER_DIR.
- *  - the live loopback backend origin — http://127.0.0.1:<ephemeral port>. The
- *    port is chosen fresh per backend launch, so the allowed origin is derived
- *    from the URL we actually loaded (`currentUrl`), never hardcoded. Before the
- *    backend is up `currentUrl` is null; we then permit only the loopback host
- *    (127.0.0.1 / localhost over http) so an in-flight load isn't broken, while
- *    still excluding every non-loopback origin.
- */
-function isAllowedNavigation(target: string): boolean {
-  let url: URL;
-  try {
-    url = new URL(target);
-  } catch (e) {
-    console.warn(`[nav] blocking navigation to unparseable URL ${target}:`, e);
-    return false;
-  }
-  // Local bundled pages (splash / setup wizard): allow ONLY our own renderer
-  // files, never an arbitrary file:// path (which would still carry the preload).
-  if (url.protocol === 'file:') {
-    try {
-      const path = resolve(fileURLToPath(url));
-      return path === RENDERER_DIR.slice(0, -1) || path.startsWith(RENDERER_DIR);
-    } catch (e) {
-      console.warn(`[nav] blocking unresolvable file:// URL ${target}:`, e);
-      return false;
-    }
-  }
-  // The running backend, pinned to the exact loopback origin we loaded.
-  if (currentUrl) {
-    try {
-      if (url.origin === new URL(currentUrl).origin) return true;
-    } catch (e) {
-      console.warn(`[nav] could not parse current backend URL ${currentUrl}:`, e);
-    }
-  }
-  // Fallback before the backend URL is known: only the loopback host over http.
-  if (url.protocol === 'http:' && (url.hostname === '127.0.0.1' || url.hostname === 'localhost')) {
-    return true;
-  }
-  return false;
+/** Bind the shared origin policy (see `./urlPolicy`) to this process's state. */
+function isAllowedTarget(target: string): boolean {
+  return isAllowedNavigation(target, currentUrl, RENDERER_DIR);
 }
 
 /**
@@ -202,7 +154,7 @@ function isAllowedNavigation(target: string): boolean {
  * we allow `https:` and `mailto:` and block (and log) everything else —
  * deny-by-default. Plain `http:` is intentionally excluded for outbound opens:
  * the only legitimate http target here is the loopback backend, which is handled
- * in-app (setWindowOpenHandler 'allow' / isAllowedNavigation), never opened
+ * in-app (setWindowOpenHandler 'allow' / isAllowedTarget), never opened
  * externally. Used by BOTH setWindowOpenHandler and the navigation guard so the
  * scheme policy lives in one place.
  */
@@ -211,14 +163,16 @@ function openExternalSafely(url: string): void {
   try {
     ({ protocol } = new URL(url));
   } catch (e) {
-    console.warn(`[external] refusing to open unparseable URL ${url}:`, e);
+    console.warn(`[external] refusing to open unparseable URL ${redactUrl(url)}:`, e);
     return;
   }
   if (protocol === 'https:' || protocol === 'mailto:') {
     void shell.openExternal(url);
     return;
   }
-  console.warn(`[external] blocked openExternal for disallowed scheme '${protocol}': ${url}`);
+  console.warn(
+    `[external] blocked openExternal for disallowed scheme '${protocol}': ${redactUrl(url)}`,
+  );
 }
 
 /** The accelerator the bundled (installer-shipped) runtime provides. */
@@ -266,14 +220,16 @@ function createMainWindow(): void {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
-  // Open external links in the user's browser, not inside the app window.
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
-      return { action: 'allow' };
-    }
+  // Open external links in the user's browser, not inside the app window. A
+  // child window is only allowed for content we load ourselves, decided by the
+  // same parsed-origin policy as in-window navigation — a string prefix test
+  // would classify http://127.0.0.1.example.com/ as loopback (#1020).
+  const openHandler = ({ url }: { url: string }): { action: 'allow' | 'deny' } => {
+    if (isAllowedTarget(url)) return { action: 'allow' };
     openExternalSafely(url);
     return { action: 'deny' };
-  });
+  };
+  mainWindow.webContents.setWindowOpenHandler(openHandler);
   // Lock down TOP-LEVEL navigation so the privileged preload bridge can never
   // end up under an untrusted origin. setWindowOpenHandler above only covers
   // window.open / new windows; in-window navigation (link clicks, meta-refresh,
@@ -281,15 +237,23 @@ function createMainWindow(): void {
   // own local content or the live loopback backend is cancelled and, if it's a
   // real external link, handed to the OS browser instead.
   const guardNavigation = (event: Electron.Event, url: string): void => {
-    if (isAllowedNavigation(url)) return;
+    if (isAllowedTarget(url)) return;
     event.preventDefault();
-    console.warn(`[nav] blocked in-window navigation to off-origin URL: ${url}`);
+    console.warn(`[nav] blocked in-window navigation to off-origin URL: ${redactUrl(url)}`);
     // Hand a real external link to the OS browser, but only through the scheme
     // allowlist (https/mailto) — never a raw file:/smb:/custom-handler URL.
     openExternalSafely(url);
   };
   mainWindow.webContents.on('will-navigate', guardNavigation);
   mainWindow.webContents.on('will-redirect', guardNavigation);
+  // A child window inherits the parent's webPreferences (preload included), so
+  // its navigation must be governed too: validating only the URL it opened with
+  // would let it navigate off-origin one hop later, bridge and all.
+  mainWindow.webContents.on('did-create-window', (child) => {
+    child.webContents.setWindowOpenHandler(openHandler);
+    child.webContents.on('will-navigate', guardNavigation);
+    child.webContents.on('will-redirect', guardNavigation);
+  });
 }
 
 /** Bring the main window to the front, recreating it if it was destroyed. */

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -2,10 +2,12 @@ import { resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * A URL safe to write to the log: scheme, host, port and path, never the
- * `user:password@` userinfo a blocked URL may carry (and never an unbounded
- * `data:` payload). Schemes with no origin (`file:`, `mailto:`, `blob:`, …)
- * report origin `null`, so they are rendered from the protocol instead.
+ * A URL safe to write to the log: enough to identify what was blocked, never
+ * the `user:password@` userinfo the URL may carry and never a page-authored
+ * payload. Schemes with no origin report origin `null`; of those only `file:`
+ * has a path worth logging (it names a real file), while a `data:` or
+ * `javascript:` "path" IS the attacker-controlled body, so it is dropped and
+ * only the scheme (plus the `data:` media type) is kept.
  */
 export function redactUrl(target: string): string {
   let url: URL;
@@ -14,7 +16,16 @@ export function redactUrl(target: string): string {
   } catch {
     return '<unparseable URL>';
   }
-  const rendered = url.origin === 'null' ? url.protocol + url.pathname : url.origin + url.pathname;
+  let rendered: string;
+  if (url.origin !== 'null') {
+    rendered = url.origin + url.pathname;
+  } else if (url.protocol === 'file:') {
+    rendered = `file://${url.pathname}`;
+  } else if (url.protocol === 'data:') {
+    rendered = `data:${url.pathname.split(',')[0]},<redacted>`;
+  } else {
+    rendered = `${url.protocol}<redacted>`;
+  }
   return rendered.length > 200 ? `${rendered.slice(0, 200)}…` : rendered;
 }
 

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -1,0 +1,99 @@
+import { resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A URL safe to write to the log: scheme, host, port and path, never the
+ * `user:password@` userinfo a blocked URL may carry (and never an unbounded
+ * `data:` payload). Schemes with no origin (`file:`, `mailto:`, `blob:`, …)
+ * report origin `null`, so they are rendered from the protocol instead.
+ */
+export function redactUrl(target: string): string {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return '<unparseable URL>';
+  }
+  const rendered = url.origin === 'null' ? url.protocol + url.pathname : url.origin + url.pathname;
+  return rendered.length > 200 ? `${rendered.slice(0, 200)}…` : rendered;
+}
+
+/**
+ * Decide whether the window may load `target` — used by BOTH the top-level
+ * navigation guard and `setWindowOpenHandler`, so the origin policy lives in one
+ * place the way the scheme policy already does. The privileged
+ * `pixlstashDesktop` preload bridge stays injected across same-window
+ * navigation (and is inherited by a child window), so any off-origin page that
+ * loaded here could call high-impact IPC (setServerSettings, commitSetup,
+ * installAccelerator, …). We therefore allow ONLY the content we load ourselves
+ * and block everything else (deny-by-default):
+ *
+ *  - `file://` — ONLY files inside our own packaged renderer directory
+ *    (renderer/index.html splash, renderer/setup.html, their assets). A blanket
+ *    `file:` allow would let a navigated page load any local HTML under the
+ *    privileged preload, so we resolve the target path and require it to live
+ *    under `rendererDir`.
+ *  - the live loopback backend origin — http://127.0.0.1:<ephemeral port>. The
+ *    port is chosen fresh per backend launch, so the allowed origin is derived
+ *    from the URL we actually loaded (`currentUrl`), never hardcoded. Before the
+ *    backend is up `currentUrl` is null; we then permit only the loopback host
+ *    (127.0.0.1 / localhost over http) so an in-flight load isn't broken, while
+ *    still excluding every non-loopback origin.
+ *
+ * Every host check compares the PARSED hostname, never a string prefix: a prefix
+ * test lets `http://127.0.0.1.example.com/` and `http://localhost.example.com/`
+ * through as "loopback" (#1020). The scheme is checked too, because an opaque
+ * scheme can carry a matching origin — `new URL('blob:http://127.0.0.1:1234/x')`
+ * reports origin `http://127.0.0.1:1234` — and such a document is authored by
+ * the page, not served by us.
+ */
+export function isAllowedNavigation(
+  target: string,
+  currentUrl: string | null,
+  rendererDir: string,
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch (e) {
+    console.warn(`[nav] blocking navigation to unparseable URL ${redactUrl(target)}:`, e);
+    return false;
+  }
+  // Embedded credentials are never part of anything we load ourselves, and
+  // `url.origin` deliberately ignores them — so refuse them rather than let
+  // `http://someone@127.0.0.1:<port>/` reach the backend as the loopback origin.
+  if (url.username || url.password) {
+    console.warn(`[nav] blocking URL carrying embedded credentials: ${redactUrl(target)}`);
+    return false;
+  }
+  // Local bundled pages (splash / setup wizard): allow ONLY our own renderer
+  // files, never an arbitrary file:// path (which would still carry the preload).
+  // Normalise the trailing separator here rather than trust the caller: without
+  // it a sibling directory sharing the prefix (…/renderer-evil) would pass.
+  if (url.protocol === 'file:') {
+    const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
+    try {
+      const path = resolve(fileURLToPath(url));
+      return path === dir.slice(0, -1) || path.startsWith(dir);
+    } catch (e) {
+      console.warn(`[nav] blocking unresolvable file:// URL ${redactUrl(target)}:`, e);
+      return false;
+    }
+  }
+  // Everything else must be a real http(s) document; blob:/data:/about: and any
+  // custom scheme are refused before the origin comparison below sees them.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  // The running backend, pinned to the exact loopback origin we loaded. Once we
+  // know that origin it is the ONLY http one allowed — another port on the same
+  // loopback host is a different local service, and letting the window load it
+  // would carry the privileged preload bridge onto its pages.
+  if (currentUrl) {
+    try {
+      return url.origin === new URL(currentUrl).origin;
+    } catch (e) {
+      console.warn(`[nav] could not parse current backend URL ${redactUrl(currentUrl)}:`, e);
+    }
+  }
+  // Fallback before the backend URL is known: only the loopback host over http.
+  return url.protocol === 'http:' && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
+}

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { join, resolve, sep } from 'node:path';
+import { isAllowedNavigation, redactUrl } from '../src/urlPolicy';
+
+// A plausible packaged renderer dir, resolved and separator-suffixed exactly as
+// main.ts builds RENDERER_DIR.
+const RENDERER_DIR = resolve('/opt/pixlstash/dist/renderer') + sep;
+const BACKEND = 'http://127.0.0.1:8723/';
+
+/** The window-open handler and the navigation guard share this one predicate. */
+const allowed = (target: string, currentUrl: string | null = BACKEND): boolean =>
+  isAllowedNavigation(target, currentUrl, RENDERER_DIR);
+
+describe('isAllowedNavigation — backend origin', () => {
+  it('allows the exact running backend origin', () => {
+    assert.ok(allowed('http://127.0.0.1:8723/'));
+    assert.ok(allowed('http://127.0.0.1:8723/pictures?page=2'));
+  });
+
+  it('rejects hosts that merely start with the loopback spelling (#1020)', () => {
+    for (const bad of [
+      'http://127.0.0.1.example.com/',
+      'http://localhost.example.com/',
+      'http://127.0.0.1.example.com:8723/',
+      'http://127.0.0.1evil.example.com/',
+      'http://localhostx.example.com/',
+    ]) {
+      assert.equal(allowed(bad), false, `${bad} must not count as loopback`);
+      assert.equal(allowed(bad, null), false, `${bad} must not count as loopback pre-boot`);
+    }
+  });
+
+  it('rejects a different port on the loopback host once the backend URL is known', () => {
+    assert.equal(allowed('http://127.0.0.1:9999/'), false);
+    assert.equal(allowed('http://localhost:8723/'), false);
+  });
+
+  it('rejects a scheme other than the backend one, even at a matching origin', () => {
+    assert.equal(allowed('https://127.0.0.1:8723/'), false);
+    // `new URL('blob:http://127.0.0.1:8723/x').origin` IS the backend origin, so
+    // the scheme check is what keeps a page-authored blob document out.
+    assert.equal(allowed('blob:http://127.0.0.1:8723/9c1e-uuid'), false);
+    assert.equal(allowed('data:text/html,<script>1</script>'), false);
+    assert.equal(allowed('javascript:alert(1)'), false);
+    assert.equal(allowed('about:blank'), false);
+    assert.equal(allowed('ftp://127.0.0.1:8723/'), false);
+  });
+
+  it('rejects embedded credentials even when the origin matches', () => {
+    assert.equal(allowed('http://someone:example-password@127.0.0.1:8723/'), false);
+    assert.equal(allowed('http://someone@127.0.0.1:8723/'), false);
+    assert.equal(allowed('http://someone@127.0.0.1:8723/', null), false);
+  });
+
+  it('rejects an unparseable URL', () => {
+    assert.equal(allowed('not a url'), false);
+    // Non-numeric port: parsing throws rather than yielding a hostname.
+    assert.equal(allowed('http://127.0.0.1:8723.example.com/'), false);
+  });
+
+  it('falls back to the loopback host only, before the backend URL is known', () => {
+    assert.ok(allowed('http://127.0.0.1:41234/', null));
+    assert.ok(allowed('http://localhost:41234/', null));
+    assert.ok(allowed('http://LOCALHOST:41234/', null), 'hostnames are case-insensitive');
+    assert.equal(allowed('http://192.0.2.10:41234/', null), false);
+    assert.equal(allowed('https://example.com/', null), false);
+    // Not currently reachable (the backend binds 127.0.0.1) but pinned so a
+    // future ::1 bind is a deliberate change rather than a surprise.
+    assert.equal(allowed('http://[::1]:41234/', null), false);
+    assert.equal(allowed('http://localhost./', null), false);
+  });
+});
+
+describe('isAllowedNavigation — bundled renderer files', () => {
+  it('allows files inside the packaged renderer directory', () => {
+    assert.ok(allowed(pathToFileURL(RENDERER_DIR + 'index.html').href));
+    assert.ok(allowed(pathToFileURL(RENDERER_DIR + 'assets/app.js').href));
+    assert.ok(allowed(pathToFileURL(RENDERER_DIR.slice(0, -1)).href));
+  });
+
+  it('rejects file:// paths outside it, including a sibling sharing the prefix', () => {
+    const sibling = pathToFileURL(resolve('/opt/pixlstash/dist/renderer-evil/x.html')).href;
+    assert.equal(allowed(pathToFileURL(resolve('/etc/passwd')).href), false);
+    assert.equal(allowed(sibling), false);
+    assert.equal(allowed(pathToFileURL(RENDERER_DIR + '../../secret.html').href), false);
+  });
+
+  it('rejects the prefix-sharing sibling even if the caller omits the trailing separator', () => {
+    const unsuffixed = RENDERER_DIR.slice(0, -1);
+    const sibling = pathToFileURL(resolve('/opt/pixlstash/dist/renderer-evil/x.html')).href;
+    assert.equal(isAllowedNavigation(sibling, BACKEND, unsuffixed), false);
+    const inside = pathToFileURL(RENDERER_DIR + 'index.html').href;
+    assert.ok(isAllowedNavigation(inside, BACKEND, unsuffixed));
+  });
+});
+
+describe('redactUrl', () => {
+  it('drops userinfo but keeps enough to debug with', () => {
+    const withCreds = 'http://someone:example-password@127.0.0.1:8723/x';
+    assert.equal(redactUrl(withCreds), 'http://127.0.0.1:8723/x');
+    assert.equal(redactUrl('not a url'), '<unparseable URL>');
+    assert.match(redactUrl('data:text/plain,' + 'a'.repeat(500)), /…$/);
+  });
+});
+
+// main.ts can't be imported here (it touches `electron` at module load), so pin
+// the wiring by source: the popup handler must go through the shared predicate,
+// and the string-prefix test that #1020 reported must not come back.
+describe('main.ts window-open wiring', () => {
+  const source = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
+
+  it('routes setWindowOpenHandler through the shared origin policy', () => {
+    assert.match(source, /const openHandler[\s\S]{0,200}?isAllowedTarget\(url\)/);
+    assert.match(source, /setWindowOpenHandler\(openHandler\)/);
+  });
+
+  it('never classifies a target by string prefix', () => {
+    assert.equal(/startsWith\(\s*['"`]http/.test(source), false);
+  });
+});

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -102,7 +102,15 @@ describe('redactUrl', () => {
     const withCreds = 'http://someone:example-password@127.0.0.1:8723/x';
     assert.equal(redactUrl(withCreds), 'http://127.0.0.1:8723/x');
     assert.equal(redactUrl('not a url'), '<unparseable URL>');
-    assert.match(redactUrl('data:text/plain,' + 'a'.repeat(500)), /…$/);
+  });
+
+  it('never echoes a page-authored payload back into the log', () => {
+    assert.equal(redactUrl('data:text/plain,' + 'a'.repeat(500)), 'data:text/plain,<redacted>');
+    assert.equal(redactUrl('javascript:alert(document.cookie)'), 'javascript:<redacted>');
+    assert.equal(redactUrl('about:blank'), 'about:<redacted>');
+    // A file: path names a real file and is what a nav failure is debugged with.
+    const filePage = pathToFileURL(resolve('/opt/pixlstash/x.html')).href;
+    assert.ok(redactUrl(filePage).endsWith('x.html'));
   });
 });
 
@@ -117,7 +125,8 @@ describe('main.ts window-open wiring', () => {
     assert.match(source, /setWindowOpenHandler\(openHandler\)/);
   });
 
-  it('never classifies a target by string prefix', () => {
-    assert.equal(/startsWith\(\s*['"`]http/.test(source), false);
+  it('never classifies a target by the loopback string prefix (#1020)', () => {
+    const loopbackPrefix = /startsWith\(\s*['"`]https?:\/\/(127\.0\.0\.1|localhost|\[::1\])/;
+    assert.equal(loopbackPrefix.test(source), false);
   });
 });


### PR DESCRIPTION
Closes #1020.

## What was wrong

`setWindowOpenHandler` classified a popup target with `url.startsWith('http://127.0.0.1')` / `'http://localhost'`, so `http://127.0.0.1.example.com/` and `http://localhost.example.com/` counted as loopback and opened in an in-app child window instead of going to the system browser. A project attachment URL (`ProjectFiles.vue` → `window.open(file.url)`) is a user-controlled way to reach that handler.

## What changed

- `isAllowedNavigation` moved out of `main.ts` into `electron/src/urlPolicy.ts`, parameterised on the current backend URL and the renderer dir, so it is unit-testable. `main.ts` binds it as `isAllowedTarget()`.
- `setWindowOpenHandler` now calls that shared predicate — the origin policy lives in one place, the way the scheme policy already did in `openExternalSafely`.
- A child window inherits the parent's `webPreferences` (preload included), so `did-create-window` now attaches the same navigation guard and window-open handler to it. Validating only the URL a popup opened with would let it navigate off-origin one hop later, bridge and all.
- Non-http(s) schemes are refused before the origin comparison. `new URL('blob:http://127.0.0.1:<port>/x').origin` **is** the backend origin, so without this the extraction would have widened the popup path to page-authored blob documents.
- URLs carrying `user:password@` userinfo are refused: `url.origin` ignores userinfo, so they would otherwise match the backend origin.
- The `file://` branch normalises the trailing separator itself rather than trusting the caller to pass a suffixed dir — without it a sibling directory sharing the prefix (`…/renderer-evil`) passes.
- Blocked URLs are logged through `redactUrl()` (scheme/host/port/path, no userinfo, bounded length) in all three log sites.
- `electron/test/urlPolicy.test.ts`: origin, prefix, port, scheme, credential, `file://` and pre-boot-fallback vectors, plus two source-level assertions pinning the `main.ts` wiring — reverting the handler to the string-prefix test fails them. Verified by mutation: `hostname === '127.0.0.1'` → `startsWith(...)` reds the suite, and restoring the old handler reds the wiring tests. `npm run lint` and `npm test` (87 tests) pass.

## Behaviour change worth a reviewer's eye

Once the backend URL is known, the loopback fallback no longer applies: **only the exact backend origin** is allowed, per the issue's expected behaviour. Previously any `http://127.0.0.1:*` or `http://localhost:*` was allowed even after boot — i.e. another local service (a Vite dev server, a local ComfyUI) could be loaded into the window carrying the privileged preload bridge. Nothing in the frontend generates such a link today (`apiClient.js` derives its base URL from `window.location`), but a link to a different local port now silently does nothing rather than opening in-app, because `openExternalSafely` deliberately refuses plain `http:`. That was already true of every other http link; flagging it in case the reviewer wants a visible refusal instead of a log line.

## Adversarial-review points not acted on

- **`http://@127.0.0.1:<port>/` is allowed.** The userinfo delimiter is present but empty, so no credentials are carried and the origin is the backend's. Rejecting the shape rather than the content would need raw-string parsing for no gain.
- **Windows path-case in the `file://` branch.** `startsWith` is case-sensitive and Windows paths are not; unchanged from before this PR and out of scope here.
- **No architecture doc updated.** `docs/` and `electron/README.md` do not document the Electron navigation guard at all, so nothing went stale.