### PR TITLE
Tighten the Docker config directory to 700 on start

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,13 @@ export PIXLSTASH_IN_DOCKER=1
 # a valid string without touching /etc/passwd.
 export USER="${USER:-pixlstash}"
 
-mkdir -p "$(dirname "$CONFIG_PATH")"
+CONFIG_DIR="$(dirname "$CONFIG_PATH")"
+mkdir -p "$CONFIG_DIR"
+
+# PixlStash refuses to start when its config directory is group/world-accessible
+# (the hub holds credentials).  mkdir under the default umask leaves 0755, and
+# the demo image bakes the directory in at 0755, so tighten it on every start.
+chmod 700 "$CONFIG_DIR" || echo "warning: could not chmod 700 $CONFIG_DIR - PixlStash will refuse to start" >&2
 
 # Write a default config on first run with Docker-appropriate settings
 # (host 0.0.0.0 so the server is reachable from outside the container).


### PR DESCRIPTION
The container refuses to start: the hub guard requires mode 700 on the app-owned config directory, and the images leave it at 755.

Both places that create it use the default umask — `mkdir -p` in `docker-entrypoint.sh` and the `mkdir` in `Dockerfile.demo` — so this hits every image (`Dockerfile`, `Dockerfile.gpu`, `Dockerfile.demo`), not just the demo.

The fix is one `chmod 700` in the shared entrypoint, which covers a freshly created directory and a baked-in one alike. A failed chmod warns instead of aborting, so a config directory the container user does not own still reaches the authoritative startup guard rather than dying in the shell.