### PR TITLE
Fix Windows shard 2: close the server, not only its vault

### DIFF
--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2489,7 +2489,7 @@ def test_tests_close_the_server_not_only_its_vault():
     """
     needle = ".vault" + ".close()"
     offenders = [
-        f"{path.relative_to(REPO_ROOT)}:{number}"
+        f"{path.relative_to(REPO_ROOT).as_posix()}:{number}"
         for path in (REPO_ROOT / "tests").rglob("*.py")
         for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
         if needle in line

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2475,3 +2475,26 @@ def test_private_address_guardrail_reads_a_named_file_of_any_kind(tmp_path):
     assert [o.split(":", 1)[0] for o in named] == ["Dockerfile.demo"], (
         f"a named file must be read whatever it is called; got {named}"
     )
+
+
+def test_tests_close_the_server_not_only_its_vault():
+    """Closing a test server's vault alone leaks the hub's SQLite connection.
+
+    Harmless on POSIX, fatal on Windows: ``TemporaryDirectory`` cleanup then
+    raises a sharing violation on ``hub.db``. ``Server.close`` closes both and
+    is the only supported teardown; this pins that, because the failure is
+    invisible until a Windows shard spends a full gate run finding it.
+
+    The needle is assembled from parts so this file is not its own offender.
+    """
+    needle = ".vault" + ".close()"
+    offenders = [
+        f"{path.relative_to(REPO_ROOT)}:{number}"
+        for path in (REPO_ROOT / "tests").rglob("*.py")
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if needle in line
+    ]
+    assert not offenders, (
+        "close the whole server, not only its vault — server.close() — at "
+        + ", ".join(offenders)
+    )

--- a/tests/test_picture_sets.py
+++ b/tests/test_picture_sets.py
@@ -223,7 +223,7 @@ def test_new_sets_rotate_default_icon_and_color():
         assert resp.json()["picture_set"]["set_icon"] == "cards"
         assert resp.json()["picture_set"]["set_color"] == "#123456"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 


### PR DESCRIPTION
`tests/test_picture_sets.py::test_new_sets_rotate_default_icon_and_color` was the last test in the file tearing down with `server.vault.close()`; every sibling uses `server.close()`. Closing only the vault leaks the hub's SQLite connection, so `TemporaryDirectory.cleanup()` hits a sharing violation on `hub.db` on Windows — exactly the failure `Server.close`'s docstring already describes.

Adds a guardrail in `test_architecture_guardrails.py` so the pattern cannot come back; verified it goes red when the fix is reverted.