### PR TITLE
Import a dropped model file instead of refusing it

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1151,7 +1151,8 @@ anything outside the file can reach them.
 | `isImportableMediaFile(file)` | *(module-local)* Extension is in `IMPORT_MEDIA_EXTENSIONS` — the import test, not the display one. |
 | `isSupportedCaptionFile(file)` | *(module-local)* `.txt` extension. |
 | `isSupportedImportFile(file)` | Importable media OR archive OR caption. Every import entry point filters through this one: the window-wide drop (`useWindowFileImport`), the grid's drop target, the sidebar set/character drops, and the import dialog. |
-| `extractSupportedImportFilesFromDataTransfer(dataTransfer)` | Async; recursively resolves `FileSystemEntry` trees via WebKit directory API, keeps what `isSupportedImportFile` allows, deduplicates by `name::size::lastModified`. |
+| `isModelFile(file)` | `.safetensors` — what the model shelf catalogues, not something the picture importer ever takes. |
+| `extractSupportedImportFilesFromDataTransfer(dataTransfer, { accept })` | Async; recursively resolves `FileSystemEntry` trees via WebKit directory API, keeps what `accept` allows (default `isSupportedImportFile`), deduplicates by `name::size::lastModified`. Call it ONCE per drop: Safari empties the DataTransfer on the first `await`, so a caller wanting two kinds out of one drop widens `accept` and splits the result. |
 
 ---
 
@@ -3355,6 +3356,37 @@ onto a folder group already does, and it does it better — with the folder in
 front of you. Both stores are refreshed afterwards, for the reason the import
 refreshes both: the shelf gained a row and the destination folder's file count
 and `shelf_bytes` moved with it, so the drive bands are stale too.
+
+**Dropping a `.safetensors` on the window is the same verb without the picker,
+and it works on the desktop only.** `useWindowFileImport` claims a model file
+before the picture importer or the grid can see it and calls the very same
+`POST /model-files` — by *path*, so nothing is uploaded. The path is the whole
+difficulty: a dropped `File` carries a name and bytes but never a location, so
+only the desktop shell can answer where it came from
+(`window.pixlstashDesktop.getDroppedFilePath`, `webUtils.getPathForFile` behind
+the preload bridge). In a browser tab there is nothing to resolve and nothing to
+send, and the drop says so, naming `Add ▾ → Add file…` rather than failing
+quietly — that menu works in a browser because the *server* enumerates the
+filesystem, which is the direction a drop cannot run in. A drop carrying both a
+model and pictures is split: the model goes to the shelf, and the pictures go to
+whichever importer owns the spot they landed on — dropped on the grid they are
+left to propagate to the grid's own handler, which threads the selected
+character into the import where the window-level one cannot. Only a drop of
+model files ALONE is stopped outright, because the grid would otherwise report
+it as unsupported while the shelf was busy accepting it.
+
+**A folder is walked, and the walk happens once.** A trainer's output directory
+holds the adapter beside its samples, and `dataTransfer.files` reports the whole
+directory as a single unreadable entry — reading the flat list imported the
+samples and lost the adapter in silence. `extractSupportedImportFilesFromDataTransfer`
+therefore takes an `accept` predicate, and the drop handler passes one widened to
+"picture **or** model" and splits the single result. It cannot call the walk twice:
+Safari empties the DataTransfer on the first `await`, so a second pass returns
+nothing. The picture import is started *before* the shelf copy is awaited and the
+two run side by side — a multi-gigabyte copy takes minutes, and the photos of a
+mixed drop must not queue behind it. Each drop also takes its own notice key, or
+a second drop coalesces onto the first one's sticky progress card and then
+dismisses it, leaving a running copy with nothing on screen.
 
 **The `Import from ai-toolkit` item is hidden, not disabled, when no `source`
 folder is registered** — unlike the selection bar's verbs, which are about a

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1136,16 +1136,17 @@ File type helpers.
 
 | Export | Description |
 |--------|-------------|
-| `PIL_IMAGE_EXTENSIONS` | Array of ~50 image format extensions. |
-| `VIDEO_EXTENSIONS` | `['mp4', 'avi', 'mov', 'webm', 'mkv', 'flv', 'wmv', 'm4v']` |
+| `PIL_IMAGE_EXTENSIONS` | Array of ~50 image format extensions. What the app can **display** — never what it will import. |
+| `VIDEO_EXTENSIONS` | `['mp4', 'avi', 'mov', 'webm', 'mkv', 'flv', 'wmv', 'm4v']` — display, as above. |
+| `IMPORT_MEDIA_EXTENSIONS` | What the importer will **take**, mirroring `STAGING_ALLOWED_MEDIA_EXTS` in `pixlstash/routes/pictures/_import.py`. Much shorter than the display lists, and the difference is not cosmetic: filtering a drop against those let a `.psd` or a `.wmv` upload in full before the route skipped it as unsupported and the commit returned "No staged files to import". `tests/test_architecture_guardrails.py::test_frontend_import_extensions_match_the_staging_allowlist` fails the build if the two lists drift. |
 | `ARCHIVE_EXTENSIONS` | `['zip']` |
 | `CAPTION_EXTENSIONS` | `['txt']` |
 | `isSupportedImageFile(file)` | Predicate by extension. |
 | `isSupportedVideoFile(file)` | Predicate by extension. |
 | `isSupportedArchiveFile(file)` | Predicate by extension. |
-| `isSupportedMediaFile(file)` | Image OR video. |
+| `isImportableMediaFile(file)` | Extension is in `IMPORT_MEDIA_EXTENSIONS` — the import test, not the display one. |
 | `isSupportedCaptionFile(file)` | `.txt` extension. |
-| `isSupportedImportFile(file)` | Media OR archive OR caption. |
+| `isSupportedImportFile(file)` | Importable media OR archive OR caption. Every import entry point filters through this one: the window-wide drop (`useWindowFileImport`), the grid's drop target, the sidebar set/character drops, and the import dialog. |
 | `collectImportFiles(dataTransfer)` | Async; recursively resolves `FileSystemEntry` trees via WebKit directory API, deduplicates by `name::size::lastModified`. |
 
 ---

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1134,20 +1134,24 @@ Pure stack ordering and leader-selection utilities (no Vue dependency).
 
 File type helpers.
 
-| Export | Description |
-|--------|-------------|
+Every name below is `export`ed **except** the five marked *(module-local)*, which
+are listed because they are how the exported predicates are built, not because
+anything outside the file can reach them.
+
+| Name | Description |
+|------|-------------|
 | `PIL_IMAGE_EXTENSIONS` | Array of ~50 image format extensions. What the app can **display** — never what it will import. |
 | `VIDEO_EXTENSIONS` | `['mp4', 'avi', 'mov', 'webm', 'mkv', 'flv', 'wmv', 'm4v']` — display, as above. |
 | `IMPORT_MEDIA_EXTENSIONS` | What the importer will **take**, mirroring `STAGING_ALLOWED_MEDIA_EXTS` in `pixlstash/routes/pictures/_import.py`. Much shorter than the display lists, and the difference is not cosmetic: filtering a drop against those let a `.psd` or a `.wmv` upload in full before the route skipped it as unsupported and the commit returned "No staged files to import". `tests/test_architecture_guardrails.py::test_frontend_import_extensions_match_the_staging_allowlist` fails the build if the two lists drift. |
-| `ARCHIVE_EXTENSIONS` | `['zip']` |
-| `CAPTION_EXTENSIONS` | `['txt']` |
+| `ARCHIVE_EXTENSIONS` | *(module-local)* `['zip']` |
+| `CAPTION_EXTENSIONS` | *(module-local)* `['txt']` |
 | `isSupportedImageFile(file)` | Predicate by extension. |
 | `isSupportedVideoFile(file)` | Predicate by extension. |
-| `isSupportedArchiveFile(file)` | Predicate by extension. |
-| `isImportableMediaFile(file)` | Extension is in `IMPORT_MEDIA_EXTENSIONS` — the import test, not the display one. |
-| `isSupportedCaptionFile(file)` | `.txt` extension. |
+| `isSupportedArchiveFile(file)` | *(module-local)* Predicate by extension. |
+| `isImportableMediaFile(file)` | *(module-local)* Extension is in `IMPORT_MEDIA_EXTENSIONS` — the import test, not the display one. |
+| `isSupportedCaptionFile(file)` | *(module-local)* `.txt` extension. |
 | `isSupportedImportFile(file)` | Importable media OR archive OR caption. Every import entry point filters through this one: the window-wide drop (`useWindowFileImport`), the grid's drop target, the sidebar set/character drops, and the import dialog. |
-| `collectImportFiles(dataTransfer)` | Async; recursively resolves `FileSystemEntry` trees via WebKit directory API, deduplicates by `name::size::lastModified`. |
+| `extractSupportedImportFilesFromDataTransfer(dataTransfer)` | Async; recursively resolves `FileSystemEntry` trees via WebKit directory API, keeps what `isSupportedImportFile` allows, deduplicates by `name::size::lastModified`. |
 
 ---
 

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,8 +1,10 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
 /**
- * Minimal, locked-down bridge for the splash / backend-manager UI. The main
- * PixlStash web app (loaded from the local server) does not use any of this.
+ * Minimal, locked-down bridge for the splash / backend-manager UI, plus the
+ * few things the main PixlStash web app (loaded from the local server) can only
+ * get from the shell: saving a picture to a chosen file, the clipboard, and the
+ * path of a file the user dropped on the window.
  */
 contextBridge.exposeInMainWorld('pixlstashDesktop', {
   bootstrap: () => ipcRenderer.invoke('app:bootstrap'),
@@ -34,6 +36,16 @@ contextBridge.exposeInMainWorld('pixlstashDesktop', {
     ipcRenderer.invoke('media:completeSaveAs', { saveId, data }),
   cancelMediaSaveAs: (saveId: string) => ipcRenderer.invoke('media:cancelSaveAs', saveId),
   copyPngToClipboard: (data: ArrayBuffer) => ipcRenderer.invoke('media:copyPng', data),
+  // Where a dropped file actually lives. A `File` from a drop carries a name and
+  // bytes but no path — a browser sandbox rule, and the reason dropping a model
+  // file on the web app can only point at the Add file… menu. The shell can
+  // answer, so on the desktop a dropped `.safetensors` goes to the same
+  // POST /model-files the menu calls: the file is already on this machine, and
+  // that endpoint copies it into the model store rather than uploading a
+  // gigabyte to land it beside where it started. Nothing crosses to main and no
+  // file is read here — `webUtils` resolves the path in the renderer, and the
+  // caller can only ask about a file the user themselves dropped.
+  getDroppedFilePath: (file: File) => webUtils.getPathForFile(file),
   // Desktop-shell preferences (hide-to-tray-on-close, ...).
   getDesktopPrefs: () => ipcRenderer.invoke('desktop:getPrefs'),
   setDesktopPrefs: (prefs: unknown) => ipcRenderer.invoke('desktop:setPrefs', prefs),

--- a/frontend/src/api/pictureImport.js
+++ b/frontend/src/api/pictureImport.js
@@ -58,10 +58,15 @@ import { apiClient } from "../utils/apiClient";
  *                                                                       cancelled_count, error }
  *
  * NOTE: the staging file endpoint accepts media, `.zip` archives (extracted
- * server-side) and `.txt` caption sidecars — the client streams whatever the
- * import file-collection allows (`isSupportedImportFile`) and lets the backend
- * decide. Truly unsupported files come back in `skipped[]`; a session that
- * stages nothing 400s on commit.
+ * server-side) and `.txt` caption sidecars, and the client streams whatever the
+ * import file-collection allows (`isSupportedImportFile`). That collection now
+ * mirrors the server's own media allowlist (`IMPORT_MEDIA_EXTENSIONS` in
+ * `utils/media.js` ↔ `STAGING_ALLOWED_MEDIA_EXTS` in the route), because
+ * "stream it and let the backend decide" charged the whole upload before
+ * refusing: a file the name already disqualifies came back in `skipped[]` after
+ * its last byte, and a session that staged nothing 400s on commit. What still
+ * reaches `skipped[]` is what only the bytes can settle — a corrupt image, a
+ * bad zip — never an extension.
  */
 
 export const IMPORT_ENDPOINTS = {

--- a/frontend/src/composables/useWindowFileImport.js
+++ b/frontend/src/composables/useWindowFileImport.js
@@ -2,18 +2,38 @@ import { onMounted, onUnmounted } from "vue";
 import {
   extractSupportedImportFilesFromDataTransfer,
   isInternalImageDrag,
+  isModelFile,
   isSupportedImportFile,
 } from "../utils/media.js";
+import { addModelFile } from "../api/modelFiles";
+import { errorDetail } from "../utils/apiError";
+import { useModelFoldersStore } from "../stores/useModelFoldersStore";
+import { useModelShelfStore } from "../stores/useModelShelfStore";
 import { useNoticeStore } from "../stores/useNoticeStore";
 import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
 
 /**
- * Import media dropped or pasted anywhere in the window.
+ * One notice key per DROP, never one for the verb.
  *
- * The grid has its own drop target, so drops that land inside it are left
- * alone; this is the catch-all for everywhere else. Listeners are registered
- * in the capture phase so a drop is claimed before the browser navigates to
- * the file.
+ * The card is sticky for as long as the copy runs, and a copy can run for
+ * minutes — so a second drop arriving mid-copy is ordinary, not exotic. A
+ * shared key made the second drop coalesce onto the first one's card and then
+ * dismiss it, leaving a running multi-gigabyte copy with nothing on screen and
+ * a success message about the other file.
+ */
+let modelDropSeq = 0;
+
+/**
+ * Import what is dropped or pasted anywhere in the window.
+ *
+ * The grid has its own drop target, so picture drops that land inside it are
+ * left alone; this is the catch-all for everywhere else. Listeners are
+ * registered in the capture phase so a drop is claimed before the browser
+ * navigates to the file.
+ *
+ * A `.safetensors` is the exception that IS claimed here wherever it lands,
+ * grid included: it is not a picture on any screen, and it has its own
+ * destination — see `addDroppedModelFiles`.
  *
  * @param {object} deps
  * @param {import("vue").Ref} deps.sidebarRef - the sidebar, which owns the
@@ -45,6 +65,124 @@ export function useWindowFileImport({ sidebarRef }) {
     return types.includes("Files") || types.includes("application/x-moz-file");
   }
 
+  /**
+   * Everything a drop carries that anything here wants, in ONE walk.
+   *
+   * One walk and not two because the walk is destructive on Safari, and one
+   * WALK rather than a read of `dataTransfer.files` because a dropped folder
+   * is a single unreadable entry there. A trainer's output directory holds the
+   * adapter *and* its samples, and reading the flat list dropped the adapter
+   * silently while importing the samples.
+   */
+  async function partitionDrop(dataTransfer) {
+    const all = await extractSupportedImportFilesFromDataTransfer(
+      dataTransfer,
+      {
+        accept: (file) => isSupportedImportFile(file) || isModelFile(file),
+      },
+    );
+    return {
+      modelFiles: all.filter(isModelFile),
+      pictureFiles: all.filter((file) => !isModelFile(file)),
+    };
+  }
+
+  /**
+   * Put dropped model files on the shelf, the way `Add file…` already does.
+   *
+   * `POST /model-files` takes a PATH, not bytes: the file is on the machine
+   * running PixlStash, so the server copies it into the model store and
+   * registers it — no upload. A drop hands over a `File`, which carries a name
+   * and bytes but no path, and only the desktop shell can answer where it came
+   * from (`webUtils.getPathForFile`, via the preload bridge). In a browser tab
+   * there is nothing to resolve and nothing to send, so the drop says where the
+   * gesture that does work lives instead of failing quietly.
+   */
+  async function addDroppedModelFiles(files) {
+    const desktop =
+      typeof window !== "undefined" ? window.pixlstashDesktop : null;
+    const resolved = [];
+    for (const file of files) {
+      let path = "";
+      try {
+        path = desktop?.getDroppedFilePath?.(file) || "";
+      } catch (err) {
+        // Never fatal: one unresolvable file must not lose the others, and the
+        // notice below is what the user sees either way.
+        console.warn(
+          `Could not resolve the path of dropped model file ${file?.name}:`,
+          err,
+        );
+      }
+      if (path) resolved.push({ name: file?.name || path, path });
+    }
+
+    if (!resolved.length) {
+      noticeStore.warning(
+        "A model file has to be added from the machine running PixlStash. " +
+          "Open Models and use Add ▾ → Add file… to pick it there.",
+        { key: `model-file-drop-${(modelDropSeq += 1)}` },
+      );
+      return;
+    }
+
+    const dropKey = `model-file-drop-${(modelDropSeq += 1)}`;
+    /** Sticky, and re-pushed per file: a copy outlasts any countdown, and a
+     * card that expires mid-copy reads as "it finished". The count is the only
+     * progress there is — the route copies a whole file per request. */
+    const sayCopying = (index) =>
+      noticeStore.push({
+        level: "info",
+        text:
+          resolved.length === 1
+            ? `Copying ${resolved[0].name} into the model store…`
+            : `Copying ${index + 1} of ${resolved.length} into the model store — ${resolved[index].name}…`,
+        key: dropKey,
+        timeout: 0,
+      });
+
+    const added = [];
+    const failures = [];
+    for (const [index, item] of resolved.entries()) {
+      sayCopying(index);
+      try {
+        const result = await addModelFile(item.path);
+        added.push(result?.filename || item.name);
+      } catch (err) {
+        failures.push(
+          `${item.name}: ${errorDetail(err) || "could not be added"}`,
+        );
+      }
+    }
+
+    if (added.length) {
+      // Both stores, for the reason `ModelShelf.onFilePicked` refreshes both:
+      // the shelf gained a row, and the store's file count and `shelf_bytes`
+      // moved with it, so the drive bands are stale too.
+      // Resolved here rather than at setup: the shelf stores are for the one
+      // screen, and every session installs this listener.
+      await Promise.all([
+        useModelShelfStore().fetchRows(),
+        useModelFoldersStore().refresh({ quiet: true }),
+      ]);
+    }
+
+    noticeStore.dismissByKey(dropKey);
+    if (added.length) {
+      noticeStore.success(
+        added.length === 1
+          ? `Added ${added[0]} to the shelf. The original is still where it was.`
+          : `Added ${added.length} model files to the shelf. The originals are still where they were.`,
+        { key: dropKey },
+      );
+    }
+    // Reported separately rather than folded into the success line: a partial
+    // drop has to name what did NOT land, or the count is the only clue.
+    for (const failure of failures) {
+      noticeStore.error(failure);
+    }
+  }
+
   function handleWindowDragOver(event) {
     if (!isExternalFileDragEvent(event)) return;
     // The review overlay is a modal review surface; dropping files into it
@@ -63,29 +201,43 @@ export function useWindowFileImport({ sidebarRef }) {
       return;
     }
     event.preventDefault();
-    if (isInsideImageGrid(event)) {
-      return;
-    }
-    // The same collect-and-filter the grid's own drop target runs, with no
-    // pre-guard of its own: this handler took `dataTransfer.files` raw, so a
-    // model file dropped on any other screen — the shelf, say — was streamed to
-    // the picture importer, which uploaded the whole gigabyte before the
-    // backend skipped it as unsupported and the commit failed with "No staged
-    // files to import". Reading through the helper also picks up a dropped
-    // DIRECTORY, which `dataTransfer.files` alone reports as one unreadable
-    // entry.
-    const files = await extractSupportedImportFilesFromDataTransfer(
+    // Decided synchronously, from the flat list, because `stopPropagation` only
+    // counts while the event is still being dispatched — which is now, before
+    // the walk below can tell us what a dropped folder holds. A drop of model
+    // files ALONE is claimed outright, grid included, or the grid's own handler
+    // would report it as unsupported while the shelf was busy accepting it.
+    // Anything else is left to propagate: inside the grid its handler threads
+    // the selected character into the picture import, and this one cannot.
+    const dropped = Array.from(event.dataTransfer?.files || []);
+    const allModels = dropped.length > 0 && dropped.every(isModelFile);
+    if (allModels) event.stopPropagation();
+    const insideGrid = isInsideImageGrid(event);
+
+    // One walk, and it takes the pictures AND the model files: the flat list
+    // reports a dropped folder as one unreadable entry, so a trainer's output
+    // directory used to import its samples and drop the adapter in silence.
+    const { modelFiles, pictureFiles } = await partitionDrop(
       event.dataTransfer,
     );
-    if (!files.length) {
-      noticeStore.warning(
-        "None of those files are a supported image, video or archive.",
-        { key: "import-unsupported-files" },
-      );
+
+    // Started BEFORE the shelf work and never awaited with it: a model copy
+    // runs for minutes, and the pictures of a mixed drop must not queue behind
+    // it. Inside the grid there is nothing to start — its own handler has the
+    // pictures already, with the character context this one lacks.
+    if (!insideGrid && pictureFiles.length) {
+      const projectId = sidebarRef.value?.currentProjectId ?? null;
+      sidebarRef.value?.startLocalImport?.(pictureFiles, projectId);
+    }
+
+    if (modelFiles.length) {
+      await addDroppedModelFiles(modelFiles);
       return;
     }
-    const projectId = sidebarRef.value?.currentProjectId ?? null;
-    sidebarRef.value?.startLocalImport?.(files, projectId);
+    if (insideGrid || pictureFiles.length) return;
+    noticeStore.warning(
+      "None of those files are a supported image, video or archive.",
+      { key: "import-unsupported-files" },
+    );
   }
 
   function handleWindowPaste(event) {

--- a/frontend/src/composables/useWindowFileImport.js
+++ b/frontend/src/composables/useWindowFileImport.js
@@ -1,5 +1,10 @@
 import { onMounted, onUnmounted } from "vue";
-import { isInternalImageDrag } from "../utils/media.js";
+import {
+  extractSupportedImportFilesFromDataTransfer,
+  isInternalImageDrag,
+  isSupportedImportFile,
+} from "../utils/media.js";
+import { useNoticeStore } from "../stores/useNoticeStore";
 import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
 
 /**
@@ -16,6 +21,7 @@ import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
  */
 export function useWindowFileImport({ sidebarRef }) {
   const reviewSessionsStore = useReviewSessionsStore();
+  const noticeStore = useNoticeStore();
 
   function isInsideImageGrid(event) {
     const target = event?.target;
@@ -48,7 +54,7 @@ export function useWindowFileImport({ sidebarRef }) {
     event.preventDefault();
   }
 
-  function handleWindowDrop(event) {
+  async function handleWindowDrop(event) {
     if (!isExternalFileDragEvent(event)) return;
     // While the review overlay is open, swallow the drop without importing
     // (still preventDefault so the browser does not navigate to the dropped file).
@@ -60,10 +66,26 @@ export function useWindowFileImport({ sidebarRef }) {
     if (isInsideImageGrid(event)) {
       return;
     }
-    const droppedFiles = Array.from(event.dataTransfer?.files || []);
-    if (!droppedFiles.length) return;
+    // The same collect-and-filter the grid's own drop target runs, with no
+    // pre-guard of its own: this handler took `dataTransfer.files` raw, so a
+    // model file dropped on any other screen — the shelf, say — was streamed to
+    // the picture importer, which uploaded the whole gigabyte before the
+    // backend skipped it as unsupported and the commit failed with "No staged
+    // files to import". Reading through the helper also picks up a dropped
+    // DIRECTORY, which `dataTransfer.files` alone reports as one unreadable
+    // entry.
+    const files = await extractSupportedImportFilesFromDataTransfer(
+      event.dataTransfer,
+    );
+    if (!files.length) {
+      noticeStore.warning(
+        "None of those files are a supported image, video or archive.",
+        { key: "import-unsupported-files" },
+      );
+      return;
+    }
     const projectId = sidebarRef.value?.currentProjectId ?? null;
-    sidebarRef.value?.startLocalImport?.(droppedFiles, projectId);
+    sidebarRef.value?.startLocalImport?.(files, projectId);
   }
 
   function handleWindowPaste(event) {
@@ -84,7 +106,11 @@ export function useWindowFileImport({ sidebarRef }) {
           (item.type.startsWith("image/") || item.type.startsWith("video/")),
       )
       .map((item) => item.getAsFile())
-      .filter(Boolean);
+      // The MIME test above is the clipboard's own word for it and is wider
+      // than the importer: a Photoshop file pastes as
+      // `image/vnd.adobe.photoshop` and would upload in full only to be skipped
+      // server-side. Same filter as the drop path.
+      .filter((file) => file && isSupportedImportFile(file));
     if (!mediaFiles.length) return;
     event.preventDefault();
     const projectId = sidebarRef.value?.currentProjectId ?? null;

--- a/frontend/src/composables/useWindowFileImport.test.js
+++ b/frontend/src/composables/useWindowFileImport.test.js
@@ -1,11 +1,14 @@
-// useWindowFileImport — what the window-wide catch-all accepts.
+// useWindowFileImport — what the window-wide catch-all does with a drop.
 //
-// The grid's own drop target filters by extension; this one did not, so a model
-// file dropped on the shelf was handed to the picture importer, which uploaded
-// the whole file before the backend skipped it as unsupported and the commit
-// failed with "No staged files to import". Both directions are pinned here: an
-// unsupported drop imports nothing and says so, and a supported one still
-// imports — over-filtering would be its own regression.
+// Two things, and they used to be one. A model file went to the PICTURE
+// importer, which uploaded it in full before the backend skipped it as
+// unsupported and the commit failed with "No staged files to import"; now it
+// goes to the shelf, by path, through the same POST /model-files the Add file…
+// menu calls. Everything else is filtered against what the staging route
+// actually accepts instead of against the (much wider) list of what the app can
+// display. Both directions are pinned: an unsupported drop imports nothing and
+// says so, a supported one still imports, and a model file lands on the shelf —
+// over-filtering would be its own regression.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ref } from "vue";
@@ -14,6 +17,11 @@ import { createPinia, setActivePinia } from "pinia";
 
 import { useWindowFileImport } from "./useWindowFileImport";
 import { useNoticeStore } from "../stores/useNoticeStore";
+import { addModelFile } from "../api/modelFiles";
+import { useModelShelfStore } from "../stores/useModelShelfStore";
+import { useModelFoldersStore } from "../stores/useModelFoldersStore";
+
+vi.mock("../api/modelFiles", () => ({ addModelFile: vi.fn() }));
 
 const startLocalImport = vi.fn();
 
@@ -42,30 +50,112 @@ function paste(...mimes) {
 }
 
 function drop(...names) {
+  return dropOn(document.body, ...names);
+}
+
+/** The same drop, aimed at an element — the grid claims its own. */
+function dropOn(target, ...names) {
   const files = names.map((name) => new File(["x"], name));
   const event = new Event("drop", { bubbles: true, cancelable: true });
   event.dataTransfer = { files, items: [], types: ["Files"] };
-  window.dispatchEvent(event);
+  target.dispatchEvent(event);
   // The handler awaits the DataTransfer walk before importing.
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** A drop of a FOLDER: only the recursive walk can see what is inside. */
+function dropFolder(folderName, ...names) {
+  const files = names.map((name) => new File(["x"], name));
+  const entry = {
+    isFile: false,
+    isDirectory: true,
+    name: folderName,
+    createReader: () => {
+      let done = false;
+      return {
+        readEntries(cb) {
+          if (done) return cb([]);
+          done = true;
+          cb(
+            files.map((file) => ({
+              isFile: true,
+              isDirectory: false,
+              name: file.name,
+              file: (ok) => ok(file),
+            })),
+          );
+        },
+      };
+    },
+  };
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  event.dataTransfer = {
+    // What a folder drop really looks like: one opaque entry in `files`.
+    files: [new File([], folderName)],
+    items: [{ kind: "file", webkitGetAsEntry: () => entry }],
+    types: ["Files"],
+  };
+  document.body.dispatchEvent(event);
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** The desktop shell's answer to "where did this file come from?". */
+function withDesktopShell(pathByName) {
+  window.pixlstashDesktop = {
+    getDroppedFilePath: (file) => pathByName[file.name] || "",
+  };
 }
 
 beforeEach(() => {
   setActivePinia(createPinia());
   notices = useNoticeStore();
   startLocalImport.mockClear();
+  addModelFile.mockReset();
+  // The route answers with the name it registered; echo it so a test can tell
+  // one file's receipt from another's.
+  addModelFile.mockImplementation(async (path) => ({
+    filename: String(path).split("/").pop(),
+  }));
+  // The shelf refresh is a fetch either way; this test is about the routing.
+  vi.spyOn(useModelShelfStore(), "fetchRows").mockResolvedValue(undefined);
+  vi.spyOn(useModelFoldersStore(), "refresh").mockResolvedValue(undefined);
   wrapper = mount(Host);
 });
 
 afterEach(() => {
   wrapper.unmount();
+  delete window.pixlstashDesktop;
+  vi.restoreAllMocks();
 });
 
 describe("useWindowFileImport", () => {
-  it("does not import a model file and warns instead", async () => {
-    await drop("qwen_image_vae.safetensors");
+  it("adds a dropped model file to the shelf, by path, on the desktop", async () => {
+    withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
+    await drop("lora.safetensors");
+    expect(addModelFile).toHaveBeenCalledWith("/models/lora.safetensors");
+    // Never the picture importer: that is the 242 MB upload this replaces.
     expect(startLocalImport).not.toHaveBeenCalled();
-    expect(notices.notices.length).toBe(1);
+    expect(notices.notices.at(-1).level).toBe("success");
+  });
+
+  it("points a browser tab at the menu instead, and uploads nothing", async () => {
+    // No shell, so no path — and without a path there is nothing to send.
+    await drop("lora.safetensors");
+    expect(addModelFile).not.toHaveBeenCalled();
+    expect(startLocalImport).not.toHaveBeenCalled();
+    expect(notices.notices.at(-1).level).toBe("warning");
+    expect(notices.notices.at(-1).text).toContain("Add file");
+  });
+
+  it("reports a refused model file rather than a bare count", async () => {
+    withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
+    addModelFile.mockRejectedValue({
+      response: { data: { detail: "That file is already inside a folder." } },
+    });
+    await drop("lora.safetensors");
+    const last = notices.notices.at(-1);
+    expect(last.level).toBe("error");
+    expect(last.text).toContain("already inside");
   });
 
   it("still imports a supported picture", async () => {
@@ -96,8 +186,87 @@ describe("useWindowFileImport", () => {
     expect(startLocalImport).toHaveBeenCalledTimes(1);
   });
 
-  it("imports the pictures out of a mixed drop", async () => {
+  it("takes a model dropped on the image grid, which has no use for it", async () => {
+    const grid = document.createElement("div");
+    grid.className = "image-grid";
+    document.body.appendChild(grid);
+    try {
+      withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
+      await dropOn(grid, "lora.safetensors");
+      expect(addModelFile).toHaveBeenCalledWith("/models/lora.safetensors");
+    } finally {
+      grid.remove();
+    }
+  });
+
+  it("leaves the pictures of a mixed grid drop to the grid", async () => {
+    const grid = document.createElement("div");
+    grid.className = "image-grid";
+    document.body.appendChild(grid);
+    try {
+      withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
+      await dropOn(grid, "lora.safetensors", "holiday.jpg");
+      expect(addModelFile).toHaveBeenCalledWith("/models/lora.safetensors");
+      // The grid's own handler imports them, with the selected character
+      // threaded in — something this handler cannot do.
+      expect(startLocalImport).not.toHaveBeenCalled();
+    } finally {
+      grid.remove();
+    }
+  });
+
+  it("finds a model inside a dropped folder, beside its samples", async () => {
+    // A trainer's output directory. The flat file list shows one opaque entry,
+    // so this used to import the samples and lose the adapter in silence.
+    withDesktopShell({ "lora.safetensors": "/runs/out/lora.safetensors" });
+    await dropFolder("out", "lora.safetensors", "sample-01.jpg");
+    expect(addModelFile).toHaveBeenCalledWith("/runs/out/lora.safetensors");
+    expect(startLocalImport.mock.calls[0][0].map((f) => f.name)).toEqual([
+      "sample-01.jpg",
+    ]);
+  });
+
+  it("does not hold the pictures of a mixed drop behind the model copy", async () => {
+    // A multi-gigabyte copy runs for minutes; the photos must not queue.
+    let finishCopy;
+    addModelFile.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishCopy = () => resolve({ filename: "lora.safetensors" });
+        }),
+    );
+    withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
     await drop("lora.safetensors", "holiday.jpg");
+    expect(startLocalImport).toHaveBeenCalledTimes(1);
+    finishCopy();
+  });
+
+  it("gives each drop its own card, so one copy cannot erase another", async () => {
+    let finishFirst;
+    addModelFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishFirst = () => resolve({ filename: "big.safetensors" });
+        }),
+    );
+    withDesktopShell({
+      "big.safetensors": "/models/big.safetensors",
+      "small.safetensors": "/models/small.safetensors",
+    });
+    await drop("big.safetensors");
+    await drop("small.safetensors");
+    // The big copy is still running, so its card must still be up next to the
+    // small one's receipt — a shared key dismissed it and said "Added".
+    const texts = notices.notices.map((n) => n.text);
+    expect(texts.some((t) => t.includes("big.safetensors"))).toBe(true);
+    expect(texts.some((t) => t.includes("Added small.safetensors"))).toBe(true);
+    finishFirst();
+  });
+
+  it("splits a mixed drop between the shelf and the importer", async () => {
+    withDesktopShell({ "lora.safetensors": "/models/lora.safetensors" });
+    await drop("lora.safetensors", "holiday.jpg");
+    expect(addModelFile).toHaveBeenCalledWith("/models/lora.safetensors");
     expect(startLocalImport.mock.calls[0][0].map((f) => f.name)).toEqual([
       "holiday.jpg",
     ]);

--- a/frontend/src/composables/useWindowFileImport.test.js
+++ b/frontend/src/composables/useWindowFileImport.test.js
@@ -1,0 +1,105 @@
+// useWindowFileImport — what the window-wide catch-all accepts.
+//
+// The grid's own drop target filters by extension; this one did not, so a model
+// file dropped on the shelf was handed to the picture importer, which uploaded
+// the whole file before the backend skipped it as unsupported and the commit
+// failed with "No staged files to import". Both directions are pinned here: an
+// unsupported drop imports nothing and says so, and a supported one still
+// imports — over-filtering would be its own regression.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+import { useWindowFileImport } from "./useWindowFileImport";
+import { useNoticeStore } from "../stores/useNoticeStore";
+
+const startLocalImport = vi.fn();
+
+const Host = {
+  setup() {
+    useWindowFileImport({
+      sidebarRef: ref({ startLocalImport, currentProjectId: null }),
+    });
+    return () => null;
+  },
+};
+
+let wrapper;
+let notices;
+
+function paste(...mimes) {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  event.clipboardData = {
+    items: mimes.map((type, i) => ({
+      kind: "file",
+      type,
+      getAsFile: () => new File(["x"], `pasted-${i}.${type.split("/").pop()}`),
+    })),
+  };
+  window.dispatchEvent(event);
+}
+
+function drop(...names) {
+  const files = names.map((name) => new File(["x"], name));
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  event.dataTransfer = { files, items: [], types: ["Files"] };
+  window.dispatchEvent(event);
+  // The handler awaits the DataTransfer walk before importing.
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  notices = useNoticeStore();
+  startLocalImport.mockClear();
+  wrapper = mount(Host);
+});
+
+afterEach(() => {
+  wrapper.unmount();
+});
+
+describe("useWindowFileImport", () => {
+  it("does not import a model file and warns instead", async () => {
+    await drop("qwen_image_vae.safetensors");
+    expect(startLocalImport).not.toHaveBeenCalled();
+    expect(notices.notices.length).toBe(1);
+  });
+
+  it("still imports a supported picture", async () => {
+    await drop("holiday.jpg");
+    expect(startLocalImport).toHaveBeenCalledTimes(1);
+    expect(startLocalImport.mock.calls[0][0].map((f) => f.name)).toEqual([
+      "holiday.jpg",
+    ]);
+  });
+
+  it("does not import a file the staging route would refuse", async () => {
+    // `.psd` is a format the app can display, so the display-side extension
+    // lists say yes and the import route says no. Before the split it uploaded
+    // in full and died on the commit, exactly like the model file did.
+    await drop("layers.psd");
+    expect(startLocalImport).not.toHaveBeenCalled();
+    expect(notices.notices.length).toBe(1);
+  });
+
+  it("does not paste a file the staging route would refuse", () => {
+    // The clipboard calls a Photoshop file an image; the importer does not.
+    paste("image/vnd.adobe.photoshop");
+    expect(startLocalImport).not.toHaveBeenCalled();
+  });
+
+  it("still pastes a screenshot", () => {
+    paste("image/png");
+    expect(startLocalImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports the pictures out of a mixed drop", async () => {
+    await drop("lora.safetensors", "holiday.jpg");
+    expect(startLocalImport.mock.calls[0][0].map((f) => f.name)).toEqual([
+      "holiday.jpg",
+    ]);
+  });
+});

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -100,6 +100,9 @@ const ARCHIVE_EXTENSIONS = ["zip"];
 
 const CAPTION_EXTENSIONS = ["txt"];
 
+/** What the model shelf catalogues — `pixlstash/routes/model_files.py`. */
+const MODEL_FILE_EXTENSION = ".safetensors";
+
 export function isSupportedImageFile(file) {
   const filename = typeof file === "string" ? file : file?.name || "";
   const ext = filename.split(".").pop().toLowerCase();
@@ -135,6 +138,12 @@ function isSupportedCaptionFile(file) {
   return CAPTION_EXTENSIONS.includes(ext);
 }
 
+/** A file the model shelf catalogues. The route refuses anything else. */
+export function isModelFile(file) {
+  const filename = typeof file === "string" ? file : file?.name || "";
+  return filename.toLowerCase().endsWith(MODEL_FILE_EXTENSION);
+}
+
 export function isSupportedImportFile(file) {
   return (
     isImportableMediaFile(file) ||
@@ -152,8 +161,8 @@ function _fileDedupKey(file) {
   return `${name}::${size}::${lastModified}`;
 }
 
-function _addIfSupportedFile(file, uniqueMap) {
-  if (!file || !isSupportedImportFile(file)) return;
+function _addIfSupportedFile(file, uniqueMap, accept) {
+  if (!file || !accept(file)) return;
   const key = _fileDedupKey(file);
   if (!uniqueMap.has(key)) {
     uniqueMap.set(key, file);
@@ -177,13 +186,13 @@ function _readAllWebkitDirectoryEntries(reader) {
   });
 }
 
-async function _collectFromWebkitEntry(entry, uniqueMap) {
+async function _collectFromWebkitEntry(entry, uniqueMap, accept) {
   if (!entry) return;
   if (entry.isFile) {
     await new Promise((resolve) => {
       entry.file(
         (file) => {
-          _addIfSupportedFile(file, uniqueMap);
+          _addIfSupportedFile(file, uniqueMap, accept);
           resolve();
         },
         () => resolve(),
@@ -196,15 +205,27 @@ async function _collectFromWebkitEntry(entry, uniqueMap) {
     const reader = entry.createReader();
     const entries = await _readAllWebkitDirectoryEntries(reader);
     for (const child of entries) {
-      await _collectFromWebkitEntry(child, uniqueMap);
+      await _collectFromWebkitEntry(child, uniqueMap, accept);
     }
   } catch {
     // Ignore directory traversal errors and continue with other items.
   }
 }
 
+/**
+ * Every file in a drop that `accept` wants, directories walked.
+ *
+ * @param {DataTransfer} dataTransfer - the drop's payload.
+ * @param {object} [options]
+ * @param {(file: File) => boolean} [options.accept] - what to keep. Defaults to
+ *   what the picture importer takes. A caller that ALSO wants something else
+ *   out of the same drop must widen this and split the result itself rather
+ *   than call twice: the walk is destructive on Safari, which empties the
+ *   DataTransfer on the first `await`, so a second pass returns nothing.
+ */
 export async function extractSupportedImportFilesFromDataTransfer(
   dataTransfer,
+  { accept = isSupportedImportFile } = {},
 ) {
   if (!dataTransfer) return [];
 
@@ -247,15 +268,15 @@ export async function extractSupportedImportFilesFromDataTransfer(
   // ---
 
   for (const entry of webkitEntries) {
-    await _collectFromWebkitEntry(entry, unique);
+    await _collectFromWebkitEntry(entry, unique, accept);
   }
 
   for (const file of fallbackFiles) {
-    _addIfSupportedFile(file, unique);
+    _addIfSupportedFile(file, unique, accept);
   }
 
   for (const file of directFiles) {
-    _addIfSupportedFile(file, unique);
+    _addIfSupportedFile(file, unique, accept);
   }
 
   return Array.from(unique.values());

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -62,6 +62,40 @@ export const VIDEO_EXTENSIONS = [
   "m4v",
 ];
 
+/**
+ * What the picture importer will actually take.
+ *
+ * NOT `PIL_IMAGE_EXTENSIONS` + `VIDEO_EXTENSIONS`: those two say what the app
+ * can *display*, and the import endpoint takes a much shorter list. Filtering a
+ * drop against the display lists let a `.psd`, a `.pdf` or a `.wmv` upload in
+ * full before the backend skipped it as unsupported and the commit came back
+ * "No staged files to import" — a gigabyte spent to reach an error the name
+ * already gave away.
+ *
+ * Mirrors `STAGING_ALLOWED_MEDIA_EXTS` in
+ * `pixlstash/routes/pictures/_import.py`, which is the one the server enforces.
+ * `tests/test_architecture_guardrails.py::test_frontend_import_extensions_match_the_staging_allowlist`
+ * fails the build if the two drift apart.
+ */
+export const IMPORT_MEDIA_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "gif",
+  "bmp",
+  "tiff",
+  "tif",
+  "heic",
+  "heif",
+  "avif",
+  "mp4",
+  "webm",
+  "mov",
+  "avi",
+  "mkv",
+];
+
 const ARCHIVE_EXTENSIONS = ["zip"];
 
 const CAPTION_EXTENSIONS = ["txt"];
@@ -85,8 +119,10 @@ function isSupportedArchiveFile(file) {
   return ARCHIVE_EXTENSIONS.includes(ext);
 }
 
-function isSupportedMediaFile(file) {
-  return isSupportedImageFile(file) || isSupportedVideoFile(file);
+function isImportableMediaFile(file) {
+  const filename = typeof file === "string" ? file : file?.name || "";
+  const ext = filename.split(".").pop().toLowerCase();
+  return IMPORT_MEDIA_EXTENSIONS.includes(ext);
 }
 
 function isSupportedCaptionFile(file) {
@@ -101,7 +137,7 @@ function isSupportedCaptionFile(file) {
 
 export function isSupportedImportFile(file) {
   return (
-    isSupportedMediaFile(file) ||
+    isImportableMediaFile(file) ||
     isSupportedArchiveFile(file) ||
     isSupportedCaptionFile(file)
   );

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2572,3 +2572,38 @@ def test_dockerfiles_install_every_runtime_dependency():
         "these runtime dependencies are never installed in the image, so the "
         "container will fail on import: " + ", ".join(missing)
     )
+
+
+def test_frontend_import_extensions_match_the_staging_allowlist():
+    """The importer's client-side filter must say exactly what the server takes.
+
+    The frontend used to filter a drop against the lists it uses to *display*
+    pictures, which are far wider than what the staging route accepts. A model
+    file, a `.psd` or a `.wmv` therefore uploaded in full — a gigabyte, in the
+    report that prompted this — before the route skipped it as unsupported and
+    the commit came back "No staged files to import". Two allowlists with
+    nothing holding them together is what made that possible, so this is the
+    thing holding them together.
+    """
+    from pixlstash.routes.pictures._import import STAGING_ALLOWED_MEDIA_EXTS
+
+    media_js = (REPO_ROOT / "frontend" / "src" / "utils" / "media.js").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"export const IMPORT_MEDIA_EXTENSIONS = \[(.*?)\];", media_js, re.DOTALL
+    )
+    assert match, (
+        "IMPORT_MEDIA_EXTENSIONS is gone from frontend/src/utils/media.js — the "
+        "importer is filtering against something else, and this guardrail can no "
+        "longer see what."
+    )
+    frontend_exts = {f".{ext}" for ext in re.findall(r'"([^"]+)"', match.group(1))}
+
+    assert frontend_exts == STAGING_ALLOWED_MEDIA_EXTS, (
+        "the client-side import filter and the staging route disagree: "
+        f"client-only={sorted(frontend_exts - STAGING_ALLOWED_MEDIA_EXTS)}, "
+        f"server-only={sorted(STAGING_ALLOWED_MEDIA_EXTS - frontend_exts)}. "
+        "A client-only extension uploads the whole file and then fails the "
+        "commit; a server-only one is refused before it is ever offered."
+    )


### PR DESCRIPTION
## The bug

Dropping a model file (`qwen_image_vae.safetensors`) onto the window uploaded all 242 MB to
the **picture** importer, and only then failed:

```
WARNING pixlstash.routes.pictures._import: Staging …: skipping unsupported file qwen_image_vae.safetensors
INFO    … "POST /api/v1/pictures/import/staging/…/commit HTTP/1.1" 400
```

The dialog said **"Import failed — No staged files to import"** after a completed upload.

## What it does now

**A dropped `.safetensors` is imported.** It goes to the shelf through the very same
`POST /model-files` that `Add ▾ → Add file…` already calls: the server copies it into the
managed store, verifies by SHA-256 and registers it, so the row appears without a rescan.
Nothing is uploaded — the endpoint takes a **path**, not bytes.

The path is the whole difficulty, and it is why this is desktop-only. A dropped `File`
carries a name and bytes but never a location, by browser sandbox rule, so only the Electron
shell can answer where it came from — `webUtils.getPathForFile`, added as one method on the
existing preload bridge. In a browser tab there is nothing to resolve and nothing to send, so
the drop says so and names the menu, which works there because the *server* enumerates the
filesystem — the direction a drop cannot run in.

## Also fixed, because it was the same bug one layer down

The shared client-side filter tested a dropped file against `PIL_IMAGE_EXTENSIONS` +
`VIDEO_EXTENSIONS` — the lists of what the app can **display**, ~57 extensions. The staging
route accepts **16** (`STAGING_ALLOWED_MEDIA_EXTS`). So a `.psd`, a `.pdf`, an `.exr` or a
`.wmv` passed the filter, uploaded in full, and reproduced the reported failure exactly. New
`IMPORT_MEDIA_EXTENSIONS` mirrors the route's allowlist, and a guardrail test fails the build
if the two drift — nothing held them together before, which is how they got 41 apart. The
display lists are untouched: the overlay still needs them to know a `.wmv` is a video.

The window-wide drop handler also had no filter at all, where the grid, the sidebar and the
import dialog all had one; and the paste handler trusted MIME alone, so a Photoshop file
(`image/vnd.adobe.photoshop`) got through.

## Details worth a reviewer's eye

- **A folder is walked.** A trainer's output directory holds the adapter beside its samples,
  and `dataTransfer.files` reports the whole directory as one opaque entry — reading the flat
  list imported the samples and lost the adapter in silence.
  `extractSupportedImportFilesFromDataTransfer` now takes an `accept` predicate; the handler
  widens it to "picture **or** model" and splits one result. It cannot walk twice: Safari
  empties the DataTransfer on the first `await`.
- **The picture import starts before the model copy is awaited.** A multi-gigabyte copy runs
  for minutes and the photos of a mixed drop must not queue behind it.
- **One notice key per drop, not per verb.** A shared key made a second drop coalesce onto the
  first one's sticky progress card and then dismiss it — a running copy with nothing on screen
  and a success message about the other file.
- **Drop targets.** A model dropped on the grid is still claimed (the grid has no use for it),
  but a *mixed* grid drop is left to propagate so the grid's own handler keeps threading the
  selected character into the import. Only an all-models drop is stopped outright.

## Verification

Full frontend suite 3584 passing, `tests/test_architecture_guardrails.py` 42 passing,
`tsc --noEmit` clean on the Electron package. The 13 tests in `useWindowFileImport.test.js`
were each confirmed to fail with the logic they assert removed. Independent security review of
the preload method: approved, no conditions — the renderer can already reach the whole
filesystem through the shipped `GET /filesystem/browse` picker on the same
`LOCAL_OWNER_ONLY` tier, and `getPathForFile` returns `""` for a File not backed by disk, so
it is no probe.

## Objections raised in review and not taken

- **"A drop starts an uncancellable multi-GB copy with no confirmation."** `Add file…` has no
  confirmation either, and `docs/frontend_architecture.md` argues why: a copy into the managed
  store writes over nothing, removes nothing, and is undone by forgetting the row — "a prompt
  would be ceremony around the least dangerous verb the shelf has". The drop inherits that.
  There is now per-file progress on a sticky card; cancellation would need the route to become
  interruptible, which is its own change.
- **"This should be a separate PR."** Reasonable in the abstract, but the card owner redirected
  this card explicitly: they do not want an error message when they drag a model in, they want
  the import to happen. Same card, same work.
- **`async` listener on `addEventListener`** — a throw after the first `await` is an unhandled
  rejection rather than a synchronous one. The grid's `handleGridDrop` has the same shape, the
  walker swallows its own traversal errors, the bridge call is wrapped, and `preventDefault()`
  still runs synchronously before any `await`.
- **The unsupported-files notice omits the `.txt` caption sidecars the filter accepts.** True,
  and it is the grid's existing string, reused verbatim so the two coalesce on their shared key
  instead of stacking. Rewording it is a copy change to both.
- **Dropping a folder can still collapse two same-named, same-sized files** in `_fileDedupKey`.
  Pre-existing in the shared walker and equally true of the grid path.

## Unrelated bug found on the way, not fixed here

Dropping photos from the desktop onto a **Set or Character row in the sidebar** appears to
lose the association. The window-level handler wins the race and starts the import first with
no `setId`; the row's own handler then hits `startImport`'s busy guard and logs *"Import
request ignored because another import is in progress."* Pre-existing, its own fix.
