### PR TITLE
Accept a group-writable directory whose group has one member

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2594,6 +2594,54 @@ module docstring is the design record: which actor each check is for, why the
 earlier DACL refusal was removed (it stopped the server starting on Windows,
 W6/W7/W18), and what a `private=True` open verifies instead.
 
+**Group-write is not automatically an exposure.** `mode & 0o022` is a *proxy*
+for "another principal can write here", and for the group bit that proxy is
+wrong wherever the group is the owner's own. Debian, Ubuntu and every other
+distro running `useradd -U` give each account a same-named group of its own and
+default to umask 002, so a directory PixlStash created before it started passing
+`0700` explicitly is `0775` with a group of exactly one member. The blanket bit
+test read that as "another account could replace the database" and exited the
+server 1 during startup on a stock Linux box with a library from an earlier
+release, with no recovery short of a manual `chmod`. `_is_private_group` names
+the actor instead of the bit: group-write is tolerated only when the group is the
+directory owner's own, same-named, and has no other member; any lookup failure
+is reported as shared, so the open is refused. World-write is refused exactly as
+before, and the file-level checks are unchanged — a `0664` database cannot come
+from a umask, since SQLite requests `0644`.
+
+A root-owned ancestor is **not** covered by this: the ownership check above
+admits `st_uid in (uid, 0)`, but the group tolerance additionally requires
+`st_uid == uid`, because for gid 0 the "owner's own group" is the administrators'
+group rather than one single owner's. `root:root 0775` directories exist in the
+wild (`/var/lib/AccountsService` on a stock Ubuntu box) and keep the blanket
+refusal.
+
+**Accepted risk, group membership (same record as W17).** Two things the group
+answer cannot see, both stated rather than fixed:
+
+- `grp.getgrgid(gid).gr_mem` lists **supplementary** members only, so an empty
+  one is the default state of every private group, not evidence about it. An
+  account whose *primary* gid is this user's own group passes the check and can
+  write the directory. `pwd.getpwall()` would see it and is deliberately not
+  called: it is unreliable exactly where it would matter (SSSD defaults to
+  `enumerate = false`, so on the managed hosts that have real user directories it
+  answers "nobody") and slow where it works. Reaching this needs
+  `useradd -g <this user> <account>` — an administrator putting a second account
+  into one user's own group.
+- Names resolve through the server process's NSS while the writers come from the
+  kernel's uid/gid on the filesystem, so a container or idmapped mount whose
+  `/etc/group` disagrees with the host answers about a different group than the
+  one that can write. An id that does not resolve at all fails closed.
+
+Both share W17's owner and revisit date below, and both would be closed by the
+same thing: an answer about the *filesystem's* principals rather than this
+process's name service.
+
+An NSS lookup on the startup path is the cost, and only for a directory that is
+already group-writable — a tightened install performs none. A lookup that fails
+is reported as shared, so the worst case is the refusal this whole section
+exists to remove, never a weaker check.
+
 **Accepted risk W17.** Python exposes neither owner SID nor directory DACL
 portably, so the POSIX `mode & 0o022` test — "another principal cannot write
 this directory" — has no Windows implementation. On Windows a library on a

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -244,14 +244,19 @@ def _is_private_group(uid: int, gid: int) -> bool:
     (``info.st_uid == uid``), so nothing here relaxes a root-owned ancestor.
 
     Any lookup failure returns False, so the caller refuses rather than trusts
-    an answer it did not get.
+    an answer it did not get. ``OverflowError`` is in that list because the two
+    modules disagree about the same input: measured on CPython 3.12,
+    ``grp.getgrgid(-2)`` raises ``OverflowError`` while ``pwd.getpwuid(-2)``
+    raises ``KeyError``. A ``st_gid`` from the kernel is a ``gid_t`` and cannot
+    be out of range, so this is unreachable from the caller — but a fail-closed
+    promise that holds only for the inputs one caller happens to pass is not one.
     """
     if grp is None or pwd is None:
         return False
     try:
         owner = pwd.getpwuid(uid).pw_name
         group = grp.getgrgid(gid)
-    except (KeyError, OSError) as exc:
+    except (KeyError, OSError, OverflowError) as exc:
         logger.warning(
             "Could not resolve uid %d / gid %d while checking whether a "
             "group-writable SQLite directory is exposed (%s); treating the "

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -44,6 +44,20 @@ timestamp comparison bought same-uid swap detection nobody needed and refused
 roughly a fifth of concurrent opens, because SQLite creating our own WAL is
 indistinguishable from tampering when you are watching a directory's mtime.
 
+The same rule cuts the other way, and cost a startup: ``mode & 0o022`` is a
+*proxy* for "another principal can write here", and for the group bit the proxy
+is wrong wherever the group is the owner's own. Debian and Ubuntu give every
+account a group of its own and default to umask 002, so a directory this app
+created before it started passing 0700 is 0775 with a one-member group — no
+other principal at all, and the blanket test refused it and exited 1 with no way
+back except a manual ``chmod``. ``_is_private_group`` names the actor instead of
+the bit: group-write is tolerated only when the group is the owner's own,
+same-named, and has no other member, on a directory this user owns. World-write
+is refused as before, root-owned ancestors are refused as before, and the two
+limits of the group answer — supplementary members only, and NSS resolved in
+this process — are recorded as accepted risk beside W17 in
+``docs/backend_architecture.md`` §13.
+
 **Windows, and what this cannot check.** Python exposes neither owner SID nor
 directory DACL portably, so the "another principal cannot write this directory"
 test — POSIX's ``mode & 0o022`` — has no Windows implementation. An earlier
@@ -111,8 +125,16 @@ a record kept there would exist only on the machine that wrote it.
 from __future__ import annotations
 
 import os
+import shlex
 import stat
 from dataclasses import dataclass
+
+try:  # POSIX-only; only ever consulted where os.geteuid() also exists.
+    import grp
+    import pwd
+except ImportError:  # pragma: no cover - Windows
+    grp = None  # type: ignore[assignment]
+    pwd = None  # type: ignore[assignment]
 
 from pixlstash.pixl_logging import get_logger
 
@@ -153,13 +175,93 @@ def _require_owned_directory(path: str, *, immediate: bool) -> os.stat_result:
             f"SQLite directory {path} is owned by uid {info.st_uid}, not this "
             "user or root."
         )
-    writable = stat.S_IMODE(info.st_mode) & 0o022
-    if writable and (immediate or not (info.st_mode & stat.S_ISVTX)):
+    exposed = stat.S_IMODE(info.st_mode) & 0o022
+    # `info.st_uid == uid`, not the `(uid, 0)` the ownership check above admits.
+    # The tolerance is only ever about *this* user's own group — that is why the
+    # helper is asked about `uid` rather than `info.st_uid`, which by itself
+    # already refuses `root:root`, whose members are administrators rather than
+    # one single owner. What the precondition adds is the odder shape:
+    # `chown root:<this user's group>` with g+w, where the group name does match.
+    # A directory this user does not own keeps the blanket refusal either way.
+    if (
+        exposed == stat.S_IWGRP
+        and info.st_uid == uid
+        and _is_private_group(uid, info.st_gid)
+    ):
+        logger.info(
+            "SQLite directory %s is group-writable (gid %d), accepted because "
+            "that group is this user's own and has no other member, so no other "
+            "account can write it. Tighten it with %s if that is not intended.",
+            path,
+            info.st_gid,
+            f"chmod g-w {shlex.quote(path)}",
+        )
+        exposed = 0
+    if exposed and (immediate or not (info.st_mode & stat.S_ISVTX)):
         raise TrustedSQLiteLocationError(
             f"SQLite directory {path} is group/world-writable; another account "
-            "could replace the database or its WAL/SHM files."
+            "could replace the database or its WAL/SHM files. Tighten it with "
+            f"chmod g-w,o-w {shlex.quote(path)}"
         )
     return info
+
+
+def _is_private_group(uid: int, gid: int) -> bool:
+    """True when *gid* is *uid*'s own one-member group.
+
+    ``mode & 0o020`` is only an exposure when somebody else is in the group, and
+    on Debian, Ubuntu and every other distro that runs ``useradd -U`` nobody
+    else is: each account gets a group of its own, named after it, and the
+    default umask is 002. Every directory created before this code started
+    passing 0700 explicitly is therefore 0775 with a group of exactly one
+    member, which the blanket bit test read as "another account could replace
+    the database" and refused — taking the server down at startup, for good, on
+    a stock Linux install with a library from an earlier release.
+
+    Deliberately narrow, and deliberately not ``pwd.getpwall()``:
+
+    * The name must match the owner's login. That is what makes this the
+      *private* group rather than any group that happens to be empty today, and
+      it is the property an admin has to undo on purpose.
+    * ``gr_mem`` carries **supplementary** members only, so an empty one is the
+      default state of every private group rather than evidence of anything.
+      What it cannot see is an account whose *primary* gid is this group, which
+      ``pwd.getpwall()`` would — and which this deliberately does not call:
+      ``getpwall`` is unreliable exactly where it would matter (SSSD defaults to
+      ``enumerate = false``, so it answers "nobody" on the managed hosts that
+      have real user directories) and slow where it works. That residue is a
+      stated accepted risk, recorded beside W17 in
+      ``docs/backend_architecture.md`` §13 rather than only here: it takes
+      ``useradd -g <this user> <account>``, an administrator putting a second
+      account into one user's own group, and the module docstring rates this
+      whole lane LOW single-owner.
+
+    Two further limits, for the same record. Names are resolved through *this*
+    process's NSS while the writers come from the kernel's uid/gid on the
+    filesystem, so a container or idmapped mount whose ``/etc/group`` disagrees
+    with the host answers about a different group than the one that can write.
+    And the caller asks only about a directory **this** user owns
+    (``info.st_uid == uid``), so nothing here relaxes a root-owned ancestor.
+
+    Any lookup failure returns False, so the caller refuses rather than trusts
+    an answer it did not get.
+    """
+    if grp is None or pwd is None:
+        return False
+    try:
+        owner = pwd.getpwuid(uid).pw_name
+        group = grp.getgrgid(gid)
+    except (KeyError, OSError) as exc:
+        logger.warning(
+            "Could not resolve uid %d / gid %d while checking whether a "
+            "group-writable SQLite directory is exposed (%s); treating the "
+            "group as shared.",
+            uid,
+            gid,
+            exc,
+        )
+        return False
+    return group.gr_name == owner and not set(group.gr_mem) - {owner}
 
 
 def _is_redirect(path: str) -> bool:

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -324,15 +324,21 @@ class TestFreshInstall:
     def test_a_loose_existing_ancestor_is_kept_and_still_refused(self, tmp_path):
         """Creation only: the fix never chmods a directory the owner already had.
 
-        The loose ancestor keeps its 0775 (owner's folder, owner's business),
+        The loose ancestor keeps its mode (owner's folder, owner's business),
         and the guarded open goes on refusing the namespace — that refusal is
         pre-existing behaviour, asserted here so the fix cannot drift into
         repairing directories it did not create.
+
+        World-writable, not the 0775 this asserted originally: group-write alone
+        is no longer an exposure when the group is the owner's own one-member
+        group, which is exactly what a developer box and a GitHub runner both
+        have, so 0775 stopped being refused and this asserted the opposite of
+        the behaviour it names.
         """
         os.chmod(tmp_path, 0o700)
         loose = tmp_path / "loose"
         loose.mkdir()
-        os.chmod(loose, 0o775)
+        os.chmod(loose, 0o777)
 
         old_umask = os.umask(0o002)
         try:
@@ -342,7 +348,7 @@ class TestFreshInstall:
         finally:
             os.umask(old_umask)
 
-        assert stat.S_IMODE(os.lstat(loose).st_mode) == 0o775
+        assert stat.S_IMODE(os.lstat(loose).st_mode) == 0o777
         assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o700
         with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
             TrustedSQLiteLocation.open(str(image_root / "vault.db"))
@@ -360,16 +366,21 @@ class TestFreshInstall:
         parent = tmp_path / "loose"
         parent.mkdir()
         # chmod, not mkdir(mode=): the mode argument is masked by the process
-        # umask, so 0o775 lands as 0o755 wherever the umask is 022 — which is
+        # umask, so the mode lands short wherever the umask is 022 — which is
         # the GitHub runner default. The directory then is not group-writable,
         # nothing is loose, and the test failed with "DID NOT RAISE" for the
         # one reason that is not a defect in the code under test.
-        os.chmod(parent, 0o775)
+        #
+        # World-writable, where this used to say 0o775: group-write alone is no
+        # longer an exposure when the group is the owner's own one-member group
+        # (``_is_private_group``), which is what a developer box has, so 0o775
+        # would make this pass there and fail nothing.
+        os.chmod(parent, 0o777)
 
         with pytest.raises(HubPermissionError, match="group/world-writable"):
             HubDatabase(str(parent / "hub.db"))
 
-        assert stat.S_IMODE(parent.stat().st_mode) == 0o775
+        assert stat.S_IMODE(parent.stat().st_mode) == 0o777
 
     def test_existing_foreign_vault_is_not_an_implicit_identity_source(self, tmp_path):
         hub_path = str(tmp_path / "hub.db")

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -743,6 +743,20 @@ class TestGroupWritableDirectories:
         """An id no name service knows must read as shared, not as private."""
         assert _is_private_group(os.geteuid(), 0x7FFFFFFE) is False
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
+    def test_the_real_lookups_fail_closed_on_an_out_of_range_id(self):
+        """Out of range is a different exception, and the two modules disagree.
+
+        ``grp.getgrgid`` raises ``OverflowError`` past the end of ``gid_t``,
+        where the unresolvable id above raises ``KeyError`` and where
+        ``pwd.getpwuid`` raises ``KeyError`` for the same value. Unreachable from
+        ``_require_owned_directory``, whose gid comes from the kernel — but the
+        helper promises to fail closed on *any* lookup failure, and an escaping
+        ``OverflowError`` would make that a startup crash instead.
+        """
+        assert _is_private_group(os.geteuid(), 2**32) is False
+        assert _is_private_group(os.geteuid(), -2) is False
+
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
     def test_an_unresolvable_group_fails_closed(self, tmp_path, monkeypatch):
         """A lookup that did not work must not be read as "nobody else"."""

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -11,6 +11,7 @@ import re
 import sqlite3
 import stat
 import threading
+import types
 
 import pytest
 from sqlmodel import select
@@ -25,6 +26,7 @@ from pixlstash import trusted_sqlite
 from pixlstash.trusted_sqlite import (
     TrustedSQLiteLocation,
     TrustedSQLiteLocationError,
+    _is_private_group,
     _reject_symlinked_path,
     _validate_file,
 )
@@ -566,6 +568,204 @@ class TestTrustedPathSymlinkCheck:
         monkeypatch.setattr(os.path, "realpath", explode)
 
         _reject_symlinked_path(str(directory / "hub.db"))
+
+
+class TestGroupWritableDirectories:
+    """Group-write is an exposure only when the group has another member.
+
+    The blanket ``mode & 0o022`` test exited the server 1 at startup on a stock
+    Linux box: Debian/Ubuntu give every account a same-named group of its own
+    and default to umask 002, so every directory PixlStash created before it
+    started passing 0700 is 0775 — group-writable by a group of exactly one.
+
+    ``grp``/``pwd`` are patched rather than read, in both directions, because
+    the real answer depends on the machine — a developer box's group is named
+    after the login, a CI runner's need not be — so an unpatched test asserting
+    a *value* would assert whatever the box happened to be configured with. Two
+    tests at the end do call the real lookups, for what is machine-independent:
+    that the production path resolves real ``pwd``/``grp`` records without an
+    attribute error, and that an unresolvable id fails closed.
+    """
+
+    @staticmethod
+    def _patch_groups(monkeypatch, *, group_name, members):
+        """Report this user as ``me`` in a group of the given shape.
+
+        uid 0 keeps its real name. A fake that answered ``me`` for *every* uid
+        would make the root-owned case fail on a name mismatch rather than on the
+        precondition it exists to pin, which is a test that cannot detect its own
+        subject going missing.
+        """
+        monkeypatch.setattr(
+            trusted_sqlite,
+            "pwd",
+            types.SimpleNamespace(
+                getpwuid=lambda uid: types.SimpleNamespace(
+                    pw_name="root" if uid == 0 else "me"
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            trusted_sqlite,
+            "grp",
+            types.SimpleNamespace(
+                getgrgid=lambda _gid: types.SimpleNamespace(
+                    gr_name=group_name, gr_mem=members
+                )
+            ),
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_private_group_makes_group_write_harmless(self, tmp_path, monkeypatch):
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(tmp_path, 0o755)
+        os.chmod(directory, 0o775)
+        self._patch_groups(monkeypatch, group_name="me", members=["me"])
+
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_shared_group_still_refuses_group_write(self, tmp_path, monkeypatch):
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o775)
+        self._patch_groups(monkeypatch, group_name="staff", members=["me", "someone"])
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_same_named_group_with_another_member_is_not_private(
+        self, tmp_path, monkeypatch
+    ):
+        """The name alone is not the property; a group of one is."""
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o775)
+        self._patch_groups(monkeypatch, group_name="me", members=["me", "someone"])
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_world_write_is_refused_whatever_the_group_is(self, tmp_path, monkeypatch):
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o777)
+        self._patch_groups(monkeypatch, group_name="me", members=["me"])
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_differently_named_group_of_one_is_not_private(
+        self, tmp_path, monkeypatch
+    ):
+        """The member count alone is not the property; the name carries half of it.
+
+        ``gr_mem`` is empty for *every* private group, so "no other member" is
+        the default state of a group rather than evidence about it — a shared
+        group with only primary members looks identical. The name is what makes
+        this the owner's own group, and without this case that half of the
+        predicate could be deleted with the suite still green.
+        """
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o775)
+        self._patch_groups(monkeypatch, group_name="staff", members=[])
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="running as root makes root-owned the owner's own directory",
+    )
+    def test_a_root_owned_group_writable_ancestor_is_still_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """gid 0 is the administrators' group, not one owner's own.
+
+        The ownership check admits an ancestor owned by root, and ``root:root
+        0775`` directories exist on a stock Ubuntu box
+        (``/var/lib/AccountsService``). Those are already refused by the name
+        comparison, since the helper is asked about *this* user's name and not
+        the directory's.
+
+        So the case pinned here is the one only the precondition refuses:
+        ``chown root:<this user's group>`` plus g+w, where the group name does
+        match and both halves of ``_is_private_group`` say "private". This
+        process stays its ordinary self; only the directory is reported as
+        root-owned, which leaves the precondition as the sole reason to refuse.
+        """
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o775)
+        real_lstat = os.lstat
+        # Identity, not a path comparison: `realpath` itself calls `os.lstat`,
+        # so matching on the resolved string recurses into the patch.
+        target = (real_lstat(directory).st_dev, real_lstat(directory).st_ino)
+
+        def as_root(path, *args, **kwargs):
+            info = real_lstat(path, *args, **kwargs)
+            if (info.st_dev, info.st_ino) != target:
+                return info
+            fields = list(info)
+            fields[4] = 0  # st_uid: root's, while the group stays this user's
+            return os.stat_result(fields)
+
+        monkeypatch.setattr(os, "lstat", as_root)
+        self._patch_groups(monkeypatch, group_name="me", members=["me"])
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="running as root makes gid 0 this user's own group",
+    )
+    def test_the_real_lookups_resolve_a_real_pwd_and_grp_record(self):
+        """One call with nothing patched, to pin the field names.
+
+        Every other test here replaces ``grp`` and ``pwd`` with stand-ins written
+        to match the code, so ``pw_name``/``gr_name``/``gr_mem`` would go on
+        agreeing with a typo. Asking about gid 0 as a non-root user has a
+        machine-independent answer — this login is not called ``root`` — while
+        still running the production lookups end to end.
+        """
+        assert _is_private_group(os.geteuid(), 0) is False
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
+    def test_the_real_lookups_fail_closed_on_an_unresolvable_id(self):
+        """An id no name service knows must read as shared, not as private."""
+        assert _is_private_group(os.geteuid(), 0x7FFFFFFE) is False
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_an_unresolvable_group_fails_closed(self, tmp_path, monkeypatch):
+        """A lookup that did not work must not be read as "nobody else"."""
+        directory = tmp_path / "images"
+        directory.mkdir()
+        os.chmod(directory, 0o775)
+
+        def explode(_gid):
+            raise KeyError("no such gid")
+
+        monkeypatch.setattr(
+            trusted_sqlite,
+            "pwd",
+            types.SimpleNamespace(
+                getpwuid=lambda _uid: types.SimpleNamespace(pw_name="me")
+            ),
+        )
+        monkeypatch.setattr(
+            trusted_sqlite, "grp", types.SimpleNamespace(getgrgid=explode)
+        )
+
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
 
 
 class TestWindowsHasNoModeBits:


### PR DESCRIPTION
## The crash

The backend exited 1 during startup, from the trusted-location guard:

```
pixlstash.trusted_sqlite.TrustedSQLiteLocationError: SQLite directory <vault dir>
is group/world-writable; another account could replace the database or its
WAL/SHM files.
```

`_require_owned_directory` treated `stat.S_IMODE(mode) & 0o022` as proof that
another account can write the directory. For the group bit that is a proxy, and
the proxy is wrong wherever the group is the owner's own: Debian, Ubuntu and
anything else running `useradd -U` give every account a same-named group of its
own and default to umask 002, so every directory PixlStash created before it
started passing `0700` explicitly is `0775` — group-writable by a group with
exactly one member. No other principal exists, the refusal was a false positive,
and it is a hard startup failure with no recovery short of a manual `chmod`.

## The fix

`_is_private_group(uid, gid)` tolerates the group-write bit only when the group
is the owner's own, same-named, and has no other supplementary member, on a
directory **this** user owns. World-write is refused as before; so is a
root-owned group-writable ancestor; so is any lookup that fails, so an
unavailable name service degrades to today's refusal rather than to a weaker
check. `_require_owned_directory` is the one chokepoint for the hub, the vault
and `services/library_backup_service.py`, so all three are covered by the one
change.

Also: the refusal now names the `chmod` that fixes it, `shlex.quote`d, since
`image_root` is user-chosen and routinely contains spaces.

Two limits of the group answer are recorded as accepted risk beside W17 in
`docs/backend_architecture.md` §13 rather than only in a docstring —
`gr_mem` carries supplementary members only, so an account whose *primary* gid
is this user's own group passes; and names resolve through the server's NSS
while writers come from the kernel's ids, so a container or idmapped mount whose
`/etc/group` disagrees answers about a different group. `pwd.getpwall()` would
see the first and is deliberately not called: SSSD defaults to
`enumerate = false`, so it answers "nobody" on exactly the managed hosts that
have real user directories, and it is slow where it works.

## Scope

`_validate_file`'s identical `& 0o022` test is deliberately untouched. Every
path that produces a database file was traced: `database.py` pre-creates `0600`,
SQLite itself lands `0644` (which no umask can widen), the restore paths
`fchmod` to `0600`. A group-writable database *file* cannot come from a umask,
so it is not a second route to this crash — and if one is ever found it is a
real event, which is what that check is for.

## Tests

`tests/test_hub_engine.py::TestGroupWritableDirectories`. `grp`/`pwd` are
faked for the value assertions, because the honest answer depends on the box —
a developer machine's group is named after the login, a CI runner's need not be
— plus two tests that call the real lookups for what *is* machine-independent:
that the production path resolves real `pwd`/`grp` records without an attribute
error, and that an unresolvable id fails closed.

Every branch was mutation-checked, one at a time, against
`tests/test_hub_engine.py`: dropping the name half, dropping the member half,
dropping the `st_uid == uid` precondition, turning `== S_IWGRP` into
`& S_IWGRP`, and making the lookup failure fail open each turn the suite red.

Two existing tests moved from `0o775` to `0o777`
(`test_a_loose_existing_ancestor_is_kept_and_still_refused`,
`test_existing_loose_hub_directory_is_reported_not_silently_repaired`). Both
name a refusal that `0775` no longer produces, so left alone they would have
asserted the opposite of their own names. World-write is refused on every box,
so they now fail for the reason they claim.

## Two review objections answered rather than obeyed

An adversarial pass over this diff raised both; I think both are wrong, and
they are the reviewer's call to overrule.

1. **"Repair the directory instead of loosening the predicate."** There is an
   existing repair lane for the hub *file* (`check_file_mode(repair=True)`) and
   the suggestion was to extend it to directories. But `_mkdir_private` states
   the opposite rule for directories on purpose — *"Existing directories are
   left untouched, so a permission someone else loosened is still reported
   rather than silently repaired"* — and
   `test_a_loose_existing_ancestor_is_kept_and_still_refused` exists so that
   rule cannot drift. `image_root` is user-chosen and may deliberately be shared
   with a media server or sync agent (`vault.py`), so chmodding it to `0700` at
   startup would break a working setup to satisfy a check that was wrong in the
   first place. Repairing is the larger blast radius here, not the smaller one.

2. **"`logger.warning`, not `logger.info`."** The cited precedents are about a
   permission *someone else loosened*, which is an event. A `0775` directory
   under umask 002 is the distro default, present on the whole installed base
   and true at every startup, so a warning per ancestor per open would be noise
   that teaches operators to ignore warnings. `info` puts it in the log, which
   is what an operator needs to see it. Happy to raise it if a reviewer
   disagrees.

Nothing in the pass's `secrets` or `privacy` lists.
