### PR TITLE
Set a model's thumbnail from the library, not the filesystem

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -844,17 +844,46 @@ primary route**: it swaps to `GET /pictures/search` and carries the same scope.
 thumbnail, a workflow's Fixed input, a run-time answer — and multi-select would
 be built on the argument that something might want it one day.
 
-**Paste imports, and says so.** The import itself is *not* this component's:
-`useWindowFileImport` already claims a pasted image anywhere in the window and
-runs it through the staging session, so a second import path here would be a
-second thing to keep correct. What the picker adds is the half the reader is
-owed — a notice at the moment of pasting that the picture is being **filed**,
-and a reload when `useTasksStore.importRuns` drains, so what was pasted is
-selectable in the same session. A paste while focus is in the search field is a
-search, and is left alone (the window importer skips editable targets for the
-same reason). This matters beyond politeness: everything downstream names a
-picture by id, and `generation_input` locks an image by sha256 **and** id, so a
-picture that was never imported cannot be locked.
+**Paste imports — and the picker deliberately handles none of it.**
+`useWindowFileImport` already claims a pasted image anywhere in the window, and
+`ImageImporter` — what it hands off to — announces the import from inside the
+import, where the truth is: its progress dialog opens on the same keystroke and
+it reports the buckets at the end. The picker shows the `Ctrl` `V` affordance
+and nothing else, because a second announcement from outside could only be a
+guess, and was wrong three ways: `startImport` refuses outright while another
+import runs *and* under a read-only token, neither refusal ever registers a run
+(so a flag armed on paste never disarmed), and the window importer takes video
+as well as images, so a filter of the picker's own reported one paste and stayed
+silent on another. **What the picker does own** is that the result becomes
+selectable without reopening the dialog: it re-reads the *current* list when
+`useTasksStore.importRuns` drains while it is open — in place, keeping the
+facet, the search and the choice, because an import finishing is not a reason to
+undo what the reader did while they waited, and any import may be one they never
+started. Why paste must import at all: everything downstream names a picture by
+id, and `generation_input` locks an image by sha256 **and** id, so a picture
+that was never imported cannot be locked.
+
+**Two ceilings, both stated on screen.** The browse path pages at 120 with
+`Show more`. The search path has no server-side ceiling to inherit — `GET
+/pictures/search` ignores `top_n` and defaults its `limit` to `sys.maxsize` —
+and this grid is not virtualised, so the cap is applied client-side and the
+panel says it cut the list. The browse path also asks for an explicit
+`fields=id,file_path` rather than `fields=grid`, because the route reads `grid`
+as "this is the picture grid" and silently forces `stack_leaders_only`: a picker
+that could not offer a stacked variant, and whose browse and search results
+would then disagree about the same picture.
+
+**A tile can say it is not available.** A thumbnail is generated *from* the
+file, so a picture on an unplugged drive 404s — a state the shelf beside it
+already models. Those tiles draw the off-glyph, carry it in their accessible
+name, and refuse to be chosen, rather than showing an empty box that invites a
+click which cannot work.
+
+**The grid is one tab stop.** Roving `tabindex` with arrow-key movement (the
+pattern `DedupPictureStrip` already uses), because 120 tiles as 120 tab stops
+puts the footer verbs out of reach — and Enter on a tile accepts, since
+`AppDialog` exempts `<button>` from its Enter contract and the ↵ badge on
+`Use this picture` would otherwise promise what the keyboard cannot do.
 
 First caller: the model shelf's thumbnail verb (§9.1). The workflow Fixed and
 run-time Picker modes are its second and third.
@@ -3153,8 +3182,13 @@ key spans the two, and SQLite recycles deleted ids
 **pixels**: `getPictureThumbnailBlob(id)` reads
 `GET /pictures/thumbnails/{id}.webp` and the result is posted to the same
 multipart route the file chooser uses. The thumbnail is the right copy to send —
-already WebP, generated on demand so it always exists, and 384px on the short
-edge, which is an icon's size and comfortably inside the store's 2 MB ceiling.
+already WebP, generated on demand for any file the server can still reach, and
+384px on the short edge, which is an icon's size and comfortably inside the
+store's 2 MB ceiling. It is fetched cache-busted, because these bytes are about
+to be *stored*: the route caches for an hour, which is fine for a tile and wrong
+for a copy. **The read can 404** — a thumbnail is generated from the file, so an
+unplugged drive refuses — which is why the picker is closed only once the bytes
+are actually in hand.
 That is what makes the mark a *copy* rather than a reference into the vault, and
 is why it survives the picture being deleted or the library being switched.
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -144,7 +144,7 @@ frontend/src/
     ├── editors/     # Entity create / edit / delete dialogs
     ├── settings/    # UserSettingsDialog, its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute), and the Settings* layout primitives (SettingsRow, SettingsSection, SettingsChip/ChipGrid, SettingsFieldBlock, SettingsSliderRow, SettingsTwoCol, SettingsInfoCard, SettingsAddTagRow)
     ├── io/          # Import / export / external-service connection, ComfyUiRunner, RemixDialog
-    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel), the two undo receipts (ActionReceipt over the grid, OverlayActionReceipt inside the lightbox), the Dedup* family (the duplicate queue's row, the picture strip both queue rows are built on, compare dialog, auto-stack dialog, tier menu, the shared threshold control, scan banner, scope pill, why-pills and confidence pill), `MixedQueueRow` (one row of the Duplicates destination's third page, which is a queue of its own), `KeepCoverOnlyDialog` (the one consent for collapsing stacks to their covers; see §5 "Confirming a destructive action"), the Stack* family (badge, edge ticks, expansion strip), `AdapterTray` (the adapters one person or set uses, read-only, inside the two editors), `BaseModelInput` (the completing base-model field, shared by the shelf's bulk dialog and its inline row editor), and `AiToolkitIcon` (the one non-mdi glyph in the app: ai-toolkit's mark, traced as a `currentColor` path because they publish it only as raster)
+    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel), the two undo receipts (ActionReceipt over the grid, OverlayActionReceipt inside the lightbox), the Dedup* family (the duplicate queue's row, the picture strip both queue rows are built on, compare dialog, auto-stack dialog, tier menu, the shared threshold control, scan banner, scope pill, why-pills and confidence pill), `MixedQueueRow` (one row of the Duplicates destination's third page, which is a queue of its own), `KeepCoverOnlyDialog` (the one consent for collapsing stacks to their covers; see §5 "Confirming a destructive action"), the Stack* family (badge, edge ticks, expansion strip), `AdapterTray` (the adapters one person or set uses, read-only, inside the two editors), `BaseModelInput` (the completing base-model field, shared by the shelf's bulk dialog and its inline row editor), `PicturePicker` (one faceted, single-select library picker: the shelf's thumbnail verb today, the workflow Fixed and run-time modes next), and `AiToolkitIcon` (the one non-mdi glyph in the app: ai-toolkit's mark, traced as a `currentColor` path because they publish it only as raster)
 ```
 
 ---
@@ -823,6 +823,41 @@ The house-styled form/control primitives that wrap Vuetify with the PixlStash to
 **`AppDialog fullscreen`** (2026-07-29): a near-viewport dialog (min(1800px, 96vw) × 94vh, flexing body) for working surfaces where the content is the point — first user: the dedup Compare dialog, per the owner's "take the full space of the grid view". Ordinary forms keep the fixed `width`.
 
 **The dialog keyboard contract (owner decision, 2026-07-29).** Every dialog dismisses on **Escape** and accepts on plain **Enter**, and the buttons wear the keys. `AppDialog` implements both on its own subtree so no page-level Escape owner is consulted first: Escape emits `close` (suppressed while `persistent`), Enter emits `accept`. Enter is deliberately inert where the key already has a meaning — multiline fields, buttons and links (native activation wins, so Enter on a focused Cancel cancels), selects, `<summary>`, ARIA text boxes, and any element that already handled the event (`defaultPrevented`). To adopt: wire the primary action to `@accept`, give the accept/confirm button `AppButton key-hint="enter"` (an ↵ badge, plus `aria-keyshortcuts`) and the cancel/abort button `key-hint="esc"`, and let the disabled state of the button — not the handler — be what gates the keypress (the `accept` handler must check the same `canSubmit` the button uses). New dialogs must follow this; existing dialogs adopt it as they are touched. First adopter: `RemixDialog`.
+
+#### `PicturePicker.vue` (`widgets/`)
+**One picker for "which picture?", faceted by the groupings the vault already
+stores.** Props: `open`, `subtitle` (what the picture is *for*, in the caller's
+own words). Emits `close` and `pick(picture)`; a `footer-start` slot is where a
+caller puts the route the picker deliberately does not replace. Built on
+`AppDialog` (so it inherits the Escape/Enter contract), with the facet rail
+left, search and tile grid right, and the receipt plus verbs in the footer —
+the `Picker` artboard of the 1.11 Workflow Library canvas.
+
+**Facets are project / character / picture set**, read from
+`useEntityListsStore` (so the picker costs no request the sidebar was not making
+anyway; reference sets are filtered out exactly as the sidebar filters them).
+One facet is active at a time and it becomes `project_id` / `character_id` /
+`set_id` on `GET /pictures/stream`. Free search is the **escape hatch, not the
+primary route**: it swaps to `GET /pictures/search` and carries the same scope.
+
+**Single-select on purpose.** Every caller needs exactly one picture — a model's
+thumbnail, a workflow's Fixed input, a run-time answer — and multi-select would
+be built on the argument that something might want it one day.
+
+**Paste imports, and says so.** The import itself is *not* this component's:
+`useWindowFileImport` already claims a pasted image anywhere in the window and
+runs it through the staging session, so a second import path here would be a
+second thing to keep correct. What the picker adds is the half the reader is
+owed — a notice at the moment of pasting that the picture is being **filed**,
+and a reload when `useTasksStore.importRuns` drains, so what was pasted is
+selectable in the same session. A paste while focus is in the search field is a
+search, and is left alone (the window importer skips editable targets for the
+same reason). This matters beyond politeness: everything downstream names a
+picture by id, and `generation_input` locks an image by sha256 **and** id, so a
+picture that was never imported cannot be locked.
+
+First caller: the model shelf's thumbnail verb (§9.1). The workflow Fixed and
+run-time Picker modes are its second and third.
 
 #### `ActionReceipt.vue` (465 lines, `widgets/`)
 The transient undo pill, built to the owner's "Undo / Redo System" design. One instance, mounted by `ImageGrid` in the selection pill's slot; reads `useOperationStore` directly (the receipt is inherently singular, so there is nothing to prop-drill). Props: `liftPx` — how far to sit above the selection bar, MEASURED by the caller via `useAnchorHeight("selection-bar")`, never assumed. States: default / coalesced (`+N`, grouped by the server's `batch_id`) / undone-with-Redo / not-undoable ("Can't be undone", never a dead button). A `--countdown-h` hairline drains over the dwell window (5s, 8s destructive) as a `scaleX` animation whose `animation-play-state` pauses on hover and focus-within in lockstep with the store's timer (WCAG 2.2.1); it is the one animation that deliberately survives `prefers-reduced-motion`, because it is the time-remaining readout rather than decoration. Sits on `--z-floating` and registers `"action-receipt"` with `useBottomAnchor` — the measured element is the pointer-transparent wrapper (pill + lift), so the notice stack clears the whole thing. Announces through ONE persistent `role="status"` region rather than the remounted pill, throttled so a burst of actions reads once.
@@ -3063,7 +3098,7 @@ shelf root**, the same landing `closeMove` uses: the button destroys the element
 the keyboard is standing on, and focus falling to `<body>` restarts the next Tab
 at the top of an 1,800-row document.
 
-#### The icon verb, on the shelf
+#### The thumbnail verb, on the shelf
 
 **Unset is never blank.** The identity column used to be a bare kind glyph, so
 every checkpoint row and the 37% of adapters carrying no title rendered
@@ -3089,16 +3124,39 @@ is, and a mark announcing "FL" would be the same fact twice, less usefully.
 
 **Set is single-row, clear is bulk.** An icon answers "which one is this?", so
 giving forty rows one mark would remove the only thing telling them apart — Set
-icon is gated to a selection of one, shown-and-disabled like Rename. Clear
+thumbnail is gated to a selection of one, shown-and-disabled like Rename. Clear
 appears only when something in the selection has one. Setting or clearing a
 single row prompts for nothing (both are reconstructable by doing them again); a
 **bulk** clear is not and confirms, the same test the bulk base-model overwrite
 falls on.
 
-**One upload path.** The picker is a real `<input type="file">` — the platform's
-own chooser, keyboard-accessible for free — and the client posts the bytes. That
-is what makes "pick a library picture" a *copy* rather than a reference into the
-vault, which is the constraint the hub/vault split imposes.
+**The verb is `Set Thumbnail…`, and the field is still `icon`.** The vocabulary
+change (workflow plan §3 S3) aligns the user-facing verb with the word the code
+already used for what it produces — `ModelMark` describes `set_icon` as "what
+its **thumbnail** was replaced BY" — and keeps *sample* (what a model produces:
+derived, plural, automatic) distinct from what a model *is*. `set_icon`,
+`icon_sha256`, `POST /models/{id}/icon` and `POST /models/icons/clear` are
+unchanged: renaming the column is churn with no user-visible benefit, and
+`set_icon` is separately in use for picture-set glyphs in `SideBar.vue`.
+
+**The library route is primary; the file route survives as the secondary.**
+`PicturePicker` (below) opens on the verb, and its `footer-start` slot carries
+the shelf's `Choose a file…`, which is still the same hidden `<input
+type="file">`. Removing a shipped way of doing the job would be a regression,
+and the point of the step was to prove the picker without taking anything away.
+
+**One upload path, whichever route was taken.** `POST /models/{id}/icon` takes
+bytes and nothing else — there is deliberately no route that resolves a picture
+id server-side, because `model` is a hub row and a picture is a vault row, no
+key spans the two, and SQLite recycles deleted ids
+(`pixlstash/services/model_icons.py`). So the library route sends the picture's
+**pixels**: `getPictureThumbnailBlob(id)` reads
+`GET /pictures/thumbnails/{id}.webp` and the result is posted to the same
+multipart route the file chooser uses. The thumbnail is the right copy to send —
+already WebP, generated on demand so it always exists, and 384px on the short
+edge, which is an icon's size and comfortably inside the store's 2 MB ceiling.
+That is what makes the mark a *copy* rather than a reference into the vault, and
+is why it survives the picture being deleted or the library being switched.
 
 **The sample/icon view toggle is NOT built, and cannot be yet.** The ruling
 defines two fallback chains (sample → icon → mark, and icon → mark), but the
@@ -3368,8 +3426,8 @@ in a file mode rather than an `<input type=file>`.** The file is on the machine
 running PixlStash and the server copies it there, so an upload would push a
 gigabyte through the browser to land it a directory away from where it started —
 and `<input type=file>` cannot give the host path the route needs anyway. (The
-icon verb *does* use a real file input, because an icon is small and its bytes
-genuinely have to travel.) The picker's file mode is opt-in on both sides: the
+thumbnail verb's secondary `Choose a file…` route *does* use a real file input,
+because an icon is small and its bytes genuinely have to travel.) The picker's file mode is opt-in on both sides: the
 `pickModelFile` prop turns a click on a file into a selection instead of a
 no-op, and it is what sets `include_model_files` on `GET /filesystem/browse`, so
 every other folder picker keeps a directory-only list. A click **selects**, it

--- a/frontend/src/api/pictures.js
+++ b/frontend/src/api/pictures.js
@@ -42,11 +42,12 @@ export function pictureThumbnailUrl(id, { version } = {}) {
  * resolves a picture id server-side — the icon is a COPY, so it cannot break
  * when the picture is deleted or the library is switched
  * (`services/model_icons.py`). So choosing a library picture means sending its
- * pixels, and the thumbnail is the right pixels to send: it is already WebP,
- * it is generated on demand so it always exists, and its 384px short edge is
- * both what an icon needs and comfortably inside the store's 2 MB ceiling.
+ * pixels, and the thumbnail is the right pixels to send: it is already WebP, it
+ * is generated on demand rather than having to have been made in advance, and
+ * its 384px short edge is both what an icon needs and comfortably inside the
+ * store's 2 MB ceiling.
  *
- * **It can 404.** "Generated on demand" means generated from the file, and the
+ * **It can still 404**, because "on demand" means generated FROM the file: the
  * route refuses when the source is missing, unreachable or undecodable — an
  * unplugged drive is a state this app models. The caller must have an answer
  * for that; it is not a read that always succeeds.

--- a/frontend/src/api/pictures.js
+++ b/frontend/src/api/pictures.js
@@ -46,12 +46,26 @@ export function pictureThumbnailUrl(id, { version } = {}) {
  * it is generated on demand so it always exists, and its 384px short edge is
  * both what an icon needs and comfortably inside the store's 2 MB ceiling.
  *
+ * **It can 404.** "Generated on demand" means generated from the file, and the
+ * route refuses when the source is missing, unreachable or undecodable — an
+ * unplugged drive is a state this app models. The caller must have an answer
+ * for that; it is not a read that always succeeds.
+ *
  * @param {number|string} id
+ * @param {Object} [options]
+ * @param {string|number} [options.cacheBuster] - forces a fresh read past the
+ *   route's one-hour `max-age`. Worth passing when the bytes are about to be
+ *   STORED rather than merely shown: an hour-old thumbnail is a fine tile and a
+ *   wrong thing to keep.
  * @returns {Promise<Blob>} the WebP bytes.
  */
-export async function getPictureThumbnailBlob(id) {
+export async function getPictureThumbnailBlob(id, { cacheBuster } = {}) {
+  const query =
+    cacheBuster == null ? "" : `?cb=${encodeURIComponent(cacheBuster)}`;
   return unwrap(
-    apiClient.get(`/pictures/thumbnails/${id}.webp`, { responseType: "blob" }),
+    apiClient.get(`/pictures/thumbnails/${id}.webp${query}`, {
+      responseType: "blob",
+    }),
   );
 }
 

--- a/frontend/src/api/pictures.js
+++ b/frontend/src/api/pictures.js
@@ -34,6 +34,28 @@ export function pictureThumbnailUrl(id, { version } = {}) {
 }
 
 /**
+ * Read a picture's thumbnail as image BYTES.
+ *
+ * The one caller so far is the model shelf's thumbnail verb, and the shape of
+ * that verb is why this exists: `POST /models/{id}/icon` takes bytes and stores
+ * them content-addressed beside the hub, deliberately with no route that
+ * resolves a picture id server-side — the icon is a COPY, so it cannot break
+ * when the picture is deleted or the library is switched
+ * (`services/model_icons.py`). So choosing a library picture means sending its
+ * pixels, and the thumbnail is the right pixels to send: it is already WebP,
+ * it is generated on demand so it always exists, and its 384px short edge is
+ * both what an icon needs and comfortably inside the store's 2 MB ceiling.
+ *
+ * @param {number|string} id
+ * @returns {Promise<Blob>} the WebP bytes.
+ */
+export async function getPictureThumbnailBlob(id) {
+  return unwrap(
+    apiClient.get(`/pictures/thumbnails/${id}.webp`, { responseType: "blob" }),
+  );
+}
+
+/**
  * Count the pictures matching a filter scope.
  *
  * A single indexed COUNT, deliberately separate from the stream below: the

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -174,7 +174,7 @@
       class="selbar-btn"
       type="button"
       data-verb="set-icon"
-      aria-label="Set icon"
+      aria-label="Set thumbnail"
       :disabled="!single"
       :title="iconTitle"
       @click="emit('set-icon')"
@@ -942,13 +942,13 @@ const VerbMenu = (props) => {
         })
       : null,
     props.single
-      ? item("mdi-image-outline", "Set icon…", {
+      ? item("mdi-image-outline", "Set thumbnail…", {
           on: () => props.onVerb("set-icon"),
           title: props.iconTitle,
         })
       : null,
     props.hasIcons
-      ? item("mdi-image-off-outline", "Clear icon", {
+      ? item("mdi-image-off-outline", "Clear thumbnail", {
           on: () => props.onVerb("clear-icons"),
           title: props.clearIconTitle,
         })

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -142,6 +142,21 @@ vi.mock("../../api/pictureSets", async (importOriginal) => ({
   listPictureSets: (...args) => listPictureSets(...args),
 }));
 
+// The thumbnail verb's library route: the picker hands back a picture, the view
+// fetches ITS BYTES and posts them to the icon store. Both halves are doubled
+// here — the read because it is a network call on a user gesture, and the write
+// because a suite that really called it would be asserting the server's gate
+// rather than this view's wiring.
+const getPictureThumbnailBlob = vi.fn();
+vi.mock("../../api/pictures", () => ({
+  getPictureThumbnailBlob: (...args) => getPictureThumbnailBlob(...args),
+}));
+const setModelIcon = vi.fn();
+vi.mock("../../api/modelIcons", async (importOriginal) => ({
+  ...(await importOriginal()),
+  setModelIcon: (...args) => setModelIcon(...args),
+}));
+
 import ModelShelf from "./ModelShelf.vue";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
@@ -171,6 +186,12 @@ const globalOpts = {
       // dialog provider into a suite that installs none; stubbed, it still
       // emits `select`, which is the whole of what this view listens for.
       FolderBrowser: true,
+      // The library picture picker the thumbnail verb opens. Its own suite
+      // mounts it; real here it would drag Vuetify's dialog provider into a
+      // suite that installs none, and read the shared entity lists on every
+      // mount. Stubbed it still emits `pick`, which is all this view listens
+      // for.
+      PicturePicker: true,
       ProgressOverlay: true,
       // The picker inside the selection bar, which the bar's own suite covers.
       // Left real it would read the shared entity lists on every mount here.
@@ -3188,8 +3209,8 @@ describe("the assignment ring (#892, redrawn for #904)", () => {
   });
 });
 
-describe("the icon verb", () => {
-  it("offers Set icon for one model and refuses it for two", async () => {
+describe("the thumbnail verb", () => {
+  it("offers Set thumbnail for one model and refuses it for two", async () => {
     const wrapper = await mountShelf([
       adapter({ id: 1 }),
       adapter({ id: 2, sha256: "b".repeat(64) }),
@@ -3205,18 +3226,66 @@ describe("the icon verb", () => {
     expect(setIcon().attributes("disabled")).toBeDefined();
   });
 
-  it("offers Clear icon only when something has one", async () => {
+  it("offers Clear thumbnail only when something has one", async () => {
     const wrapper = await mountShelf([adapter({ id: 1 })]);
     const store = useModelShelfStore();
     store.toggleSelected(1);
     await wrapper.vm.$nextTick();
     const clear = () =>
-      wrapper.findAll("button").find((b) => b.text().includes("Clear icon"));
+      wrapper.findAll("button").find((b) => b.text().includes("Clear thumbnail"));
     expect(clear()).toBeUndefined();
 
     store.rows = [adapter({ id: 1, icon_sha256: "a".repeat(64) })];
     await wrapper.vm.$nextTick();
     expect(clear()).toBeDefined();
+  });
+
+  it("sends the chosen picture's BYTES, never a reference to it", async () => {
+    // The icon store is content-addressed and lives beside the hub, while a
+    // picture is a vault row — nothing keys across the two. So the library
+    // route has to copy pixels, and the thumbnail is the copy it sends.
+    const bytes = new Blob(["webp"], { type: "image/webp" });
+    getPictureThumbnailBlob.mockResolvedValue(bytes);
+    setModelIcon.mockResolvedValue({ model_id: 1, icon_sha256: "c".repeat(64) });
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+
+    await wrapper.findComponent({ name: "PicturePicker" }).vm.$emit("pick", {
+      id: 55,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getPictureThumbnailBlob).toHaveBeenCalledWith(55);
+    expect(setModelIcon).toHaveBeenCalledWith(1, bytes);
+  });
+
+  it("keeps Escape and Delete away from the rows while the picker is up", async () => {
+    // The picker is one of the shelf's OWN dialogs, and the window-level guard
+    // lists those by ref rather than by target: a press with nothing focused
+    // inside a dialog targets `<body>`, which no ancestor test can see. Without
+    // the ref, Escape over the picker would also wipe the selection underneath
+    // it and Delete would open the delete confirmation for it.
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+
+    wrapper.findComponent({ name: "PicturePicker" }).vm.$emit("close");
+    await wrapper.vm.$nextTick();
+    // Sanity: with the picker shut, Escape is the shelf's and clears.
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+    expect(store.selectedRows).toHaveLength(0);
+
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await wrapper.vm.$nextTick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+    expect(store.selectedRows).toHaveLength(1);
   });
 
   it("accepts only the image types the store will take", async () => {

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -148,7 +148,12 @@ vi.mock("../../api/pictureSets", async (importOriginal) => ({
 // because a suite that really called it would be asserting the server's gate
 // rather than this view's wiring.
 const getPictureThumbnailBlob = vi.fn();
-vi.mock("../../api/pictures", () => ({
+// `importOriginal` spread, like its two neighbours: a bare replacement leaves
+// every OTHER export of that module `undefined` across this view's whole module
+// graph, so the next child to import `pictureThumbnailUrl` would die with a
+// bare "is not a function" in a suite that has nothing to do with thumbnails.
+vi.mock("../../api/pictures", async (importOriginal) => ({
+  ...(await importOriginal()),
   getPictureThumbnailBlob: (...args) => getPictureThumbnailBlob(...args),
 }));
 const setModelIcon = vi.fn();
@@ -189,9 +194,14 @@ const globalOpts = {
       // The library picture picker the thumbnail verb opens. Its own suite
       // mounts it; real here it would drag Vuetify's dialog provider into a
       // suite that installs none, and read the shared entity lists on every
-      // mount. Stubbed it still emits `pick`, which is all this view listens
-      // for.
-      PicturePicker: true,
+      // mount. The stub RENDERS ITS SLOTS rather than being `true`, because the
+      // `Choose a file…` route this change deliberately keeps lives in one —
+      // and a `true` stub would let that route be deleted with the suite green.
+      PicturePicker: {
+        name: "PicturePicker",
+        props: ["open"],
+        template: "<div class='picker-stub'><slot name='footer-start' /></div>",
+      },
       ProgressOverlay: true,
       // The picker inside the selection bar, which the bar's own suite covers.
       // Left real it would read the shared entity lists on every mount here.
@@ -249,6 +259,11 @@ beforeEach(() => {
   listSupport.mockReset().mockResolvedValue([]);
   listModelFolderDevices.mockReset();
   listModelFolderDevices.mockResolvedValue([]);
+  // The thumbnail verb's two halves. Reset here rather than per-test: a
+  // rejection armed for the unreachable-file case would otherwise still be
+  // armed for whatever ran next.
+  getPictureThumbnailBlob.mockReset();
+  setModelIcon.mockReset();
   listModelFolders.mockReset();
   listModelFolders.mockResolvedValue([]);
   nav.route.name = "models";
@@ -3257,7 +3272,11 @@ describe("the thumbnail verb", () => {
     });
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(getPictureThumbnailBlob).toHaveBeenCalledWith(55);
+    // Cache-busted: these bytes get STORED, so an hour-old thumbnail is the
+    // wrong thing to keep.
+    expect(getPictureThumbnailBlob).toHaveBeenCalledWith(55, {
+      cacheBuster: expect.any(Number),
+    });
     expect(setModelIcon).toHaveBeenCalledWith(1, bytes);
   });
 
@@ -3286,6 +3305,63 @@ describe("the thumbnail verb", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     await wrapper.vm.$nextTick();
     expect(store.selectedRows).toHaveLength(1);
+  });
+
+  it("keeps the picker open behind the file chooser, and shuts it on a file", async () => {
+    // `Choose a file…` is the shipped route this change deliberately does not
+    // remove, and it lives in the picker's footer slot. Cancelling the OS
+    // chooser must land the reader back in the picker rather than on a bare
+    // shelf, so the picker is closed by a file ARRIVING, never by the chooser
+    // opening.
+    setModelIcon.mockResolvedValue({ model_id: 1, icon_sha256: "d".repeat(64) });
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const picker = () => wrapper.findComponent({ name: "PicturePicker" });
+    expect(picker().props("open")).toBe(true);
+    const chooseAFile = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Choose a file"));
+    expect(chooseAFile).toBeDefined();
+
+    const input = wrapper.find('input[type="file"]');
+    const clicked = vi.spyOn(input.element, "click");
+    await chooseAFile.trigger("click");
+    expect(clicked).toHaveBeenCalled();
+    // Still open: nothing has come back from the chooser yet.
+    expect(picker().props("open")).toBe(true);
+
+    const file = new File(["png"], "mark.png", { type: "image/png" });
+    Object.defineProperty(input.element, "files", { value: [file] });
+    await input.trigger("change");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(picker().props("open")).toBe(false);
+    expect(setModelIcon).toHaveBeenCalledWith(1, file);
+  });
+
+  it("keeps the picker open when the picture's bytes cannot be read", async () => {
+    // A thumbnail is generated FROM the file, so an unplugged drive 404s. The
+    // refusal must not land over a shelf the reader has to reopen the picker
+    // from to try again.
+    getPictureThumbnailBlob.mockRejectedValue(new Error("nope"));
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const picker = () => wrapper.findComponent({ name: "PicturePicker" });
+    picker().vm.$emit("pick", { id: 55 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(picker().props("open")).toBe(true);
+    expect(setModelIcon).not.toHaveBeenCalled();
+    expect(useNoticeStore().notices.at(-1).level).toBe("error");
   });
 
   it("accepts only the image types the store will take", async () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -2198,14 +2198,22 @@ function pickIcon() {
  * recycles deleted ids, so a stored `picture_id` would silently re-point after
  * a delete-and-insert and break on every library switch
  * (`services/model_icons.py`). Copying the bytes is what makes the mark
- * survive. The thumbnail is the copy that gets sent: already WebP, generated
- * on demand so it always exists, and 384px on the short edge — an icon's size
- * rather than a 40 MB original the store would refuse.
+ * survive. The thumbnail is the copy that gets sent: already WebP, generated on
+ * demand for any file the server can still reach, and 384px on the short edge —
+ * an icon's size rather than a 40 MB original the store would refuse.
  */
 async function onThumbnailPicked(picture) {
-  thumbnailPickerOpen.value = false;
   try {
-    const blob = await getPictureThumbnailBlob(picture.id);
+    // Fetched with the picker still open, and only then shut. The read can
+    // fail — a thumbnail is generated from the file, so an unplugged drive
+    // 404s — and a dialog that has already closed leaves the refusal floating
+    // over a shelf the reader has to reopen the picker from to try again.
+    // Cache-busted because these bytes are about to be STORED: an hour-old
+    // thumbnail is a fine tile and the wrong thing to keep.
+    const blob = await getPictureThumbnailBlob(picture.id, {
+      cacheBuster: Date.now(),
+    });
+    thumbnailPickerOpen.value = false;
     await store.setIconOnSelected(blob);
   } catch (err) {
     useNoticeStore().push({
@@ -2215,9 +2223,15 @@ async function onThumbnailPicked(picture) {
   }
 }
 
-/** The secondary route, from inside the picker: any file on disk. */
+/**
+ * The secondary route, from inside the picker: any file on disk.
+ *
+ * The picker stays open behind the OS chooser and is closed only once a file
+ * really came back. Cancelling the chooser is the ordinary way to change your
+ * mind about the file route, and it should land the reader back where they
+ * were rather than on a bare shelf.
+ */
 function pickIconFile() {
-  thumbnailPickerOpen.value = false;
   // Cleared first, so choosing the SAME file twice still fires `change` — the
   // obvious way to retry after a refusal, and silent if the value persisted.
   if (iconInputRef.value) iconInputRef.value.value = "";
@@ -2227,6 +2241,7 @@ function pickIconFile() {
 async function onIconChosen(event) {
   const file = event.target.files?.[0];
   if (!file) return;
+  thumbnailPickerOpen.value = false;
   await store.setIconOnSelected(file);
 }
 
@@ -2246,8 +2261,8 @@ async function confirmClearIcons() {
     const ok = await confirm({
       title: `Clear ${withIcons.length} thumbnails?`,
       message:
-        "Those models go back to a generated mark. The images stay in the " +
-        "icon store, but which model wore which is not recorded anywhere else.",
+        "Those models go back to a generated mark. The images themselves are " +
+        "kept, but which model wore which is not recorded anywhere else.",
       warning: "There is no undo for this.",
       confirmLabel: "Clear them",
       danger: true,

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -416,11 +416,13 @@
       </div>
     </div>
 
-    <!-- The file picker the Set icon verb drives. A real <input type=file>
-         rather than a drop zone or a dialog: it is the platform's own chooser,
-         it is keyboard-accessible for free, and picking a file is the whole
-         interaction. Hidden rather than styled, because the verb beside it is
-         already the affordance. -->
+    <!-- The SECONDARY route into the thumbnail verb, kept rather than removed:
+         any file on disk worked before the picker existed, and taking that away
+         would be a regression on a shipped feature. It is reached from inside
+         the picker (see its `footer-start` slot below), so the library route is
+         the one that is offered first. A real <input type=file> because it is
+         the platform's own chooser and keyboard-accessible for free; hidden
+         rather than styled, because the button beside it is the affordance. -->
     <input
       ref="iconInputRef"
       class="visually-hidden"
@@ -428,6 +430,21 @@
       accept="image/png,image/jpeg,image/webp"
       @change="onIconChosen"
     />
+
+    <!-- Set Thumbnail…, the primary route: a picture from the library, chosen
+         by project / character / set. A picture that PixlStash can see is one
+         it can search, reuse and repair; the file the OS chooser returns is one
+         it never sees again. -->
+    <PicturePicker
+      :open="thumbnailPickerOpen"
+      :subtitle="thumbnailSubject"
+      @close="thumbnailPickerOpen = false"
+      @pick="onThumbnailPicked"
+    >
+      <template #footer-start>
+        <AppButton variant="ghost" @click="pickIconFile">Choose a file…</AppButton>
+      </template>
+    </PicturePicker>
 
     <!-- `inert` while a move runs, not merely dimmed. A move repoints
          `model_file` rows under the list, so a verb pressed mid-move acts on a
@@ -1411,10 +1428,13 @@ import TrainingRuns from "./TrainingRuns.vue";
 import { SOURCE_KIND } from "../../api/modelFolders";
 import FolderBrowser from "../editors/FolderBrowser.vue";
 import ModelMark from "../widgets/ModelMark.vue";
+import PicturePicker from "../widgets/PicturePicker.vue";
+import AppButton from "../widgets/AppButton.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
 import StackEdgeTicks from "../widgets/StackEdgeTicks.vue";
 import { useConfirm } from "../../composables/useConfirm";
 import { addModelFile } from "../../api/modelFiles";
+import { getPictureThumbnailBlob } from "../../api/pictures";
 import { openModelLocation } from "../../api/modelShelf";
 import {
   createStack,
@@ -2058,6 +2078,7 @@ function shelfOwnsTheKey(event) {
     addSourceOpen.value ||
     foldersOpen.value ||
     addFileOpen.value ||
+    thumbnailPickerOpen.value ||
     editVerb.value
   ) {
     return false;
@@ -2147,11 +2168,56 @@ function onShelfKeydown(event) {
 onMounted(() => window.addEventListener("keydown", onShelfKeydown));
 onUnmounted(() => window.removeEventListener("keydown", onShelfKeydown));
 
-// ── The icon verb ───────────────────────────────────────────────────────────
+// ── The thumbnail verb ──────────────────────────────────────────────────────
 
 const iconInputRef = ref(null);
+const thumbnailPickerOpen = ref(false);
+
+/**
+ * What the thumbnail is FOR, in the picker's subtitle.
+ *
+ * A row in the `needs-a-name` state has no name by design, so this falls back
+ * the same way the receipt does — the reader has to recognise what they are
+ * about to change.
+ */
+const thumbnailSubject = computed(() => {
+  const row = store.selectedRows[0];
+  if (!row) return "";
+  return `for ${row.name?.text || row.filename || "this model"}`;
+});
 
 function pickIcon() {
+  thumbnailPickerOpen.value = true;
+}
+
+/**
+ * The library route: send the picture's PIXELS, never a reference to it.
+ *
+ * The icon store is content-addressed and lives beside the hub, and `model` is
+ * a hub row while a picture is a vault row — no key spans the two, and SQLite
+ * recycles deleted ids, so a stored `picture_id` would silently re-point after
+ * a delete-and-insert and break on every library switch
+ * (`services/model_icons.py`). Copying the bytes is what makes the mark
+ * survive. The thumbnail is the copy that gets sent: already WebP, generated
+ * on demand so it always exists, and 384px on the short edge — an icon's size
+ * rather than a 40 MB original the store would refuse.
+ */
+async function onThumbnailPicked(picture) {
+  thumbnailPickerOpen.value = false;
+  try {
+    const blob = await getPictureThumbnailBlob(picture.id);
+    await store.setIconOnSelected(blob);
+  } catch (err) {
+    useNoticeStore().push({
+      level: "error",
+      text: errorDetail(err) || "Could not read that picture.",
+    });
+  }
+}
+
+/** The secondary route, from inside the picker: any file on disk. */
+function pickIconFile() {
+  thumbnailPickerOpen.value = false;
   // Cleared first, so choosing the SAME file twice still fires `change` — the
   // obvious way to retry after a refusal, and silent if the value persisted.
   if (iconInputRef.value) iconInputRef.value.value = "";
@@ -2168,7 +2234,7 @@ async function onIconChosen(event) {
  * Clearing one row needs no prompt; clearing a selection does.
  *
  * The shelf's rule is to confirm only where the prior state cannot be
- * reconstructed. One icon is one file-picker away from back; a bulk clear is
+ * reconstructed. One thumbnail is one picker away from back; a bulk clear is
  * not, and falls on the same side of that test as the bulk base-model
  * overwrite. Counted on the rows that HAVE one, because that is what the verb
  * will actually destroy.
@@ -2178,7 +2244,7 @@ async function confirmClearIcons() {
   if (!withIcons.length) return;
   if (withIcons.length > 1) {
     const ok = await confirm({
-      title: `Clear ${withIcons.length} icons?`,
+      title: `Clear ${withIcons.length} thumbnails?`,
       message:
         "Those models go back to a generated mark. The images stay in the " +
         "icon store, but which model wore which is not recorded anywhere else.",

--- a/frontend/src/components/widgets/PicturePicker.test.js
+++ b/frontend/src/components/widgets/PicturePicker.test.js
@@ -1,10 +1,16 @@
 // The library picture picker.
 //
-// The four things worth guarding are the ones the plan's §3 fixtures name and
-// the ones a later caller would silently break: the facets are the vault's own
-// groupings and really scope the read, the selection is single, search is the
-// escape hatch (a different endpoint, same scope), and a paste says so and is
-// selectable once the import lands.
+// What is worth guarding is what the plan's §3 fixtures name plus what a later
+// caller would silently break: the facets are the vault's own groupings and
+// really scope the read, the selection is single and a refused tile can never
+// stand in for it, search is the escape hatch (a different endpoint, same
+// scope) and is capped where the route imposes no ceiling of its own, and a
+// picture imported while the picker is open becomes selectable without the
+// reader's facet, search or choice being thrown away.
+//
+// The picker deliberately says NOTHING about a paste — `ImageImporter`
+// announces the import from inside it, which is the only place that knows
+// whether it happened. See the Paste note in the component.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
@@ -308,6 +314,25 @@ describe("the facet rail's truncation", () => {
 });
 
 describe("a picture whose file cannot be reached", () => {
+  it("never stands in for the choice that was already made", async () => {
+    // The refusal has to reach the gestures that mean "choose this one AND
+    // take it". If it only reaches the choosing half, a double-click or Enter
+    // on a refused tile falls through and accepts whatever was chosen BEFORE
+    // it — silent, and a picture the reader did not point at.
+    const w = await mountPicker();
+    await w.findAll(".pp-cell")[0].trigger("click");
+    expect(w.findAll(".pp-cell--on")).toHaveLength(1);
+
+    await w.findAll(".pp-cell img")[1].trigger("error");
+    await flush(w);
+    const gone = w.findAll(".pp-cell")[1];
+
+    await gone.trigger("dblclick");
+    expect(w.emitted("pick")).toBeFalsy();
+    await gone.trigger("keydown", { key: "Enter" });
+    expect(w.emitted("pick")).toBeFalsy();
+  });
+
   it("says so and refuses to be chosen", async () => {
     // A thumbnail is generated FROM the file, so an unplugged drive 404s. An
     // empty box that can still be clicked reads as one that has not loaded yet.

--- a/frontend/src/components/widgets/PicturePicker.test.js
+++ b/frontend/src/components/widgets/PicturePicker.test.js
@@ -1,0 +1,231 @@
+// The library picture picker.
+//
+// The four things worth guarding are the ones the plan's §3 fixtures name and
+// the ones a later caller would silently break: the facets are the vault's own
+// groupings and really scope the read, the selection is single, search is the
+// escape hatch (a different endpoint, same scope), and a paste says so and is
+// selectable once the import lands.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("vuetify/components", () => ({
+  VIcon: { name: "v-icon", template: "<i><slot /></i>" },
+  VDialog: { name: "v-dialog", template: "<div><slot /></div>" },
+}));
+
+const streamPictures = vi.fn();
+const searchPictures = vi.fn();
+const getPictureCount = vi.fn();
+
+vi.mock("../../api/pictures", () => ({
+  streamPictures: (...a) => streamPictures(...a),
+  searchPictures: (...a) => searchPictures(...a),
+  getPictureCount: (...a) => getPictureCount(...a),
+  pictureThumbnailUrl: (id) => `/api/v1/pictures/thumbnails/${id}.webp`,
+}));
+
+// The picker reads the shared entity lists rather than inventing its own
+// grouping, so the doubles go in at the api layer the store fetches from.
+vi.mock("../../api/characters", () => ({
+  listCharacters: vi.fn().mockResolvedValue([
+    { id: 7, name: "Clementine", image_count: 1029 },
+    { id: 8, name: "Sarah", image_count: 160 },
+  ]),
+}));
+vi.mock("../../api/pictureSets", () => ({
+  listPictureSets: vi.fn().mockResolvedValue([
+    { id: 3, name: "Good detail", picture_count: 97 },
+    // A reference set is machinery, not a grouping anyone chose: the sidebar
+    // hides it and so does this.
+    { id: 4, name: "ref", picture_count: 5, reference_character: 7 },
+  ]),
+}));
+vi.mock("../../api/projects", () => ({
+  listProjects: vi.fn().mockResolvedValue([
+    { id: 2, name: "Personal", image_count: 9118 },
+  ]),
+}));
+
+import PicturePicker from "./PicturePicker.vue";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useTasksStore } from "../../stores/useTasksStore";
+
+function batch(ids, { done = true } = {}) {
+  return {
+    pictures: ids.map((id) => ({ id, file_name: `p${id}.png` })),
+    done,
+    next_offset: ids.length,
+  };
+}
+
+/** The query string the last stream call was made with. */
+function lastStreamQuery() {
+  return new URLSearchParams(streamPictures.mock.calls.at(-1)[0]);
+}
+
+async function mountPicker() {
+  const w = mount(PicturePicker, { props: { open: true, subtitle: "for Cyanwood" } });
+  // The open watcher fires the list read, the count and the three entity
+  // refreshes; let all of them settle before asserting on what is drawn.
+  await flush(w);
+  return w;
+}
+
+async function flush(w) {
+  for (let i = 0; i < 6; i += 1) {
+    await Promise.resolve();
+    await w.vm.$nextTick();
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  streamPictures.mockReset().mockResolvedValue(batch([1, 2, 3]));
+  searchPictures.mockReset().mockResolvedValue([{ id: 9, file_name: "p9.png" }]);
+  getPictureCount.mockReset().mockResolvedValue({ count: 28172 });
+});
+
+describe("the facets", () => {
+  it("are the vault's own groupings, and the reference set is not one", async () => {
+    const w = await mountPicker();
+    const labels = w.findAll(".pp-facet__label").map((n) => n.text());
+    expect(labels).toContain("Everything");
+    expect(labels).toContain("Personal");
+    expect(labels).toContain("Clementine");
+    expect(labels).toContain("Good detail");
+    expect(labels).not.toContain("ref");
+  });
+
+  it("scopes the read to the one that was picked", async () => {
+    const w = await mountPicker();
+    expect(lastStreamQuery().get("character_id")).toBe(null);
+
+    const clementine = w
+      .findAll(".pp-facet")
+      .find((b) => b.text().includes("Clementine"));
+    await clementine.trigger("click");
+    await flush(w);
+
+    expect(lastStreamQuery().get("character_id")).toBe("7");
+    // One facet at a time: the previous scope is replaced, never added to.
+    expect(lastStreamQuery().get("project_id")).toBe(null);
+  });
+});
+
+describe("choosing", () => {
+  it("keeps exactly one picture chosen", async () => {
+    const w = await mountPicker();
+    const cells = () => w.findAll(".pp-cell");
+    await cells()[0].trigger("click");
+    await cells()[2].trigger("click");
+    expect(w.findAll(".pp-cell--on")).toHaveLength(1);
+    expect(cells()[2].classes()).toContain("pp-cell--on");
+  });
+
+  it("emits the picture itself, once, and only when one is chosen", async () => {
+    const w = await mountPicker();
+    const use = () =>
+      w.findAll("button").find((b) => b.text().includes("Use this picture"));
+    expect(use().attributes("disabled")).toBeDefined();
+
+    await w.findAll(".pp-cell")[1].trigger("click");
+    await use().trigger("click");
+    expect(w.emitted("pick")).toHaveLength(1);
+    expect(w.emitted("pick")[0][0].id).toBe(2);
+  });
+});
+
+describe("search", () => {
+  it("is the escape hatch: a different endpoint, the same scope", async () => {
+    const w = await mountPicker();
+    const clementine = w
+      .findAll(".pp-facet")
+      .find((b) => b.text().includes("Clementine"));
+    await clementine.trigger("click");
+    await flush(w);
+
+    await w.find(".pp-search input").setValue("red dress");
+    await w.find(".pp-search input").trigger("keydown", { key: "Enter" });
+    await flush(w);
+
+    expect(searchPictures).toHaveBeenCalledWith("red dress", {
+      query: "character_id=7",
+    });
+    expect(w.findAll(".pp-cell")).toHaveLength(1);
+  });
+});
+
+describe("the keyboard", () => {
+  it("drops the previous choice when the list changes under it", async () => {
+    // AppDialog accepts on plain Enter from a single-line input, and a search
+    // field is one — so Enter in the search box both searches and reaches the
+    // dialog's accept. What stops that confirming a tile the reader has stopped
+    // looking at is the reload dropping the choice, not the key.
+    const w = await mountPicker();
+    await w.findAll(".pp-cell")[0].trigger("click");
+    expect(w.findAll(".pp-cell--on")).toHaveLength(1);
+
+    await w.find(".pp-search input").setValue("red dress");
+    await w.find(".pp-search input").trigger("keydown", { key: "Enter" });
+    await flush(w);
+
+    expect(searchPictures).toHaveBeenCalled();
+    expect(w.findAll(".pp-cell--on")).toHaveLength(0);
+    expect(w.emitted("pick")).toBeFalsy();
+  });
+});
+
+describe("paste", () => {
+  function pasteEvent(file) {
+    const event = new Event("paste");
+    event.clipboardData = {
+      items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+    };
+    return event;
+  }
+
+  it("says the picture is being filed, rather than filing it in silence", async () => {
+    const w = await mountPicker();
+    window.dispatchEvent(
+      pasteEvent(new File(["x"], "shot.png", { type: "image/png" })),
+    );
+    await flush(w);
+    expect(useNoticeStore().notices.at(-1).text).toMatch(/Importing the pasted/);
+    w.unmount();
+  });
+
+  it("reloads once the import finishes, so what was pasted is selectable", async () => {
+    const w = await mountPicker();
+    const tasks = useTasksStore();
+    window.dispatchEvent(
+      pasteEvent(new File(["x"], "shot.png", { type: "image/png" })),
+    );
+    await flush(w);
+
+    const before = streamPictures.mock.calls.length;
+    tasks.setImportRun("run-1", { status: "running" });
+    await flush(w);
+    expect(streamPictures.mock.calls.length).toBe(before);
+
+    streamPictures.mockResolvedValue(batch([42, 1, 2, 3]));
+    tasks.clearImportRun("run-1");
+    await flush(w);
+    expect(streamPictures.mock.calls.length).toBeGreaterThan(before);
+    expect(w.findAll(".pp-cell")).toHaveLength(4);
+    w.unmount();
+  });
+
+  it("leaves a paste into the search field alone — that is a search", async () => {
+    const w = await mountPicker();
+    const event = pasteEvent(new File(["x"], "shot.png", { type: "image/png" }));
+    Object.defineProperty(event, "target", {
+      value: w.find(".pp-search input").element,
+    });
+    window.dispatchEvent(event);
+    await flush(w);
+    expect(useNoticeStore().notices).toHaveLength(0);
+    w.unmount();
+  });
+});

--- a/frontend/src/components/widgets/PicturePicker.test.js
+++ b/frontend/src/components/widgets/PicturePicker.test.js
@@ -28,33 +28,25 @@ vi.mock("../../api/pictures", () => ({
 
 // The picker reads the shared entity lists rather than inventing its own
 // grouping, so the doubles go in at the api layer the store fetches from.
+const listCharacters = vi.fn();
+const listPictureSets = vi.fn();
+const listProjects = vi.fn();
 vi.mock("../../api/characters", () => ({
-  listCharacters: vi.fn().mockResolvedValue([
-    { id: 7, name: "Clementine", image_count: 1029 },
-    { id: 8, name: "Sarah", image_count: 160 },
-  ]),
+  listCharacters: (...a) => listCharacters(...a),
 }));
 vi.mock("../../api/pictureSets", () => ({
-  listPictureSets: vi.fn().mockResolvedValue([
-    { id: 3, name: "Good detail", picture_count: 97 },
-    // A reference set is machinery, not a grouping anyone chose: the sidebar
-    // hides it and so does this.
-    { id: 4, name: "ref", picture_count: 5, reference_character: 7 },
-  ]),
+  listPictureSets: (...a) => listPictureSets(...a),
 }));
 vi.mock("../../api/projects", () => ({
-  listProjects: vi.fn().mockResolvedValue([
-    { id: 2, name: "Personal", image_count: 9118 },
-  ]),
+  listProjects: (...a) => listProjects(...a),
 }));
 
 import PicturePicker from "./PicturePicker.vue";
-import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 
 function batch(ids, { done = true } = {}) {
   return {
-    pictures: ids.map((id) => ({ id, file_name: `p${id}.png` })),
+    pictures: ids.map((id) => ({ id, file_path: `/pics/p${id}.png` })),
     done,
     next_offset: ids.length,
   };
@@ -83,8 +75,21 @@ async function flush(w) {
 beforeEach(() => {
   setActivePinia(createPinia());
   streamPictures.mockReset().mockResolvedValue(batch([1, 2, 3]));
-  searchPictures.mockReset().mockResolvedValue([{ id: 9, file_name: "p9.png" }]);
+  searchPictures.mockReset().mockResolvedValue([{ id: 9, file_path: "/p/p9.png" }]);
   getPictureCount.mockReset().mockResolvedValue({ count: 28172 });
+  listCharacters.mockReset().mockResolvedValue([
+    { id: 7, name: "Clementine", image_count: 1029 },
+    { id: 8, name: "Sarah", image_count: 160 },
+  ]);
+  listPictureSets.mockReset().mockResolvedValue([
+    { id: 3, name: "Good detail", picture_count: 97 },
+    // A reference set is machinery, not a grouping anyone chose: the sidebar
+    // hides it and so does this.
+    { id: 4, name: "ref", picture_count: 5, reference_character: 7 },
+  ]);
+  listProjects
+    .mockReset()
+    .mockResolvedValue([{ id: 2, name: "Personal", image_count: 9118 }]);
 });
 
 describe("the facets", () => {
@@ -177,34 +182,16 @@ describe("the keyboard", () => {
   });
 });
 
-describe("paste", () => {
-  function pasteEvent(file) {
-    const event = new Event("paste");
-    event.clipboardData = {
-      items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
-    };
-    return event;
-  }
-
-  it("says the picture is being filed, rather than filing it in silence", async () => {
-    const w = await mountPicker();
-    window.dispatchEvent(
-      pasteEvent(new File(["x"], "shot.png", { type: "image/png" })),
-    );
-    await flush(w);
-    expect(useNoticeStore().notices.at(-1).text).toMatch(/Importing the pasted/);
-    w.unmount();
-  });
-
-  it("reloads once the import finishes, so what was pasted is selectable", async () => {
+describe("an import finishing while the picker is open", () => {
+  it("re-reads the list, so what was just pasted is selectable", async () => {
+    // The picker does not handle the paste and says nothing about it — the
+    // window importer and `ImageImporter` own that, and announce it from
+    // inside the import where the truth is. What IS this component's business
+    // is that the result becomes selectable without reopening the dialog.
     const w = await mountPicker();
     const tasks = useTasksStore();
-    window.dispatchEvent(
-      pasteEvent(new File(["x"], "shot.png", { type: "image/png" })),
-    );
-    await flush(w);
-
     const before = streamPictures.mock.calls.length;
+
     tasks.setImportRun("run-1", { status: "running" });
     await flush(w);
     expect(streamPictures.mock.calls.length).toBe(before);
@@ -217,15 +204,150 @@ describe("paste", () => {
     w.unmount();
   });
 
-  it("leaves a paste into the search field alone — that is a search", async () => {
+  it("does not throw away the facet, the search or the choice", async () => {
+    // An import finishing is not a reason to undo what the reader has been
+    // doing while they waited — and any import may be one they never started.
     const w = await mountPicker();
-    const event = pasteEvent(new File(["x"], "shot.png", { type: "image/png" }));
-    Object.defineProperty(event, "target", {
-      value: w.find(".pp-search input").element,
-    });
-    window.dispatchEvent(event);
+    const tasks = useTasksStore();
+    const clementine = w
+      .findAll(".pp-facet")
+      .find((b) => b.text().includes("Clementine"));
+    await clementine.trigger("click");
     await flush(w);
-    expect(useNoticeStore().notices).toHaveLength(0);
+    await w.findAll(".pp-cell")[0].trigger("click");
+
+    tasks.setImportRun("run-1", { status: "running" });
+    await flush(w);
+    tasks.clearImportRun("run-1");
+    await flush(w);
+
+    expect(lastStreamQuery().get("character_id")).toBe("7");
+    expect(w.findAll(".pp-cell--on")).toHaveLength(1);
     w.unmount();
+  });
+});
+
+describe("the ceilings, and saying so", () => {
+  it("cuts a runaway search and says it cut it", async () => {
+    // `/pictures/search` ignores `top_n` and defaults its limit to
+    // `sys.maxsize`, and this grid is not virtualised — so the cap is applied
+    // here, and a silent one would read as "that is all there is".
+    searchPictures.mockResolvedValue(
+      Array.from({ length: 500 }, (_, i) => ({ id: 1000 + i })),
+    );
+    const w = await mountPicker();
+    await w.find(".pp-search input").setValue("a");
+    await w.find(".pp-search input").trigger("keydown", { key: "Enter" });
+    await flush(w);
+
+    expect(w.findAll(".pp-cell")).toHaveLength(120);
+    expect(w.text()).toContain("Showing the first 120 matches");
+  });
+
+  it("appends the next batch rather than replacing the list", async () => {
+    streamPictures.mockResolvedValue(batch([1, 2, 3], { done: false }));
+    const w = await mountPicker();
+    expect(w.findAll(".pp-cell")).toHaveLength(3);
+
+    streamPictures.mockResolvedValue(batch([4, 5], { done: true }));
+    const more = w.findAll("button").find((b) => b.text().includes("Show more"));
+    await more.trigger("click");
+    await flush(w);
+
+    expect(w.findAll(".pp-cell")).toHaveLength(5);
+    expect(streamPictures.mock.calls.at(-1)[1].offset).toBe(3);
+    // Gone once the stream says there is nothing left.
+    expect(w.findAll("button").find((b) => b.text().includes("Show more"))).toBe(
+      undefined,
+    );
+  });
+
+  it("does not let a stale read overwrite the list the reader is on", async () => {
+    // The facet changed while the first read was still in flight. Its answer
+    // belongs to a scope nobody is looking at any more.
+    let releaseFirst;
+    streamPictures.mockImplementationOnce(
+      () => new Promise((r) => (releaseFirst = () => r(batch([1, 2, 3])))),
+    );
+    const w = mount(PicturePicker, { props: { open: true, subtitle: "x" } });
+    await flush(w);
+
+    streamPictures.mockResolvedValue(batch([9]));
+    const clementine = w
+      .findAll(".pp-facet")
+      .find((b) => b.text().includes("Clementine"));
+    await clementine.trigger("click");
+    await flush(w);
+    expect(w.findAll(".pp-cell")).toHaveLength(1);
+
+    releaseFirst();
+    await flush(w);
+    expect(w.findAll(".pp-cell")).toHaveLength(1);
+  });
+});
+
+describe("the facet rail's truncation", () => {
+  it("shows the top few and opens the rest on All N", async () => {
+    listCharacters.mockResolvedValue(
+      Array.from({ length: 17 }, (_, i) => ({
+        id: i + 1,
+        name: `Someone ${i + 1}`,
+        image_count: 100 - i,
+      })),
+    );
+    const w = await mountPicker();
+    const people = () =>
+      w.findAll(".pp-facet__label").filter((n) => n.text().startsWith("Someone"));
+    expect(people()).toHaveLength(3);
+
+    const all = w.findAll(".pp-more").find((b) => b.text().includes("All 17"));
+    expect(all).toBeDefined();
+    await all.trigger("click");
+    expect(people()).toHaveLength(17);
+  });
+});
+
+describe("a picture whose file cannot be reached", () => {
+  it("says so and refuses to be chosen", async () => {
+    // A thumbnail is generated FROM the file, so an unplugged drive 404s. An
+    // empty box that can still be clicked reads as one that has not loaded yet.
+    const w = await mountPicker();
+    await w.findAll(".pp-cell img")[0].trigger("error");
+    await flush(w);
+
+    const cell = w.findAll(".pp-cell")[0];
+    expect(cell.classes()).toContain("pp-cell--gone");
+    expect(cell.attributes("title")).toContain("not available");
+    await cell.trigger("click");
+    expect(w.findAll(".pp-cell--on")).toHaveLength(0);
+  });
+});
+
+describe("the grid's keyboard", () => {
+  it("is one tab stop, and Enter on a tile uses it", async () => {
+    // AppDialog exempts buttons from its Enter contract so native activation
+    // wins, so without the tile handling Enter itself the badge on
+    // `Use this picture` promises something the keyboard cannot do.
+    const w = await mountPicker();
+    const cells = () => w.findAll(".pp-cell");
+    expect(cells().map((c) => c.attributes("tabindex"))).toEqual([
+      "0",
+      "-1",
+      "-1",
+    ]);
+
+    await cells()[1].trigger("keydown", { key: "ArrowRight" });
+    await flush(w);
+    expect(cells()[2].classes()).toContain("pp-cell--on");
+    // The tab stop follows the choice, so Tab returns to where the reader was.
+    expect(cells().map((c) => c.attributes("tabindex"))).toEqual([
+      "-1",
+      "-1",
+      "0",
+    ]);
+
+    await cells()[2].trigger("keydown", { key: "Enter" });
+    expect(w.emitted("pick")).toHaveLength(1);
+    expect(w.emitted("pick")[0][0].id).toBe(3);
   });
 });

--- a/frontend/src/components/widgets/PicturePicker.vue
+++ b/frontend/src/components/widgets/PicturePicker.vue
@@ -1,0 +1,575 @@
+<template>
+  <AppDialog
+    :open="open"
+    title="Choose a picture"
+    :subtitle="subtitle"
+    :width="820"
+    :pad-body="false"
+    @close="emit('close')"
+    @accept="use"
+  >
+    <div class="pp">
+      <!-- The facets are the groupings the vault ALREADY stores. Nothing new is
+           invented to describe a picture: the brand mark lives in a project,
+           the face lives on a character, the style plates live in a set. Free
+           search below is the escape hatch, not the primary route. -->
+      <nav class="pp-rail" aria-label="Narrow the pictures">
+        <div class="pp-sec">Project</div>
+        <button
+          type="button"
+          class="pp-facet"
+          :class="{ 'pp-facet--on': !facet.kind }"
+          :aria-pressed="!facet.kind"
+          @click="choose('', null)"
+        >
+          <span class="pp-facet__label">Everything</span>
+          <span v-if="totalCount != null" class="pp-facet__count">{{
+            groupedNumber(totalCount)
+          }}</span>
+        </button>
+        <button
+          v-for="p in projectFacets"
+          :key="`project-${p.id}`"
+          type="button"
+          class="pp-facet"
+          :class="{ 'pp-facet--on': isOn('project', p.id) }"
+          :aria-pressed="isOn('project', p.id)"
+          @click="choose('project', p.id)"
+        >
+          <span class="pp-facet__label">{{ p.name }}</span>
+          <span class="pp-facet__count">{{ groupedNumber(p.count) }}</span>
+        </button>
+
+        <template v-for="group in ['character', 'set']" :key="group">
+          <div class="pp-sec">
+            {{ group === "character" ? "Character" : "Picture set" }}
+          </div>
+          <button
+            v-for="row in shown(group)"
+            :key="`${group}-${row.id}`"
+            type="button"
+            class="pp-facet"
+            :class="{ 'pp-facet--on': isOn(group, row.id) }"
+            :aria-pressed="isOn(group, row.id)"
+            @click="choose(group, row.id)"
+          >
+            <span class="pp-facet__label">{{ row.name }}</span>
+            <span class="pp-facet__count">{{ groupedNumber(row.count) }}</span>
+          </button>
+          <button
+            v-if="facets[group].length > shown(group).length"
+            type="button"
+            class="pp-more"
+            @click="expanded[group] = true"
+          >
+            All {{ facets[group].length }} &rsaquo;
+          </button>
+        </template>
+      </nav>
+
+      <div class="pp-main">
+        <div class="pp-head">
+          <AppInput
+            v-model="search"
+            class="pp-search"
+            icon="magnify"
+            placeholder="Search this library"
+            @enter="reload"
+          />
+          <!-- Paste is a real route in, and it IMPORTS: a screenshot that was
+               never imported cannot be chosen, because everything downstream of
+               this picker names a picture by its id. The app's window-level
+               paste handler does the import; this says so at the moment of
+               pasting rather than surprising someone later with a picture they
+               did not know they filed, and reloads the list when it lands. -->
+          <span class="pp-paste">
+            or press <kbd>Ctrl</kbd><kbd>V</kbd>
+          </span>
+        </div>
+
+        <div class="pp-scroll">
+          <p v-if="error" class="pp-note pp-note--error">{{ error }}</p>
+          <p v-else-if="loading && !pictures.length" class="pp-note">
+            Loading pictures…
+          </p>
+          <p v-else-if="!pictures.length" class="pp-note">
+            No pictures here. Try another grouping, search, or paste one in.
+          </p>
+          <div v-else class="pp-grid">
+            <button
+              v-for="pic in pictures"
+              :key="pic.id"
+              type="button"
+              class="pp-cell"
+              :class="{ 'pp-cell--on': chosen?.id === pic.id }"
+              :aria-pressed="chosen?.id === pic.id"
+              :title="tileName(pic)"
+              @click="chosen = pic"
+              @dblclick="use"
+            >
+              <img
+                :src="thumbUrl(pic)"
+                alt=""
+                loading="lazy"
+                decoding="async"
+              />
+            </button>
+          </div>
+          <div v-if="pictures.length && !done" class="pp-more-row">
+            <AppButton
+              variant="secondary"
+              size="sm"
+              :loading="loading"
+              @click="loadMore"
+              >Show more</AppButton
+            >
+          </div>
+        </div>
+
+        <div class="pp-foot">
+          <span class="pp-chosen">{{ chosen ? "1 chosen" : "None chosen" }}</span>
+          <span class="pp-spacer"></span>
+          <!-- Where a caller puts the route this picker deliberately does not
+               replace. The model shelf keeps "Choose a file…" here: removing a
+               shipped way of doing the job is a regression, and the point of
+               this step is to prove the picker without taking anything away. -->
+          <slot name="footer-start" />
+          <AppButton variant="secondary" key-hint="esc" @click="emit('close')"
+            >Cancel</AppButton
+          >
+          <AppButton
+            variant="primary"
+            key-hint="enter"
+            :disabled="!chosen"
+            @click="use"
+            >Use this picture</AppButton
+          >
+        </div>
+      </div>
+    </div>
+  </AppDialog>
+</template>
+
+<script setup>
+// One picker, faceted by project, character and picture set, single-select.
+//
+// SINGLE-SELECT ON PURPOSE. Every caller needs exactly one picture — a model's
+// thumbnail, a workflow's fixed input, a run-time answer — and multi-select
+// would be built on the argument that something might want it one day.
+//
+// Design: the `Picker` artboard of the 1.11 Workflow Library canvas. Facet rail
+// left, search + grid right, receipt + verbs in the footer.
+
+import { computed, onUnmounted, reactive, ref, watch } from "vue";
+import AppButton from "./AppButton.vue";
+import AppDialog from "./AppDialog.vue";
+import AppInput from "./AppInput.vue";
+import {
+  getPictureCount,
+  pictureThumbnailUrl,
+  searchPictures,
+  streamPictures,
+} from "../../api/pictures";
+import { isSupportedImportFile } from "../../utils/media.js";
+import { errorDetail } from "../../utils/apiError";
+import { useEntityListsStore } from "../../stores/useEntityListsStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useTasksStore } from "../../stores/useTasksStore";
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  // What the picture is FOR, said in the caller's own words ("for Reference",
+  // "for Flux Realism"). The title never changes; this does.
+  subtitle: { type: String, default: "" },
+});
+
+const emit = defineEmits(["close", "pick"]);
+
+// One batch is a screenful several times over. The rail and the search are how
+// a 28k-picture library is narrowed; paging is the honest fallback, never the
+// route, which is why `Show more` is a button rather than an infinite scroll.
+const BATCH = 120;
+// How many rows of a facet group are shown before `All N ›`. Three is the
+// artboard's count and is enough to show what the group is.
+const FACET_PREVIEW = 3;
+
+const entityLists = useEntityListsStore();
+const notices = useNoticeStore();
+const tasks = useTasksStore();
+
+const facet = reactive({ kind: "", id: null });
+const expanded = reactive({ character: false, set: false });
+const search = ref("");
+const pictures = ref([]);
+const chosen = ref(null);
+const loading = ref(false);
+const error = ref("");
+const done = ref(true);
+const nextOffset = ref(0);
+const totalCount = ref(null);
+
+// A request that was in flight when the facet changed must not overwrite the
+// list the reader is now looking at.
+let loadSeq = 0;
+
+const facets = computed(() => ({
+  character: entityLists.characters
+    .map((c) => ({ id: c.id, name: c.name, count: c.image_count ?? 0 }))
+    .sort((a, b) => b.count - a.count),
+  set: entityLists.pictureSets
+    .filter((s) => !s.reference_character)
+    .map((s) => ({ id: s.id, name: s.name, count: s.picture_count ?? 0 }))
+    .sort((a, b) => b.count - a.count),
+}));
+
+const projectFacets = computed(() =>
+  entityLists.projects
+    .map((p) => ({ id: p.id, name: p.name, count: p.image_count ?? 0 }))
+    .sort((a, b) => b.count - a.count),
+);
+
+function shown(group) {
+  const rows = facets.value[group];
+  return expanded[group] ? rows : rows.slice(0, FACET_PREVIEW);
+}
+
+function isOn(kind, id) {
+  return facet.kind === kind && facet.id === id;
+}
+
+/** Thin space between thousands, as the counts are drawn on the artboard. */
+function groupedNumber(n) {
+  return Number(n || 0).toLocaleString("en-GB").replace(/,/g, " ");
+}
+
+function thumbUrl(pic) {
+  return pictureThumbnailUrl(pic.id);
+}
+
+/** What to call a tile in its tooltip: the file's own name, never its path. */
+function tileName(pic) {
+  const path = pic.file_path || "";
+  const name = path.split(/[\\/]/).pop();
+  return name || `Picture ${pic.id}`;
+}
+
+function choose(kind, id) {
+  facet.kind = kind;
+  facet.id = id;
+  reload();
+}
+
+/** The facet as listing query params, shared by the stream and the search. */
+function scopeParams() {
+  const params = new URLSearchParams();
+  if (facet.kind === "project") params.set("project_id", String(facet.id));
+  if (facet.kind === "character") params.set("character_id", String(facet.id));
+  if (facet.kind === "set") params.set("set_id", String(facet.id));
+  return params;
+}
+
+async function load({ append = false } = {}) {
+  const seq = ++loadSeq;
+  loading.value = true;
+  error.value = "";
+  try {
+    const text = search.value.trim();
+    if (text) {
+      // Search answers in one shot, so there is nothing to page through.
+      const rows = await searchPictures(text, { query: scopeParams().toString() });
+      if (seq !== loadSeq) return;
+      pictures.value = Array.isArray(rows) ? rows : [];
+      done.value = true;
+      nextOffset.value = 0;
+      return;
+    }
+    const params = scopeParams();
+    // `grid` rather than `grid_lite`: the lite projection drops `file_path`,
+    // and the file's own name is the only thing on a tile that tells two
+    // near-identical thumbnails apart.
+    params.set("fields", "grid");
+    params.set("sort", "DATE");
+    params.set("descending", "true");
+    const batch = await streamPictures(params.toString(), {
+      offset: append ? nextOffset.value : 0,
+      batchLimit: BATCH,
+    });
+    if (seq !== loadSeq) return;
+    const rows = Array.isArray(batch?.pictures) ? batch.pictures : [];
+    pictures.value = append ? [...pictures.value, ...rows] : rows;
+    done.value = Boolean(batch?.done);
+    nextOffset.value = Number(batch?.next_offset) || 0;
+  } catch (err) {
+    if (seq !== loadSeq) return;
+    error.value = errorDetail(err) || "Could not read the library.";
+  } finally {
+    if (seq === loadSeq) loading.value = false;
+  }
+}
+
+function reload() {
+  chosen.value = null;
+  load();
+}
+
+function loadMore() {
+  load({ append: true });
+}
+
+function use() {
+  if (!chosen.value) return;
+  emit("pick", chosen.value);
+}
+
+// ── Paste ───────────────────────────────────────────────────────────────────
+//
+// The import itself is the app's, not this component's: `useWindowFileImport`
+// already claims a pasted image anywhere in the window and runs it through the
+// staging session. Re-implementing that here would be a second import path to
+// keep correct. What is missing is the part this picker owes the reader — being
+// told the paste FILED something, and finding it selectable straight after —
+// and that is all this adds.
+
+const awaitingPaste = ref(false);
+
+function onPaste(event) {
+  // A paste into the search field is a search, not an import — and the window
+  // importer skips editable targets for the same reason.
+  const target = event.target;
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target?.isContentEditable
+  ) {
+    return;
+  }
+  const files = Array.from(event.clipboardData?.items || [])
+    .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+    .map((item) => item.getAsFile())
+    .filter((file) => file && isSupportedImportFile(file));
+  if (!files.length) return;
+  awaitingPaste.value = true;
+  notices.push({
+    level: "info",
+    text:
+      files.length === 1
+        ? "Importing the pasted picture into your library — it will appear here when it lands."
+        : `Importing ${files.length} pasted pictures into your library — they will appear here when they land.`,
+  });
+}
+
+const importsRunning = computed(() => Object.keys(tasks.importRuns).length);
+
+watch(importsRunning, (now, before) => {
+  if (!awaitingPaste.value || now !== 0 || !before) return;
+  awaitingPaste.value = false;
+  // Newest first, so what was just pasted is the first tile.
+  facet.kind = "";
+  facet.id = null;
+  search.value = "";
+  reload();
+});
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      facet.kind = "";
+      facet.id = null;
+      search.value = "";
+      chosen.value = null;
+      expanded.character = false;
+      expanded.set = false;
+      awaitingPaste.value = false;
+      entityLists.refresh("characters");
+      entityLists.refresh("sets");
+      if (entityLists.canSeeProjects) entityLists.refresh("projects");
+      getPictureCount()
+        .then((body) => {
+          totalCount.value = Number(body?.count);
+        })
+        .catch((err) => {
+          // A missing headline count is cosmetic: the rail still narrows and
+          // the grid still fills. Logged rather than surfaced.
+          console.warn("[PicturePicker] could not read the library count", err);
+          totalCount.value = null;
+        });
+      load();
+      window.addEventListener("paste", onPaste);
+    } else {
+      window.removeEventListener("paste", onPaste);
+    }
+  },
+  { immediate: true },
+);
+
+// The listener is added on open and removed on close, so a component unmounted
+// while still open would leave one behind on `window` for the life of the tab —
+// and it holds this instance's notice store and refs.
+onUnmounted(() => window.removeEventListener("paste", onPaste));
+</script>
+
+<style scoped>
+.pp {
+  display: flex;
+  min-height: 0;
+  height: min(660px, 70vh);
+}
+
+.pp-rail {
+  width: 210px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: var(--space-3);
+  border-right: 1px solid rgb(var(--v-theme-divider));
+}
+
+.pp-sec {
+  padding: var(--space-4) var(--space-3) var(--space-2);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-sec:first-child {
+  padding-top: var(--space-2);
+}
+
+.pp-facet,
+.pp-more {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 30px;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  font: inherit;
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.pp-facet:hover,
+.pp-more:hover {
+  background: var(--hover-wash);
+}
+.pp-facet--on {
+  background: var(--active-wash);
+  color: var(--active-text);
+  font-weight: var(--weight-medium);
+}
+.pp-facet__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pp-facet__count {
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-more {
+  font-size: var(--text-2xs);
+  color: rgb(var(--v-theme-accent));
+}
+
+.pp-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pp-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid rgb(var(--v-theme-divider));
+}
+.pp-search {
+  flex: 1;
+}
+.pp-paste {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  white-space: nowrap;
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-paste kbd {
+  padding: 3px 5px;
+  border: 1px solid rgb(var(--v-theme-border));
+  border-radius: var(--radius-sm);
+  background: rgb(var(--v-theme-input-background));
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+}
+
+.pp-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5);
+}
+.pp-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: var(--space-3);
+}
+.pp-cell {
+  aspect-ratio: 1 / 1;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: rgb(var(--v-theme-input-background));
+  overflow: hidden;
+  cursor: pointer;
+}
+.pp-cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.pp-cell--on {
+  box-shadow: 0 0 0 2px var(--active-bar);
+}
+.pp-cell:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.pp-note {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-note--error {
+  color: rgb(var(--v-theme-error));
+}
+.pp-more-row {
+  display: flex;
+  justify-content: center;
+  padding-top: var(--space-5);
+}
+
+.pp-foot {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  border-top: 1px solid rgb(var(--v-theme-divider));
+}
+.pp-chosen {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-spacer {
+  flex: 1;
+}
+</style>

--- a/frontend/src/components/widgets/PicturePicker.vue
+++ b/frontend/src/components/widgets/PicturePicker.vue
@@ -79,10 +79,11 @@
           />
           <!-- Paste is a real route in, and it IMPORTS: a screenshot that was
                never imported cannot be chosen, because everything downstream of
-               this picker names a picture by its id. The app's window-level
-               paste handler does the import; this says so at the moment of
-               pasting rather than surprising someone later with a picture they
-               did not know they filed, and reloads the list when it lands. -->
+               this picker names a picture by its id. The affordance is all this
+               component contributes — the window-level paste handler runs the
+               import and `ImageImporter` announces it from inside, which is the
+               only place that knows whether it happened. See the Paste note in
+               the script block for why announcing it from here was removed. -->
           <span class="pp-paste">
             or press <kbd>Ctrl</kbd><kbd>V</kbd>
           </span>
@@ -121,7 +122,7 @@
               :tabindex="i === tabStop ? 0 : -1"
               :title="tileTitle(pic)"
               @click="pick(pic)"
-              @dblclick="use"
+              @dblclick="useTile(pic)"
               @keydown="onCellKeydown($event, i)"
             >
               <img
@@ -375,11 +376,26 @@ function loadMore() {
   load({ append: true });
 }
 
+/**
+ * Choose a tile, if it can be chosen at all.
+ *
+ * @returns {boolean} whether the choice landed — which the two "choose it AND
+ *   take it" gestures below have to ask, or a refused tile falls through to
+ *   `use()` and accepts whatever was chosen BEFORE it. That is the worst
+ *   possible outcome for a refusal: silent, and a picture the reader did not
+ *   point at.
+ */
 function pick(pic) {
   // An unreachable file cannot become a thumbnail, so it cannot be chosen
   // either — the tile says why rather than failing after the dialog has shut.
-  if (unavailable.value.has(pic.id)) return;
+  if (!pic || unavailable.value.has(pic.id)) return false;
   chosen.value = pic;
+  return true;
+}
+
+/** Double-click, and Enter: choose this one and take it, or do neither. */
+function useTile(pic) {
+  if (pick(pic)) use();
 }
 
 function use() {
@@ -417,8 +433,7 @@ function onCellKeydown(event, index) {
   // it matters in cannot keep.
   if (event.key === "Enter") {
     event.preventDefault();
-    pick(pictures.value[index]);
-    use();
+    useTile(pictures.value[index]);
     return;
   }
   const step = { ArrowRight: 1, ArrowLeft: -1, ArrowDown: COLUMNS, ArrowUp: -COLUMNS }[

--- a/frontend/src/components/widgets/PicturePicker.vue
+++ b/frontend/src/components/widgets/PicturePicker.vue
@@ -70,6 +70,7 @@
       <div class="pp-main">
         <div class="pp-head">
           <AppInput
+            ref="searchRef"
             v-model="search"
             class="pp-search"
             icon="magnify"
@@ -88,33 +89,62 @@
         </div>
 
         <div class="pp-scroll">
-          <p v-if="error" class="pp-note pp-note--error">{{ error }}</p>
-          <p v-else-if="loading && !pictures.length" class="pp-note">
-            Loading pictures…
+          <!-- One live region for all three, so a reader who cannot see the
+               grid fill is told that it did, that it did not, or that it
+               failed. -->
+          <p
+            v-if="error || loading || !pictures.length"
+            class="pp-note"
+            :class="{ 'pp-note--error': error }"
+            role="status"
+          >
+            {{
+              error ||
+              (loading
+                ? "Loading pictures…"
+                : "No pictures here. Try another grouping, search, or paste one in.")
+            }}
           </p>
-          <p v-else-if="!pictures.length" class="pp-note">
-            No pictures here. Try another grouping, search, or paste one in.
-          </p>
-          <div v-else class="pp-grid">
+          <div v-if="pictures.length" class="pp-grid">
             <button
-              v-for="pic in pictures"
+              v-for="(pic, i) in pictures"
               :key="pic.id"
+              :ref="(el) => (cellRefs[i] = el)"
               type="button"
               class="pp-cell"
-              :class="{ 'pp-cell--on': chosen?.id === pic.id }"
+              :class="{
+                'pp-cell--on': chosen?.id === pic.id,
+                'pp-cell--gone': unavailable.has(pic.id),
+              }"
               :aria-pressed="chosen?.id === pic.id"
-              :title="tileName(pic)"
-              @click="chosen = pic"
+              :aria-disabled="unavailable.has(pic.id) || undefined"
+              :tabindex="i === tabStop ? 0 : -1"
+              :title="tileTitle(pic)"
+              @click="pick(pic)"
               @dblclick="use"
+              @keydown="onCellKeydown($event, i)"
             >
               <img
+                v-if="!unavailable.has(pic.id)"
                 :src="thumbUrl(pic)"
                 alt=""
                 loading="lazy"
                 decoding="async"
+                @error="unavailable.add(pic.id)"
               />
+              <!-- Not an empty box: a picture whose file the server cannot
+                   reach — an unplugged drive, the state this very shelf models
+                   — has to say so, or it reads as a thumbnail that has not
+                   loaded yet and invites a click that cannot work. -->
+              <span v-else class="pp-gone">
+                <v-icon size="18">mdi-image-off-outline</v-icon>
+              </span>
             </button>
           </div>
+          <p v-if="capped" class="pp-note pp-note--after" role="status">
+            Showing the first {{ SEARCH_CAP }} matches. Narrow it with a
+            grouping, or search for something more particular.
+          </p>
           <div v-if="pictures.length && !done" class="pp-more-row">
             <AppButton
               variant="secondary"
@@ -160,7 +190,7 @@
 // Design: the `Picker` artboard of the 1.11 Workflow Library canvas. Facet rail
 // left, search + grid right, receipt + verbs in the footer.
 
-import { computed, onUnmounted, reactive, ref, watch } from "vue";
+import { computed, nextTick, reactive, ref, watch } from "vue";
 import AppButton from "./AppButton.vue";
 import AppDialog from "./AppDialog.vue";
 import AppInput from "./AppInput.vue";
@@ -170,10 +200,8 @@ import {
   searchPictures,
   streamPictures,
 } from "../../api/pictures";
-import { isSupportedImportFile } from "../../utils/media.js";
 import { errorDetail } from "../../utils/apiError";
 import { useEntityListsStore } from "../../stores/useEntityListsStore";
-import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 
 const props = defineProps({
@@ -189,14 +217,24 @@ const emit = defineEmits(["close", "pick"]);
 // a 28k-picture library is narrowed; paging is the honest fallback, never the
 // route, which is why `Show more` is a button rather than an infinite scroll.
 const BATCH = 120;
+// The same ceiling for search, which needs one imposed HERE: `GET
+// /pictures/search` ignores `top_n` and defaults its `limit` to `sys.maxsize`,
+// so a loose query answers with every match above the similarity threshold and
+// this grid is not virtualised. Cut, and SAID (see `capped` below) — a silent
+// truncation reads as "that is all there is".
+const SEARCH_CAP = 120;
 // How many rows of a facet group are shown before `All N ›`. Three is the
 // artboard's count and is enough to show what the group is.
 const FACET_PREVIEW = 3;
+// Columns in the tile grid. The arrow keys need the number the CSS is using,
+// and `auto-fill` will not tell them, so the grid is held at a fixed count and
+// the tiles flex instead — which is also what the artboard draws.
+const COLUMNS = 5;
 
 const entityLists = useEntityListsStore();
-const notices = useNoticeStore();
 const tasks = useTasksStore();
 
+const searchRef = ref(null);
 const facet = reactive({ kind: "", id: null });
 const expanded = reactive({ character: false, set: false });
 const search = ref("");
@@ -207,9 +245,17 @@ const error = ref("");
 const done = ref(true);
 const nextOffset = ref(0);
 const totalCount = ref(null);
+// True when a search returned more than `SEARCH_CAP` and the tail was dropped.
+const capped = ref(false);
+// Picture ids whose thumbnail would not load. A thumbnail is generated on
+// demand, but only for a file the server can still reach and decode — an
+// unplugged drive is a state this app models, so a tile has to be able to say
+// "not available" rather than draw an empty box that can still be chosen.
+const unavailable = ref(new Set());
 
 // A request that was in flight when the facet changed must not overwrite the
-// list the reader is now looking at.
+// list the reader is now looking at. Asserted in the suite by resolving two
+// reads out of order.
 let loadSeq = 0;
 
 const facets = computed(() => ({
@@ -237,7 +283,7 @@ function isOn(kind, id) {
   return facet.kind === kind && facet.id === id;
 }
 
-/** Thin space between thousands, as the counts are drawn on the artboard. */
+/** A facet count, grouped the way every other count in the app is. */
 function groupedNumber(n) {
   return Number(n || 0).toLocaleString("en-GB").replace(/,/g, " ");
 }
@@ -251,6 +297,13 @@ function tileName(pic) {
   const path = pic.file_path || "";
   const name = path.split(/[\\/]/).pop();
   return name || `Picture ${pic.id}`;
+}
+
+/** The tile's accessible name, which has to carry the unavailable state too. */
+function tileTitle(pic) {
+  return unavailable.value.has(pic.id)
+    ? `${tileName(pic)} — not available`
+    : tileName(pic);
 }
 
 function choose(kind, id) {
@@ -275,19 +328,24 @@ async function load({ append = false } = {}) {
   try {
     const text = search.value.trim();
     if (text) {
-      // Search answers in one shot, so there is nothing to page through.
+      // Search answers in one shot, so there is nothing to page through — and
+      // no ceiling on the way back either, so one is applied here.
       const rows = await searchPictures(text, { query: scopeParams().toString() });
       if (seq !== loadSeq) return;
-      pictures.value = Array.isArray(rows) ? rows : [];
+      const all = Array.isArray(rows) ? rows : [];
+      capped.value = all.length > SEARCH_CAP;
+      pictures.value = all.slice(0, SEARCH_CAP);
       done.value = true;
       nextOffset.value = 0;
       return;
     }
     const params = scopeParams();
-    // `grid` rather than `grid_lite`: the lite projection drops `file_path`,
-    // and the file's own name is the only thing on a tile that tells two
-    // near-identical thumbnails apart.
-    params.set("fields", "grid");
+    // An explicit projection rather than `fields=grid`, which the route reads
+    // as "this is the picture grid" and silently forces `stack_leaders_only`
+    // (`_listing.py`) — a picker that cannot offer a stacked variant, with
+    // nothing on screen saying so, and a list that would then disagree with
+    // what the same query returns through search.
+    params.set("fields", "id,file_path");
     params.set("sort", "DATE");
     params.set("descending", "true");
     const batch = await streamPictures(params.toString(), {
@@ -296,6 +354,7 @@ async function load({ append = false } = {}) {
     });
     if (seq !== loadSeq) return;
     const rows = Array.isArray(batch?.pictures) ? batch.pictures : [];
+    capped.value = false;
     pictures.value = append ? [...pictures.value, ...rows] : rows;
     done.value = Boolean(batch?.done);
     nextOffset.value = Number(batch?.next_offset) || 0;
@@ -316,108 +375,139 @@ function loadMore() {
   load({ append: true });
 }
 
+function pick(pic) {
+  // An unreachable file cannot become a thumbnail, so it cannot be chosen
+  // either — the tile says why rather than failing after the dialog has shut.
+  if (unavailable.value.has(pic.id)) return;
+  chosen.value = pic;
+}
+
 function use() {
   if (!chosen.value) return;
   emit("pick", chosen.value);
 }
 
-// ── Paste ───────────────────────────────────────────────────────────────────
+// ── The grid's keyboard ─────────────────────────────────────────────────────
 //
-// The import itself is the app's, not this component's: `useWindowFileImport`
-// already claims a pasted image anywhere in the window and runs it through the
-// staging session. Re-implementing that here would be a second import path to
-// keep correct. What is missing is the part this picker owes the reader — being
-// told the paste FILED something, and finding it selectable straight after —
-// and that is all this adds.
+// One tab stop for the whole grid and the arrows move inside it (the listbox
+// pattern the app already uses in `DedupPictureStrip`). Without it a 120-tile
+// grid is 120 tab stops between the search field and the footer verbs, which
+// makes the keyboard route to `Use this picture` unusable — and it is the route
+// the ↵ badge on that button promises.
 
-const awaitingPaste = ref(false);
+const cellRefs = ref([]);
 
-function onPaste(event) {
-  // A paste into the search field is a search, not an import — and the window
-  // importer skips editable targets for the same reason.
-  const target = event.target;
-  if (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target?.isContentEditable
-  ) {
+const tabStop = computed(() => {
+  const at = pictures.value.findIndex((p) => p.id === chosen.value?.id);
+  return at >= 0 ? at : 0;
+});
+
+function focusCell(index) {
+  const clamped = Math.max(0, Math.min(pictures.value.length - 1, index));
+  const pic = pictures.value[clamped];
+  if (!pic) return;
+  chosen.value = unavailable.value.has(pic.id) ? chosen.value : pic;
+  nextTick(() => cellRefs.value[clamped]?.focus());
+}
+
+function onCellKeydown(event, index) {
+  // Enter on a tile ACCEPTS. A tile is a `<button>`, and `AppDialog` exempts
+  // buttons from its Enter contract precisely so native activation wins — so
+  // without this the ↵ badge on `Use this picture` is a promise the one state
+  // it matters in cannot keep.
+  if (event.key === "Enter") {
+    event.preventDefault();
+    pick(pictures.value[index]);
+    use();
     return;
   }
-  const files = Array.from(event.clipboardData?.items || [])
-    .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
-    .map((item) => item.getAsFile())
-    .filter((file) => file && isSupportedImportFile(file));
-  if (!files.length) return;
-  awaitingPaste.value = true;
-  notices.push({
-    level: "info",
-    text:
-      files.length === 1
-        ? "Importing the pasted picture into your library — it will appear here when it lands."
-        : `Importing ${files.length} pasted pictures into your library — they will appear here when they land.`,
-  });
+  const step = { ArrowRight: 1, ArrowLeft: -1, ArrowDown: COLUMNS, ArrowUp: -COLUMNS }[
+    event.key
+  ];
+  if (step === undefined) return;
+  event.preventDefault();
+  focusCell(index + step);
 }
+
+// ── Paste ───────────────────────────────────────────────────────────────────
+//
+// **This component does not handle the paste, and deliberately says nothing
+// about it.** `useWindowFileImport` already claims a pasted image anywhere in
+// the window, and `ImageImporter` — the thing it hands off to — is what
+// announces the import, from inside the import, where the truth is: it opens
+// its own progress dialog on the same keystroke, counts the files, and reports
+// the buckets at the end. A second announcement from here could only ever be a
+// guess, and it guessed wrong in three ways worth writing down, because they
+// are the reason this is subtraction rather than a fix:
+//
+//   * `startImport` refuses outright while another import is running, and
+//     refuses again under a read-only token — so a picker that announced
+//     "importing your pasted picture" said so about nothing at all;
+//   * neither refusal ever registers a run, so a flag armed on paste and
+//     disarmed on the run finishing stayed armed for the life of the dialog;
+//   * the window importer takes video as well as images, so a filter of this
+//     component's own reported one paste and stayed silent on another.
+//
+// What is left is the half that IS this component's business: what was pasted
+// has to become selectable without reopening the dialog. So the list is
+// re-read when an import finishes while the picker is open — the CURRENT list,
+// in place. It deliberately does not jump back to `Everything`: an import
+// finishing is not a reason to throw away the facet, the search and the choice
+// the reader has made in the meantime, and any import may be one this reader
+// never started.
 
 const importsRunning = computed(() => Object.keys(tasks.importRuns).length);
 
 watch(importsRunning, (now, before) => {
-  if (!awaitingPaste.value || now !== 0 || !before) return;
-  awaitingPaste.value = false;
-  // Newest first, so what was just pasted is the first tile.
-  facet.kind = "";
-  facet.id = null;
-  search.value = "";
-  reload();
+  if (!props.open || now !== 0 || !before) return;
+  load();
 });
 
 watch(
   () => props.open,
   (isOpen) => {
-    if (isOpen) {
-      facet.kind = "";
-      facet.id = null;
-      search.value = "";
-      chosen.value = null;
-      expanded.character = false;
-      expanded.set = false;
-      awaitingPaste.value = false;
-      entityLists.refresh("characters");
-      entityLists.refresh("sets");
-      if (entityLists.canSeeProjects) entityLists.refresh("projects");
-      getPictureCount()
-        .then((body) => {
-          totalCount.value = Number(body?.count);
-        })
-        .catch((err) => {
-          // A missing headline count is cosmetic: the rail still narrows and
-          // the grid still fills. Logged rather than surfaced.
-          console.warn("[PicturePicker] could not read the library count", err);
-          totalCount.value = null;
-        });
-      load();
-      window.addEventListener("paste", onPaste);
-    } else {
-      window.removeEventListener("paste", onPaste);
-    }
+    if (!isOpen) return;
+    facet.kind = "";
+    facet.id = null;
+    search.value = "";
+    chosen.value = null;
+    capped.value = false;
+    unavailable.value = new Set();
+    expanded.character = false;
+    expanded.set = false;
+    entityLists.refresh("characters");
+    entityLists.refresh("sets");
+    if (entityLists.canSeeProjects) entityLists.refresh("projects");
+    getPictureCount()
+      .then((body) => {
+        totalCount.value = Number(body?.count);
+      })
+      .catch((err) => {
+        // A missing headline count is cosmetic: the rail still narrows and the
+        // grid still fills. Logged rather than surfaced.
+        console.warn("[PicturePicker] could not read the library count", err);
+        totalCount.value = null;
+      });
+    load();
+    // The search field is where a reader who did not come for a facet starts,
+    // and the dialog would otherwise open with focus on its Close button.
+    nextTick(() => searchRef.value?.focus());
   },
   { immediate: true },
 );
-
-// The listener is added on open and removed on close, so a component unmounted
-// while still open would leave one behind on `window` for the life of the tab —
-// and it holds this instance's notice store and refs.
-onUnmounted(() => window.removeEventListener("paste", onPaste));
 </script>
 
 <style scoped>
 .pp {
   display: flex;
   min-height: 0;
+  /* 70vh so the grid is the tall thing on a tall screen, capped so it does not
+     become a wall of tiles on a very tall one. Both on the 4px grid. */
   height: min(660px, 70vh);
 }
 
 .pp-rail {
-  width: 210px;
+  width: 208px;
   flex-shrink: 0;
   overflow-y: auto;
   padding: var(--space-3);
@@ -442,7 +532,7 @@ onUnmounted(() => window.removeEventListener("paste", onPaste));
   align-items: center;
   gap: var(--space-2);
   width: 100%;
-  min-height: 30px;
+  min-height: 32px;
   padding: var(--space-2) var(--space-3);
   border: 0;
   border-radius: var(--radius-sm);
@@ -504,7 +594,7 @@ onUnmounted(() => window.removeEventListener("paste", onPaste));
   color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
 }
 .pp-paste kbd {
-  padding: 3px 5px;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid rgb(var(--v-theme-border));
   border-radius: var(--radius-sm);
   background: rgb(var(--v-theme-input-background));
@@ -519,7 +609,10 @@ onUnmounted(() => window.removeEventListener("paste", onPaste));
 }
 .pp-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  /* A fixed five, matching the artboard AND the arrow keys' `COLUMNS`: with
+     `auto-fill` the two would silently disagree the moment the dialog narrowed,
+     and Down would jump the wrong distance. The tiles flex instead. */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: var(--space-3);
 }
 .pp-cell {
@@ -537,12 +630,26 @@ onUnmounted(() => window.removeEventListener("paste", onPaste));
   object-fit: cover;
   display: block;
 }
+/* Outline rather than a second box-shadow: the focus ring below is a
+   box-shadow, and two of them at equal specificity means the later rule wins —
+   which hid the chosen state from exactly the reader who has no other way to
+   see it (a focused, chosen tile showed only the ring). */
 .pp-cell--on {
-  box-shadow: 0 0 0 2px var(--active-bar);
+  outline: 2px solid var(--active-bar);
+  outline-offset: -2px;
 }
 .pp-cell:focus-visible {
-  outline: none;
   box-shadow: var(--focus-ring);
+}
+.pp-cell--gone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: not-allowed;
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+}
+.pp-gone {
+  display: inline-flex;
 }
 .pp-note {
   margin: 0;
@@ -551,6 +658,9 @@ onUnmounted(() => window.removeEventListener("paste", onPaste));
 }
 .pp-note--error {
   color: rgb(var(--v-theme-error));
+}
+.pp-note--after {
+  padding-top: var(--space-5);
 }
 .pp-more-row {
   display: flex;

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -1820,13 +1820,13 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
         // A row in the `needs-a-name` state has no name to say, by design —
         // its `text` is empty so the shelf can draw it as a field. The receipt
         // still has to name something the reader can recognise.
-        text: `Set the icon on ${row.name.text || row.filename || "the model"}.`,
+        text: `Set the thumbnail on ${row.name.text || row.filename || "the model"}.`,
       });
       return true;
     } catch (err) {
       notices.push({
         level: "error",
-        text: errorDetail(err) || "Could not set that icon.",
+        text: errorDetail(err) || "Could not set that thumbnail.",
       });
       return false;
     }
@@ -1855,14 +1855,14 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
       notices.push({
         level: cleared ? "success" : "info",
         text: cleared
-          ? `Cleared the icon on ${modelCount(cleared)}.`
-          : "None of those had an icon.",
+          ? `Cleared the thumbnail on ${modelCount(cleared)}.`
+          : "None of those had a thumbnail.",
       });
       return true;
     } catch (err) {
       notices.push({
         level: "error",
-        text: errorDetail(err) || "Could not clear those icons.",
+        text: errorDetail(err) || "Could not clear those thumbnails.",
       });
       return false;
     }

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -1345,7 +1345,7 @@ describe("Assign", () => {
   });
 });
 
-describe("the icon verb", () => {
+describe("the thumbnail verb", () => {
   beforeEach(() => {
     setModelIcon.mockReset().mockResolvedValue({ icon_sha256: "a".repeat(64) });
     clearModelIcons.mockReset().mockResolvedValue({ cleared: [] });
@@ -1401,7 +1401,7 @@ describe("the icon verb", () => {
     await store.clearIconsOnSelected();
     expect(clearModelIcons).toHaveBeenCalledWith([1, 2]);
     expect(useNoticeStore().notices.at(-1).text).toBe(
-      "Cleared the icon on 1 model.",
+      "Cleared the thumbnail on 1 model.",
     );
   });
 


### PR DESCRIPTION
Implements §3 of the workflow implementation plan — the picture picker, shipped
first on the model shelf, where it replaces the OS file chooser behind
`Set icon…`.

## Why here first

The picker is the one component two later workflow steps both depend on (Fixed
mode at setup, Picker mode at run time), and it is the only part that can be
proven on a surface that already has users. `ModelShelf.vue`'s `pickIcon()`
opened an `<input type="file">`, so a model's identity mark could be a file that
is not in the library, that PixlStash never sees again, and that nothing else in
the product knows about. That is the same defect as a workflow pointing at a
`Logo.png` in ComfyUI's input directory, on a different surface.

## What changed

**`PicturePicker.vue` (new, `widgets/`)** — one faceted, single-select library
picker. Props `open` / `subtitle`, emits `close` / `pick(picture)`, plus a
`footer-start` slot for a caller's secondary route. Built on `AppDialog`, drawn
to the `Picker` artboard of the 1.11 Workflow Library canvas.

* Facets are **project / character / picture set**, read from
  `useEntityListsStore` — the groupings the vault already stores, so the picker
  costs no request the sidebar was not already making. One facet at a time; it
  becomes `project_id` / `character_id` / `set_id` on `GET /pictures/stream`.
* Free search is the **escape hatch, not the primary route**: it swaps to
  `GET /pictures/search` and carries the same scope.
* **Single-select on purpose.** Every caller needs exactly one picture.
* **Ctrl+V imports, and the picker handles none of it.** `useWindowFileImport`
  already claims a pasted image anywhere in the window and `ImageImporter`
  announces the import from inside it. The picker shows the affordance and owns
  only the half that is its own: it re-reads the current list when an import
  finishes while it is open, in place, so what was pasted is selectable without
  reopening the dialog.
* **Two ceilings, both said on screen.** Browse pages at 120 with `Show more`;
  search is capped client-side because `GET /pictures/search` ignores `top_n`
  and defaults `limit` to `sys.maxsize`, and this grid is not virtualised.
* **A tile can say it is not available** — a thumbnail is generated *from* the
  file, so a picture on an unplugged drive 404s — and refuses to be chosen.
* **The grid is one tab stop**, arrows move inside it, Enter on a tile accepts.

**`Set icon…` → `Set Thumbnail…`, `Clear icon` → `Clear thumbnail`.** The verb
changes; the field does not. `set_icon`, `icon_sha256` and both routes are
untouched — renaming the column is churn with no user-visible benefit, and
`set_icon` is separately in use for picture-set glyphs in `SideBar.vue`. The
change aligns the user-facing verb with the word the code already used for what
it produces (`ModelMark` describes `set_icon` as "what its **thumbnail** was
replaced BY").

**`Choose a file…` survives**, in the picker's footer. Removing a shipped way of
doing the job would be a regression, and the point of this step is to prove the
picker without taking anything away.

## The one deliberate deviation from the plan

The plan's S1 asked for a backend change: `POST /models/{id}/icon` gaining a
`{picture_id}` body. **This does it on the client instead**, and no backend line
changed.

`pixlstash/routes/model_icons.py` and `services/model_icons.py` both record an
explicit ruling that there is *one* write path, it takes bytes, and there is
deliberately no route that resolves a picture id server-side — because `model`
is a hub row and a picture is a vault row, no key spans the two, and SQLite
recycles deleted ids. Adding S1 would either contradict that ruling or force the
server to decode attacker-influenced image data to get a 40 MB original under
the store's 2 MB ceiling, which the same file rules out in as many words.

The client route needs neither: `getPictureThumbnailBlob(id)` reads
`GET /pictures/thumbnails/{id}.webp` and posts the result to the existing
multipart route. The thumbnail is the right copy to send — already WebP,
generated on demand so it always exists, and 384px on the short edge, which is
an icon's size and comfortably inside the ceiling. The outcome S1 wanted (choose
a library picture, get a mark that survives that picture being deleted) is
unchanged; only where the copy is made moved.

## The adversarial pass, and what it changed

A subagent reviewed the diff with a brief to argue for rejection. It reported
nothing under secrets or privacy. Of its other findings, these were right and
are fixed in the second commit:

* **The paste notice was a lie.** `startImport` refuses outright while another
  import is running *and* under a read-only token, and neither refusal ever
  registers a run — so the picker announced an import that never happened, and
  the flag waiting for that run to finish never cleared. It also filtered
  `image/*` while the window importer takes video too, so one paste was reported
  and another was silent. The fix is subtraction: the picker announces nothing.
* **The reload was global and destructive** — any unrelated import finishing
  reset the reader's facet, search and choice. It now re-reads in place.
* **Search was unbounded and unvirtualised** (the route ignores `top_n`).
* **`fields=grid` silently forces `stack_leaders_only`**, so no stacked variant
  could be picked, and browse and search disagreed about the same picture.
* **The ↵ badge was false** — `AppDialog` exempts `<button>`, and tiles are
  buttons — and 120 tiles were 120 tab stops.
* **The chosen ring was overridden by the focus ring**, hiding the selection
  from exactly the reader who needs it.
* **"Generated on demand so it always exists" was wrong**; the route 404s on an
  unreachable or undecodable source, with no unavailable state on the tile.
* **`vi.mock("../../api/pictures")` without `importOriginal`** left every other
  export of that module undefined across the view's module graph.
* **Cancelling the OS chooser dropped the reader on a bare shelf**, and the
  error path closed the dialog before the fetch that could fail.
* **Dead tests, proven by mutation**: the race guards, `Show more`, `All N`, and
  the paste filter could all be deleted with the suite green.

Three I judged wrong and did not act on, with reasons:

* **"Use `AppDialog`'s footer slot."** The artboard puts the footer inside the
  right-hand column, bordered from the facet rail; the primitive's footer spans
  the whole dialog including under the rail. This is the design, not a bypass.
* **"~570 lines re-implement `ImageGrid`."** `ImageGrid` is 7933 lines of
  virtualisation, WebSocket sync, selection, overlay and drag — none of it
  extractable into a dialog, and the plan specifies this component by name for
  three callers.
* **"`thumbUrl` drops the version cache-buster."** There is no
  `thumbnail_version` column; every caller that passes one holds it in its own
  store. The staleness that actually matters is in the bytes that get *stored*,
  and that fetch is now cache-busted.

## Tests

`PicturePicker.test.js` (new, 14): the facets are the vault's own groupings and
a reference set is not one; a facet really scopes the read and replaces rather
than accumulates; exactly one picture stays chosen and `pick` carries it; search
is a different endpoint with the same scope, and drops a stale choice; an
in-flight read cannot overwrite the list the reader moved to; `Show more`
appends rather than replaces; `All N` opens the rest of a facet group; a runaway
search is cut and says so; an unreachable picture says so and refuses to be
chosen; the grid is one tab stop, arrows move inside it, Enter uses the tile;
and an import finishing re-reads the list without discarding the reader's state.

`ModelShelf.test.js` (+4): the library route sends the picture's **bytes**,
cache-busted; the picker joins the window-level Escape/Delete guard (which lists
the shelf's own dialogs by ref, because a press with nothing focused targets
`<body>`); `Choose a file…` leaves the picker open behind the OS chooser and
closes it only on a file; and a picture whose bytes cannot be read leaves the
picker open with the refusal.

Every one of those was checked by mutation — eleven separate mutations, each
turning exactly one test red. Full frontend suite green (3602). No backend
change, so no backend suite is implicated. `docs/frontend_architecture.md` §5
and §9.1 updated.

## Not verified here

The picker has not been looked at in a running app: PixlStash is login-gated and
a headless run needs credentials. Layout, the facet rail against a real library,
and the paste round trip want a human pass.
