### PR TITLE
Quiet the model shelf toolbar's two filled controls

### DIFF
--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -3835,7 +3835,7 @@ watch(
 /* The one filled button in the bar. It is the only control here with a result
    behind it — everything else changes what you are looking at — and that is
    what the fill says. `on-primary` and not the surface ink: this is a solid
-   accent fill, which is the pairing that measures (§4).
+   primary fill, which is the pairing that measures (§4).
 
    28px, not `.bar-btn`'s 32, and `--radius-sm` rather than the nothing it
    inherited. A filled control is the only kind whose box you can actually see:

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -55,10 +55,12 @@
            on one segment against mdi line art on the other unbalances a control
            that has to read as symmetric.
 
-           The selected segment FILLS, the way the shipped `.tbm-seg` control
-           does. Not a wash plus a bolder label: a bolder label is a wider
-           label, so the pair resized on every switch and shoved the whole left
-           group sideways. -->
+           The selected segment FILLS, in a wash rather than the solid accent
+           `.tbm-seg` uses inside a menu — this one sits in a toolbar beside the
+           bar's one accent button, and two solid fills in one strip is what
+           made this bar read louder than the other two. Never a bolder label: a
+           bolder label is a wider label, so the pair resized on every switch and
+           shoved the whole left group sideways. -->
       <div class="shelf-viewswitch" role="tablist" aria-label="Model view">
         <button
           id="shelf-tab-shelf"
@@ -3833,9 +3835,21 @@ watch(
 /* The one filled button in the bar. It is the only control here with a result
    behind it — everything else changes what you are looking at — and that is
    what the fill says. `on-primary` and not the surface ink: this is a solid
-   accent fill, which is the pairing that measures (§4). */
+   accent fill, which is the pairing that measures (§4).
+
+   28px, not `.bar-btn`'s 32, and `--radius-sm` rather than the nothing it
+   inherited. A filled control is the only kind whose box you can actually see:
+   the boxed buttons beside it are transparent at rest, so their 32px shows as a
+   hover wash and never as a silhouette, while this one's 32px in a 36px band
+   (35 inside the bottom hairline) left 1.5px of clearance and read as a
+   bar-height object rather than a control sitting in a bar. The radius was
+   simply missing — `--boxed` is what carries `--radius-sm` and this never took
+   it, so the one accent button in the app was also the one square-cornered one,
+   at a radius (0) that is not on the scale (§6). */
 .shelf-toolbar .bar-btn--accent {
   gap: var(--space-2);
+  height: 28px;
+  border-radius: var(--radius-sm);
   border-color: rgb(var(--v-theme-primary));
   background: rgb(var(--v-theme-primary));
   color: rgb(var(--v-theme-on-primary));
@@ -3928,15 +3942,20 @@ watch(
   border-radius: var(--radius-pill);
 }
 
-/* 30px, not `.bar-btn`'s 32: this is the one control on any of the three bars
+/* 26px, not `.bar-btn`'s 32: this is the one control on any of the three bars
    that wraps its buttons in a bordered track, so 32px segments made the switch
    34px against every neighbour's 32. In the old 48px band that only misaligned
    it; in the 36px band it also left 0.5px between the switch and the band edge,
-   so a focused segment's 3px ring painted over the first list row. 30 + 2×1px
-   border = 32, the height every other control in every bar already is. */
+   so a focused segment's 3px ring painted over the first list row.
+
+   26 + 2×1px border = 28, matching `Add` beside it rather than the 32 of the
+   boxed buttons — and for the same reason `Add` moved: this switch and that
+   button are the only two objects on the bar that are visibly filled at rest,
+   so they are the only two whose height reads as a silhouette. 28 in a 36px
+   band leaves 3.5px above and below instead of 1.5. */
 .shelf-viewseg {
   border-radius: 0;
-  height: 30px;
+  height: 26px;
   color: rgba(var(--v-theme-on-panel), 0.7);
 }
 
@@ -3957,19 +3976,36 @@ watch(
   background: var(--hover-wash);
 }
 
-/* The selected segment FILLS, exactly as `.tbm-seg-btn--on` does, and carries
-   no weight change. A bolder label is a wider label, so the pair resized on
-   every switch and the whole left group jumped — the fill says the same thing
-   and costs no layout. `on-primary` on `primary` measures 4.86:1 in both
-   themes, so the label clears the text floor on the fill. */
+/* The selected segment fills, and carries no weight change. A bolder label is a
+   wider label, so the pair resized on every switch and the whole left group
+   jumped — the fill says the same thing and costs no layout (and the guardrail
+   in `ModelShelf.test.js` holds this rule to any property that would).
+
+   A WASH and not the solid `primary` `.tbm-seg-btn--on` uses. That control
+   lives inside a menu panel, where a branded fill is the only thing on the
+   surface; here it sat in a 36px band beside `Add`, and two solid accents in
+   one strip is what made this bar read as louder than the other two. Every
+   other bar in the app runs on transparent buttons — ink and a hover wash,
+   nothing filled at rest.
+
+   The label leaves `on-primary` with the fill, because warm white on a 28%
+   tint does not measure; it goes to `toolbar-text` at FULL strength against the
+   0.7 its neighbour keeps. That step is not decoration — `.shelf-row--selected`
+   below states the rule this obeys: a wash alone is a hue, and it needs a
+   partner that survives greyscale and forced-colors. Here the partner is the
+   ink, since a pill cannot carry that rule's inset bar.
+
+   The two alphas live in `style.css` beside `--hover-wash` and `--active-wash`,
+   which is where every theme-varying value in this app is declared — including
+   the shelf's own drive-band meter colours. */
 .shelf-viewseg--on {
-  background: rgb(var(--v-theme-primary));
-  color: rgb(var(--v-theme-on-primary));
+  background: var(--shelf-viewseg-wash);
+  color: rgb(var(--v-theme-toolbar-text));
 }
 
 .shelf-viewseg--on:hover {
-  background: rgb(var(--v-theme-primary));
-  color: rgb(var(--v-theme-on-primary));
+  background: var(--shelf-viewseg-wash);
+  color: rgb(var(--v-theme-toolbar-text));
 }
 
 /* Raised so the focus ring is not clipped by the welded sibling. */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -68,6 +68,15 @@ body {
      `on-surface` (10.84:1) and needs no change either. */
   --active-text: rgb(var(--v-theme-on-primary));
 
+  /* The model shelf's view switch, whose selected segment is a wash rather than
+     a solid fill (`.shelf-viewseg--on`). Not `--active-wash`: that one selects
+     in the warm accent on light and the olive on dark, and this control keeps
+     one hue in both because it sits beside the bar's olive `Add` and a warm
+     chip next to it would read as a second, different accent. The +.06 over
+     light is the same compensation the line above makes, for the same reason —
+     the deepened olive needs more of itself to register on the dark track. */
+  --shelf-viewseg-wash: rgba(var(--v-theme-primary), 0.34);
+
   /* Drive-band capacity meter (#893). Three segments, so TWO adjacencies to
      keep readable: ours|other and other|free. `ours` is `primary` in both
      themes; it is the NEUTRAL that steps per theme.
@@ -106,6 +115,10 @@ body {
   --active-wash: rgba(var(--v-theme-accent), 0.2);
   --active-bar: rgb(var(--v-theme-accent));
   --active-text: rgb(var(--v-theme-on-surface));
+
+  /* See the dark block above: this control holds one hue across both themes,
+     so it stays olive here rather than following `--active-wash` into accent. */
+  --shelf-viewseg-wash: rgba(var(--v-theme-primary), 0.28);
 
   /* Drive-band capacity meter (#893) — see the dark block above for the rule.
      Here the canvas is near-white, so the neutral goes to the DARK extreme,


### PR DESCRIPTION
The Models bar read as louder than the photo grid's and the duplicate
queue's, even though all three share the same 36px band recipe. The cause
was mass, not height: the view switch and `Add` were the only controls in
any toolbar filled at rest. Every other bar runs entirely on transparent
`.bar-btn`s — ink and a hover wash, nothing filled.

Three findings, all fixed here:

1. **Two solid `primary` fills in one band**, and one of them (the selected
   view segment) is a *state* claiming as much attention as the bar's only
   verb. The segment becomes a wash instead of a solid fill.
2. **A filled 32px control in a 36px band** (35 inside the bottom hairline)
   leaves 1.5px of clearance. On a transparent button 32px is invisible; on a
   filled one it is the whole silhouette. Both filled controls drop to 28px.
   The boxed icon buttons keep their 32 — their box only ever shows as a hover
   wash, so their height is not a silhouette.
3. **`Add` had no radius.** `.bar-btn--accent` never declared one and
   `--boxed` is what carries `--radius-sm`, so the one accent button in the app
   was also the one square-cornered one, at a radius (0) that is not on the
   scale in `visual-language.md` §6. It takes `--radius-sm`.

## The wash

`--shelf-viewseg-wash` joins `--hover-wash` and `--active-wash` in
`style.css`, which is where every theme-varying value in this app is
declared, including the shelf's own drive-band meter colours.
`rgba(primary, 0.28)` light, `0.34` dark — the +0.06 is the same
compensation the `--active-wash` line above it makes, for the same reason:
the deepened olive needs more of itself to register against the dark track.

Deliberately **not** `--active-wash` itself. That token selects in the warm
accent on light and the olive on dark; this control holds one hue across both
themes, because a warm chip beside the bar's olive `Add` would read as a
second, different accent rather than as a selection.

The label leaves `on-primary` with the fill — warm white on a 28% tint does
not measure — and lands on `toolbar-text` at full strength against the 0.7 its
neighbour keeps. That step is not decoration: `.shelf-row--selected`, a few
rules below in the same file, states the rule this obeys — a wash alone is a
hue, and it needs a partner that survives greyscale and forced-colors. Here
the partner is the ink, since a pill cannot carry that rule's inset bar.

## Testing

`ModelShelf.test.js` and `Toolbar.test.js` pass (210 tests). The relevant
guardrail is the one asserting `.shelf-viewseg--on` changes no property that
costs layout — a bolder or larger label would resize the pair and shove the
whole left group sideways on every switch. This change touches only
`background` and `color`, so that rule still holds.