### PR TITLE
Scroll the plugin lists, not the Models pane; fit the Backend pane

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -565,6 +565,21 @@ Thin multi-tab settings shell. It now owns only the tab chrome and routing — e
 - **Backend** → `<ComputeSection>` (desktop only, `isDesktop && !isReadOnly`)
 - **Account Settings** → `<AccountSection>` (`!isReadOnly`)
 
+**Pane height is fixed** (`.settings-content`, 524px) so the dialog does not
+resize as the rail is clicked. A pane that outgrows it scrolls whole, header and
+all, which is what the Models pane did once a library had six tagger plugins.
+A pane with unbounded content should bound and scroll that content instead:
+Models gives the Auto-tagging section the leftover height and scrolls each
+plugin table inside its column (`BehaviourSection` below).
+
+A pane whose content is merely *long* has to fit, and the budget is roughly
+500px. Two things spend it faster than they look: a row's sub is only ~190px
+wide inside `SettingsTwoCol`, and a path is one unbreakable word, so a row whose
+sub names a path belongs at full width rather than in the pair — that is why the
+Backend pane's Shell command row sits below its `SettingsTwoCol` instead of in
+it. The remaining slack is ~13px on the worst platform, so lengthening any
+Backend sub is a change that has to be measured.
+
 **Libraries.** An ordinary rail item ordered next to Scrapheap and Snapshots —
 the open library's bin and its backups — rather than set apart at the top by a
 divider, which read as a section of its own. The rail is one flat list with no
@@ -602,6 +617,13 @@ Appearance tab content: sidebar thumbnail size, sidebar width (Full / Dock toggl
 
 #### `BehaviourSection.vue`
 Behaviour tab content (extracted from inline `UserSettingsDialog` markup): hidden tags, VRAM limits, tagger configuration.
+The pane is a flex column: Model Memory and VRAM Budget keep their natural
+height and Auto-tagging takes what is left. Two things inside it can grow
+without limit, and both are bounded and scrolled rather than allowed to push the
+pane: the plugin tables (one scroll region per column) and the plugin load-error
+list (capped, since the text is a third-party exception). `.tagger-cols` keeps a
+96px floor, so on a window too short to give the section a usable height the
+pane falls back to scrolling whole rather than crushing the tables to nothing.
 
 #### `WorkflowsSection.vue`
 Workflows tab content (extracted from inline markup): ComfyUI URL, workflow import/management.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -625,6 +625,13 @@ list (capped, since the text is a third-party exception). `.tagger-cols` keeps a
 96px floor, so on a window too short to give the section a usable height the
 pane falls back to scrolling whole rather than crushing the tables to nothing.
 
+The columns also carry `min-width: 0`. A grid item's automatic minimum is its
+min-content, so a `PluginsTable` that refused to wrap widened its own `1fr`
+track and pushed the pane sideways — a horizontal scrollbar on the *pane*, not
+on the table. Plugin names therefore wrap (`PluginsTable`'s `.pt-plugin-name`),
+and the three fixed-width columns are padded at `--space-2` so the name column
+keeps enough of the ~280px to hold an ordinary name on one line.
+
 #### `WorkflowsSection.vue`
 Workflows tab content (extracted from inline markup): ComfyUI URL, workflow import/management.
 

--- a/frontend/src/components/settings/BehaviourSection.vue
+++ b/frontend/src/components/settings/BehaviourSection.vue
@@ -451,7 +451,12 @@ watch(
   min-height: 96px;
 }
 
+/* min-width as well as min-height: a grid item's automatic minimum is its
+   min-content, so a table that refuses to wrap widens its own 1fr track and
+   pushes the whole pane sideways. That is a horizontal scrollbar on the pane,
+   not on the table, and it is why PluginsTable lets a long plugin name wrap. */
 .tagger-col {
+  min-width: 0;
   min-height: 0;
 }
 

--- a/frontend/src/components/settings/BehaviourSection.vue
+++ b/frontend/src/components/settings/BehaviourSection.vue
@@ -266,7 +266,7 @@ watch(
 </script>
 
 <template>
-  <div>
+  <div class="behaviour-pane">
     <SettingsSection
       title="Model Memory"
       desc="Keep models loaded in RAM/VRAM for faster processing. Turn off to unload models when idle and save memory."
@@ -315,11 +315,12 @@ watch(
     </SettingsSection>
 
     <SettingsSection
+      class="tagger-section"
       title="Auto-tagging"
       desc="Plugins that generate tags and captions automatically. Hint: you can also pick taggers for selected pictures in the tag panel or context menu."
     >
-      <SettingsTwoCol>
-        <SettingsFieldBlock title="Tag plugin" top>
+      <SettingsTwoCol class="tagger-cols">
+        <SettingsFieldBlock class="tagger-col" title="Tag plugin" top>
           <div v-if="taggerLoading" class="settings-tagger-loading">
             Loading…
           </div>
@@ -331,7 +332,7 @@ watch(
             @update:settings="(s) => (taggerSettings.value = s)"
           />
         </SettingsFieldBlock>
-        <SettingsFieldBlock title="Description plugin" top>
+        <SettingsFieldBlock class="tagger-col" title="Description plugin" top>
           <div v-if="taggerLoading" class="settings-tagger-loading">
             Loading…
           </div>
@@ -424,6 +425,40 @@ watch(
 </template>
 
 <style scoped>
+/* The plugin lists scroll, the pane does not: the pane is a column, the
+   Auto-tagging section takes the leftover height, and each column's table body
+   is the only thing that overflows. Without this the two tables push the whole
+   Settings pane past its fixed height and the dialog grows a scrollbar. */
+.behaviour-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.tagger-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* A floor, not 0: on a short window the pane is allowed to overflow and scroll
+   as it used to rather than crush the tables to nothing. */
+.tagger-cols {
+  flex: 1 1 auto;
+  min-height: 96px;
+}
+
+.tagger-col {
+  min-height: 0;
+}
+
+.tagger-col :deep(.field-block__control) {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .settings-tagger-loading {
   font-size: var(--text-xs);
   color: rgba(var(--v-theme-on-surface), 0.55);
@@ -563,6 +598,9 @@ watch(
   }
 }
 
+/* A plugin's load error is exception text from third-party code and has no
+   length limit, so it is bounded and scrolled too — otherwise it is a second
+   unbounded thing in this section and squeezes the tables it sits under. */
 .settings-tagger-plugin-errors {
   list-style: none;
   padding: 0;
@@ -570,6 +608,9 @@ watch(
   font-size: var(--text-xs);
   color: rgb(var(--v-theme-error));
   overflow-wrap: anywhere;
+  flex-shrink: 0;
+  max-height: 72px;
+  overflow-y: auto;
 }
 
 .settings-error {

--- a/frontend/src/components/settings/BehaviourSection.vue
+++ b/frontend/src/components/settings/BehaviourSection.vue
@@ -426,8 +426,10 @@ watch(
 
 <style scoped>
 /* The plugin lists scroll, the pane does not: the pane is a column, the
-   Auto-tagging section takes the leftover height, and each column's table body
-   is the only thing that overflows. Without this the two tables push the whole
+   Auto-tagging section takes the leftover height, and each column's plugin
+   table is the only thing that overflows. The scroll box wraps the whole
+   table, header included, so PluginsTable pins its header row (see the
+   `position: sticky` there). Without this the two tables push the whole
    Settings pane past its fixed height and the dialog grows a scrollbar. */
 .behaviour-pane {
   display: flex;

--- a/frontend/src/components/settings/ComputeSection.vue
+++ b/frontend/src/components/settings/ComputeSection.vue
@@ -229,7 +229,7 @@ async function setHideToTray(value) {
 // only reaches a shell started after it, so the row has to say so.
 const shellCommandSub = computed(
   () =>
-    `Puts a pixlstash command in ${shellCommandDir.value || "your user bin directory"} so you can attach libraries and install plugins from a terminal. Open a new terminal afterwards.`,
+    `Puts a pixlstash command in ${shellCommandDir.value || "your user bin directory"} so you can attach libraries and install plugins from a terminal. Open a new terminal.`,
 );
 
 // Installing can be refused (a `pixlstash` the user wrote themselves is in the
@@ -385,7 +385,7 @@ watch(
   <div v-if="isBackend" class="compute-backend">
     <SettingsSection
       title="Remote access"
-      desc="Let other devices on your network open this library in a browser. The app window always uses a private local connection — this only controls the separate connection from the outside. Changing it restarts the local server."
+      desc="Let other devices on your network open this library in a browser. The app window always uses a private local connection. Changing this restarts the local server."
       first
     >
       <template v-if="server">
@@ -535,7 +535,7 @@ watch(
       <SettingsTwoCol>
         <SettingsRow
           label="Hide to tray on close"
-          sub="Keep PixlStash (and any remote server) running in the background when you close the window. Reopen it from the tray icon."
+          sub="Keeps PixlStash and any remote server running; reopen it from the tray icon."
         >
           <v-switch
             :model-value="hideToTrayOnClose"
@@ -546,21 +546,8 @@ watch(
           />
         </SettingsRow>
         <SettingsRow
-          v-if="shellCommand !== null"
-          label="Shell command"
-          :sub="shellCommandSub"
-        >
-          <v-switch
-            :model-value="shellCommand"
-            color="accent"
-            density="compact"
-            hide-details
-            @update:model-value="setShellCommand($event)"
-          />
-        </SettingsRow>
-        <SettingsRow
           label="Check for updates"
-          sub="Checks once a day and shows a sidebar notice when a new version is out. Sends only your app version and install type, anonymously."
+          sub="Checks daily. Sends only your version and install type, anonymously."
         >
           <v-switch
             v-model="checkForUpdatesModel"
@@ -570,6 +557,22 @@ watch(
           />
         </SettingsRow>
       </SettingsTwoCol>
+      <!-- Full width, not a half of the pair above: its sub names a path, and
+           the Windows one wraps to four lines in a half-width row — most of what
+           pushed this pane past its fixed height. -->
+      <SettingsRow
+        v-if="shellCommand !== null"
+        label="Shell command"
+        :sub="shellCommandSub"
+      >
+        <v-switch
+          :model-value="shellCommand"
+          color="accent"
+          density="compact"
+          hide-details
+          @update:model-value="setShellCommand($event)"
+        />
+      </SettingsRow>
       <!-- The other copy of this lives in the compute pane, which the backend
            pane never renders, so a failure here had nowhere to be shown. -->
       <div v-if="error" class="settings-error">{{ error }}</div>

--- a/frontend/src/components/settings/PrivacySection.vue
+++ b/frontend/src/components/settings/PrivacySection.vue
@@ -3,7 +3,7 @@
     <SettingsTwoCol>
       <SettingsRow
         label="Check for updates"
-        sub="Checks once a day and shows a sidebar notice when a new version is out. Sends only your app version and install type."
+        sub="Checks daily. Sends only your version and install type, anonymously."
       >
         <v-switch
           v-model="checkForUpdatesModel"

--- a/frontend/src/components/widgets/PluginsTable.vue
+++ b/frontend/src/components/widgets/PluginsTable.vue
@@ -199,15 +199,24 @@ function onParamsSaved({ name, params }) {
   font-size: var(--text-sm);
 }
 
+/* Sticky because the table is scrolled inside its Settings column (see
+   BehaviourSection): the scroll box wraps the whole table, so an unpinned
+   header row would scroll out of a viewport only a few rows tall. The rule
+   under it is a box-shadow rather than a border — `border-collapse: collapse`
+   hands the border to the table, which does not travel with a sticky cell. */
 .pt-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   text-align: left;
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: rgba(var(--v-theme-on-surface), 0.55);
+  background: rgb(var(--v-theme-surface));
   padding: var(--space-2) var(--space-3) var(--space-2);
-  border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  box-shadow: inset 0 -1px 0 rgba(var(--v-theme-on-surface), 0.12);
 }
 
 .pt-table td {

--- a/frontend/src/components/widgets/PluginsTable.vue
+++ b/frontend/src/components/widgets/PluginsTable.vue
@@ -239,16 +239,28 @@ function onParamsSaved({ name, params }) {
   text-align: right;
 }
 
+/* The name column is whatever these three leave it, and inside a ~280px
+   Settings column that is the difference between a plugin name on one line and
+   two — so the fixed-width columns take the tighter padding step. */
+.pt-table .pt-col-active,
+.pt-table .pt-col-loaded,
+.pt-table .pt-col-actions {
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}
+
+/* The name column is whatever is left of a ~280px Settings column, so a long
+   plugin name wraps rather than holding the table open: nowrap here made the
+   table wider than its column, and the column wider than the pane. */
 .pt-plugin-name {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  white-space: nowrap;
+  overflow-wrap: anywhere;
   cursor: default;
 }
 
 .pt-info-icon {
+  margin-left: var(--space-2);
   opacity: 0.5;
+  vertical-align: -2px;
 }
 
 .pt-radio {


### PR DESCRIPTION
Two Settings panes overflowed the fixed 524px content area and grew a vertical
scrollbar. Three commits: the pane fixes, then two rounds of fallout from them.

## Models pane — the plugin lists scroll, the pane does not

`BehaviourSection` is now a flex column: Model Memory and VRAM Budget keep their
natural height, Auto-tagging takes what is left, and each plugin table scrolls
inside its own column. The section header, the plugin load-error list and the
"How to install plugins" button stay put.

Measured against a replica of the pane's own CSS: before, the pane scrolled from
six plugins per capability upward (544px of content in a 522px box at six, 658px
at ten). After, the pane never scrolls and the column takes over at six.

Two things in that section can grow without bound, not one, so the plugin
load-error list is capped at 72px and scrolls too — its text is a third-party
exception and has no length limit, and left unbounded it would squeeze the
tables it sits above. `.tagger-cols` keeps a 96px floor, so on a window too
short for the section (the 480px breakpoint sizes the pane at `min(58vh, 524px)`)
the pane falls back to scrolling whole rather than crushing the tables to
nothing.

**`acd2cdd0` — the header stays put.** The scroll box wraps the whole table, so
`PluginsTable`'s `th` is `position: sticky; top: 0` on an opaque surface
background. Its rule line moved from `border-bottom` to
`box-shadow: inset 0 -1px 0`, because `border-collapse: collapse` hands the
border to the table and it does not travel with a sticky cell.

**`57079789` — the columns stop widening the pane.** Reported in testing as a
horizontal scrollbar, and it was one level above the table: `.two-col` is a grid,
a grid item's automatic minimum is its min-content, and `.pt-plugin-name` was
`white-space: nowrap` — so each table's longest plugin name forced its `1fr`
track open. The columns measured 355px inside a 280px budget and the pane's
scroll width 750px against a 622px box. Fixed by `min-width: 0` on the grid
items (I had set only `min-height: 0`) plus letting a long name wrap. The three
fixed-width columns take `--space-2` horizontal padding rather than `--space-3`,
which moves the name column from 128px to 138px — the difference between an
ordinary plugin name on one line and on two.

## Backend pane — made to fit

The row that spent the budget was **Shell command**: its sub names a path, a path
is one unbreakable word, and a sub inside `SettingsTwoCol` is only ~190px wide.
`C:\Users\<name>\AppData\Local\PixlStash\bin` wraps to four lines there. That row
now sits at full width below the pair, where it is two lines, and the copy edits
are correspondingly small:

- Remote access desc: dropped the "this only controls the separate connection
  from the outside" clause; kept the fact that the app window uses a private
  local connection.
- Hide to tray: "Keeps PixlStash and any remote server running; reopen it from
  the tray icon."
- Shell command: dropped one word ("afterwards").
- Check for updates: "Checks daily. Sends only your version and install type,
  anonymously." — this loses "shows a sidebar notice"; everything else,
  including the privacy claim, is intact.

`PrivacySection` carries a second copy of the Check for updates row; it now
reads the same as this one, which it did not before.

Content height on the worst platform goes 606px → 509px in a 522px box, so
~13px of slack. That is thin, and it is why the architecture doc now records the
budget: lengthening a Backend sub is a change that has to be measured.

## What I did not fix

**First run still overflows.** The owner-username/password block only appears
until an owner login exists, and it adds ~130px on top of a pane with 13px to
spare. It overflowed before this change too. Making the first-run form fit is a
layout question of its own, not a copy one.

## A rejected suggestion

An adversarial review pass argued for abbreviating the Windows shim directory to
`%LOCALAPPDATA%\…` (I had done that in an earlier draft, and reverted it). It was
right to object: `pixlstash/hub/cli_hint.py::_shorten` deliberately refuses to
abbreviate on Windows because neither cmd nor PowerShell expands the short form,
and a shorter string nobody can paste is worse than a long one. Moving the row to
full width gets the same height back without touching what the row says.

## Verification

No backend or Electron changes. `npx vitest run src/components/settings/
src/components/widgets/` — 678 pass; eslint clean.

The pane measurements above come from static replicas of the components' own CSS
driven by Playwright, not from the running app: the Backend pane is gated on the
Electron bridge and never renders in a browser, and `vitest`/jsdom has no layout.
The Models pane has since been checked in the real dev server.
