### PR TITLE
Point the dev desktop entry at a stable icon path

### DIFF
--- a/electron/scripts/dev-desktop-integration.mjs
+++ b/electron/scripts/dev-desktop-integration.mjs
@@ -46,9 +46,6 @@ if (!existsSync(iconSrc)) {
   process.exit(0);
 }
 
-mkdirSync(dirname(iconPath), { recursive: true });
-copyFileSync(iconSrc, iconPath);
-
 const contents = `[Desktop Entry]
 Type=Application
 Name=PixlStash (dev)
@@ -60,8 +57,18 @@ Categories=Graphics;Photography;
 StartupWMClass=${WM_CLASS}
 `;
 
-mkdirSync(appsDir, { recursive: true });
-writeFileSync(desktopFile, contents);
+// Best effort, like the update-desktop-database nudge below: this is a cosmetic
+// nicety, and `npm run dev` chains straight into launching the app. A read-only
+// or locked-down home must cost you the icon, never the dev run.
+try {
+  mkdirSync(dirname(iconPath), { recursive: true });
+  copyFileSync(iconSrc, iconPath);
+  mkdirSync(appsDir, { recursive: true });
+  writeFileSync(desktopFile, contents);
+} catch (e) {
+  console.warn('dev-desktop: could not install the desktop entry; skipping:', e);
+  process.exit(0);
+}
 console.log(`dev-desktop: installed ${desktopFile}`);
 console.log(`             StartupWMClass=${WM_CLASS}  Icon=${iconPath}`);
 

--- a/electron/scripts/dev-desktop-integration.mjs
+++ b/electron/scripts/dev-desktop-integration.mjs
@@ -9,7 +9,7 @@
 // This writes a minimal per-user .desktop that maps that WM_CLASS to the app
 // icon, giving the dev window a proper icon. Idempotent and Linux-only; a no-op
 // elsewhere. Remove ~/.local/share/applications/pixlstash.desktop to undo.
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
 import { execFile } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -21,9 +21,16 @@ if (platform() !== 'linux') {
 
 const here = dirname(fileURLToPath(import.meta.url));
 const projectDir = join(here, '..');
-// Absolute path to the canonical square icon (stable repo location, always
-// present). Cinnamon/GNOME read absolute Icon paths directly — no theme install.
-const iconPath = join(projectDir, 'assets', 'icon.png');
+const iconSrc = join(projectDir, 'assets', 'icon.png');
+// The entry has to outlive the checkout that wrote it. Every `npm run dev`
+// rewrites this file with the directory it ran from, and a session worktree is
+// deleted once its PR merges — so an `Icon=` pointing into the checkout goes
+// dangling and the alt-tab icon silently disappears. (It already did: an entry
+// written before the repo moved to the container layout kept pointing at a path
+// that no longer existed.) Copy the icon to a stable per-user location instead
+// and reference that. Cinnamon/GNOME read absolute Icon paths directly, so no
+// theme install is involved.
+const iconPath = join(homedir(), '.local', 'share', 'icons', 'pixlstash.png');
 const electronBin = join(projectDir, 'node_modules', '.bin', 'electron');
 
 // Electron derives the X11 WM_CLASS / app_id from package.json `desktopName`
@@ -34,10 +41,13 @@ const WM_CLASS = 'pixlstash';
 const appsDir = join(homedir(), '.local', 'share', 'applications');
 const desktopFile = join(appsDir, `${WM_CLASS}.desktop`);
 
-if (!existsSync(iconPath)) {
-  console.warn(`dev-desktop: icon missing at ${iconPath}; skipping`);
+if (!existsSync(iconSrc)) {
+  console.warn(`dev-desktop: icon missing at ${iconSrc}; skipping`);
   process.exit(0);
 }
+
+mkdirSync(dirname(iconPath), { recursive: true });
+copyFileSync(iconSrc, iconPath);
 
 const contents = `[Desktop Entry]
 Type=Application


### PR DESCRIPTION
The dev `.desktop` entry that gives the Electron window its Linux taskbar/alt-tab icon wrote `Icon=` as a path inside the checkout that ran `npm run dev`. Every dev run rewrites the entry with its own directory, and session worktrees are deleted when their PR merges — so the icon path goes dangling and the alt-tab icon silently disappears. The same thing happened when the repo moved to the container layout: an entry written against the old path kept pointing at a directory that no longer existed.

Copy the icon to `~/.local/share/icons/pixlstash.png` and point the entry there, so the association survives the checkout it was created from. `Exec=` still names the checkout, which is what it is for.