### PR TITLE
Select every shown model with Ctrl+A in the model shelf

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2659,13 +2659,36 @@ double click on the name, or F2 on the row for the keyboard.
 
 Arrows move the stop **without** selecting, so a reader can walk the list
 without arming a verb against every row they pass; Space and Enter pick;
-Shift+arrow extends from the anchor, the keyboard's Shift+click; Escape clears.
+Shift+arrow extends from the anchor, the keyboard's Shift+click; Escape clears;
+**Ctrl/Cmd+A takes every shown model**, the chord the photo grid
+(`useGridKeyboardNav`) and the duplicate queue (`useDedupQueueKeyboard`) already
+claim. It runs `selectVisible()` — the same store action the pill's *Select all
+shown* runs, and the pill shows the chord as a keycap beside that item — so
+"all" means whatever the current `Show` selection DRAWS, runs taken whole. It is
+refused on `event.repeat`, as the queue's is, because a held chord would rebuild
+a set over every drawn row per repeat. Unclaimed it was not a no-op: it reached
+the browser's own select-all, and `.shelf` being `user-select: none` (below)
+while the app around it is not, what it highlighted was whatever text the app
+still leaves selectable *outside* the shelf — the reported symptom.
+**With nothing drawn the press is swallowed and the selection left untouched.**
+`selectedIds` is pruned against a fetch (`pruneSelection`), never against the
+`Show` narrowing, so a selection outlives a narrowing that empties the list —
+and `selectVisible()` there would replace it with an empty set: a silent clear
+from a key that says *select*, with no undo and no control on screen to do it
+deliberately, since the pill is gated on `selectedRows`. The press is still
+claimed, or it would fall back to the native select-all.
 **Escape is bound on the `window`, not on the shelf's root**, because a keydown
 only reaches an element that contains the focus: bound to the root it worked
 from a row and from the toolbar and did nothing once the sidebar or the app bar
 had been clicked, while the selection was still on screen. A window listener
 then has to know what else owns the key, and hand it back rather than clear
-underneath. Five checks, in this order, each for its own reason:
+underneath. All three keys are bound there, and all three ask `shelfOwnsTheKey`
+first — which does **not** test the selection: Escape and Delete need one and
+check for it themselves, while Ctrl+A is pressed precisely because nothing is
+selected yet. A declined key is handed back *intact*, so Ctrl+A behind a dialog
+or a menu reaches the browser's own select-all — deliberately, since those
+surfaces teleport out of `.shelf` and their text is selectable. Five checks, in
+this order, each for its own reason:
 
 - **The shelf's own dialogs, by REF** (`moveOpen`, `importOpen`, `stacksOpen`,
   `foldersOpen`, `addFileOpen`, `editVerb`) — they are `AppDialog`s inside this

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -46,6 +46,7 @@
         >
           <v-icon size="16">mdi-select-all</v-icon>
           <span>Select all shown</span>
+          <span class="shelf-mi-kbd">{{ selectAllHint }}</span>
         </button>
         <button class="shelf-mi" type="button" role="menuitem" @click="clear">
           <v-icon size="16">mdi-close</v-icon>
@@ -282,6 +283,7 @@ import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { formatKeyHint, selectAllKeyHint } from "../../utils/shortcutHints";
 import {
   deletableModels,
   formatModelSize,
@@ -308,6 +310,11 @@ const emit = defineEmits([
 const store = useModelShelfStore();
 const folders = useModelFoldersStore();
 const moves = useModelMovesStore();
+
+// The keycap beside "Select all shown", so the chord is taught where the button
+// is — the same job the `Esc` cap next to Clear does. Read once at setup: the
+// platform cannot change under a mounted component.
+const selectAllHint = formatKeyHint(selectAllKeyHint());
 
 const countMenuOpen = ref(false);
 const assignMenuOpen = ref(false);

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1458,6 +1458,149 @@ describe("selecting rows", () => {
     wrapper.unmount();
   });
 
+  it("takes every shown model on Ctrl+A, and the browser's select-all with it", async () => {
+    // The bug was never that the chord did nothing: unclaimed it reached the
+    // browser's own select-all, which — `.shelf` being `user-select: none` —
+    // highlighted every part of the app EXCEPT the rows it was aimed at. Both
+    // halves are asserted, because the selection can be right with that
+    // highlight still there. The press starts with NOTHING selected, which is
+    // the state `shelfOwnsTheKey` used to refuse outright.
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+    ]);
+    // Attached, because this is a window listener exactly as Escape's is.
+    document.body.appendChild(wrapper.element);
+    const store = useModelShelfStore();
+    const press = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    rowAt(wrapper, 0).element.dispatchEvent(press);
+    await wrapper.vm.$nextTick();
+
+    expect([...store.selectedIds].sort()).toEqual([1, 2, 3]);
+    expect(press.defaultPrevented).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("leaves Ctrl+A to a field being typed in", async () => {
+    // Select-all inside a text field is the field's. Asserted from a field
+    // OUTSIDE the shelf — the sidebar's search box, the app bar — because that
+    // is the only place `isTypingTarget` is what declines: the shelf's own
+    // rename field stops the event (`onRenameKeydown`) and the base-model field
+    // carries `@keydown.stop`, so neither ever reaches this window listener,
+    // and a press aimed at one of them would pass with the guard deleted.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    document.body.appendChild(wrapper.element);
+    const field = document.createElement("input");
+    document.body.appendChild(field);
+    const store = useModelShelfStore();
+    const press = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    field.dispatchEvent(press);
+    await wrapper.vm.$nextTick();
+
+    expect(store.selectedRows).toHaveLength(0);
+    expect(press.defaultPrevented).toBe(false);
+    field.remove();
+    wrapper.unmount();
+  });
+
+  it("swallows Ctrl+A with nothing drawn, and keeps the selection", async () => {
+    // `selectedIds` is pruned against a FETCH and never against the `Show`
+    // narrowing, so a selection outlives a narrowing that empties the list.
+    // `selectVisible()` there would replace it with an empty set — a silent
+    // clear from a key that says "select", with the pill gone (it is gated on
+    // `selectedRows`) so nothing on screen could have done it on purpose. The
+    // press is still claimed, or it falls back to the native select-all.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    document.body.appendChild(wrapper.element);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 0).trigger("click");
+    await rowAt(wrapper, 1).trigger("click", { ctrlKey: true });
+    store.setFilters({ adapters: false });
+    await wrapper.vm.$nextTick();
+    expect(store.visibleRows).toHaveLength(0);
+
+    const press = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(press);
+    await wrapper.vm.$nextTick();
+
+    expect([...store.selectedIds].sort()).toEqual([1, 2]);
+    expect(press.defaultPrevented).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("answers to Cmd+A, and to no other chord on the A key", async () => {
+    // Meta is Ctrl on a Mac. Alt is what AltGr sends on a European layout, and
+    // Ctrl+Shift+A is a chord this list does not define: both are the browser's.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    document.body.appendChild(wrapper.element);
+    const store = useModelShelfStore();
+    const press = (init) =>
+      new KeyboardEvent("keydown", {
+        key: "a",
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      });
+
+    for (const declined of [
+      press({ ctrlKey: true, altKey: true }),
+      press({ ctrlKey: true, shiftKey: true }),
+      press({ ctrlKey: true, repeat: true }),
+    ]) {
+      window.dispatchEvent(declined);
+      await wrapper.vm.$nextTick();
+      expect(store.selectedRows).toHaveLength(0);
+      expect(declined.defaultPrevented).toBe(false);
+    }
+
+    const cmd = press({ metaKey: true });
+    window.dispatchEvent(cmd);
+    await wrapper.vm.$nextTick();
+    expect([...store.selectedIds].sort()).toEqual([1, 2]);
+    expect(cmd.defaultPrevented).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("does not claim Ctrl+A from the runs tab", async () => {
+    // The shelf stays mounted behind the runs panel, so its listener would
+    // select rows nobody can see. This is about the SHELF's listener declining;
+    // the runs grid owns its own keyboard model and its own selection.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    document.body.appendChild(wrapper.element);
+    const store = useModelShelfStore();
+    nav.route.name = "models-runs";
+    await wrapper.vm.$nextTick();
+
+    const press = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(press);
+    await wrapper.vm.$nextTick();
+
+    expect(store.selectedRows).toHaveLength(0);
+    expect(press.defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+
   it("shows no selection bar until something is selected", async () => {
     const wrapper = await mountShelf([adapter()]);
     expect(wrapper.find(".shelf-selbar").exists()).toBe(false);

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -1935,10 +1935,17 @@ function onBandDrop(band, event) {
 /**
  * Does the shelf own this press, or does something in front of it?
  *
- * The guard both window-level keys ask first — Escape, which clears the
- * selection from anywhere including outside the shelf, and Delete, which is in
+ * The guard all three window-level keys ask first — Escape, which clears the
+ * selection from anywhere including outside the shelf, Delete, which is in
  * front of a file deletion and must never fire against a surface that is merely
- * drawn over the rows.
+ * drawn over the rows, and Ctrl+A, which selects the whole list.
+ *
+ * A declined key is handed back INTACT — no `preventDefault` — which for Ctrl+A
+ * means the browser's own select-all runs behind a dialog or a menu. That is
+ * the intent: those surfaces teleport out of `.shelf` and their text IS
+ * selectable, so select-all there is a real gesture the shelf has no business
+ * taking. It is the same bargain the `Esc` keycap in the pill's menu already
+ * strikes — with the menu open that press closes the menu instead.
  *
  * On the WINDOW rather than on the shelf root, because a keydown only reaches
  * an element that contains the focus: bound to the root it worked from a row
@@ -1975,6 +1982,11 @@ function onBandDrop(band, event) {
  *
  * Bubble phase, not capture: every owner above is meant to resolve the key
  * FIRST, and a capture-phase listener would take it from them.
+ *
+ * **It does not test the selection.** Escape and Delete need one and ask for
+ * it themselves; Ctrl+A is the key pressed precisely BECAUSE nothing is selected
+ * yet, so a shared "something is selected" line here would be the one guard
+ * that made the new key impossible.
  */
 function shelfOwnsTheKey(event) {
   // The shelf component stays mounted while the runs panel is showing, and this
@@ -2001,26 +2013,69 @@ function shelfOwnsTheKey(event) {
   if (sidebarStore.sidebarOverlay && sidebarStore.sidebarVisible) return false;
   if (event.target?.closest?.(".ate, [role='dialog']")) return false;
   if (isTypingTarget(event.target)) return false;
-  return Boolean(store.selectedRows.length);
+  return true;
 }
 
 /**
- * Escape clears, Delete deletes.
+ * Escape clears, Delete deletes, Ctrl+A takes the lot.
  *
- * One handler and one set of guards, because the question both keys ask first
- * is the same one: does the shelf own this press, or does something in front of
- * it? Splitting them would be two copies of the list above, and the copy that
- * drifted would be the one in front of a file deletion.
+ * One handler and one set of guards, because the question all three keys ask
+ * first is the same one: does the shelf own this press, or does something in
+ * front of it? Splitting them would be copies of the list above, and the copy
+ * that drifted would be the one in front of a file deletion.
  *
  * **Delete is the file-manager gesture and is spelled the way Explorer spells
  * it**: on its own it moves to the trash, with Shift it deletes permanently.
  * `event.shiftKey` is read off the press itself and handed to the same
  * confirmation the pill uses, so the key opens a prompt and never a deletion —
  * a stray Del with forty rows selected costs one Escape.
+ *
+ * **Ctrl+A is claimed rather than left to the browser**, the same chord the
+ * photo grid (`useGridKeyboardNav`) and the duplicate queue
+ * (`useDedupQueueKeyboard`) already claim. Unhandled it did not merely do
+ * nothing: it fell through to the native select-all, and `.shelf` is
+ * `user-select: none` (#932) while the app around it is not, so the one thing
+ * a select-all aimed at the rows could highlight was whatever text the app
+ * still leaves selectable everywhere else — which is what the reporter saw.
+ * It runs the store action the selection pill's "Select all shown" already
+ * runs, so the key and the button say the same thing: everything the current
+ * `Show` selection DRAWS, runs taken whole. Cmd counts as Ctrl (`metaKey`),
+ * Shift and Alt do not — those are chords this list does not define and are
+ * left to the browser, AltGr+A among them.
+ *
+ * **With nothing drawn the key is swallowed and the selection left alone.**
+ * Two things are true at once there and only one of them is obvious: there is
+ * nothing to select, and `selectedIds` may still be full, because it is pruned
+ * against a FETCH (`pruneSelection`) and not against the `Show` narrowing that
+ * emptied the list. Running `selectVisible()` would then replace a selection
+ * the reader still holds with an empty one — a silent clear, from a key that
+ * says "select", with no undo and (the pill being gated on `selectedRows`) no
+ * control on screen to do it deliberately. The press is still claimed, or
+ * declining would hand it back to the native select-all above.
+ *
+ * `event.repeat` is refused for the same reason `useDedupQueueKeyboard` refuses
+ * it: a held chord would rebuild a set over every drawn row, up to 1,800 of
+ * them, once per repeat.
  */
 function onShelfKeydown(event) {
-  if (event.key !== "Escape" && event.key !== "Delete") return;
+  const wantsSelectAll =
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.shiftKey &&
+    String(event.key).toLowerCase() === "a";
+  if (event.key !== "Escape" && event.key !== "Delete" && !wantsSelectAll) {
+    return;
+  }
   if (!shelfOwnsTheKey(event)) return;
+  if (wantsSelectAll) {
+    if (event.repeat) return;
+    event.preventDefault();
+    if (store.visibleRows.length) store.selectVisible();
+    return;
+  }
+  // Escape and Delete are both about a selection, and the guard above no longer
+  // asks for one.
+  if (!store.selectedRows.length) return;
   if (event.key === "Escape") {
     store.clearSelection();
     return;

--- a/frontend/src/components/widgets/ShortcutsDialog.vue
+++ b/frontend/src/components/widgets/ShortcutsDialog.vue
@@ -1,12 +1,19 @@
 <script setup>
 import { computed } from "vue";
 import { isReadOnly } from "../../utils/apiClient";
-import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+import {
+  redoKeyHint,
+  selectAllKeyHint,
+  undoKeyHint,
+} from "../../utils/shortcutHints";
 
 // The undo/redo chords differ per platform, so the table renders whatever the
-// hint helper reports rather than hard-coding Ctrl.
+// hint helper reports rather than hard-coding Ctrl. Select-all differs the same
+// way — a macOS reader was being taught `Ctrl+A` for a chord their keyboard
+// spells `⌘A`, and the shelf's own keycap now reports the platform.
 const undoKeyHintKeys = undoKeyHint();
 const redoKeyHintKeys = redoKeyHint();
+const selectAllKeyHintKeys = selectAllKeyHint();
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -44,7 +51,11 @@ const open = computed({
               <td>Tag selected images</td>
             </tr>
             <tr>
-              <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
+              <td>
+                <template v-for="(key, i) in selectAllKeyHintKeys" :key="key"
+                  ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
+                >
+              </td>
               <td>Select all images</td>
             </tr>
             <tr :class="{ 'shortcut-disabled': isReadOnly }">

--- a/frontend/src/utils/shortcutHints.js
+++ b/frontend/src/utils/shortcutHints.js
@@ -48,6 +48,19 @@ export function redoKeyHint(nav) {
 }
 
 /**
+ * Keycap labels for "select all", in press order.
+ *
+ * The shelf, the grid and the duplicate queue all accept either Ctrl or Meta;
+ * only the label differs.
+ *
+ * @param {Object} [nav] - injectable navigator.
+ * @returns {Array<string>} e.g. `["Ctrl", "A"]` or `["⌘", "A"]`.
+ */
+export function selectAllKeyHint(nav) {
+  return isApplePlatform(nav) ? ["⌘", "A"] : ["Ctrl", "A"];
+}
+
+/**
  * The same hint as one flat string, for a `title` attribute or an aria-label
  * where separate keycap elements are not available.
  * @param {Array<string>} keys - a hint from {@link undoKeyHint}.

--- a/frontend/src/utils/shortcutHints.test.js
+++ b/frontend/src/utils/shortcutHints.test.js
@@ -3,6 +3,7 @@ import {
   formatKeyHint,
   isApplePlatform,
   redoKeyHint,
+  selectAllKeyHint,
   undoKeyHint,
 } from "./shortcutHints";
 
@@ -44,6 +45,13 @@ describe("undoKeyHint / redoKeyHint", () => {
     expect(undoKeyHint(MAC_UA)).toEqual(["⌘", "Z"]);
     // macOS has no Ctrl+Y convention; the system redo is shift-command-Z.
     expect(redoKeyHint(MAC_UA)).toEqual(["⇧", "⌘", "Z"]);
+  });
+});
+
+describe("selectAllKeyHint", () => {
+  it("follows the platform, like the undo hint beside it", () => {
+    expect(selectAllKeyHint(WIN_UA)).toEqual(["Ctrl", "A"]);
+    expect(selectAllKeyHint(MAC_UA)).toEqual(["⌘", "A"]);
   });
 });
 


### PR DESCRIPTION
## What

`Ctrl/Cmd+A` now selects every model the shelf draws. The shelf's existing
window handler — the one that already owns `Escape` and `Delete` — claims the
chord and runs `useModelShelfStore.selectVisible()`, which is the same action
the selection pill's **Select all shown** menu item runs. "All" therefore means
whatever the current `Show` selection draws, runs taken whole, and the key
cannot mean something different from the button.

Unclaimed it was not a no-op: it reached the browser's own select-all, and since
`.shelf` carries `user-select: none` while the app around it does not, what it
highlighted was text everywhere *except* the rows it was aimed at — the symptom
in the report.

Three details worth reading:

- **With nothing drawn, the press is swallowed but the selection is left
  alone.** `selectedIds` is pruned against a fetch, never against the `Show`
  narrowing, so a selection outlives a narrowing that empties the list.
  `selectVisible()` there would replace it with an empty set: a silent clear,
  from a key that says *select*, with no undo and — the pill being gated on
  `selectedRows` — no control on screen that could have done it deliberately.
  The press is still claimed, or it falls back to the native select-all.
- **`shelfOwnsTheKey` no longer tests the selection.** It used to end at
  "something is selected", which is the one condition this key exists to fix.
  That test moved to the `Escape`/`Delete` branch, so both behave exactly as
  before (`confirmDelete` already refused an empty selection independently).
- **`event.repeat` is refused**, matching `useDedupQueueKeyboard`: a held chord
  would otherwise rebuild a set over every drawn row per repeat.

Also: the pill's *Select all shown* item now carries a `Ctrl+A` / `⌘+A` keycap,
the same affordance as the `Esc` cap beside *Clear selection*, via a new
`selectAllKeyHint()` alongside the existing undo/redo hints — which also fixes
the shortcuts dialog, where the grid's select-all was hardcoded `Ctrl+A` and
read wrong on macOS.

Tests: three in `ModelShelf.test.js` (selects all shown *and* refuses the
browser's select-all; declines to a field being typed in; declines from the runs
tab), one for the narrowed-to-empty case, one covering the modifier branches
(`metaKey` yes, AltGr / Shift / repeat no), and one for the new hint. Each was
checked by mutation — deleting the guard it covers fails it. Full frontend suite
green (3543).

## Base branch

**Opened against `develop`, not `main`.** The model shelf does not exist on
`main` — the worktree for this card was cut from a `main` that predates it, so
the branch was rebased onto `origin/develop`, where the shelf lives and where
every recent PR here lands. Against `main` this would be hundreds of unrelated
commits.

## Answers to the pre-push review

An adversarial pass over the diff raised ten points. Six are fixed above (the
narrowed-list clear, the missing `repeat` guard, an inaccurate claim in both the
code comment and the architecture doc about which surfaces the native select-all
highlights, a typing-target test that passed with its guard deleted, the
hardcoded keycap in the shortcuts dialog, and the untested modifier branches).
Four I disagree with, and say so here rather than silently:

- **"Ctrl+A still reaches the browser when a dialog or menu is open, so the
  symptom survives."** Deliberate. A declined key is handed back intact, and
  those surfaces teleport out of `.shelf`, so their text *is* selectable and
  select-all there is a real gesture. Same bargain as the `Esc` cap in that
  menu, which closes the menu rather than clearing the selection while it is up.
- **"The root cause is the `user-select: none` asymmetry, not the keybinding."**
  The report asks for the model entries to be selected by `Ctrl+A`; the stray
  highlight is what an unhandled chord left behind. Making the shelf's own text
  selectable is a separate decision the architecture doc already defers (it
  notes `DuplicateQueue` has the same asymmetry).
- **"`TrainingRuns` is left without the chord, so this is half a fix."** The
  runs tab is a different list of different objects with its own keyboard model,
  and its handler is bound to the grid element, not the window. Adding the chord
  there would work only while focus sat inside the grid — reproducing the exact
  mistake the shelf's window listener was written to correct. Worth its own card
  if the inconsistency bites.
- **"The shelf has no section in the shortcuts dialog."** True, and neither does
  Duplicates; that dialog covers the grid, the overlay and general keys only.
  Out of scope here.

No secrets or private information in the diff; the review checked for both.
