### PR TITLE
Install send2trash in the Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN pip install --no-cache-dir \
     click \
     accelerate \
     bitsandbytes \
-    zstandard
+    zstandard \
+    send2trash
 
 # Remove build tools — not needed at runtime
 RUN apt-get purge -y --auto-remove build-essential && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,13 @@ COPY --chown=pixlstash:pixlstash pixlstash/ pixlstash/
 # Install the pixlstash package itself (no deps — already installed above)
 RUN pip install --no-cache-dir --no-deps -e .
 
+# Smoke test: import the server exactly as the entrypoint will. The pip list
+# above is hand-maintained and the install is --no-deps, so a dependency added
+# to pyproject.toml but not to that list produces a green build and an image
+# that dies on start-up (send2trash did, in v1.10.0). This fails the build
+# instead, before anything is tagged or pushed.
+RUN python -c "import pixlstash.server"
+
 # Copy the pre-built frontend into the package's expected location.
 # Vite outDir is ../pixlstash/frontend/dist relative to /build/frontend.
 COPY --chown=pixlstash:pixlstash --from=frontend-builder /build/pixlstash/frontend/dist pixlstash/frontend/dist/

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -105,6 +105,13 @@ COPY --chown=pixlstash:pixlstash pixlstash/ pixlstash/
 
 RUN pip install --no-cache-dir --no-deps -e .
 
+# Smoke test: import the server exactly as the entrypoint will. The pip list
+# above is hand-maintained and the install is --no-deps, so a dependency added
+# to pyproject.toml but not to that list produces a green build and an image
+# that dies on start-up (send2trash did, in v1.10.0). This fails the build
+# instead, before anything is tagged or pushed.
+RUN python -c "import pixlstash.server"
+
 COPY --chown=pixlstash:pixlstash --from=frontend-builder /build/pixlstash/frontend/dist pixlstash/frontend/dist/
 
 # ── Bake in demo data ─────────────────────────────────────────────────────────

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -91,7 +91,8 @@ RUN pip install --no-cache-dir \
     click \
     accelerate \
     bitsandbytes \
-    zstandard
+    zstandard \
+    send2trash
 
 RUN apt-get purge -y --auto-remove build-essential && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -84,7 +84,8 @@ RUN pip install --no-cache-dir \
     click \
     accelerate \
     bitsandbytes \
-    zstandard
+    zstandard \
+    send2trash
 
 
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -133,6 +133,13 @@ COPY --chown=pixlstash:pixlstash pixlstash/ pixlstash/
 # Install the pixlstash package itself (no deps — already installed above)
 RUN pip install --no-cache-dir --no-deps -e .
 
+# Smoke test: import the server exactly as the entrypoint will. The pip list
+# above is hand-maintained and the install is --no-deps, so a dependency added
+# to pyproject.toml but not to that list produces a green build and an image
+# that dies on start-up (send2trash did, in v1.10.0). This fails the build
+# instead, before anything is tagged or pushed.
+RUN python -c "import pixlstash.server"
+
 # Copy the pre-built frontend into the package's expected location
 COPY --chown=pixlstash:pixlstash --from=frontend-builder /build/pixlstash/frontend/dist pixlstash/frontend/dist/
 

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2498,3 +2498,43 @@ def test_tests_close_the_server_not_only_its_vault():
         "close the whole server, not only its vault — server.close() — at "
         + ", ".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# Guardrail: every runtime dependency is installed in every Docker image
+# ---------------------------------------------------------------------------
+
+
+def test_dockerfiles_install_every_runtime_dependency():
+    """A dependency added to ``pyproject.toml`` must reach the images too.
+
+    All three Dockerfiles hand-maintain their ``pip install`` list and then run
+    ``pip install --no-deps -e .``, so a new dependency is silently absent from
+    the built image and only shows up as a ``ModuleNotFoundError`` at start-up.
+    That is how ``send2trash`` reached the demo image and crashed it on import.
+
+    The check is a substring one on purpose: it is aliases like
+    ``opencv-python-headless`` and ``onnxruntime-gpu`` that legitimately satisfy
+    a plain name, and total absence is the failure worth catching.
+    """
+    import tomllib
+
+    dependencies = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["dependencies"]
+    names = {
+        re.split(r"[<>=!~;\[]", spec)[0].strip().lower().replace("_", "-")
+        for spec in dependencies
+    }
+
+    missing = []
+    for filename in ("Dockerfile", "Dockerfile.gpu", "Dockerfile.demo"):
+        text = (
+            (REPO_ROOT / filename).read_text(encoding="utf-8").lower().replace("_", "-")
+        )
+        missing += [f"{filename}: {name}" for name in sorted(names) if name not in text]
+
+    assert not missing, (
+        "these runtime dependencies are never installed in the image, so the "
+        "container will fail on import: " + ", ".join(missing)
+    )


### PR DESCRIPTION
The demo container crashed at start-up with `ModuleNotFoundError: No module named 'send2trash'`.

Root cause: all three Dockerfiles hand-maintain their `pip install` list and then run `pip install --no-deps -e .`, so a dependency added to `pyproject.toml` never reaches the image. `send2trash` (model-shelf delete) was the one that got missed.

- Adds `send2trash` to `Dockerfile`, `Dockerfile.gpu` and `Dockerfile.demo`.
- Adds `test_dockerfiles_install_every_runtime_dependency` so the next dependency added without updating the images fails the gate instead of the container. Verified it goes red without the Dockerfile change.