### PR TITLE
Report a filter run whose output is already in the library

### DIFF
--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1841,6 +1841,33 @@ async function runPluginWithParameters(
     const createdIds = Array.isArray(res?.created_picture_ids)
       ? res.created_picture_ids
       : [];
+    // A deterministic filter re-run produces a byte-identical output, which the
+    // importer correctly refuses as a duplicate. Nothing is created and nothing
+    // moves on screen, so without this the run is indistinguishable from one
+    // that silently did nothing.
+    //
+    // De-duplicated because the backend builds `duplicate_picture_ids` by
+    // walking the output hashes (`image_plugins/service.py`), so two sources
+    // that filter down to the same image report the same picture id twice —
+    // and the sentence counts pictures in the library, not outputs produced.
+    const duplicateIds = Array.isArray(res?.duplicate_picture_ids)
+      ? res.duplicate_picture_ids
+      : [];
+    const duplicateCount = new Set(duplicateIds).size;
+    if (duplicateCount) {
+      const subject = duplicateCount === 1 ? "image is" : "images are";
+      const label =
+        availablePlugins.value.find((plugin) => plugin?.name === pluginName)
+          ?.display_name || pluginName;
+      noticeStore.info(
+        `${label}: ${duplicateCount} ${subject} already in your library`,
+        // Keyed per plugin, not globally: a second run of the SAME filter is a
+        // repeat of this sentence and should coalesce, while a run of a
+        // DIFFERENT one is its own report and must not overwrite this text and
+        // then wear a count badge that contradicts it.
+        { key: `plugin-run-duplicate:${pluginName}` },
+      );
+    }
     if (createdIds.length) {
       const newIds = createdIds
         .map((id) => getPictureId(id))

--- a/frontend/src/components/views/ImageGridPluginDuplicates.test.js
+++ b/frontend/src/components/views/ImageGridPluginDuplicates.test.js
@@ -1,0 +1,244 @@
+// A filter whose output the library already holds.
+//
+// Re-running a deterministic filter reproduces a byte-identical image, the
+// importer refuses it as a duplicate, and no picture is created. Nothing on the
+// grid moves, so the only thing separating that from a filter that silently did
+// nothing is the notice asserted here.
+//
+// Driven through `handlePluginRunRequest` — the handler behind `@run-plugin`,
+// which is what both the selection bar and the lightbox emit. Calling the inner
+// function directly would assert against an argument shape no caller produces.
+//
+// Two things beyond the sentence are pinned, because both are wrong by default:
+// the level (an `error` is sticky and would leave the card on screen) and the
+// key (a global one lets the next plugin's run overwrite this text while
+// wearing a count badge that then contradicts it).
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { ref } from "vue";
+import { useNoticeStore } from "../../stores/useNoticeStore.js";
+
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef, computed: makeComputed } = await import("vue");
+  return {
+    onSessionReset: () => () => {},
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: (...args) => apiPost(...args),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    },
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeComputed(() => false),
+    login: vi.fn(),
+    logout: vi.fn(),
+    sessionContext: makeRef({ scope: "ALL" }),
+    setRequestClientId: vi.fn(),
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", async () => {
+  const { vuetifyComponentStubs } = await import("../../testing/vuetifyStubs");
+  return vuetifyComponentStubs();
+});
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: {}, params: {}, path: "/", name: "grid" }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    currentRoute: ref({ query: {} }),
+  }),
+}));
+
+import ImageGrid from "./ImageGrid.vue";
+
+/** Keyed by plugin name — what `POST /pictures/plugins/{name}` answers. */
+let pluginResponses = {};
+
+function mountGrid() {
+  const wrapper = mount(ImageGrid, {
+    shallow: true,
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+    props: { backendUrl: "/api/v1" },
+  });
+  return wrapper;
+}
+
+/** Emit what SelectionBar/ImageOverlay emit, and let the run settle. */
+async function runPlugin(wrapper, pluginName, pictureIds = [42]) {
+  // Let the mount's own registry fetch land first, so the run reads the same
+  // plugin list the menus do.
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+  wrapper.vm.handlePluginRunRequest({ pluginName, pictureIds, parameters: {} });
+  for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+function notices() {
+  return useNoticeStore().notices;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  apiGet.mockReset();
+  apiPost.mockReset();
+  apiGet.mockImplementation(async (url) => {
+    // The registry the plugin menus render from: the user picked "Auto Crop",
+    // so that is the name they are owed back.
+    if (String(url ?? "").endsWith("/pictures/plugins")) {
+      return {
+        data: {
+          plugins: [
+            { name: "auto_crop", display_name: "Auto Crop" },
+            { name: "blur", display_name: "Blur" },
+          ],
+        },
+      };
+    }
+    return { data: { pictures: [], count: 0, total: 0 } };
+  });
+  apiPost.mockImplementation(async (url) => {
+    const match = /\/pictures\/plugins\/([^/?]+)/.exec(String(url ?? ""));
+    if (match) return { data: pluginResponses[match[1]] ?? {} };
+    return { data: {} };
+  });
+  pluginResponses = {};
+});
+
+describe("ImageGrid — plugin run whose output already exists", () => {
+  it("says so, by the plugin's display name, when the output was a duplicate", async () => {
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [],
+      duplicate_picture_ids: [7],
+      output_picture_ids: [7],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop");
+
+    expect(notices()).toHaveLength(1);
+    expect(notices()[0].text).toBe(
+      "Auto Crop: 1 image is already in your library",
+    );
+    // Not `error`: nothing failed, and an error card carries no dismiss timer.
+    expect(notices()[0].level).toBe("info");
+    expect(notices()[0].timeout).toBeGreaterThan(0);
+    wrapper.unmount();
+  });
+
+  it("counts pictures, not outputs", async () => {
+    // The backend walks output hashes, so two sources that filter down to the
+    // same image name the same picture id twice. One picture, one image.
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [],
+      duplicate_picture_ids: [7, 7],
+      output_picture_ids: [7, 7],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop", [42, 43]);
+
+    expect(notices()[0].text).toBe(
+      "Auto Crop: 1 image is already in your library",
+    );
+    wrapper.unmount();
+  });
+
+  it("reports the duplicates in a run that also created something", async () => {
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [9],
+      duplicate_picture_ids: [7, 8],
+      output_picture_ids: [9, 7, 8],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop", [42, 43, 44]);
+
+    expect(notices()[0].text).toBe(
+      "Auto Crop: 2 images are already in your library",
+    );
+    wrapper.unmount();
+  });
+
+  it("says nothing when every output was new", async () => {
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [9],
+      duplicate_picture_ids: [],
+      output_picture_ids: [9],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop");
+
+    expect(notices()).toEqual([]);
+    wrapper.unmount();
+  });
+
+  it("says nothing when the field is absent altogether", async () => {
+    // An older backend, or any response that simply does not carry the list.
+    pluginResponses.auto_crop = { status: "success", created_picture_ids: [9] };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop");
+
+    expect(notices()).toEqual([]);
+    wrapper.unmount();
+  });
+
+  it("keeps one plugin's report from overwriting another's", async () => {
+    // A global key would coalesce these: the Auto Crop sentence would be
+    // replaced by the Blur one and badged ×2, claiming a count it never had.
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [],
+      duplicate_picture_ids: [7, 8],
+      output_picture_ids: [7, 8],
+    };
+    pluginResponses.blur = {
+      status: "success",
+      created_picture_ids: [],
+      duplicate_picture_ids: [11],
+      output_picture_ids: [11],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop", [42, 43]);
+    await runPlugin(wrapper, "blur");
+
+    expect(notices().map((n) => n.text)).toEqual([
+      "Auto Crop: 2 images are already in your library",
+      "Blur: 1 image is already in your library",
+    ]);
+    expect(notices().map((n) => n.count)).toEqual([1, 1]);
+    wrapper.unmount();
+  });
+
+  it("coalesces a repeat run of the same plugin", async () => {
+    pluginResponses.auto_crop = {
+      status: "success",
+      created_picture_ids: [],
+      duplicate_picture_ids: [7],
+      output_picture_ids: [7],
+    };
+    const wrapper = mountGrid();
+    await runPlugin(wrapper, "auto_crop");
+    await runPlugin(wrapper, "auto_crop");
+
+    expect(notices()).toHaveLength(1);
+    expect(notices()[0].count).toBe(2);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
Fixes #1080.

## What was wrong

`runPluginWithParameters` (`frontend/src/components/views/ImageGrid.vue`) read only
`created_picture_ids` from the plugin-run response. When a deterministic filter is
re-run, its output is byte-identical to a picture the library already holds, the
importer correctly refuses it as a duplicate, and `created_picture_ids` comes back
empty. The branch was skipped, the grid refresh changed nothing visible, and the run
was indistinguishable from a filter that silently did nothing.

## The change

The same function now also reads `duplicate_picture_ids` and reports it:

> **Auto Crop: 1 image is already in your library**

That is the one place worth touching. `runPicturePlugin` has exactly one caller, and
both plugin-run surfaces — the selection bar and the lightbox — emit `run-plugin` into
the same `handlePluginRunRequest`, so a single branch covers every entry point.

Three details that are not obvious from the diff:

- **The count is of pictures, not outputs.** The backend builds `duplicate_picture_ids`
  by walking output hashes (`pixlstash/image_plugins/service.py`), so two sources whose
  filtered outputs converge name the same picture id twice. `new Set(...).size` is what
  makes the sentence true.
- **The notice key is per plugin.** A single global key would let a second plugin's run
  overwrite the first one's text while inheriting a `×2` badge that contradicts the
  count in the sentence it now shows. Keyed per plugin, a repeat of the *same* filter
  still coalesces, which is the case where `×N` means something.
- **The label is `display_name || name`**, matching every other plugin surface in the
  app. The user clicked "Auto Crop"; they should not be answered with `auto_crop`.

Deduplication itself is unchanged — it is doing its job, and re-importing a picture the
library already holds would be the worse outcome. Only the silence was the defect.

## Tests

`ImageGridPluginDuplicates.test.js` drives the real entry point (`handlePluginRunRequest`,
what `@run-plugin` is bound to) against a stubbed backend, and pins seven behaviours:
the sentence, the display name, singular/plural, pictures-not-outputs, silence when
nothing was a duplicate, silence when the field is absent, the level (an `error` would
be sticky), and both directions of the coalescing key.

Every one of them was proved live by mutating the source and watching the suite go red:
dropping the `Set`, using a global key, switching `info` to `error`, and dropping the
display-name lookup each fail. One did not: removing the `Array.isArray` guard leaves
the suite green, because `new Set(undefined)` is already empty. The guard stays — it is
the idiom used on `created_picture_ids` two lines above and it does guard a non-array
value — but it is not independently observable, and it would be dishonest to claim the
test covers it.

## Reviewer objections answered up front

An adversarial pass over the diff raised these; the first three are fixed above.

- **`errors` from the same response is still ignored.** Left alone deliberately. It is
  not silent: `_emit_error` (`pixlstash/services/plugin_service.py`) publishes a
  `PLUGIN_PROGRESS` event with `status: "error"` and the grid shows it. There *is* a
  real defect next to it — the banner's hide timer covers only `completed` and `failed`,
  so an `error` status pins it on screen — but that is a different fault on a different
  surface, and folding it in would make this diff about two things.
- **The "Related" item in the issue** (image plugin `list_errors()` is exposed by no
  route) is not addressed. It needs a route, an authz registry entry and a Settings
  pane display; the issue itself offers it as its own issue, and it should be one.
- **`info` rather than `warning`.** `docs/design/notice-surface.md` §3 reserves warning
  for "it partly succeeded and the user should know what did not happen". Nothing here
  failed or was refused: the filter ran, and the image it produced is already in the
  library, in the right place. No scope is needed either — §9.6 exempts event reports,
  which are true forever and need only a timeout.
- **No new documentation.** `docs/frontend_architecture.md` mentions notice keys where
  the key itself is load-bearing to a mechanism; there is no key inventory to append to,
  and the reasoning for this one is in a comment beside it.
