### PR TITLE
Keep a READ session out of the model shelf

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1545,6 +1545,45 @@ express that. Like Duplicates it is excluded from `selectionOwnsHighlight` in
 `SideBar.vue`, or the underlying picture selection would light a second active
 destination in the rail.
 
+**It is owner-only, and a READ session sees it without reaching it.** Every
+backend route the shelf calls — `/adapters*`, `/checkpoints`, `/models*`,
+`/model-folders*`, `/model-icons/*`, `/model-moves`, `/model-stacks*`,
+`/model-imports`, `/model-files*` — sits on an owner-only tier (`OWNER_ONLY`, or
+the §16.3 local/loopback variants where it touches the filesystem). So a share
+session is refused by all of them: nothing leaks, but it was offered the
+destination anyway, and a pasted `/models` URL mounted the shelf so it could fire
+a burst of requests it could never satisfy (issue #1014). Three parts fix it:
+
+- **The sidebar entries stay visible and go inert**, expanded row and collapsed
+  dock, on exactly the `Duplicates` pattern beside them —
+  `sidebar-list-item--unavailable`, `aria-disabled`, and a title saying why. Not
+  hidden: the demo site is a READ session, and hiding a feature there advertises
+  a smaller product than PixlStash is (`e2e/specs/read-only-features.spec.js`,
+  which is where Undo and Duplicates stopped being hidden).
+- **`isModelsView` in `useAppNavigation` folds in `!isReadOnly`**, so `App.vue`
+  never mounts `ModelShelf` and not one model request is issued.
+- **A pasted URL is bounced** to `all-pictures` — a **watcher, not a router
+  guard**: the router's first navigation resolves at mount, before `Root.vue` has
+  fetched the session context, and this session then never navigates again, so a
+  guard would see "not read-only" on exactly the boot it exists to catch and
+  never run again. It goes through `replaceAppRoute`, which carries `?token=`
+  forward like every other navigation in the file — the only session that can
+  reach that line is one whose credential lives in the query string. The watcher
+  writes no store state, so `useViewStore` remains the app's only route→store
+  watcher.
+
+  **This is the one place the shelf diverges from Duplicates**, which mounts and
+  renders an explanatory body instead (`dedup-read-only`). The queue can do that
+  because its toolbar is small and its body is a list of the library's own
+  pictures; the shelf's body IS the host machine's filesystem, so a read-only
+  render would be an empty state under a live toolbar of owner-only verbs — Add,
+  the stack sweep, Model folders, the scan. The row above is where the
+  destination explains itself, which is where a visitor meets it.
+
+`SideBar` keeps its own ungated `isModelsView` for `aria-current` and
+`selectionOwnsHighlight`, which want the narrower "is this a shelf route";
+`routeNames.js` records why the pair differ.
+
 **The shelf has TWO views, and `/models/runs` is the second one.** The ai-toolkit
 training runs are models too — still in the output folder rather than on the
 shelf, and importing one is the act of moving it from here to there — so they

--- a/frontend/e2e/specs/read-only-features.spec.js
+++ b/frontend/e2e/specs/read-only-features.spec.js
@@ -40,8 +40,20 @@ test.describe('read-only session: owner-only features stay visible', () => {
     page.on('response', (res) => {
       const url = res.url()
       if (res.status() !== 403) return
-      if (/\/api\/v1\/(operations|dedup|adapters|checkpoints|models|model-)/.test(url))
+      if (
+        /\/api\/v1\/(operations|dedup|adapters|checkpoints|models|model-)/.test(
+          url,
+        )
+      )
         forbidden.push(url)
+    })
+
+    // Every path the SPA has been on, including the history pushes vue-router
+    // makes without a document load. An inert destination must never appear
+    // here, even for the moment it would take a guard elsewhere to undo it.
+    const visited = []
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) visited.push(new URL(frame.url()).pathname)
     })
 
     try {
@@ -87,9 +99,29 @@ test.describe('read-only session: owner-only features stay visible', () => {
         'title',
         'The model shelf is only available in your own library',
       )
+      // Unlike the Duplicates row above, this one is a <button>, so
+      // `aria-disabled` reaches the accessibility tree as a real disabled
+      // state — which is the point of using a button, and which a screen
+      // reader announces. Asserted rather than assumed.
+      await expect(models).toBeDisabled()
+      // …but it stays tabbable, so a keyboard user can land on it and hear the
+      // explanation. That is why `aria-disabled` and not the native attribute.
+      await expect(models).not.toHaveAttribute('disabled', /.*/)
 
-      await models.click()
+      // `force`, because Playwright refuses to click a control the a11y tree
+      // reports as disabled — correctly, and that refusal is asserted above.
+      // Forcing it through is what proves the second guard: the handler itself
+      // declines, so even an activation that got past the disabled state
+      // navigates nowhere.
+      await models.click({ force: true })
       await page.waitForTimeout(500)
+      // Asserted on where the page WENT, not on where it ended up. The shelf
+      // route is guarded twice for this session — the row refuses to emit, and
+      // `useAppNavigation` bounces the route if anything else reaches it — so a
+      // final-URL check passes with the row's guard deleted and only tests the
+      // bounce. `visited` sees the push that a broken row would make, before the
+      // bounce undoes it.
+      expect(visited).not.toContain('/models')
       expect(new URL(page.url()).pathname).not.toContain('models')
 
       // ── None of the three woke the owner-only API ──────────────────────
@@ -149,12 +181,15 @@ test.describe('read-only session: owner-only features stay visible', () => {
     try {
       await page.goto(`/models?token=${encodeURIComponent(token)}`)
 
-      // Landed somewhere it may actually use…
-      await expect(page.locator('.sidebar-list-item').first()).toBeVisible({
+      // Landed somewhere it may actually use. Waiting on the navigation rather
+      // than on the sidebar: the bounce is queued in `App.vue`'s setup, so the
+      // rail paints a tick before the URL settles and sampling `page.url()` off
+      // the render reads the route the visitor is being moved OFF.
+      await page.waitForURL((u) => new URL(u).pathname === '/', {
         timeout: 15_000,
       })
+      await expect(page.locator('.sidebar-list-item').first()).toBeVisible()
       const url = new URL(page.url())
-      expect(url.pathname).toBe('/')
       // …still holding its credential. The bounce is the only navigation that
       // fires exclusively for a share session, so dropping `?token=` here would
       // break the link on the visitor's next reload and nobody else's.

--- a/frontend/e2e/specs/read-only-features.spec.js
+++ b/frontend/e2e/specs/read-only-features.spec.js
@@ -5,9 +5,10 @@ import { test, expect } from '../fixtures/test.js'
 // This is the demo site's contract: pixlstash.dev links to demo.pixlstash.dev
 // with a whole-library READ token, and the demo's job is to demonstrate the
 // product. The rule is show-but-disable — never hide a feature, never show data
-// the token cannot have. Undo and Duplicates are the two owner-only surfaces
-// with a permanent home in the chrome, and both were hidden outright until this
-// spec: the demo silently advertised a smaller product than PixlStash is.
+// the token cannot have. Undo, Duplicates and the model shelf are the owner-only
+// surfaces with a permanent home in the chrome, and all three were hidden or
+// live-and-403ing until this spec covered them: the demo silently advertised a
+// smaller product than PixlStash is.
 //
 // Driven end to end because the interesting half is the backend: /operations*
 // and /dedup/* are OWNER_ONLY, so the affordances must be inert AND quiet. A
@@ -39,7 +40,8 @@ test.describe('read-only session: owner-only features stay visible', () => {
     page.on('response', (res) => {
       const url = res.url()
       if (res.status() !== 403) return
-      if (/\/api\/v1\/(operations|dedup)\b/.test(url)) forbidden.push(url)
+      if (/\/api\/v1\/(operations|dedup|adapters|checkpoints|models|model-)/.test(url))
+        forbidden.push(url)
     })
 
     try {
@@ -75,7 +77,22 @@ test.describe('read-only session: owner-only features stay visible', () => {
       await page.waitForTimeout(500)
       expect(new URL(page.url()).pathname).not.toContain('duplicates')
 
-      // ── Neither control woke the owner-only API ────────────────────────
+      // ── Models: the shelf is a third such destination (#1014) ──────────
+      const models = page
+        .locator('.sidebar-list-item', { hasText: 'Models' })
+        .first()
+      await expect(models).toBeVisible()
+      await expect(models).toHaveAttribute('aria-disabled', 'true')
+      await expect(models).toHaveAttribute(
+        'title',
+        'The model shelf is only available in your own library',
+      )
+
+      await models.click()
+      await page.waitForTimeout(500)
+      expect(new URL(page.url()).pathname).not.toContain('models')
+
+      // ── None of the three woke the owner-only API ──────────────────────
       expect(forbidden).toEqual([])
     } finally {
       await context.close()
@@ -102,6 +119,48 @@ test.describe('read-only session: owner-only features stay visible', () => {
       // forever, since the counts it waits on are owner-only.
       await expect(page.locator('.qdone h3')).toHaveText('Duplicate review')
       await expect(page.locator('.dq-state')).toHaveCount(0)
+    } finally {
+      await context.close()
+    }
+  })
+
+  // Models diverges from Duplicates here on purpose, and only here. The shelf
+  // is the one destination whose whole body is the host machine's filesystem,
+  // so there is no partial view of it to render: mounting it would be a screen
+  // of empty state above a live toolbar of owner-only verbs. It bounces
+  // instead, and the destination explains itself where the visitor actually
+  // meets it — the sidebar row, above.
+  test('bounces the model shelf when it is reached by URL', async ({
+    browser,
+    apiContext,
+    baseURL,
+  }) => {
+    const token = await mintLibraryReadToken(apiContext)
+    const context = await browser.newContext({ baseURL, storageState: undefined })
+    const page = await context.newPage()
+
+    const shelfCalls = []
+    page.on('request', (req) => {
+      const path = new URL(req.url()).pathname
+      if (/^\/api\/v1\/(adapters|checkpoints|models|model-)/.test(path))
+        shelfCalls.push(path)
+    })
+
+    try {
+      await page.goto(`/models?token=${encodeURIComponent(token)}`)
+
+      // Landed somewhere it may actually use…
+      await expect(page.locator('.sidebar-list-item').first()).toBeVisible({
+        timeout: 15_000,
+      })
+      const url = new URL(page.url())
+      expect(url.pathname).toBe('/')
+      // …still holding its credential. The bounce is the only navigation that
+      // fires exclusively for a share session, so dropping `?token=` here would
+      // break the link on the visitor's next reload and nobody else's.
+      expect(url.searchParams.get('token')).toBe(token)
+      // …and asked the shelf for nothing on the way through.
+      expect(shelfCalls).toEqual([])
     } finally {
       await context.close()
     }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -172,6 +172,13 @@ const isModelsView = computed(() => MODEL_SHELF_ROUTES.includes(route.name));
 const READ_ONLY_DEDUP_HINT =
   "Duplicate review is only available in your own library";
 
+// The shelf is the same shape of refusal: every /models, /adapters,
+// /checkpoints and /model-* route is owner-only, because the shelf lists files
+// on the machine PixlStash runs on. Same show-but-disable rule as Duplicates —
+// the destination stays visible and says why (issue #1014).
+const READ_ONLY_SHELF_HINT =
+  "The model shelf is only available in your own library";
+
 const props = defineProps({
   backendUrl: { type: String, default: () => API_BASE_URL },
   installType: { type: String, default: "pip" },
@@ -4940,15 +4947,20 @@ defineExpose({
           </div>
 
           <!-- The shelf's dock mirror. Same <button> reasoning as the
-               expanded row. -->
+               expanded row, and the same read-only treatment as Duplicates
+               above it. -->
           <div :class="['sidebar-collapsed-row', { active: isModelsView }]">
             <button
               type="button"
               class="sidebar-collapsed-item sidebar-destination-btn"
-              :class="{ active: isModelsView }"
+              :class="{
+                active: isModelsView,
+                'sidebar-collapsed-item--unavailable': isReadOnly,
+              }"
               :aria-current="isModelsView ? 'page' : undefined"
-              title="Models"
-              @click="emit('select-models')"
+              :aria-disabled="isReadOnly || undefined"
+              :title="isReadOnly ? READ_ONLY_SHELF_HINT : 'Models'"
+              @click="isReadOnly || emit('select-models')"
             >
               <v-icon>mdi-layers-outline</v-icon>
             </button>
@@ -5407,14 +5419,27 @@ defineExpose({
                  and checkpoints on this machine, which no picture view can
                  express. A <button>, unlike the rows above it, because a new
                  destination must not be born unreachable by keyboard; the
-                 other three are filed to follow. -->
+                 other three are filed to follow.
+
+                 Inert rather than hidden for a READ session, exactly like
+                 Duplicates above and for the same reason: the demo site is a
+                 READ session, and hiding a feature there advertises a smaller
+                 product than PixlStash is (`e2e/specs/read-only-features.spec.js`).
+                 Every /models route is owner-only, so the row must be quiet as
+                 well as inert — it can carry no count and start no fetch
+                 (issue #1014). -->
             <div class="sidebar-all-pictures-row">
               <button
                 type="button"
                 class="sidebar-list-item sidebar-destination-btn"
-                :class="{ active: isModelsView }"
+                :class="{
+                  active: isModelsView,
+                  'sidebar-list-item--unavailable': isReadOnly,
+                }"
                 :aria-current="isModelsView ? 'page' : undefined"
-                @click="emit('select-models')"
+                :aria-disabled="isReadOnly || undefined"
+                :title="isReadOnly ? READ_ONLY_SHELF_HINT : undefined"
+                @click="isReadOnly || emit('select-models')"
               >
                 <span class="sidebar-list-icon sidebar-list-icon--toplevel"
                   ><v-icon size="18">mdi-layers-outline</v-icon></span

--- a/frontend/src/components/panels/SideBarModelsReadOnly.test.js
+++ b/frontend/src/components/panels/SideBarModelsReadOnly.test.js
@@ -1,0 +1,221 @@
+// The sidebar's two Models entries against a READ/share credential (#1014).
+//
+// Every route the shelf calls is owner-only, so the destination was live for a
+// session the backend refuses on all of it. The rule it now follows is the
+// demo site's, stated in `e2e/specs/read-only-features.spec.js`: show-but-
+// disable, never hide — the demo IS a read-only session, and a hidden feature
+// there advertises a smaller product than PixlStash is. So the row stays, goes
+// inert, and says why, exactly like Duplicates beside it.
+//
+// Both entries are covered because they are separate markup: the expanded rail
+// and the collapsed dock. The dock half was written twice before this file
+// existed and neither version was tested.
+//
+// `useAppNavigationModels.test.js` covers the other half — that a pasted
+// `/models` URL never mounts the shelf.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const apiGet = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    onSessionReset: () => () => {},
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeRef(false),
+    sessionContext: makeRef(null),
+    login: vi.fn(),
+    logout: vi.fn(),
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    toBackendWebSocketUrl: () => "",
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", async () => {
+  const { vuetifyComponentStubs } = await import("../../testing/vuetifyStubs");
+  return vuetifyComponentStubs();
+});
+
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual("vue");
+  const route = reactive({
+    query: {},
+    params: {},
+    path: "/",
+    name: "all-pictures",
+  });
+  const { vi: vitest } = await import("vitest");
+  return {
+    useRoute: () => route,
+    useRouter: () => ({
+      push: vitest.fn(),
+      replace: vitest.fn(),
+      currentRoute: { value: { query: {} } },
+    }),
+  };
+});
+
+import { isReadOnly, sessionContext } from "../../utils/apiClient";
+import { useSidebarStore } from "../../stores/useSidebarStore";
+import SideBar from "./SideBar.vue";
+
+function respond(url) {
+  const u = String(url ?? "");
+  if (u.includes("/characters")) return { data: [] };
+  if (u.includes("/projects")) return { data: [] };
+  if (u.includes("/picture_sets")) return { data: [] };
+  if (u.includes("/summary")) return { data: { image_count: 0 } };
+  return { data: [] };
+}
+
+/**
+ * Mount the sidebar. `docked` renders the collapsed dock instead of the
+ * expanded rail — a separate branch of the template with its own copy of both
+ * destinations.
+ */
+async function mountSidebar({ docked = false } = {}) {
+  if (docked) useSidebarStore().sidebarDocked = true;
+  const wrapper = mount(SideBar, {
+    shallow: true,
+    props: { backendUrl: "/api/v1" },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  wrapper.vm.refreshSidebar();
+  for (let i = 0; i < 5; i += 1) await flushPromises();
+  return wrapper;
+}
+
+const SHELF_HINT = "The model shelf is only available in your own library";
+const DEDUP_HINT = "Duplicate review is only available in your own library";
+
+/** The expanded rail's Models button, by its label. */
+function expandedModels(wrapper) {
+  return wrapper
+    .findAll("button.sidebar-list-item")
+    .find((b) => b.text().includes("Models"));
+}
+
+/**
+ * The collapsed dock's Models button. Located by class, not by title: the title
+ * is the thing under test and swaps to the refusal hint for a READ session.
+ */
+function dockedModels(wrapper) {
+  return wrapper.find("button.sidebar-collapsed-item.sidebar-destination-btn");
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  isReadOnly.value = false;
+  sessionContext.value = null;
+  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the expanded rail's Models entry", () => {
+  it("is visible, inert and explained for a READ session", async () => {
+    isReadOnly.value = true;
+    const wrapper = await mountSidebar();
+
+    // The anchor. A read-only render that produced no rail at all would leave
+    // every "the entry is not clickable" assertion below passing for the wrong
+    // reason — and Duplicates being inert-not-hidden is the very contract this
+    // change is following, so it is worth pinning in the same breath.
+    const duplicates = wrapper
+      .findAll(".sidebar-list-item")
+      .find((el) => el.text().includes("Duplicates"));
+    expect(duplicates).toBeTruthy();
+    expect(duplicates.attributes("aria-disabled")).toBe("true");
+    expect(duplicates.attributes("title")).toBe(DEDUP_HINT);
+
+    const models = expandedModels(wrapper);
+    expect(models).toBeTruthy();
+    expect(models.attributes("aria-disabled")).toBe("true");
+    expect(models.attributes("title")).toBe(SHELF_HINT);
+    // `aria-disabled`, not the native attribute: the control stays tabbable so
+    // a keyboard user reaches the explanation too.
+    expect(models.attributes("disabled")).toBeUndefined();
+
+    await models.trigger("click");
+    expect(wrapper.emitted("select-models")).toBeUndefined();
+
+    wrapper.unmount();
+  });
+
+  it("still navigates for the owner", async () => {
+    // The positive control: an inert-for-everybody row is its own regression.
+    const wrapper = await mountSidebar();
+
+    const models = expandedModels(wrapper);
+    expect(models).toBeTruthy();
+    expect(models.attributes("aria-disabled")).toBeUndefined();
+    expect(models.attributes("title")).toBeUndefined();
+
+    await models.trigger("click");
+    expect(wrapper.emitted("select-models")).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+});
+
+describe("the collapsed dock's Models entry", () => {
+  it("is visible, inert and explained for a READ session", async () => {
+    isReadOnly.value = true;
+    const wrapper = await mountSidebar({ docked: true });
+
+    const duplicates = wrapper
+      .findAll(".sidebar-collapsed-item")
+      .find((el) => String(el.attributes("title") ?? "") === DEDUP_HINT);
+    expect(duplicates).toBeTruthy();
+
+    const models = dockedModels(wrapper);
+    expect(models.exists()).toBe(true);
+    expect(models.attributes("aria-disabled")).toBe("true");
+    expect(models.attributes("title")).toBe(SHELF_HINT);
+
+    await models.trigger("click");
+    expect(wrapper.emitted("select-models")).toBeUndefined();
+
+    wrapper.unmount();
+  });
+
+  it("still navigates for the owner", async () => {
+    const wrapper = await mountSidebar({ docked: true });
+
+    const models = dockedModels(wrapper);
+    expect(models.exists()).toBe(true);
+    expect(models.attributes("title")).toBe("Models");
+    expect(models.attributes("aria-disabled")).toBeUndefined();
+
+    await models.trigger("click");
+    expect(wrapper.emitted("select-models")).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -1,6 +1,7 @@
 import { MODEL_SHELF_ROUTES } from "../router/routeNames";
-import { computed, nextTick } from "vue";
+import { computed, nextTick, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { isReadOnly } from "../utils/apiClient";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useProjectStore } from "../stores/useProjectStore";
 import { useSearchStore } from "../stores/useSearchStore";
@@ -216,14 +217,28 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
   // ============================================================
 
   /**
+   * Carry the share token onto a route target. A share session's credential
+   * lives in `?token=`, so a navigation that drops it leaves the visitor on a
+   * URL that 401s on the next reload.
+   */
+  function withShareToken(target) {
+    if (route.query.token) {
+      target.query = { token: route.query.token, ...target.query };
+    }
+    return target;
+  }
+
+  /**
    * Push a route without cluttering history on duplicate navigations.
    * Swallows NavigationDuplicated errors (vue-router throws on same-route push).
    */
   function pushAppRoute(target) {
-    if (route.query.token) {
-      target.query = { token: route.query.token, ...target.query };
-    }
-    router.push(target).catch(() => {});
+    router.push(withShareToken(target)).catch(() => {});
+  }
+
+  /** Same, replacing the current entry rather than adding one. */
+  function replaceAppRoute(target) {
+    router.replace(withShareToken(target)).catch(() => {});
   }
 
   /**
@@ -352,7 +367,41 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
   // Both of the shelf's views. `/models/runs` is the ai-toolkit runs waiting to
   // be imported — the same destination, a second tab — so the sidebar's Models
   // entry stays the current page across both and no second destination lights.
-  const isModelsView = computed(() => MODEL_SHELF_ROUTES.includes(route.name));
+  // A READ session is never showing it: the shelf lists the owner's machine and
+  // every route behind it is owner-only, so mounting it would only fire requests
+  // the credential can never satisfy (issue #1014). Gating the predicate rather
+  // than the component keeps the decision in the one place that already answers
+  // "is the shelf showing".
+  const isModelsView = computed(
+    () => !isReadOnly.value && MODEL_SHELF_ROUTES.includes(route.name),
+  );
+
+  // …and a pasted /models URL is bounced to the library rather than left on a
+  // route that renders the grid under a Models heading. The sidebar row cannot
+  // reach this: it is inert for a READ session, so the only way in is an
+  // address bar.
+  //
+  // A watcher and not a router guard. The router's first navigation resolves at
+  // mount, before `Root.vue` has fetched the session context, and for this
+  // session nothing ever navigates a second time — so a guard would see "not
+  // read-only" on exactly the boot it exists to catch, and never run again.
+  //
+  // It writes no selection or project state, so `useViewStore` remains the only
+  // route→store watcher; this one only navigates, which is this file's job.
+  //
+  // `replace` and not `push`, so Back leaves the app rather than returning to
+  // the bounce — and through the same token-preserving path every other
+  // navigation here uses, because the ONLY session that reaches this line is
+  // one whose credential lives in `?token=`. Dropping it would leave a share
+  // visitor on a URL that 401s the moment they reload or bookmark it.
+  watch(
+    [isReadOnly, () => route.name],
+    ([readOnly, name]) => {
+      if (readOnly && MODEL_SHELF_ROUTES.includes(name))
+        replaceAppRoute({ name: "all-pictures" });
+    },
+    { immediate: true },
+  );
 
   /** Open the model shelf. */
   function handleSelectModels() {

--- a/frontend/src/composables/useAppNavigationModels.test.js
+++ b/frontend/src/composables/useAppNavigationModels.test.js
@@ -1,0 +1,176 @@
+// The model shelf against a READ/share credential (issue #1014).
+//
+// Every route the shelf calls is owner-only, so the backend answers a share
+// session with 403 on all of them. Nothing leaks — but the session was still
+// offered the destination, and a direct `/models` URL mounted the whole screen
+// so it could fire a burst of requests it could never satisfy. Two halves fix
+// it, and this file pins the navigation half:
+//
+//   * `isModelsView` is false for a READ session, so `App.vue` never mounts
+//     `ModelShelf` and no model request is issued at all;
+//   * the session is bounced to the library, so it does not sit on a URL that
+//     renders the picture grid.
+//
+// `sessionContext` here is the REAL one from `apiClient`, not a mocked
+// `isReadOnly` ref, so the scoped and unscoped cases genuinely differ in what
+// they feed the predicate rather than both being the same hand-set boolean.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { defineComponent, h } from "vue";
+import { mount } from "@vue/test-utils";
+
+const nav = vi.hoisted(() => ({ route: null, replace: null, push: null }));
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual("vue");
+  const { vi: vitest } = await import("vitest");
+  nav.route = reactive({
+    path: "/",
+    name: "all-pictures",
+    params: {},
+    query: {},
+  });
+  nav.replace = vitest.fn();
+  nav.push = vitest.fn();
+  return {
+    useRoute: () => nav.route,
+    useRouter: () => ({
+      push: nav.push,
+      replace: nav.replace,
+      currentRoute: { value: nav.route },
+    }),
+  };
+});
+
+import { sessionContext } from "../utils/apiClient";
+import { useAppNavigation } from "./useAppNavigation";
+
+/** Mount a bare component whose only job is to hold the composable. */
+function mountNav() {
+  let api = null;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useAppNavigation();
+        return () => h("div");
+      },
+    }),
+  );
+  return { wrapper, api };
+}
+
+const UNSCOPED_READ = { scope: "READ" };
+const SCOPED_READ = {
+  scope: "READ",
+  resource_type: "picture_set",
+  resource_id: 12,
+};
+
+// A share session's credential lives in the query string, so every session that
+// can reach the bounce has one, and the bounce has to carry it forward.
+const SHARE_TOKEN = "example-share-token";
+
+/** Where the bounce must land, credential intact. */
+const BOUNCE_TARGET = {
+  name: "all-pictures",
+  query: { token: SHARE_TOKEN },
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  sessionContext.value = null;
+  nav.route.name = "all-pictures";
+  nav.route.path = "/";
+  nav.route.query = {};
+  nav.replace.mockReset().mockReturnValue(Promise.resolve());
+  nav.push.mockReset().mockReturnValue(Promise.resolve());
+});
+
+describe("the model shelf and a READ session", () => {
+  for (const [label, ctx] of [
+    ["an unscoped READ credential", UNSCOPED_READ],
+    ["a scoped READ credential", SCOPED_READ],
+  ]) {
+    it(`does not show the shelf to ${label} that lands on /models`, () => {
+      sessionContext.value = ctx;
+      nav.route.name = "models";
+      nav.route.query = { token: SHARE_TOKEN };
+      const { wrapper, api } = mountNav();
+
+      expect(api.isModelsView.value).toBe(false);
+      expect(nav.replace).toHaveBeenCalledWith(BOUNCE_TARGET);
+
+      wrapper.unmount();
+    });
+
+    it(`does not show the runs tab to ${label} either`, () => {
+      sessionContext.value = ctx;
+      nav.route.name = "models-runs";
+      nav.route.query = { token: SHARE_TOKEN };
+      const { wrapper, api } = mountNav();
+
+      expect(api.isModelsView.value).toBe(false);
+      expect(nav.replace).toHaveBeenCalledWith(BOUNCE_TARGET);
+
+      wrapper.unmount();
+    });
+  }
+
+  it("bounces a READ session that navigates to /models after mount", async () => {
+    // The share session is already in the app when the URL changes — a pasted
+    // link, a Back into a models entry left in history.
+    sessionContext.value = UNSCOPED_READ;
+    nav.route.query = { token: SHARE_TOKEN };
+    const { wrapper, api } = mountNav();
+    expect(nav.replace).not.toHaveBeenCalled();
+
+    nav.route.name = "models";
+    await wrapper.vm.$nextTick();
+
+    expect(api.isModelsView.value).toBe(false);
+    expect(nav.replace).toHaveBeenCalledWith(BOUNCE_TARGET);
+
+    wrapper.unmount();
+  });
+
+  // The bounce is the ONLY navigation in the app that fires exclusively for a
+  // share session, so a dropped `?token=` here would break the share link for
+  // every visitor it fires for and nobody else — invisible until the next
+  // reload, when `Root.vue` finds no token and shows the login screen.
+  it("carries the share token through the bounce", () => {
+    sessionContext.value = SCOPED_READ;
+    nav.route.name = "models";
+    nav.route.query = { token: SHARE_TOKEN };
+    const { wrapper } = mountNav();
+
+    const target = nav.replace.mock.calls[0][0];
+    expect(target.query?.token).toBe(SHARE_TOKEN);
+
+    wrapper.unmount();
+  });
+
+  it("leaves a READ session alone on the routes it may use", () => {
+    sessionContext.value = SCOPED_READ;
+    nav.route.name = "set";
+    const { wrapper } = mountNav();
+
+    expect(nav.replace).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  // The positive control: over-blocking is its own regression, and a guard that
+  // reads `isReadOnly` inverted would still pass every assertion above.
+  it("still shows the owner both of the shelf's routes", async () => {
+    nav.route.name = "models";
+    const { wrapper, api } = mountNav();
+    expect(api.isModelsView.value).toBe(true);
+
+    nav.route.name = "models-runs";
+    await wrapper.vm.$nextTick();
+    expect(api.isModelsView.value).toBe(true);
+    expect(nav.replace).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/router/routeNames.js
+++ b/frontend/src/router/routeNames.js
@@ -17,5 +17,12 @@
  * sidebar half silently: on `/models/runs` the Models entry went dark AND the
  * underlying selection lit a second destination, which is the exact
  * two-active-destinations defect the sidebar guard exists to prevent.
+ *
+ * The two predicates built from this list are deliberately not identical:
+ * `useAppNavigation`'s also requires `!isReadOnly`, because it decides whether
+ * `App.vue` MOUNTS the shelf and a READ session must never mount it (#1014).
+ * `SideBar`'s answers the narrower "is the route a shelf route", which is what
+ * `aria-current` and `selectionOwnsHighlight` want. The route list is the part
+ * that has to agree, and it is the part this constant holds.
  */
 export const MODEL_SHELF_ROUTES = ["models", "models-runs"];

--- a/frontend/src/router/routeNames.js
+++ b/frontend/src/router/routeNames.js
@@ -18,11 +18,12 @@
  * underlying selection lit a second destination, which is the exact
  * two-active-destinations defect the sidebar guard exists to prevent.
  *
- * The two predicates built from this list are deliberately not identical:
- * `useAppNavigation`'s also requires `!isReadOnly`, because it decides whether
- * `App.vue` MOUNTS the shelf and a READ session must never mount it (#1014).
- * `SideBar`'s answers the narrower "is the route a shelf route", which is what
- * `aria-current` and `selectionOwnsHighlight` want. The route list is the part
- * that has to agree, and it is the part this constant holds.
+ * The two predicates built from this list are deliberately not identical.
+ * `useAppNavigation` additionally requires `!isReadOnly`, because its predicate
+ * decides whether `App.vue` MOUNTS the shelf, and a READ session must never
+ * mount it (#1014). `SideBar` asks the narrower question — is this a shelf
+ * route — which is what `aria-current` and `selectionOwnsHighlight` want. The
+ * route list is the part that has to agree, and it is the part this constant
+ * holds.
  */
 export const MODEL_SHELF_ROUTES = ["models", "models-runs"];


### PR DESCRIPTION
Closes #1014.

A READ/share session was offered the **Models** destination and could mount the
model shelf from a pasted `/models` URL. Every route behind it — `/adapters*`,
`/checkpoints`, `/models*`, `/model-folders*`, `/model-icons/*`, `/model-moves`,
`/model-stacks*`, `/model-imports`, `/model-files*` — is on an owner-only tier
(29 routes: `owner_only`, or the §16.3 local/loopback variants where the route
touches the filesystem). So nothing leaked; the visitor just got a screen that
could not work, firing a burst of requests the backend answered with 403.

## What changed

**The sidebar entries stay visible and go inert** — expanded rail and collapsed
dock — with `sidebar-list-item--unavailable`, `aria-disabled`, and a title
saying why. That is the `Duplicates` row beside them, and it is deliberate:
`e2e/specs/read-only-features.spec.js` states the demo site's contract as
*show-but-disable, never hide*, because demo.pixlstash.dev **is** a read-only
session and a hidden feature there advertises a smaller product than PixlStash
is. My first cut hid the rows; that was the wrong side of an already-decided
question.

**`isModelsView` folds in `!isReadOnly`**, so `App.vue` never mounts
`ModelShelf` and not one model request is issued.

**A pasted URL bounces** to `all-pictures`. A watcher rather than a router
guard: the router's first navigation resolves at mount, before `Root.vue` has
fetched the session context, and this session then never navigates again — a
guard would see "not read-only" on exactly the boot it exists to catch. It goes
through a new `replaceAppRoute`, which shares `pushAppRoute`'s token-carrying
step: the only session that can reach that line is one whose credential lives in
`?token=`, so a bare `router.replace` would have broken the share link on the
visitor's next reload.

## Two things a reviewer may want to push back on

**The shelf bounces where Duplicates explains in place.** `DuplicateQueue`
mounts for a read-only session and renders `dedup-read-only`. The shelf does
not, and the divergence is argued in `docs/frontend_architecture.md` §9.1a and
in the e2e spec: the queue's body is the library's own pictures under a small
toolbar, while the shelf's body *is* the host machine's filesystem — a read-only
render would be an empty state under a live toolbar of owner-only verbs (Add,
the stack sweep, Model folders, the scan), so it would need the whole toolbar
disabled and a new empty state written. That is a design change past this issue,
and the issue's own acceptance criteria ask for a redirect. Happy to file the
explain-in-place version as follow-up if you'd rather have the symmetry.

**`SideBar` keeps an ungated `isModelsView`.** It answers the narrower "is this
a shelf route", which is what `aria-current` and `selectionOwnsHighlight` want;
`useAppNavigation`'s answers "is the shelf mounting". `routeNames.js` now records
why the pair differ, since that file exists to stop them drifting.

## Tests

- `frontend/src/composables/useAppNavigationModels.test.js` — scoped and
  unscoped READ, `/models` and `/models/runs`, direct landing and mid-session
  navigation, the token carried through the bounce, plus an owner control.
  Uses the real `sessionContext`, so scoped and unscoped genuinely differ.
- `frontend/src/components/panels/SideBarModelsReadOnly.test.js` — both entries,
  both sessions, anchored on the Duplicates row so a blank render cannot pass
  the negatives.
- `frontend/e2e/specs/read-only-features.spec.js` — Models added to the
  inert-and-quiet case, plus a new case for the URL bounce asserting the token
  survives and no shelf request is made.

Mutation-verified: deleting the `!isReadOnly` gate, deleting the watcher, or
removing either sidebar guard (including the collapsed dock's, which had no
coverage at all) turns the relevant tests red.

Full frontend suite green: 183 files, 3485 tests. The e2e additions were not run
locally — they need a live backend.

No backend change, so `docs/authz-coverage-matrix.md` is untouched.
