### PR TITLE
Stop a stale source's runs reaching the current source

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -3107,6 +3107,23 @@ checkpoints. A run that has *vanished* — imported from another window, or
 deleted — drops the selection instead, or the import bar would point at a run
 that is no longer there.
 
+**And it must not land out of order.** Mount, the output-root watcher,
+`visibilitychange` and `window.focus` all start a read and none of them cancels
+the last, so two are in flight whenever one is slow. `loadRuns` therefore
+allocates a generation and captures the folder id it asks about — the request is
+made against the captured id, never a re-read of the store — and every
+completion (rows, count, error, spinner) is dropped unless its generation is
+still the newest.
+
+**Changing the output root clears the rows, the count and the selection
+immediately**, before the new read starts. That, and not the response ordering,
+is what closes #1019: leaving the old root's cards up until the new listing
+replaces them puts them under the new root's path with Import live, and a run
+name means nothing outside the root it was read under — so a tick surviving that
+window sends the new root's id with the old root's run name. `submit` then
+captures the folder id once for the whole batch, because the batch is sequential
+and the registry can change between two of its requests.
+
 **The card grid is built on a promise the listing route makes**, and the promise
 is what must not be eroded: `GET /model-folders/{id}/runs` reads filenames and
 one `config.yaml` per run, and hashes, copies, moves and writes nothing. So the

--- a/frontend/src/components/views/TrainingRuns.test.js
+++ b/frontend/src/components/views/TrainingRuns.test.js
@@ -492,6 +492,172 @@ describe("staying current without moving the ground", () => {
     expect(checked).toEqual(["Foxglove"]);
   });
 
+  // Mount, a folder change, a visibility change and a window focus each start a
+  // read, and none of them cancels the last, so two are in flight whenever one
+  // is slow. Ordering is not promised: the older read can answer last, and what
+  // it carries is another folder's runs — or the same folder's, from before the
+  // run that just finished existed.
+  describe("with two reads in flight", () => {
+    const SOURCE_B = {
+      id: 4,
+      path: "/other-runs",
+      kind: "source",
+      delete_after_import: false,
+    };
+
+    function deferred() {
+      let resolve;
+      let reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    }
+
+    /** Mount against folder 1 with its read held, then register folder 4. */
+    async function switchSource() {
+      const a = deferred();
+      const b = deferred();
+      listRuns.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+      const store = useModelFoldersStore();
+      store.folders = FOLDERS;
+      store.loaded = true;
+      const wrapper = mount(TrainingRuns, globalOpts);
+      mounted.push(wrapper);
+      await wrapper.vm.$nextTick();
+      expect(listRuns).toHaveBeenNthCalledWith(1, 1);
+
+      store.folders = [SOURCE_B, FOLDERS[1], FOLDERS[2]];
+      await wrapper.vm.$nextTick();
+      expect(listRuns).toHaveBeenNthCalledWith(2, 4);
+      return { wrapper, a, b };
+    }
+
+    it("takes the old folder's rows down the moment the folder changes", async () => {
+      // The window that makes #1019 reachable without any response ordering at
+      // all: the new folder's walk takes as long as it takes, and until it
+      // lands the OLD folder's cards are sitting under the NEW folder's path
+      // with Import live. A tick that survives that sends the new folder's id
+      // with a run name read from the old one.
+      const wrapper = await openWith([run(), run("Foxglove")]);
+      await tick(wrapper, "Clementine");
+
+      let release;
+      listRuns.mockReturnValue(new Promise((r) => (release = r)));
+      useModelFoldersStore().folders = [SOURCE_B, FOLDERS[1], FOLDERS[2]];
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.findAll(".tr-card")).toHaveLength(0);
+      expect(importBtn(wrapper)).toBeUndefined();
+      expect(wrapper.emitted("count").at(-1)).toEqual([null]);
+      expect(wrapper.find(".tr-loading").exists()).toBe(true);
+
+      release([run("Hazel")]);
+      await settle(wrapper);
+      expect(wrapper.findAll(".tr-card-name").map((n) => n.text())).toEqual([
+        "Hazel",
+      ]);
+    });
+
+    it("keeps the new folder's runs when the old folder answers last", async () => {
+      const { wrapper, a, b } = await switchSource();
+
+      b.resolve([run("Foxglove")]);
+      await settle(wrapper);
+      a.resolve([run("Clementine")]);
+      await settle(wrapper);
+
+      expect(wrapper.findAll(".tr-card-name").map((n) => n.text())).toEqual([
+        "Foxglove",
+      ]);
+      expect(wrapper.emitted("count").at(-1)).toEqual([1]);
+    });
+
+    it("does not report the current read finished when an older one ends", async () => {
+      const { wrapper, a } = await switchSource();
+
+      a.resolve([run("Clementine")]);
+      await settle(wrapper);
+
+      // Folder 4's read is still running, so the panel must still say so
+      // rather than showing folder 1's grid or an empty one.
+      expect(wrapper.findAll(".tr-card")).toHaveLength(0);
+      expect(wrapper.find(".tr-loading").exists()).toBe(true);
+    });
+
+    it("does not show the old folder's failure against the new folder", async () => {
+      const { wrapper, a, b } = await switchSource();
+
+      b.resolve([run("Foxglove")]);
+      await settle(wrapper);
+      a.reject(new Error("gone"));
+      await settle(wrapper);
+
+      expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+      expect(wrapper.findAll(".tr-card")).toHaveLength(1);
+    });
+
+    it("imports from the folder the chosen runs were read under", async () => {
+      // The batch is sequential and each request is awaited, so the registry
+      // can change between two of them. Every run in the batch came out of ONE
+      // listing, and both roots can hold a run of the same name — so naming
+      // whichever folder is registered when its turn arrives is how run 2 gets
+      // imported from a folder its row was never read from.
+      const wrapper = await openWith([run(), run("Foxglove")]);
+      await tick(wrapper, "Clementine");
+      await tick(wrapper, "Foxglove");
+
+      const store = useModelFoldersStore();
+      importRun.mockImplementation(async () => {
+        store.folders = [SOURCE_B, FOLDERS[1], FOLDERS[2]];
+        return { run_name: "x", files: [] };
+      });
+      await importBtn(wrapper).trigger("click");
+      await settle(wrapper);
+
+      expect(importRun.mock.calls.map((c) => c[0].sourceFolderId)).toEqual([
+        1, 1,
+      ]);
+    });
+
+    it("drops the selection when the folder changes, rather than re-matching names", async () => {
+      const wrapper = await openWith([run(), run("Foxglove")]);
+      await tick(wrapper, "Clementine");
+      expect(wrapper.findAll(".tr-card--checked")).toHaveLength(1);
+
+      listRuns.mockResolvedValue([run(), run("Foxglove")]);
+      useModelFoldersStore().folders = [SOURCE_B, FOLDERS[1], FOLDERS[2]];
+      await settle(wrapper);
+
+      expect(wrapper.findAll(".tr-card")).toHaveLength(2);
+      expect(wrapper.findAll(".tr-card--checked")).toHaveLength(0);
+    });
+
+    it("keeps the newer listing when the same folder is read twice", async () => {
+      // Two focus events, no folder change: the older read still must not win,
+      // or a run that has just finished importing comes back.
+      const wrapper = await openWith([run()]);
+      const first = deferred();
+      const second = deferred();
+      listRuns
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      await wrapper.vm.$nextTick();
+
+      second.resolve([run("Foxglove")]);
+      await settle(wrapper);
+      first.resolve([run(), run("Foxglove"), run("Hazel")]);
+      await settle(wrapper);
+
+      expect(wrapper.findAll(".tr-card-name").map((n) => n.text())).toEqual([
+        "Foxglove",
+      ]);
+    });
+  });
+
   it("stops listening once it is left", async () => {
     // The listeners are on `document` and `window`, so an unmounted view that
     // kept them would keep fetching runs for a screen nobody is looking at.

--- a/frontend/src/components/views/TrainingRuns.test.js
+++ b/frontend/src/components/views/TrainingRuns.test.js
@@ -445,6 +445,30 @@ describe("importing the batch", () => {
       await box.setValue(false);
     expect(importBtn(wrapper).attributes("disabled")).toBeDefined();
   });
+
+  it("cannot be submitted with no source root registered", async () => {
+    // Both ends have to be named. Without the source clause, `submit` reaches
+    // its loop with no `sourceFolderId` and spends a request per run to be
+    // told so — and the receipt reports each refusal against the run rather
+    // than against the missing folder.
+    //
+    // Asserted BEFORE the flush deliberately. The watcher empties the rows and
+    // the tick when the root goes away, so a tick later `chosenRuns` is empty
+    // and every other clause of `canSubmit` is false too — the assertion would
+    // then pass with the source clause deleted. This instant, with the folder
+    // already gone from the registry and the rows still up, is the only one
+    // where the clause is what answers.
+    const wrapper = await openWith([run()]);
+    await tick(wrapper, "Clementine");
+    expect(wrapper.vm.canSubmit).toBe(true);
+
+    useModelFoldersStore().folders = [FOLDERS[1], FOLDERS[2]];
+    expect(wrapper.vm.canSubmit).toBe(false);
+
+    await settle(wrapper);
+    expect(wrapper.vm.canSubmit).toBe(false);
+    expect(importRun).not.toHaveBeenCalled();
+  });
 });
 
 describe("staying current without moving the ground", () => {

--- a/frontend/src/components/views/TrainingRuns.vue
+++ b/frontend/src/components/views/TrainingRuns.vue
@@ -431,9 +431,15 @@ const confirmLabel = computed(() => {
     : `Import ${n} runs · ${fileCountLabel.value}`;
 });
 
+// An import needs BOTH ends named. The destination has always been stated
+// here; the source root is stated beside it so `submit` cannot reach its loop
+// without one and send a request whose `sourceFolderId` is missing — a
+// round-trip that can only come back refused, reported per run as if the run
+// were at fault.
 const canSubmit = computed(
   () =>
     !working.value &&
+    source.value?.id != null &&
     chosenRuns.value.length > 0 &&
     fileTotal.value > 0 &&
     destinationId.value != null,
@@ -701,8 +707,9 @@ async function submit() {
   // between two of its requests. The rows and the tick are dropped the moment
   // the root changes (see the watcher), so what is captured here is the root
   // the chosen runs were read under — and every request in the batch names it,
-  // rather than whichever folder is registered when its turn arrives.
-  const sourceId = source.value?.id;
+  // rather than whichever folder is registered when its turn arrives. Non-null
+  // by `canSubmit`, which is checked above.
+  const sourceId = source.value.id;
   const batch = [...chosenRuns.value];
   const imported = [];
   const failed = [];

--- a/frontend/src/components/views/TrainingRuns.vue
+++ b/frontend/src/components/views/TrainingRuns.vue
@@ -542,11 +542,27 @@ function onGridKeydown(event) {
  * scroll offset is restored, and every still-present run keeps its tick. Runs
  * that have VANISHED (imported from another window, or deleted) drop out of the
  * selection rather than leaving it pointing at nothing.
+ *
+ * Reads overlap — mount, a folder change, a visibility change and a window
+ * focus all start one, and none of them cancels the last — so every completion
+ * is checked against the generation before it writes anything. An older read
+ * answering last would otherwise replace the newer one's rows, and the
+ * selection reconciled below would be filtering the newer listing's names
+ * against the older one's. The folder id is captured too and the request is
+ * made against THAT rather than re-read from the store, so a read is always
+ * asking about the folder it was started for.
  */
+let generation = 0;
 async function loadRuns() {
-  if (source.value?.id == null) {
+  const sourceId = source.value?.id ?? null;
+  const gen = ++generation;
+  const current = () => gen === generation;
+  if (sourceId == null) {
     runs.value = [];
     emit("count", null);
+    // This read is over, and it owns the flag as much as any other: an
+    // in-flight one is now stale and will decline to clear it.
+    loading.value = false;
     return;
   }
   const scrollTop = gridEl.value?.scrollTop ?? 0;
@@ -555,7 +571,9 @@ async function loadRuns() {
   loading.value = true;
   error.value = "";
   try {
-    runs.value = await listRuns(source.value.id);
+    const found = await listRuns(sourceId);
+    if (!current()) return;
+    runs.value = found;
     emit("count", runs.value.length);
     const names = new Set(runs.value.map((run) => run.name));
     chosen.value = keep.filter((name) => names.has(name));
@@ -566,12 +584,15 @@ async function loadRuns() {
     await nextTick();
     if (gridEl.value) gridEl.value.scrollTop = scrollTop;
   } catch (err) {
+    if (!current()) return;
     error.value = errorDetail(err) || "Could not read that folder.";
     runs.value = [];
     emit("count", null);
     clearSelection();
   } finally {
-    loading.value = false;
+    // Only the current read owns the spinner: an older one clearing it would
+    // report the newer, still-running read as finished.
+    if (current()) loading.value = false;
   }
 }
 
@@ -592,10 +613,22 @@ function reload() {
  *
  * `loadRuns` clears and reports an empty count when the id goes away, so
  * forgetting the folder is the same edge handled by the same call.
+ *
+ * The old root's rows and its selection are dropped FIRST, before the new read
+ * is even started. Waiting for the new listing to replace them leaves the old
+ * root's cards on screen under the new root's path for as long as the walk
+ * takes, with Import live: a run name means nothing outside the root it was
+ * read under, so a tick surviving that window sends the new root's id with the
+ * old root's run name — which is issue #1019 whatever the response ordering
+ * does. Same reason the count is cleared rather than left describing a folder
+ * the shelf is no longer pointing at.
  */
 watch(
   () => source.value?.id,
   () => {
+    runs.value = [];
+    emit("count", null);
+    clearSelection();
     loadRuns();
   },
 );
@@ -664,6 +697,12 @@ onBeforeUnmount(() => {
 async function submit() {
   if (!canSubmit.value) return;
   const notices = useNoticeStore();
+  // Captured once, because the batch is sequential and the registry can change
+  // between two of its requests. The rows and the tick are dropped the moment
+  // the root changes (see the watcher), so what is captured here is the root
+  // the chosen runs were read under — and every request in the batch names it,
+  // rather than whichever folder is registered when its turn arrives.
+  const sourceId = source.value?.id;
   const batch = [...chosenRuns.value];
   const imported = [];
   const failed = [];
@@ -675,7 +714,7 @@ async function submit() {
         : (run.checkpoints || []).map((cp) => cp.step ?? null);
       try {
         const report = await importRun({
-          sourceFolderId: source.value.id,
+          sourceFolderId: sourceId,
           runName: run.name,
           destinationFolderId: destinationId.value,
           steps,


### PR DESCRIPTION
Closes #1019.

`TrainingRuns.vue` starts a run-list read from four places — mount, the
output-root watcher, `visibilitychange` and `window.focus` — and none of them
cancels the last. Two overlapping reads could therefore land out of order, and
the view had no way to tell.

## What changed

**`loadRuns` allocates a generation and captures the folder id.** The request
is made against the captured id rather than a re-read of the store, and every
completion — rows, count, error, spinner — is discarded unless its generation
is still the newest. The `finally` is guarded too: an older read clearing
`loading` would report the newer, still-running one as finished.

**Changing the output root now clears the rows, the count and the selection
before the new read starts.** This is the part that actually closes the issue,
and it is not about response ordering at all: leaving the old root's cards up
until the new listing replaces them puts them on screen under the new root's
path with Import live, for as long as the walk takes. A run name means nothing
outside the root it was read under, so a tick surviving that window sends the
new root's id with the old root's run name — which is exactly the inconsistent
request the issue describes.

**`submit` captures the folder id once for the whole batch.** The batch is
sequential by design (`POST /model-imports` holds a non-blocking lock), so the
registry can change between two of its requests.

## Tests

Seven deferred-promise tests under `with two reads in flight`, each verified to
fail with its guard removed: rows taken down on the switch, B resolving before
A, an older read not clearing the spinner, an older read's failure not shown
against the new folder, a same-folder double read, submission bound to the
folder the rows came from, and the selection dropped on a source change.

## One thing I did differently from the issue

The acceptance criteria ask to ignore completions that are not the newest
generation **for the current source**, i.e. to check both. I check the
generation only. The watcher fires `loadRuns` on any id change, which bumps the
generation, so a comparison against the captured id can never be the thing that
rejects a response — an adversarial pass confirmed the id half of the condition
could be deleted with the whole suite still green. The id is still captured and
still what the request is made with; it just is not a second, dead branch in
the guard.

`loading` is also now reset on the "no folder registered" path, which returns
before the `try` and so has no `finally`. That one has no test: with no source
the template shows the empty state and neither the spinner nor the reload
button renders, so the flag is unobservable from the DOM in that state.