### PR TITLE
Ctrl+A selects all people in the sidebar

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -410,11 +410,13 @@ The tab/category switch is **stateless** (see Key Design Principles). Concretely
   field, to a Vuetify scrim / the lightbox / the review overlay (which
   deliberately leaves `Ctrl+A` copyable), and to the Duplicates view, whose own
   `Ctrl+A` takes the queue.
-  - The listener is capture-phase on `document` and calls `stopPropagation`,
-    because the grid's `Ctrl+A` (select all *images*) sits on `window` in the
-    bubble phase and would otherwise win. Without an owner the key fell through
-    to that listener, or — with a sidebar field focused — to the browser's
-    native select-all, which is what "Ctrl+A selects the sidebar's text" was.
+  - **`Ctrl+A` is owned per surface**: the grid takes every picture
+    (`useGridKeyboardNav`), the Duplicates queue every group
+    (`useDedupQueueKeyboard`), and now the People list every person. A surface
+    with no implementation gets the page default instead, which is what "Ctrl+A
+    selects the sidebar's text" was. The listener is capture-phase on `document`
+    and calls `stopPropagation`, because the grid's listener sits on `window` in
+    the bubble phase and would otherwise overrule it.
   - It goes through `emitCharacterMultiSelection(ids, primaryId, multiMode)`,
     the same emit Ctrl/Cmd-click uses. **`primaryId` must name a real person:**
     `pushRouteForCurrentSelection` only puts `?ids=…&mode=…` on the URL when

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -400,6 +400,40 @@ The tab/category switch is **stateless** (see Key Design Principles). Concretely
   set / project emits the corresponding `select-*` event → `App.vue` calls
   `router.push()` → the route (the single source of truth) drives the grid.
   The grid is otherwise unaffected by tab switches.
+- **`Ctrl/Cmd+A` selects every person the People list is showing, while the
+  pointer is in the sidebar** (`onSidebarSelectAllKeydown`). The list it acts on
+  is `selectAllPeopleIds`, which is empty — leaving the key to the grid — on the
+  Folders tab, in project view mode (the project tree renders several projects'
+  people from a different list, so "all people" has no single answer there), in
+  a set-scoped share session, with the People section or the dock rail
+  collapsed, and with nobody in the library. It also declines to a focused text
+  field, to a Vuetify scrim / the lightbox / the review overlay (which
+  deliberately leaves `Ctrl+A` copyable), and to the Duplicates view, whose own
+  `Ctrl+A` takes the queue.
+  - The listener is capture-phase on `document` and calls `stopPropagation`,
+    because the grid's `Ctrl+A` (select all *images*) sits on `window` in the
+    bubble phase and would otherwise win. Without an owner the key fell through
+    to that listener, or — with a sidebar field focused — to the browser's
+    native select-all, which is what "Ctrl+A selects the sidebar's text" was.
+  - It goes through `emitCharacterMultiSelection(ids, primaryId, multiMode)`,
+    the same emit Ctrl/Cmd-click uses. **`primaryId` must name a real person:**
+    `pushRouteForCurrentSelection` only puts `?ids=…&mode=…` on the URL when
+    `selectedCharacter` is not `ALL_PICTURES_ID`, so a primary of `ALL` drops
+    the whole multi-selection on the floor, and the route is the single source
+    of truth for the grid. For the same reason this path must **not** emit
+    `select-set: null` first — `handleSelectSet(null)` writes
+    `selectedCharacter = ALL_PICTURES_ID` synchronously — and it does not need
+    to, because `handleSelectCharacter` clears the set selection itself.
+    `multiMode: "union"` is forced: the remembered mode is sessionStorage-backed
+    and intersecting every person is an empty grid by construction.
+  - **Hover is the ownership signal** because the rows are still non-focusable
+    `div`s, so there is no keyboard route into the list and this shortcut is
+    pointer-gated (WCAG 2.1.1 is satisfied for the *view* by clicking rows, not
+    for this shortcut). A roving-tabindex listbox for the People list would fix
+    that and is the natural follow-up. The flag is cleared when the auto-hide
+    sidebar goes invisible, because Escape dismisses it with no pointer move and
+    therefore no `mouseleave`; the teleported dock flyout carries the same hover
+    handlers, since it renders the list outside `.sidebar`.
 - **Every entry is also a drop target.** Each character and set row (and the
   project entries) accepts a drop of the current grid selection
   (`application/json` payload via `dataTransfer`) to assign those pictures —

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -211,6 +211,10 @@ const securityUpdateClass = computed(() => {
 
 const imageImporterRef = ref(null);
 const sidebarRootRef = ref(null);
+// Is the pointer inside the sidebar? The shelf's Ctrl+A owner reads this: the
+// rows are not focusable, so hover is the only signal for "the user is working
+// in here" (the grid uses the same signal for its digit-scoring keys).
+const sidebarHovered = ref(false);
 const labelOverflow = ref({});
 const labelRefs = new Map();
 const labelObservers = new Map();
@@ -1540,6 +1544,42 @@ const charsCollapsed = computed(() => {
   );
 });
 
+/**
+ * The people a Ctrl/Cmd+A over the sidebar takes, or `[]` when there is no
+ * list to take.
+ *
+ * Only the global library's People list qualifies, because it is the only
+ * surface where "all people" has one answer: the project tab renders a tree of
+ * several projects' people from a different list, the Folders tab and a
+ * set-scoped share session render no People list at all, and a collapsed
+ * section (or a collapsed dock rail with its flyout shut) renders no rows.
+ * Every one of those cases leaves Ctrl+A to the grid, unchanged.
+ */
+const selectAllPeopleIds = computed(() => {
+  if (sidebarPrimaryTab.value !== "library") return [];
+  if (projectViewMode.value !== "global") return [];
+  if (scopedResourceType.value === "picture_set") return [];
+  const rowsShowing = sidebarStore.effectiveDocked
+    ? !charsCollapsed.value || collapsedCharMenuOpen.value
+    : !peopleSectionCollapsed.value;
+  if (!rowsShowing) return [];
+  return visibleCharacters.value
+    .map((char) => Number(char.id))
+    .filter((id) => Number.isFinite(id) && id > 0)
+    .sort((a, b) => a - b);
+});
+
+/**
+ * A person row's tooltip. It only promises Ctrl/Cmd+A where that key would
+ * actually act on the list the row belongs to.
+ */
+function characterRowTitle(char) {
+  const name = char?.name || "Character";
+  return selectAllPeopleIds.value.length
+    ? `${name} (Ctrl/Cmd + click to multi-select, Ctrl/Cmd + A for all)`
+    : `${name} (Ctrl/Cmd + click to multi-select)`;
+}
+
 const sidebarFolderChildIconSize = computed(() =>
   Math.round(sidebarThumbnailSizeModel.value * 0.5),
 );
@@ -1821,18 +1861,34 @@ function selectCharacter(id, label = null, event = null) {
     return;
   }
 
-  // Keep the primary view unchanged on ctrl-click
-  const primaryId = selectionStore.selectedCharacter ?? nextIds[0];
+  // Keep the primary view unchanged on ctrl-click.
+  emitCharacterMultiSelection(
+    nextIds,
+    selectionStore.selectedCharacter ?? nextIds[0],
+  );
+}
+
+/**
+ * Emit a multi-character selection for `ids` (a sorted list of character ids).
+ *
+ * Shared by Ctrl/Cmd-click and by the People list's Ctrl/Cmd+A. `primaryId` is
+ * the route's `:id` — `App.vue` only puts `?ids=…` on the URL when it names a
+ * real person (`pushRouteForCurrentSelection`), so a caller that hands it
+ * `ALL_PICTURES_ID` silently loses the whole multi-selection. `multiMode`
+ * overrides the remembered union/intersect mode when the gesture implies one.
+ */
+function emitCharacterMultiSelection(ids, primaryId, multiMode = null) {
   const multiProjectIds = {};
-  for (const cid of nextIds) {
+  for (const cid of ids) {
     const c = characters.value.find((ch) => ch.id === cid);
     multiProjectIds[cid] = c?.project_id ?? null;
   }
   emit("select-character", {
     id: primaryId,
     label: null,
-    ids: nextIds,
+    ids,
     projectIds: multiProjectIds,
+    multiMode,
   });
 }
 
@@ -3365,14 +3421,110 @@ function onSidebarCtxKeydown(event) {
   }
 }
 
+/** Does this element keep Ctrl+A for its own text? */
+function isTypingTarget(el) {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.isContentEditable) return true;
+  if (["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName)) return true;
+  return el.getAttribute("role") === "textbox";
+}
+
+/**
+ * Is a surface that owns the keyboard for itself currently up?
+ *
+ * A Vuetify dialog and the lightbox render their own scrim over the sidebar, so
+ * a selection made behind them would be invisible; the review overlay
+ * deliberately leaves Ctrl+A alone so its text stays copyable
+ * (`ReviewSessionsOverlay.vue`), and stealing it here would undo that.
+ */
+function modalSurfaceOwnsKeyboard() {
+  return Boolean(
+    document.querySelector(".v-overlay--active .v-overlay__scrim") ||
+      document.querySelector(".image-overlay") ||
+      document.querySelector(".rs-overlay"),
+  );
+}
+
+/**
+ * Ctrl/Cmd+A over the sidebar selects every person the People list is showing.
+ *
+ * Select-all belongs to the surface the user is working in, and the sidebar
+ * owned no keys at all: Ctrl+A fell through to the grid's window listener
+ * (select all IMAGES) or, with a sidebar field focused, to the browser's own
+ * select-all, which just highlighted the sidebar's text. The pointer is the
+ * ownership signal because the rows are still non-focusable divs (a
+ * roving-tabindex listbox for the list is its own change, and until it exists
+ * there is no keyboard route into the sidebar); a focused sidebar control
+ * counts too, since the event target is then inside the sidebar.
+ *
+ * Capture phase + `stopPropagation`: the grid's Ctrl+A listener sits on
+ * `window` in the bubble phase, so the sidebar has to claim the key before the
+ * event ever gets there — the same way the sidebar context menu claims Escape.
+ * That is also why the Duplicates queue is excluded rather than overruled: its
+ * own Ctrl+A takes the whole queue from a document bubble listener, and a
+ * navigation would throw the user out of their triage position.
+ *
+ * `union` is forced because the remembered mode is sessionStorage-backed: a
+ * user who last used Overlap would otherwise get "all N people, intersected",
+ * which is an empty grid by construction.
+ */
+function onSidebarSelectAllKeydown(event) {
+  if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) {
+    return;
+  }
+  if (event.repeat) return; // a HELD chord must not push a route per repeat
+  if (event.key !== "a" && event.key !== "A") return;
+  const root = sidebarRootRef.value;
+  if (!root) return;
+  const overSidebar =
+    sidebarHovered.value ||
+    (event.target instanceof Node && root.contains(event.target));
+  if (!overSidebar) return;
+  // Native select-all is what Ctrl+A means in a text field.
+  if (isTypingTarget(event.target) || isTypingTarget(document.activeElement)) {
+    return;
+  }
+  if (modalSurfaceOwnsKeyboard()) return;
+  if (isDuplicatesView.value) return;
+  const ids = selectAllPeopleIds.value;
+  if (!ids.length) return;
+  event.preventDefault();
+  event.stopPropagation();
+  // No `select-set` reset here: `App.handleSelectSet(null)` writes
+  // `selectedCharacter = ALL_PICTURES_ID` synchronously, which would strip the
+  // ids from the route. `handleSelectCharacter` clears the set selection
+  // anyway, which is why ctrl-click does not emit it either.
+  emitCharacterMultiSelection(
+    ids,
+    ids.includes(Number(selectionStore.selectedCharacter))
+      ? selectionStore.selectedCharacter
+      : ids[0],
+    "union",
+  );
+}
+
+// The sidebar can leave under a stationary pointer — Escape dismisses the
+// auto-hide overlay without a mouse move — and no mouseleave follows, so the
+// hover flag has to be cleared on the visibility change itself.
+watch(
+  () => sidebarStore.sidebarVisible,
+  (visible) => {
+    if (!visible) sidebarHovered.value = false;
+  },
+);
+
 document.addEventListener("mousedown", onSidebarCtxOutside);
 document.addEventListener("keydown", onSidebarCtxKeydown, true);
+onMounted(() =>
+  document.addEventListener("keydown", onSidebarSelectAllKeydown, true),
+);
 
 let sidebarNoticeCleanup = null;
 let _dockedScrollObserver = null;
 onBeforeUnmount(() => {
   document.removeEventListener("mousedown", onSidebarCtxOutside);
   document.removeEventListener("keydown", onSidebarCtxKeydown, true);
+  document.removeEventListener("keydown", onSidebarSelectAllKeydown, true);
   // Drop any in-flight sidebar-resize drag listeners.
   onSidebarResizeEnd();
   if (sidebarNoticeCleanup) {
@@ -4002,6 +4154,8 @@ defineExpose({
       'sidebar--narrow': sidebarIsNarrow,
     }"
     :style="sidebarThumbStyle"
+    @mouseenter="sidebarHovered = true"
+    @mouseleave="sidebarHovered = false"
   >
     <!-- Drag the right edge to resize the expanded sidebar (hidden when docked). -->
     <div
@@ -4422,7 +4576,7 @@ defineExpose({
                       selectionOwnsHighlight,
                   },
                 ]"
-                :title="`${char.name || 'Character'} (Ctrl/Cmd + click to multi-select)`"
+                :title="characterRowTitle(char)"
                 @click="
                   selectCharacter(char.id, char.name || 'Character', $event)
                 "
@@ -4531,6 +4685,8 @@ defineExpose({
                 top: collapsedCharMenuPos.top + 'px',
                 left: collapsedCharMenuPos.left + 'px',
               }"
+              @mouseenter="sidebarHovered = true"
+              @mouseleave="sidebarHovered = false"
             >
               <div
                 class="sidebar-collapsed-flyout-header"
@@ -5497,7 +5653,7 @@ defineExpose({
                       },
                     ]"
                     :ref="(el) => registerCharacterRef(char.id, el)"
-                    :title="`${char.name || 'Character'} (Ctrl/Cmd + click to multi-select)`"
+                    :title="characterRowTitle(char)"
                     @click="
                       selectCharacter(char.id, char.name || 'Character', $event)
                     "
@@ -5985,7 +6141,7 @@ defineExpose({
                           onEntityDragStart('character', char.id, $event)
                         "
                         @dragend="onEntityDragEnd"
-                        :title="`${char.name || 'Character'} (Ctrl/Cmd + click to multi-select)`"
+                        :title="characterRowTitle(char)"
                         @click="
                           selectCharacter(
                             char.id,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -3448,21 +3448,22 @@ function modalSurfaceOwnsKeyboard() {
 /**
  * Ctrl/Cmd+A over the sidebar selects every person the People list is showing.
  *
- * Select-all belongs to the surface the user is working in, and the sidebar
- * owned no keys at all: Ctrl+A fell through to the grid's window listener
- * (select all IMAGES) or, with a sidebar field focused, to the browser's own
- * select-all, which just highlighted the sidebar's text. The pointer is the
- * ownership signal because the rows are still non-focusable divs (a
- * roving-tabindex listbox for the list is its own change, and until it exists
- * there is no keyboard route into the sidebar); a focused sidebar control
- * counts too, since the event target is then inside the sidebar.
+ * Select-all is implemented per surface: the grid takes every picture
+ * (`useGridKeyboardNav`), the Duplicates queue takes every group
+ * (`useDedupQueueKeyboard`). The People list had no implementation, so the key
+ * there did whatever the page default was — a text selection — which is the
+ * bug. The pointer is the ownership signal because the rows are still
+ * non-focusable divs (a roving-tabindex listbox for the list is its own change,
+ * and until it exists there is no keyboard route into the sidebar); a focused
+ * sidebar control counts too, since the event target is then inside the sidebar.
  *
  * Capture phase + `stopPropagation`: the grid's Ctrl+A listener sits on
  * `window` in the bubble phase, so the sidebar has to claim the key before the
- * event ever gets there — the same way the sidebar context menu claims Escape.
- * That is also why the Duplicates queue is excluded rather than overruled: its
- * own Ctrl+A takes the whole queue from a document bubble listener, and a
- * navigation would throw the user out of their triage position.
+ * event gets there or select-all-images would overrule it — the same way the
+ * sidebar context menu claims Escape. That is also why the Duplicates queue is
+ * excluded rather than overruled: its own Ctrl+A takes the whole queue from a
+ * document bubble listener, and a navigation would throw the user out of their
+ * triage position.
  *
  * `union` is forced because the remembered mode is sessionStorage-backed: a
  * user who last used Overlap would otherwise get "all N people, intersected",

--- a/frontend/src/components/panels/SideBarSelectAllPeople.test.js
+++ b/frontend/src/components/panels/SideBarSelectAllPeople.test.js
@@ -1,0 +1,341 @@
+// Ctrl/Cmd+A over the sidebar selects every person the People list is showing.
+//
+// The sidebar owned no keys at all, so Ctrl+A there went one of two places,
+// neither of them the People list: the grid's `window` listener (select all
+// IMAGES), or — with a sidebar field focused, which is what a user has after
+// touching the sort selector or a rename box — the browser's own select-all,
+// which highlighted the sidebar's text.
+//
+// What this file pins is the ownership, in both directions, against the REAL
+// grid handler rather than a stand-in: over the sidebar the key selects the
+// people and the grid's selection is left alone; away from the sidebar the grid
+// still takes every image. Plus the payload shape the route depends on, and the
+// surfaces that keep the key for themselves.
+//
+// The route half of the contract — that this payload actually reaches the URL
+// as `?ids=…&mode=union` — is pinned in
+// `composables/useAppNavigationMultiSelect.test.js`, because that is where the
+// payload is consumed.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+import { ref } from "vue";
+
+const apiGet = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    onSessionReset: () => () => {},
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeRef(false),
+    sessionContext: makeRef(null),
+    login: vi.fn(),
+    logout: vi.fn(),
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    toBackendWebSocketUrl: () => "",
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", () => {
+  const stubs = new Map();
+  return new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "__esModule") return true;
+        if (typeof prop !== "string") return undefined;
+        if (!stubs.has(prop)) {
+          stubs.set(prop, { name: prop, template: "<div><slot /></div>" });
+        }
+        return stubs.get(prop);
+      },
+      has: () => true,
+    },
+  );
+});
+
+// The sidebar declines on the Duplicates view, so the route name has to be
+// switchable per test.
+let routeName = "all-pictures";
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: {}, params: {}, path: "/", name: routeName }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    currentRoute: ref({ query: {} }),
+  }),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+globalThis.IntersectionObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import { isReadOnly, sessionContext } from "../../utils/apiClient";
+import { useProjectStore } from "../../stores/useProjectStore";
+import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav";
+import SideBar from "./SideBar.vue";
+
+const ADA = { id: 7, name: "Ada", image_count: 3, project_image_count: 3 };
+const GRACE = { id: 9, name: "Grace", image_count: 5, project_image_count: 5 };
+const CHARACTERS = [ADA, GRACE];
+
+function respond(url) {
+  const u = String(url ?? "");
+  if (u.includes("/characters")) return { data: CHARACTERS };
+  if (u.includes("/projects")) return { data: [] };
+  if (u.includes("/picture_sets")) return { data: [] };
+  if (u.includes("/summary")) return { data: { image_count: 3 } };
+  return { data: [] };
+}
+
+async function mountSidebar() {
+  const wrapper = mount(SideBar, {
+    shallow: true,
+    attachTo: document.body,
+    props: { backendUrl: "/api/v1" },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  wrapper.vm.refreshSidebar();
+  for (let i = 0; i < 5; i += 1) await flushPromises();
+  return wrapper;
+}
+
+/**
+ * The REAL grid Ctrl+A owner, on `window` in the bubble phase exactly as
+ * `ImageGrid` registers it. A stub would only prove the test's own wiring; this
+ * proves the key never reaches the code that would select every image.
+ */
+function attachGridKeyboardNav() {
+  const selectedImageIds = ref([]);
+  const deps = {
+    scrollWrapper: ref(null),
+    allGridImages: ref([{ id: "p1" }, { id: "p2" }]),
+    rowHeight: ref(128),
+    visibleStart: ref(0),
+    overlayOpen: ref(false),
+    reviewOverlayOpen: ref(false),
+    showSelectionBar: ref(false),
+    searchResultsActive: ref(false),
+    selectedImageIds,
+    lastSelectedImageId: null,
+    cursorIdx: ref(null),
+    isMultiCharacterView: ref(false),
+    isSetOverlapView: ref(false),
+    hoveredImageIdx: ref(null),
+    toolbarSelectionMenuOpen: ref(false),
+    isJustifiedMode: ref(false),
+    justifiedLayout: ref(null),
+  };
+  const { handleKeyDown } = useGridKeyboardNav(deps, {}, vi.fn(), {
+    clearFaceSelection: vi.fn(),
+    clearSearchQuery: vi.fn(),
+    scrollCursorIntoView: vi.fn(),
+    openOverlay: vi.fn(),
+    deleteSelected: vi.fn(),
+    selectionBarRef: ref({ openTagInput: vi.fn() }),
+    applyScoresForSelection: vi.fn(),
+    setScore: vi.fn(),
+  });
+  window.addEventListener("keydown", handleKeyDown);
+  return {
+    selectedImageIds,
+    detach: () => window.removeEventListener("keydown", handleKeyDown),
+  };
+}
+
+/** Dispatch Ctrl+A the way a real key press arrives, and report what happened. */
+function pressSelectAll(target = document.body) {
+  const event = new KeyboardEvent("keydown", {
+    key: "a",
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+/** The last `select-character` payload, or null. */
+function lastSelection(wrapper) {
+  const emitted = wrapper.emitted("select-character");
+  if (!emitted || !emitted.length) return null;
+  return emitted[emitted.length - 1][0] ?? null;
+}
+
+let grid;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  routeName = "all-pictures";
+  isReadOnly.value = false;
+  sessionContext.value = null;
+  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  grid = attachGridKeyboardNav();
+});
+
+afterEach(() => {
+  grid.detach();
+  vi.restoreAllMocks();
+});
+
+describe("Ctrl+A over the sidebar's People list", () => {
+  it("selects every person it is showing, in a payload the route can carry", async () => {
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+
+    const event = pressSelectAll();
+    const selection = lastSelection(wrapper);
+
+    expect(selection?.ids).toEqual([ADA.id, GRACE.id]);
+    // The primary id has to name a real person: `pushRouteForCurrentSelection`
+    // drops `?ids=…` when it is ALL_PICTURES_ID, which loses the selection.
+    expect(selection.ids).toContain(Number(selection.id));
+    // And the mode has to be stated, or a remembered "intersection" turns
+    // "select all people" into an empty grid.
+    expect(selection.multiMode).toBe("union");
+    // Emitting `select-set: null` would be the same bug by another route:
+    // `handleSelectSet(null)` writes selectedCharacter = ALL synchronously.
+    expect(wrapper.emitted("select-set")).toBeUndefined();
+    // The browser's text select-all is what the bug looked like; it must not run.
+    expect(event.defaultPrevented).toBe(true);
+    // Neither must the grid's select-all-images.
+    expect(grid.selectedImageIds.value).toEqual([]);
+
+    wrapper.unmount();
+  });
+
+  it("leaves the key to the grid when the pointer is not over the sidebar", async () => {
+    const wrapper = await mountSidebar();
+
+    const event = pressSelectAll();
+
+    expect(lastSelection(wrapper)).toBe(null);
+    expect(event.defaultPrevented).toBe(true); // the grid claims it instead
+    expect(grid.selectedImageIds.value).toEqual(["p1", "p2"]);
+
+    wrapper.unmount();
+  });
+
+  it("leaves a focused text field its native select-all", async () => {
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+    // A sidebar field with focus — the state that produced the reported
+    // "selects all text in the sidebar".
+    const field = document.createElement("input");
+    wrapper.find(".sidebar").element.appendChild(field);
+    field.focus();
+
+    const event = pressSelectAll(field);
+
+    expect(lastSelection(wrapper)).toBe(null);
+    expect(event.defaultPrevented).toBe(false);
+    expect(grid.selectedImageIds.value).toEqual([]);
+
+    wrapper.unmount();
+  });
+
+  it.each([
+    [
+      "a Vuetify dialog",
+      "v-overlay--active",
+      '<div class="v-overlay__scrim"></div>',
+    ],
+    ["the review overlay", "rs-overlay", ""],
+  ])("declines while %s covers the app", async (_label, className, inner) => {
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+    // Those surfaces own the keyboard: acting behind a scrim is invisible, and
+    // the review overlay deliberately leaves Ctrl+A free so its text copies.
+    const cover = document.createElement("div");
+    cover.className = className;
+    cover.innerHTML = inner;
+    document.body.appendChild(cover);
+
+    pressSelectAll();
+
+    // Declining means the key is left to whoever else owns it; what this pins
+    // is that the sidebar took nothing.
+    expect(lastSelection(wrapper)).toBe(null);
+
+    cover.remove();
+    wrapper.unmount();
+  });
+
+  it("declines on the Duplicates view, which owns Ctrl+A for its queue", async () => {
+    routeName = "duplicates";
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+
+    pressSelectAll();
+
+    // The queue's own Ctrl+A lives on a document BUBBLE listener, so the
+    // sidebar declining is what keeps it reachable.
+    expect(lastSelection(wrapper)).toBe(null);
+
+    wrapper.unmount();
+  });
+
+  it("declines in project view mode, where the tree shows a different list", async () => {
+    // The project tab renders per-project People groups from
+    // `sortedCharacters.filter(…)`, several projects at once, so "all people"
+    // has no single answer there.
+    useProjectStore().projectViewMode = "project";
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+
+    pressSelectAll();
+
+    expect(lastSelection(wrapper)).toBe(null);
+
+    wrapper.unmount();
+  });
+
+  it("ignores a held chord, so it cannot push a route per repeat", async () => {
+    const wrapper = await mountSidebar();
+    await wrapper.find(".sidebar").trigger("mouseenter");
+
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      repeat: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(event);
+
+    expect(lastSelection(wrapper)).toBe(null);
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/panels/SideBarSelectAllPeople.test.js
+++ b/frontend/src/components/panels/SideBarSelectAllPeople.test.js
@@ -1,10 +1,8 @@
 // Ctrl/Cmd+A over the sidebar selects every person the People list is showing.
 //
-// The sidebar owned no keys at all, so Ctrl+A there went one of two places,
-// neither of them the People list: the grid's `window` listener (select all
-// IMAGES), or — with a sidebar field focused, which is what a user has after
-// touching the sort selector or a rename box — the browser's own select-all,
-// which highlighted the sidebar's text.
+// Select-all is implemented per surface — the grid takes every picture, the
+// Duplicates queue every group — and the People list had no implementation, so
+// the key there fell back to the page default: a text selection.
 //
 // What this file pins is the ownership, in both directions, against the REAL
 // grid handler rather than a stand-in: over the sidebar the key selects the

--- a/frontend/src/components/widgets/ShortcutsDialog.vue
+++ b/frontend/src/components/widgets/ShortcutsDialog.vue
@@ -45,7 +45,7 @@ const open = computed({
             </tr>
             <tr>
               <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
-              <td>Select all images</td>
+              <td>Select all images (pointer anywhere but the sidebar)</td>
             </tr>
             <tr :class="{ 'shortcut-disabled': isReadOnly }">
               <td>
@@ -133,6 +133,16 @@ const open = computed({
             <tr>
               <td><kbd>Esc</kbd></td>
               <td>Close overlay</td>
+            </tr>
+            <tr>
+              <td colspan="2" class="shortcuts-section">Sidebar</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
+              <td>
+                Select all people — takes Ctrl+A from the grid while the pointer
+                is over the sidebar
+              </td>
             </tr>
             <tr>
               <td colspan="2" class="shortcuts-section">General</td>

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -54,6 +54,7 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
             ? payload.projectIds
             : {},
         projectContext: payload.projectContext ?? null,
+        multiMode: payload.multiMode ?? null,
       };
     }
     return {
@@ -62,6 +63,7 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       ids: [],
       projectIds: {},
       projectContext: null,
+      multiMode: null,
     };
   }
 
@@ -82,6 +84,7 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       ids,
       projectIds,
       projectContext,
+      multiMode,
     } = SelectionPayload(payload);
     projectStore.characterProjectIds = projectIds;
     if (projectContext) {
@@ -113,6 +116,11 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
     selectionStore.selectedCharacterIds = ids.length ? ids : [];
     if (ids.length <= 1) {
       selectionStore.setCharacterMultiMode("union");
+    } else if (multiMode) {
+      // A gesture may state the mode it means. "Select all people" does: the
+      // remembered mode is sessionStorage-backed, and intersecting everyone is
+      // an empty grid by construction.
+      selectionStore.setCharacterMultiMode(multiMode);
     }
     if (charId !== ALL_PICTURES_ID) {
       filterStore.unassignedOnlyFilter = false;

--- a/frontend/src/composables/useAppNavigationMultiSelect.test.js
+++ b/frontend/src/composables/useAppNavigationMultiSelect.test.js
@@ -1,0 +1,92 @@
+// The other half of the sidebar's "select all people": the payload has to reach
+// the URL, because the route is the single source of truth for what the grid
+// shows (§2 of the frontend architecture).
+//
+// `pushRouteForCurrentSelection` only attaches `?ids=…&mode=…` when
+// `selectedCharacter` names a real person, so a multi-selection whose primary id
+// is ALL_PICTURES_ID pushes `all-pictures` and silently loses every id. That is
+// exactly what an intermediate `select-set: null` emit caused, and it is the
+// failure this file exists to catch: a sidebar-only test still passes while the
+// feature does nothing.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { ref } from "vue";
+
+const push = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: {}, params: {}, path: "/", name: "all-pictures" }),
+  useRouter: () => ({
+    push: (...args) => {
+      push(...args);
+      return Promise.resolve();
+    },
+    replace: vi.fn(),
+    currentRoute: ref({ query: {} }),
+  }),
+}));
+
+import { useAppNavigation } from "./useAppNavigation";
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { ALL_PICTURES_ID } from "../stores/useViewStore";
+
+const SELECT_ALL_PAYLOAD = {
+  id: 7,
+  label: null,
+  ids: [7, 9],
+  projectIds: { 7: null, 9: null },
+  multiMode: "union",
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  push.mockReset();
+});
+
+describe("handleSelectCharacter — a multi-selection from the sidebar", () => {
+  it("puts every id and the mode on the route", async () => {
+    const selection = useSelectionStore();
+    // The landing view: this is where the primary-id mistake was invisible,
+    // because `all-pictures` → `all-pictures` is a swallowed duplicate push.
+    selection.selectedCharacter = ALL_PICTURES_ID;
+    selection.selectedCharacterIds = [];
+    const nav = useAppNavigation();
+
+    await nav.handleSelectCharacter(SELECT_ALL_PAYLOAD);
+
+    expect(push).toHaveBeenCalledWith({
+      name: "character",
+      params: { id: "7" },
+      query: { ids: "7,9", mode: "union" },
+    });
+    expect(selection.selectedCharacterIds).toEqual([7, 9]);
+  });
+
+  it("lets the payload's mode override a remembered intersection", async () => {
+    // `characterMultiMode` is sessionStorage-backed, so a user who last used
+    // Overlap would otherwise get "all N people, intersected" — empty by
+    // construction — from a key called "select all".
+    const selection = useSelectionStore();
+    selection.setCharacterMultiMode("intersection");
+    selection.selectedCharacter = ALL_PICTURES_ID;
+    const nav = useAppNavigation();
+
+    await nav.handleSelectCharacter(SELECT_ALL_PAYLOAD);
+
+    expect(selection.characterMultiMode).toBe("union");
+    expect(push.mock.calls[0][0].query.mode).toBe("union");
+  });
+
+  it("keeps the remembered mode when the gesture states none (ctrl-click)", async () => {
+    const selection = useSelectionStore();
+    selection.setCharacterMultiMode("intersection");
+    selection.selectedCharacter = 7;
+    const nav = useAppNavigation();
+
+    await nav.handleSelectCharacter({ ...SELECT_ALL_PAYLOAD, multiMode: null });
+
+    expect(selection.characterMultiMode).toBe("intersection");
+    expect(push.mock.calls[0][0].query.mode).toBe("intersection");
+  });
+});

--- a/website/upgrade.html
+++ b/website/upgrade.html
@@ -109,6 +109,14 @@
         margin: 0;
       }
 
+      /* The one upgrade step that is not "download and restart". It is shown
+         statically because the changelog panel that carries the same warning as
+         1.9.0's lead note only renders when ?v= tells us the old version; when
+         that panel does render, the static copy is hidden as a duplicate. */
+      .upgrade-notice {
+        margin: 0 0 24px;
+      }
+
       .whatsnew-banner {
         display: grid;
         grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.25fr);
@@ -388,22 +396,31 @@
         <div id="changes-since-list"></div>
       </div>
 
+      <div id="upgrade-notice" class="method-warning upgrade-notice">
+        ⚠️ <strong>Coming from 1.8.0 or earlier?</strong> Updating clears every
+        API token, as it did in 1.8.1. Create replacements from Settings, share
+        your links again with their new values, and enter your public URL and
+        ComfyUI URL again. If you already updated to 1.8.1 or later this has
+        happened and your current tokens are left alone.
+      </div>
+
       <a class="whatsnew-banner" href="whatsnew.html">
         <div>
-          <span class="whatsnew-kicker">New in 1.8</span>
+          <span class="whatsnew-kicker">New in 1.9</span>
           <h2 class="whatsnew-title">
             Explore what changed before you upgrade
           </h2>
           <p class="whatsnew-copy">
-            Try the new justified grid layout, background imports, Scrapheap delete and auto-empty, the
-            Agreement chart.
+            Undo and redo across your library, the new Duplicates view, Keep
+            cover only for clearing out stacks, characters and sets in several
+            projects at once, and a new Privacy pane.
           </p>
           <span class="whatsnew-cta">Open the What's New page →</span>
         </div>
         <div class="whatsnew-media">
           <img
-            src="assets/ScreenshotsJustified.jpg"
-            alt="PixlStash 1.8: the justified grid layout"
+            src="assets/ScreenshotDuplicates.jpg"
+            alt="PixlStash 1.9: the Duplicates view grouping likely copies for review"
           />
         </div>
       </a>
@@ -838,6 +855,9 @@
           })
           .join("");
         document.getElementById("changes-since").style.display = "block";
+        // The rendered entries carry each version's own lead note, including the
+        // token-clearing warning, so the static callout above would repeat it.
+        document.getElementById("upgrade-notice").style.display = "none";
       }
 
       function fetchText(url) {


### PR DESCRIPTION
## What this does

Ctrl+A is implemented per surface in this app: in the ImageGrid it selects every
picture, in the Duplicates view every group. The model shelf — the sidebar's
People list — had no implementation, so pressing it there fell back to the page
default and selected text. This adds the missing implementation: Ctrl/Cmd+A
while the pointer is in the sidebar selects **every person the People list is
showing**, as one union multi-selection.

The owner is a capture-phase `document` keydown listener in `SideBar.vue`
(`onSidebarSelectAllKeydown`). Capture phase because the grid's Ctrl+A is a
`window` bubble listener and would otherwise overrule the sidebar's — the same
pattern the sidebar context menu already uses for Escape.

It selects `selectAllPeopleIds` — one computed that answers "is there a People
list here to take, and which people". It is empty (so Ctrl+A stays the grid's)
on the Folders tab, in project view mode, in a set-scoped share session, with
the People section or the docked rail collapsed, and with nobody in the library.
The handler additionally declines to a focused text field, to a Vuetify scrim /
the lightbox / the review overlay (which deliberately keeps Ctrl+A copyable),
and to the Duplicates view, whose own Ctrl+A takes the queue.

Two things about the payload are load-bearing and are what the tests pin:

- **The primary id must name a real person.** `pushRouteForCurrentSelection`
  only puts `?ids=…&mode=…` on the URL when `selectedCharacter` isn't
  `ALL_PICTURES_ID`, and the route is the single source of truth for the grid.
  For the same reason this path must not emit `select-set: null` first —
  `handleSelectSet(null)` writes `selectedCharacter = ALL_PICTURES_ID`
  synchronously — and it doesn't need to, since `handleSelectCharacter` clears
  the set selection itself.
- **`multiMode: "union"` is stated.** `characterMultiMode` is sessionStorage
  backed, so someone who last used Overlap would otherwise get "all N people,
  intersected" — an empty grid by construction. `handleSelectCharacter` now
  honours a `multiMode` in the payload; ctrl-click still omits it and keeps the
  remembered mode.

Discoverability: the person-row tooltips mention the key (only where it actually
acts — `characterRowTitle`), and the shortcuts dialog has a Sidebar row plus a
note on the Grid row about which one takes the key.

## Tests

- `SideBarSelectAllPeople.test.js` — ownership in both directions against the
  **real** `useGridKeyboardNav` handler on `window`, not a stub: over the
  sidebar the people are selected and the grid's selection is untouched; away
  from it the grid still takes every image. Plus the payload shape (ids,
  a real primary id, `multiMode`, no `select-set` emit) and each decline.
- `useAppNavigationMultiSelect.test.js` — the route half: the payload arrives as
  `/character/7?ids=7,9&mode=union`, union overrides a remembered intersection,
  and ctrl-click's mode is left alone.

Every assertion was mutation-checked (forcing the primary to `ALL`, re-adding
the `select-set` emit, dropping the mode, ignoring `multiMode`, removing the
Duplicates guard — each fails a test). Full frontend suite green (140 files,
2561 tests); eslint clean.

## Assumption, stated plainly

I read "model shelf" as the sidebar's People list, since the ticket also says
the wrong thing happens *in the sidebar*. The only other list in the app
literally labelled "Models" is the ComfyUI checkpoint filter inside the
toolbar's global-filter panel — not the sidebar — so I ruled it out. If "model
shelf" meant something else, say so and I'll move it.

## Reviewer objections I did not act on

An adversarial pass over this diff raised these; my answers rather than silent
drops:

- *"Union of every person is approximately All Pictures, and the id list is
  uncapped."* It isn't the same view — the union excludes pictures with nobody
  in them — and select-all is the primitive the ticket asks for. The app already
  puts `?ids=` on multi-selections; a few hundred numeric ids is well inside URL
  limits.
- *"`isTypingTarget` and the modal-surface query are a third copy of helpers in
  `useGlobalKeydown`."* True, and that duplication is exactly what made the
  first draft miss the review overlay. The miss is fixed here; unifying the
  three keyboard owners onto one shared helper touches `useGlobalKeydown` and
  `useDedupQueueKeyboard` too and belongs in its own change.
- *"Pointer-gated, so there is no keyboard path to it (WCAG 2.1.1)."* Correct
  and recorded in the architecture doc. The rows are non-focusable `div`s today,
  so the sidebar has no keyboard model to hang this on; a roving-tabindex
  listbox for the People list is the natural follow-up. Nothing here removes an
  existing keyboard path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
