### PR TITLE
Keep the CLI out of the macOS dock

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1283,6 +1283,10 @@ function registerIpc(): void {
  * work whether or not the app is already open. Nothing here creates a window,
  * so this stays a fast process spawn rather than a full Chromium start.
  *
+ * Windowless is not the same as invisible on macOS, though: AppKit reads the
+ * bundle's Info.plist and makes every launch a *regular* foreground app before
+ * any of this runs, so each CLI invocation left a dock tile behind (#1061).
+ *
  * `stdio: 'inherit'` because the CLI writes to the terminal and asks for a y/n
  * on destructive verbs; piping would hang that prompt with nothing shown.
  */
@@ -1291,6 +1295,11 @@ function runCli(args: string[]): void {
   // otherwise starts anyway and writes driver-probe noise ("MESA-LOADER: failed
   // to open dri...") to the terminal *after* the CLI's own output.
   app.disableHardwareAcceleration();
+  // Same reason, macOS side: drop the regular-app activation policy so this run
+  // leaves no dock tile behind. Typed `Dock | undefined`, so the optional call
+  // is the platform check — unlike app.setActivationPolicy, which the typings
+  // declare unconditionally but which does not exist off macOS.
+  app.dock?.hide();
   const declared = declaredCliCommand();
   // Same interpreter choice the backend makes, so a dev run drives the repo's
   // .venv and the CLI branch is exercisable without building the bundled env.


### PR DESCRIPTION
Closes #1061.

## What

One line in `runCli()` (`electron/src/main.ts`), next to the existing `app.disableHardwareAcceleration()`:

```ts
app.dock?.hide();
```

## Why

The desktop CLI runs the app bundle's own binary with a leading `cli` token, and `runCli()` spawns the bundled Python ahead of the single-instance lock and `whenReady`. It opens no window — but on macOS dock presence comes from the process's *activation policy*, which AppKit sets to regular from the bundle's `Info.plist` before any of our JavaScript runs. So every CLI invocation started a full foreground application that merely happened to be windowless, and left a tile behind. The cap at three matches the Dock's recent-applications section.

`runCli`'s docstring already asserted the intended property ("Nothing here creates a window") in terms macOS does not use; the docstring now says what actually governs it.

`app.dock?.hide()` rather than `app.setActivationPolicy('prohibited')`, which the issue proposed:

- `app.dock` is typed `Dock | undefined`, so the optional call *is* the platform check. `setActivationPolicy` is declared unconditionally on `App` — `@platform darwin` is only a doc comment — and is genuinely `undefined` off macOS, so it needs a hand-written `process.platform === 'darwin'` guard that `tsc` cannot enforce. On the platforms where the shim is most used, a missing guard would throw before the child is even spawned.
- The Electron typings say of `accessory`, which `dock.hide()` sets: "The application doesn't appear in the Dock and doesn't have a menu bar." That is the reported symptom, fully.
- `prohibited` additionally forbids activation. The CLI's headline verb is `libraries attach <folder>`, and attaching under `~/Pictures` etc. is a TCC-consent trigger; whether a prohibited-policy process can front that system prompt is untested. `accessory` raises no such question.

## Review objections answered rather than acted on

An adversarial pass raised several more. Two are worth answering here:

- **"Symptom, not root cause — AppKit creates the tile before this runs, so it is retracted rather than prevented."** True, and stated in the comment. The prevention-shaped fix is `mac.extendInfo.LSUIElement: true` plus `setActivationPolicy('regular')` in the GUI branch's `whenReady`, which makes the *windowed* app's dock icon depend on a JS call — worse. The other root-cause option, having the shim exec the bundled interpreter directly, was considered and rejected on #1061: it makes the shim platform-divergent and bakes in interpreter and hub paths that `main.ts` owns. If a tile is still *recorded* after this change, `LSUIElement` is the documented next step.
- **"No test."** `runCli` runs at module top level against `app` and `spawn`; there is nothing importable to assert on, and CI's macOS runner only builds. Extracting a platform predicate to make it testable is not worth it now that the platform check is the optional-call operator. Verification is manual, below.

## Verification

No CI job can observe this. It needs a manual run against a packaged macOS build: CLI output correct, exit statuses still propagating (1 refusal, 2 usage, 3 hub unavailable), and no tile left behind after three consecutive runs. The `cliShim` suite (21 tests) and `tsc --noEmit` both pass; neither covers the macOS behaviour.

Unverified from a Linux box: that `app.dock` is populated this early. `disableHardwareAcceleration` beside it documents a before-ready contract; `dock.hide()` documents none either way, and the underlying `[NSApp setActivationPolicy:]` no-ops silently on a nil `NSApp` — so a wrong ordering would look identical to success. If the packaged run still shows a tile, moving the call is the first thing to try.