### PR TITLE
Show directory symlinks in the folder picker

### DIFF
--- a/pixlstash/routes/filesystem.py
+++ b/pixlstash/routes/filesystem.py
@@ -162,20 +162,39 @@ def create_router(server) -> APIRouter:
             if not show_hidden and entry.name.startswith("."):
                 continue
 
-            # Keep results constrained to the browsed directory even if an
-            # entry is a symlink that points somewhere else.
-            try:
-                safe_entry_path = resolve_path_within(safe_browse_path, entry.name)
-                if safe_entry_path == safe_browse_path:
-                    continue
-            except (OSError, ValueError):
-                # Skip entries that cannot be resolved within the parent directory (e.g. broken symlinks or entries with permission issues).
-                continue
-
             try:
                 is_dir = entry.is_dir(follow_symlinks=True)
             except OSError:
                 # Skip entries that cannot be accessed (e.g. permission issues).
+                continue
+
+            # Keep results constrained to the browsed directory even if an
+            # entry is a symlink that points somewhere else.
+            try:
+                safe_entry_path = resolve_path_within(safe_browse_path, entry.name)
+            except (OSError, ValueError):
+                # Skip entries that cannot be resolved within the parent directory (e.g. broken symlinks or entries with permission issues).
+                #
+                # A DIRECTORY symlink leaving the tree is the exception, and it
+                # is ordinary rather than suspect: `Models -> /vault/Models` is
+                # how a launcher keeps its models off the system disk, and the
+                # folder picker was dropping exactly those — silently, so the
+                # folder simply was not there to click. Nothing is loosened by
+                # listing it: this route browses any directory the owner names,
+                # so it is reachable by typing the path already, and the
+                # fallback is the same sanitizer the browsed path itself goes
+                # through (blocklist, configured roots, then the fullmatch
+                # barrier). Files still get containment — a listed file is a
+                # file this route is offering to read.
+                if not is_dir:
+                    continue
+                try:
+                    safe_entry_path = _resolve_safe_directory_path(
+                        os.path.join(safe_browse_path, entry.name)
+                    )
+                except HTTPException:
+                    continue
+            if safe_entry_path == safe_browse_path:
                 continue
             if is_dir:
                 entries.append(

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -4766,6 +4766,50 @@ def test_the_picker_lists_model_files_only_when_it_is_asked_to(shelf_env, loose_
     assert entries[0]["is_dir"] is True
 
 
+def test_the_picker_lists_a_directory_symlink_that_leaves_the_tree(
+    shelf_env, loose_file, tmp_path
+):
+    """`Models -> /vault/Models` has to be clickable, or it cannot be registered.
+
+    A launcher keeping its models off the system disk is the ordinary case, and
+    the entry-level containment check dropped every one of them — silently, so
+    the folder simply was not in the listing. Nothing is loosened by listing it:
+    the route browses any directory the owner names, so the target is reachable
+    by typing its path already.
+
+    A file symlink leaving the tree still goes, which is the other half of the
+    assertion: a listed file is one this route is offering to read.
+    """
+    home = loose_file.source.parent
+    outside = tmp_path / "vault"
+    outside.mkdir()
+    (outside / "VAE").mkdir()
+    (outside / "secret.safetensors").write_bytes(b"not yours")
+
+    (home / "Models").symlink_to(outside, target_is_directory=True)
+    (home / "escaping.safetensors").symlink_to(outside / "secret.safetensors")
+
+    r = shelf_env.owner.get(
+        f"{API}/filesystem/browse",
+        params={"path": str(home), "include_model_files": True},
+    )
+    assert r.status_code == 200, r.text
+    entries = {entry["name"]: entry for entry in r.json()["entries"]}
+
+    assert "Models" in entries, "the symlinked folder was dropped from the picker"
+    assert entries["Models"]["is_dir"] is True
+    # The resolved target, so browsing into it (and registering it) works.
+    assert entries["Models"]["path"] == os.path.realpath(str(outside))
+    assert "escaping.safetensors" not in entries
+
+    # And it can be browsed once clicked.
+    into = shelf_env.owner.get(
+        f"{API}/filesystem/browse", params={"path": entries["Models"]["path"]}
+    )
+    assert into.status_code == 200, into.text
+    assert [entry["name"] for entry in into.json()["entries"]] == ["VAE"]
+
+
 def test_the_copy_is_hashed_on_its_way_in_and_never_read_again(
     shelf_env, loose_file, monkeypatch
 ):


### PR DESCRIPTION
`Models -> /vault/Models` is how a launcher keeps its models off the system disk, and the picker was dropping exactly those: every entry went through `resolve_path_within`, which raises for a symlink whose target leaves the browsed directory, and the `except` skipped it silently. The folder was simply not there to click, so it could not be registered.

A directory entry that fails containment now resolves through `_resolve_safe_directory_path` instead — the same sanitizer the browsed path itself goes through (blocklist, configured roots, then the fullmatch barrier). Nothing is loosened: this route browses any directory the owner names, so the target was reachable by typing its path already.

Files keep containment. A listed file is one this route is offering to read, which is a different question from one the owner is navigating to.
