### PR TITLE
Resolve the hub path's symlinked ancestors instead of refusing them

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2660,6 +2660,49 @@ route back to tightening this. Recorded here rather than in a review document
 because `docs/reviews/` is gitignored: an accepted risk nobody else can read is
 not a record.
 
+**Accepted risk W19 — the hub path is resolved, not refused.** The guard refuses
+a *caller-supplied* path that reaches its target through a symlink. A library's
+path never presents one, because `registry.resolve_path` has always
+canonicalised it at attach and stored the resolved string; the hub's did,
+because it is derived from the config directory on every boot and handed over as
+derived. The refusal therefore fell entirely on the hub, and it fell hard: a
+stow- or chezmoi-managed `~/.config`, a `$HOME` symlinked onto another disk, or
+a macOS path crossing `/var` -> `/private/var` produced a server that would not
+start, with no route back — `startup_permissions` mirrors the guard's walk over
+`realpath`, so it cannot see a redirect that exists only before resolution and
+reported "no issues" for the startup that then failed, and the Electron shell
+exposes no way to override the config path. Nothing like this existed in v1.9.0,
+which had neither the hub nor the guard.
+
+`hub/db.py`'s `canonical_hub_path` resolves the *ancestors* of the hub path in
+`HubDatabase.__init__`, so both the server and CLI lanes now agree with what the
+registry does for libraries. The final component is deliberately left
+unresolved, so a symlink standing at `hub.db` itself still reaches
+`_reject_symlinked_path` and is refused: that is the classic pre-positioned
+attack and nobody legitimately makes the database file a link.
+
+What this gives up: a redirect is followed once per boot rather than refused, so
+an attacker who can write a directory on the pre-resolution path can point us at
+a *different* database this user already owns. It is confusion, not
+substitution — the namespace walk still refuses a target whose parent another
+principal can write, and the file checks still refuse one this user does not own
+at mode 600, so the attacker cannot author the content. A concrete target does
+exist: `default_hub_path()` fixes the CLI's hub under `user_config_dir`, while
+Electron drives one under its own `userData`, so a machine that has run both
+holds two 0600 hubs at fixed paths. It is accepted because the precondition
+dominates the payoff — write access inside the owner's own config directory,
+which also holds `autostart/` and `systemd/user/`, is code execution as the
+owner by a shorter route than swapping a hub.
+
+Windows keeps `_reject_symlinked_path` intact, including junctions: there
+`_require_owned_directory` returns early, so the redirect refusal is one of only
+three controls that actually run and removing it would be a straight downgrade.
+
+Owner: lindkvis. Revisit with W17. The wider change this was carved out of —
+retiring the POSIX ancestor refusal outright, canonicalising the vault
+connection pool, and repairing `startup_permissions`'s blindness — is not in
+this record and needs its own independent adversarial sign-off.
+
 ### Vector storage
 
 - Embeddings (`image_embedding`, `text_embedding`, `Face.features`) are stored as `BLOB` columns.

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -158,8 +158,23 @@ def canonical_hub_path(path: str) -> str:
     ``_reject_symlinked_path`` and is refused: nobody legitimately makes the
     database file a link, and that is the classic pre-positioned-symlink
     attack.  ``os.path.realpath`` over the whole path would follow it silently.
+
+    On Windows the path is returned absolute but otherwise *unchanged*, ancestors
+    included.  ``os.path.realpath`` there resolves junctions and symlinks, so
+    pre-resolving the ancestors would hand ``TrustedSQLiteLocation.open`` a
+    redirect-free path and defeat ``_reject_symlinked_path`` on an ancestor
+    junction -- the redirect an unprivileged account can create with only
+    directory write access (``mklink /J``).  The two POSIX controls that make
+    following a redirect tolerable both return early on ``nt``:
+    ``_require_owned_directory``'s namespace walk (which would refuse an exposed
+    parent) and ``check_file_mode``'s mode-600 check.  Windows therefore keeps
+    refusing ancestor redirects rather than following them; see the W19 record in
+    ``docs/backend_architecture.md`` section 13.
     """
-    directory, name = os.path.split(os.path.abspath(os.path.expanduser(path)))
+    absolute = os.path.abspath(os.path.expanduser(path))
+    if os.name == "nt":
+        return absolute
+    directory, name = os.path.split(absolute)
     return os.path.join(os.path.realpath(directory), name)
 
 

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -125,6 +125,44 @@ def default_hub_path() -> str:
     return os.path.join(user_config_dir(APP_NAME), "hub.db")
 
 
+def canonical_hub_path(path: str) -> str:
+    """Return *path* with every symlinked ancestor resolved.
+
+    ``TrustedSQLiteLocation`` opens by the canonical path but refuses a
+    *caller-supplied* path that reaches its target through a symlink, and the
+    hub's path is derived from the config directory rather than registered the
+    way a library's is.  A user whose ``~/.config`` is managed by stow or
+    chezmoi, whose ``$HOME`` is symlinked onto another disk, or whose path
+    crosses macOS's ``/var`` -> ``/private/var`` therefore had a server that
+    would not start at all -- and no route back, because ``startup_permissions``
+    mirrors the guard's walk over ``realpath`` and so cannot see a redirect that
+    only exists before resolution, and the Electron shell exposes no way to
+    override the config path.
+
+    Resolving here is what the library registry has always done for vault paths
+    (``registry.resolve_path``), so the two lanes now agree.  It is deliberately
+    weaker than the refusal it replaces: a redirect is followed once per boot
+    rather than refused, which admits an attacker who can write a directory on
+    the pre-resolution path redirecting us to a *different* database this user
+    already owns.  Every other guard still holds -- the namespace walk refuses a
+    target whose parent another principal can write, and the file checks refuse
+    one this user does not own at mode 600 -- so the residue is confusion
+    between our own hubs, not substitution.  Reaching even that needs write
+    access inside the owner's own config directory, which also holds
+    ``autostart/`` and ``systemd/user/``: code execution as the owner by a
+    shorter route.  Accepted risk, recorded beside W17 in
+    ``docs/backend_architecture.md`` section 13.
+
+    Only the *ancestors* are resolved.  The final component is left exactly as
+    given so that a symlink standing at ``hub.db`` itself still reaches
+    ``_reject_symlinked_path`` and is refused: nobody legitimately makes the
+    database file a link, and that is the classic pre-positioned-symlink
+    attack.  ``os.path.realpath`` over the whole path would follow it silently.
+    """
+    directory, name = os.path.split(os.path.abspath(os.path.expanduser(path)))
+    return os.path.join(os.path.realpath(directory), name)
+
+
 def check_file_mode(path: str, *, repair: bool) -> None:
     """Verify that *path* is not group- or world-accessible.
 
@@ -195,7 +233,7 @@ class HubDatabase:
             repair_permissions: Passed to :func:`check_file_mode`. The CLI sets
                 it; the server does not.
         """
-        self._path = path or default_hub_path()
+        self._path = canonical_hub_path(path or default_hub_path())
         self._closed = False
 
         parent = Path(self._path).parent

--- a/pixlstash/startup_permissions.py
+++ b/pixlstash/startup_permissions.py
@@ -222,9 +222,15 @@ def find_startup_permission_issues(
         return []
 
     config_dir = os.path.abspath(os.path.dirname(server_config_path))
-    hub_path = os.path.join(config_dir, "hub.db")
     issues: list[PermissionIssue] = []
     canonical_config_dir = os.path.realpath(config_dir)
+    # Build the hub path from the *resolved* directory, matching what
+    # `canonical_hub_path` hands the guard. A symlinked config directory
+    # otherwise leaves this scan inspecting one spelling while the guard opens
+    # another, which is how the offer came to report "no issues" for a startup
+    # that then failed. The leaf is joined rather than resolved, so a symlink
+    # standing at hub.db is still the guard's to refuse.
+    hub_path = os.path.join(canonical_config_dir, "hub.db")
     private_config_dir = canonical_config_dir in _app_owned_config_directories()
 
     config_issue = _repairable_issue(

--- a/scripts/smoke_install.py
+++ b/scripts/smoke_install.py
@@ -310,10 +310,11 @@ def run_smoke(venv_dir: Path, port: int, expected_version: str | None) -> None:
     base_url = f"http://127.0.0.1:{port}"
 
     with tempfile.TemporaryDirectory(prefix="pixlstash-smoke-") as tmp:
-        # Resolve through any OS-level symlinks (e.g. /var → /private/var on
-        # macOS) so trusted_sqlite's symlink rejection never fires on a path
-        # the caller did not construct.
-        tmp_path = Path(tmp).resolve()
+        # Deliberately NOT resolved. On macOS this path runs through
+        # /var -> /private/var, so the unresolved spelling is exactly the
+        # symlinked-ancestor case that used to stop the server starting; the
+        # smoke test is where that stays proven on a real macOS runner.
+        tmp_path = Path(tmp)
         image_root = tmp_path / "images"
         image_root.mkdir()
         config_path = tmp_path / "server-config.json"

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -20,7 +20,11 @@ from pixlstash.auth import AuthService
 from pixlstash.db_models import User
 from pixlstash.db_models.user_token import UserToken
 from pixlstash.hub.db import HubDatabase
-from pixlstash.hub.db import HubPermissionError, check_file_mode
+from pixlstash.hub.db import (
+    HubPermissionError,
+    canonical_hub_path,
+    check_file_mode,
+)
 from pixlstash.hub.engine import HubEngine
 from pixlstash import trusted_sqlite
 from pixlstash.trusted_sqlite import (
@@ -1311,3 +1315,107 @@ def test_transaction_survives_an_already_open_transaction(hub_path):
     finally:
         survivor.close()
     assert "/written/inside" in paths, "the block's own write must still commit"
+
+
+class TestHubUnderASymlinkedAncestor:
+    """A symlinked config directory must not stop the server starting.
+
+    v1.10.0 introduced both the hub and ``trusted_sqlite``'s guard. The guard
+    refuses a *caller-supplied* path that crosses a symlink, and the hub's path
+    — unlike a library's, which ``registry.resolve_path`` has always canonicalised
+    at attach — was handed over exactly as derived from the config directory.
+    A stow/chezmoi-managed ``~/.config``, a ``$HOME`` symlinked onto another
+    disk, or a macOS path crossing ``/var`` -> ``/private/var`` therefore
+    bricked startup with no route back, since ``startup_permissions`` mirrors
+    the guard over ``realpath`` and cannot see a redirect that exists only
+    before resolution.
+
+    Both directions, because the ancestor relaxation must not cost the leaf
+    refusal: an ancestor link is followed, a link standing at ``hub.db``
+    itself is still refused.
+    """
+
+    def test_a_hub_under_a_symlinked_ancestor_opens(self, tmp_path):
+        real = tmp_path / "real-config"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "config"
+        link.symlink_to(real, target_is_directory=True)
+
+        HubDatabase(str(link / "hub.db")).close()
+
+        # The bytes must land at the canonical location, opened once, rather
+        # than at a second file reached through the link.
+        assert (real / "hub.db").is_file()
+        assert not (real / "hub.db").is_symlink()
+
+    def test_the_opened_path_is_canonical(self, tmp_path):
+        real = tmp_path / "real-config"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "config"
+        link.symlink_to(real, target_is_directory=True)
+
+        hub = HubDatabase(str(link / "hub.db"))
+        try:
+            # The pool, the sidecars and `os.replace` all reopen by this string
+            # over the process lifetime; if it still held the link they would
+            # re-resolve it on every use.
+            assert hub.path == str(real / "hub.db")
+        finally:
+            hub.close()
+
+    def test_a_symlinked_leaf_under_a_symlinked_ancestor_is_still_refused(
+        self, tmp_path
+    ):
+        real = tmp_path / "real-config"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "config"
+        link.symlink_to(real, target_is_directory=True)
+        target = real / "elsewhere.db"
+        target.write_bytes(b"do not open")
+        (real / "hub.db").symlink_to(target)
+
+        with pytest.raises(HubPermissionError, match="symlink"):
+            HubDatabase(str(link / "hub.db"))
+
+        assert target.read_bytes() == b"do not open"
+
+    def test_a_symlink_to_an_exposed_directory_is_still_refused(self, tmp_path):
+        """Resolving the ancestor must not smuggle past the namespace walk.
+
+        This is what carries the security load now that the redirect itself is
+        followed: the link is resolved, and then the directory it lands on is
+        judged on its own ownership and mode.
+        """
+        exposed = tmp_path / "exposed"
+        exposed.mkdir()
+        # chmod, not mkdir(mode=...): the process umask is commonly 0o022, which
+        # would silently make this 0o755 and leave nothing for the guard to
+        # refuse — the assertion would then pass for the wrong reason.
+        os.chmod(exposed, 0o777)
+        link = tmp_path / "config"
+        link.symlink_to(exposed, target_is_directory=True)
+
+        with pytest.raises(HubPermissionError, match="writable"):
+            HubDatabase(str(link / "hub.db"))
+
+
+class TestCanonicalHubPath:
+    def test_ancestors_are_resolved_and_the_leaf_is_not(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "via-link"
+        link.symlink_to(real, target_is_directory=True)
+        leaf = real / "hub.db"
+        leaf.symlink_to(real / "target.db")
+
+        resolved = canonical_hub_path(str(link / "hub.db"))
+
+        assert resolved == str(real / "hub.db")
+        # Preserved as a link so `_reject_symlinked_path` still gets to refuse
+        # it; `os.path.realpath` over the whole path would have followed it.
+        assert os.path.islink(resolved)
+
+    def test_a_path_without_links_is_unchanged(self, tmp_path):
+        plain = str(tmp_path / "hub.db")
+
+        assert canonical_hub_path(plain) == os.path.realpath(plain)

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -1335,6 +1335,7 @@ class TestHubUnderASymlinkedAncestor:
     itself is still refused.
     """
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_a_hub_under_a_symlinked_ancestor_opens(self, tmp_path):
         real = tmp_path / "real-config"
         real.mkdir(mode=0o700)
@@ -1348,21 +1349,20 @@ class TestHubUnderASymlinkedAncestor:
         assert (real / "hub.db").is_file()
         assert not (real / "hub.db").is_symlink()
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_the_opened_path_is_canonical(self, tmp_path):
         real = tmp_path / "real-config"
         real.mkdir(mode=0o700)
         link = tmp_path / "config"
         link.symlink_to(real, target_is_directory=True)
 
-        hub = HubDatabase(str(link / "hub.db"))
-        try:
-            # The pool, the sidecars and `os.replace` all reopen by this string
-            # over the process lifetime; if it still held the link they would
-            # re-resolve it on every use.
+        # The pool, the sidecars and `os.replace` all reopen by this string
+        # over the process lifetime; if it still held the link they would
+        # re-resolve it on every use.
+        with HubDatabase(str(link / "hub.db")) as hub:
             assert hub.path == str(real / "hub.db")
-        finally:
-            hub.close()
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_a_symlinked_leaf_under_a_symlinked_ancestor_is_still_refused(
         self, tmp_path
     ):
@@ -1379,6 +1379,7 @@ class TestHubUnderASymlinkedAncestor:
 
         assert target.read_bytes() == b"do not open"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_a_symlink_to_an_exposed_directory_is_still_refused(self, tmp_path):
         """Resolving the ancestor must not smuggle past the namespace walk.
 
@@ -1400,6 +1401,7 @@ class TestHubUnderASymlinkedAncestor:
 
 
 class TestCanonicalHubPath:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_ancestors_are_resolved_and_the_leaf_is_not(self, tmp_path):
         real = tmp_path / "real"
         real.mkdir(mode=0o700)
@@ -1415,7 +1417,34 @@ class TestCanonicalHubPath:
         # it; `os.path.realpath` over the whole path would have followed it.
         assert os.path.islink(resolved)
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     def test_a_path_without_links_is_unchanged(self, tmp_path):
         plain = str(tmp_path / "hub.db")
 
         assert canonical_hub_path(plain) == os.path.realpath(plain)
+
+    @pytest.mark.skipif(os.name == "nt", reason="creates a symlink to simulate nt")
+    def test_on_windows_a_symlinked_ancestor_is_not_resolved(
+        self, tmp_path, monkeypatch
+    ):
+        """The Windows carve-out that keeps ``_reject_symlinked_path`` intact.
+
+        On ``nt`` resolving the ancestors would defeat the redirect refusal, one
+        of the only controls left there (W19, ``docs/backend_architecture.md``
+        section 13). A real symlink is made on this POSIX gate, ``os.name`` is
+        forced to ``nt``, and the ancestor must come back *unresolved* — the
+        symlink still present — so the leaf-and-ancestor walk in
+        ``_reject_symlinked_path`` still gets to see and refuse it. Without the
+        guard this resolves the link and the assertion fails.
+        """
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "via-link"
+        link.symlink_to(real, target_is_directory=True)
+
+        monkeypatch.setattr("pixlstash.hub.db.os.name", "nt")
+
+        resolved = canonical_hub_path(str(link / "hub.db"))
+
+        assert resolved == str(link / "hub.db")
+        assert os.path.islink(os.path.dirname(resolved))

--- a/tests/test_startup_permissions.py
+++ b/tests/test_startup_permissions.py
@@ -218,3 +218,35 @@ def test_offers_the_writable_ancestor_the_guard_refuses(tmp_path, app_owned_conf
     assert mode(shared) == 0o755
     assert not find_startup_permission_issues(server_config, str(library))
     TrustedSQLiteLocation.open(str(vault)).close()
+
+
+def test_a_server_starts_with_its_config_under_a_symlinked_directory(tmp_path):
+    """The macOS ``/var`` -> ``/private/var`` case, reproduced on any POSIX box.
+
+    That failure is not macOS-specific: it is simply a symlinked ancestor, and
+    every ancestor of the config path is one the caller did not construct. The
+    guard used to refuse it outright, so `pixlstash-server --server-config
+    <path under a symlinked dir>` exited 1 before serving anything, which is
+    what `scripts/smoke_install.py` had to work around on its macOS runner.
+
+    Asserting a *successful start* rather than a guard call, because the hub is
+    only one of the databases opened on that path and the point is that the
+    whole startup chain now agrees on one spelling.
+    """
+    from pixlstash.server import Server
+
+    real = tmp_path / "real-home"
+    real.mkdir(mode=0o700)
+    link = tmp_path / "home"
+    link.symlink_to(real, target_is_directory=True)
+
+    server_config = str(link / "server-config.json")
+    with Server(server_config_path=server_config) as server:
+        # The hub landed at the resolved location and is opened by that name,
+        # so the pool and every later reopen agree with the guard.
+        assert server.hub.path == str(real / "hub.db")
+        assert (real / "hub.db").is_file()
+
+    # And the scan that gates startup sees the same file rather than reporting
+    # "no issues" about a path nothing opens.
+    assert not find_startup_permission_issues(server_config, None)


### PR DESCRIPTION
## What this changes

The server now follows symlinks in the folder path leading to `hub.db` instead of refusing to start. A symlink on the database file itself is still refused.

## Why

v1.10.0 added the hub database along with a new safety check on where it lives. That check refuses any path that goes through a symlink.

Library folders were never affected, because their paths already get resolved when you attach them. The hub's path didn't, so the check only ever hit the hub — and the result was that the server wouldn't start at all if the config folder was reached through a symlink.

That happens more often than it sounds: dotfile managers like stow or chezmoi, a home folder moved to a bigger disk, and on macOS any path going through `/var`, which is itself a symlink to `/private/var`.

There was also no way out of it. The startup permission check resolves symlinks before it looks, so it reported "no problems found" and then the server died anyway. And the desktop app gives you no way to point it at a different folder.

The fix resolves the folders leading to the hub, which is what the library registry has always done. The filename itself is left alone, so a symlink planted at `hub.db` is still rejected.

This is a little less strict than before: we follow such a link once at startup rather than refusing it outright. Everything else still applies — a database owned by someone else, or sitting in a folder other people can write to, is still refused. The trade-off is written up as W19 in `docs/backend_architecture.md` §13. Windows keeps the old stricter behaviour, because the checks that replace it don't work there.

## How it was verified

- A new test starts a real server with its config in a symlinked folder. I checked that it fails without the fix and passes with it, so it's genuinely testing the thing it claims to.
- Other new tests: a symlinked `hub.db` is still refused, and a link pointing into a world-writable folder is still refused.
- `test_startup_permissions.py` and `test_hub_engine.py`: 81 passed. There's one failure, `test_a_private_group_makes_group_write_harmless`, which also fails on a clean checkout when the tests run as root — unrelated to this change.
- `ruff format` and `ruff check` are clean.
- Removes the workaround that was added to the macOS smoke test, so that job exercises the real `/var` case again instead of stepping around it.

Not tested on Windows or macOS — those runners are the first real check of those paths.

Since this changes a database safety check, it should be signed off by someone who wasn't involved in designing the change.

## Contributor licence agreement

Required only for changes under `pixlstash/**` (the backend). Tick the box
yourself; nobody can tick it on your behalf. The check wants this exact line
with an `x` in it, so edit the box rather than rewriting the sentence.

- [ ] I have read and agree to the CLA in `pixlstash/CLA.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdKoJ8fSETWcTiGdQ34F5k