### PR TITLE
Add `plugins create`: scaffold a plugin PR from the repository's own example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,7 @@ jobs:
           tests/test_picture_sets_query_cost.py
           tests/test_picture_stack_utils.py
           tests/test_pictures_stream.py
+          tests/test_plugin_create.py
           tests/test_plugin_install.py
           tests/test_project_membership_service.py
           tests/test_projects_api.py

--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ pixlstash-cli plugins install ./my_filter.py        # a single module
 pixlstash-cli plugins test ./my_captioner.py       # does it load and render?
 pixlstash-cli plugins list
 pixlstash-cli plugins remove my_captioner
+pixlstash-cli plugins create                          # start writing one
+pixlstash-cli plugins submit                          # ...and open its PR
 ```
 
 `plugins available` lists what
@@ -564,7 +566,118 @@ single `.py` file or a folder containing `__init__.py`.
 
 ### Writing a plugin
 
-Use the template from `pixlstash/image_plugins/built-in/plugin_template.py` in the source repository as a starting point:
+```bash
+pixlstash-cli plugins create
+```
+
+Run with no arguments it is a wizard. It works out first whether it can fork
+[PixlStash-plugins](https://github.com/Pikselkroken/PixlStash-plugins) for you,
+and names the repository it would create:
+
+```
+This will create https://github.com/you/PixlStash-plugins, a public fork of
+Pikselkroken/PixlStash-plugins on your account, and clone it.
+```
+
+If you already have that fork it says so, and that it will be reused rather
+than created. If it cannot fork at all it says why: `gh` missing, or `gh` not
+signed in.
+
+Then it asks what kind of plugin you are writing, and that question carries the
+way out:
+
+```
+What kind of plugin is it?
+  1  image       turns a picture into another picture (the Filters menu)
+  2  captioning  turns an image into tags or a description
+  3  abort       stop here, creating nothing
+Choose [1]:
+```
+
+Answer with the number or the name. `3` stops with nothing forked, cloned or
+created, and the question is asked before any of those happen for exactly that
+reason. After it, you are asked what the plugin should do and what to call it.
+
+Everyone contributes from a fork, maintainers included. A plugin reaches the
+repository as a pull request or not at all, and a shortcut for the few people
+with write access would be a second path that only those people ever exercise.
+
+From those answers it clones, branches, copies one of the repository's example
+plugins into `plugins/<kind>/<name>/`, renames its folder, module and class,
+puts your git identity and your licence in the header, writes what you said it
+should do into the plugin's README and docstring, and prints the commands that
+open the pull request. Nothing is committed or pushed: the plugin at that point
+is still the example.
+
+Last, it offers a command that hands the job to a coding agent:
+
+```bash
+cd /home/you/PixlStash-plugins && claude 'Read plugins/image/edge_glow/BRIEF.md and do what it says.'
+```
+
+One line, because the command is the part that gets pasted. The brief itself is
+written to disk as `BRIEF.md` inside the new plugin's folder, where it can be
+read, edited and re-run without retyping anything. It says what you asked the
+plugin to do, that the folder holds a renamed copy of an example whose
+behaviour must be replaced rather than described, what "done" looks like, and
+that it should delete itself when finished. `BRIEF.md` is gitignored, so
+forgetting cannot put it in the pull request.
+
+The command carries its own `cd`, because the brief is named relative to the
+checkout and the agent reads that checkout's instructions: pasted anywhere else
+it would find neither.
+
+For everything general, the brief points at the plugins repository's own
+[`AGENTS.md`](https://github.com/Pikselkroken/PixlStash-plugins/blob/main/AGENTS.md)
+(and a byte-identical `CLAUDE.md`) that both agents read on their own, covering
+the contract to follow, the header rules, what a plugin README needs and the
+commands to finish with. Restating any of that in the prompt would be a second
+copy of instructions that repository maintains and its tests keep honest. All
+the command adds is which README holds the brief.
+
+It is printed rather than run: starting an agent on your checkout is your call,
+and you should read what it writes before committing it.
+
+### Submitting it
+
+```bash
+cd PixlStash-plugins
+pixlstash-cli plugins submit
+```
+
+`submit` is the other half of `create`, and there is nothing to type because
+the branch already names the plugin. It runs the plugins repository's own
+checks with that checkout's `.venv` if it has one (its ruff is pinned, and a
+different version formats differently), stages the one plugin folder, commits
+it, pushes the branch and opens the pull request.
+
+A failing check stops it, which is the point: the same failure found in CI
+costs a red pull request and a force-push. `--dry-run` runs the checks and
+stops; `--skip-checks` runs none of them.
+
+It asks one thing first: what you tested the plugin against, which model, which
+PixlStash version, on what hardware. That goes in the pull request body,
+verbatim and with nothing else read off your machine. CI checks the shape of a
+model-backed plugin and never runs the model, so that sentence is what makes it
+reviewable at all. Pushing and opening the PR are confirmed before they happen
+(`--yes` skips the question).
+
+Everything the wizard asks can be given as an option instead, and giving a name
+and `--kind` skips the questions entirely:
+
+```bash
+pixlstash-cli plugins create edge_glow --kind image \
+  --purpose "Adds a soft glow around every edge." --agent claude
+```
+
+It copies the example the plugins repository's own CI keeps green, rather than a
+template kept here, so a scaffold cannot be out of date with the contract tests
+it has to pass. `--from` starts from a different published plugin,
+`--display-name`, `--description`, `--author` and `--license` fill in the
+header, `--dir` says where the checkout goes, and `--no-fork` skips the fork.
+
+To write one by hand instead, start from
+`pixlstash/image_plugins/built-in/plugin_template.py` in this repository:
 
 1. Create a new `.py` file in your user plugin directory.
 2. Subclass `ImagePlugin`, set a unique `name` and `plugin_id`, and implement `run()`.

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from pathlib import Path
 from typing import Sequence
 
 from pixlstash.hub.cli_hint import desktop_windows_command
@@ -36,7 +37,7 @@ from pixlstash.hub.registry import (
     resolve_path,
 )
 from pixlstash.hub.schema import HubSchemaTooNewError
-from pixlstash import plugin_install
+from pixlstash import plugin_create, plugin_install
 from pixlstash.plugin_install import PluginError
 
 # Exit codes. 0 success, 1 a refusal the user can act on (not a vault, already
@@ -337,7 +338,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
-    """Add the `plugins` group: install, list, remove."""
+    """Add the `plugins` group: create, install, test, available, list, remove."""
     plugins = groups.add_parser(
         "plugins",
         help="Install, list and remove plugins.",
@@ -399,7 +400,254 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Also pip-install the plugin's requirements.txt, if it has one.",
     )
+    install_parser.add_argument(
+        "--force-deps",
+        action="store_true",
+        help=(
+            "Install the dependencies even when they replace a package "
+            "PixlStash is using. This can stop PixlStash starting."
+        ),
+    )
     install_parser.set_defaults(handler=_cmd_plugins_install)
+
+    create_parser = commands.add_parser(
+        "create",
+        help="Start a new plugin as a branch in a checkout of the plugins repo.",
+        # Wrapped by hand: the two-line summary of what lands on disk is what
+        # someone needs before they run a command that clones a repository.
+        description=(
+            "Set up everything a plugin pull request needs, so the only work\n"
+            "left is the plugin itself. Run it with no arguments and it asks:\n"
+            "what kind of plugin, what it should do, what to call it. Give\n"
+            "a name and --kind and it asks nothing.\n"
+            "\n"
+            "It first works out whether it can fork\n"
+            f"{plugin_install.PLUGINS_REPO} for you, naming the repository it\n"
+            "would create on your account, and says why not when it cannot.\n"
+            "The first question asked is the way out: its last numbered\n"
+            "option stops before anything is forked, cloned or written.\n"
+            "Then it clones,\n"
+            "branches, copies one of the repository's\n"
+            "example plugins to `plugins/<kind>/<name>/`, renames its folder,\n"
+            "module and class, puts your name and licence in the header,\n"
+            "writes what you said it should do into its README, and prints\n"
+            "the commands that open the pull request.\n"
+            "\n"
+            "Last, it offers a one-line `claude` or `codex` command pointing\n"
+            "the agent at that README. The rest of the brief is the plugins\n"
+            "repository's own AGENTS.md, which both agents read for\n"
+            "themselves. It prints the command rather than running it:\n"
+            "starting an agent on your checkout is your call.\n"
+            "\n"
+            "Nothing is committed, nothing is pushed and no pull request is\n"
+            "opened: the plugin at that point is still the example, and the\n"
+            "repository takes one finished plugin per pull request.\n"
+            "\n"
+            "The copy is the example CI keeps green rather than a template\n"
+            "kept in PixlStash, so a scaffold cannot be out of date with the\n"
+            "contract tests it has to pass. Nothing is imported or run."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    create_parser.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        help=(
+            "The new plugin's name: lower-case, starting with a letter, "
+            "letters, digits and underscores only. It names the folder, the "
+            "module, the branch and the plugin's `name` attribute. Asked for "
+            "if you leave it out."
+        ),
+    )
+    create_parser.add_argument(
+        "--kind",
+        choices=[plugin_install.CAPTIONING, plugin_install.IMAGE],
+        default=None,
+        help=(
+            "What you are writing: `captioning` turns an image into tags or a "
+            "description, `image` turns a picture into another picture (the "
+            "Filters menu). It picks the directory, the example and the "
+            "shape. Asked for if you leave it out."
+        ),
+    )
+    create_parser.add_argument(
+        "--purpose",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "What the plugin should do, in a sentence or three. It becomes "
+            "the README's opening paragraph, the class `description`, and "
+            "what a coding agent is told to build. Asked for if you leave it "
+            "out and there is a terminal to ask on."
+        ),
+    )
+    create_parser.add_argument(
+        "--agent",
+        choices=[*sorted(plugin_create.AGENTS), "no"],
+        default=None,
+        help=(
+            "Print a command handing the plugin to this coding agent, instead "
+            "of asking which. `no` prints none."
+        ),
+    )
+    create_parser.add_argument(
+        "--dir",
+        dest="directory",
+        default=plugin_create.DEFAULT_CHECKOUT,
+        metavar="PATH",
+        help=(
+            "Where the checkout lives (default: ./"
+            f"{plugin_create.DEFAULT_CHECKOUT}). An existing checkout is "
+            "reused and branched again; anything else there is refused."
+        ),
+    )
+    create_parser.add_argument(
+        "--from",
+        dest="example",
+        default=None,
+        metavar="PLUGIN",
+        help=(
+            "Copy this published plugin instead of the default example "
+            f"({plugin_create.DEFAULT_EXAMPLES[plugin_install.CAPTIONING]} or "
+            f"{plugin_create.DEFAULT_EXAMPLES[plugin_install.IMAGE]}). Use it "
+            "to start from something closer to what you are building."
+        ),
+    )
+    create_parser.add_argument(
+        "--branch",
+        default=None,
+        help="Branch to create (default: add-<name>).",
+    )
+    create_parser.add_argument(
+        "--display-name",
+        default=None,
+        metavar="LABEL",
+        help=(
+            "The label PixlStash shows in its menus (default: the name with "
+            "the underscores turned into spaces)."
+        ),
+    )
+    create_parser.add_argument(
+        "--description",
+        default=None,
+        help=(
+            "One line saying what the plugin does, shown in the UI. Left as a "
+            "TODO in the source when you do not give it."
+        ),
+    )
+    create_parser.add_argument(
+        "--author",
+        default=None,
+        metavar="'NAME <CONTACT>'",
+        help=(
+            "Who to credit, as `Your Name <you@example.com>` or a URL between "
+            "the brackets. Defaults to your git identity; the repository's "
+            "tests require this shape."
+        ),
+    )
+    create_parser.add_argument(
+        "--license",
+        dest="plugin_license",
+        default=None,
+        metavar="SPDX",
+        help=(
+            "The license of your plugin's own code, as an SPDX identifier "
+            "where there is one (default: MIT). This says nothing about the "
+            "license of any model it downloads; that goes in `models`."
+        ),
+    )
+    create_parser.add_argument(
+        "--no-fork",
+        dest="fork",
+        action="store_false",
+        help=(
+            "Clone the repository directly instead of forking it first. You "
+            "will not be able to push until you point `origin` somewhere you "
+            "can, so this is for looking rather than contributing."
+        ),
+    )
+    create_parser.set_defaults(handler=_cmd_plugins_create)
+
+    submit_parser = commands.add_parser(
+        "submit",
+        help="Check, commit, push and open the pull request for a new plugin.",
+        # Wrapped by hand: what it pushes, and where, is what someone needs to
+        # read before running a command that publishes their work.
+        description=(
+            "Finish what `plugins create` started. It runs the repository's\n"
+            "own checks, stages the one plugin folder, commits it, pushes the\n"
+            "branch, and opens the pull request.\n"
+            "\n"
+            "Which plugin is read off the branch, so from a checkout `plugins\n"
+            "create` made there is nothing to type. Only the plugin's own\n"
+            "folder is staged: the checkout is yours and may hold other work,\n"
+            "and the repository takes one plugin per pull request.\n"
+            "\n"
+            "It stops on a failing check, and asks before it pushes, because\n"
+            "pushing and opening a pull request are the two steps that leave\n"
+            "this machine. --yes skips the question; --dry-run stops after\n"
+            "the checks and pushes nothing.\n"
+            "\n"
+            "You are asked what you tested the plugin against, which goes in\n"
+            "the pull request. CI checks the shape of a model-backed plugin\n"
+            "and never runs the model, so that sentence is what makes it\n"
+            "reviewable at all."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    submit_parser.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        help=(
+            "Which plugin to submit. Taken from the branch name (`add-<name>`) "
+            "when you leave it out."
+        ),
+    )
+    submit_parser.add_argument(
+        "--dir",
+        dest="directory",
+        default=plugin_create.DEFAULT_CHECKOUT,
+        metavar="PATH",
+        help=(
+            "The checkout holding the plugin (default: ./"
+            f"{plugin_create.DEFAULT_CHECKOUT})."
+        ),
+    )
+    submit_parser.add_argument(
+        "--tested",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "What you ran the plugin against: which model, which PixlStash "
+            "version, on what hardware. Goes in the pull request. Asked for "
+            "if you leave it out."
+        ),
+    )
+    submit_parser.add_argument(
+        "--message",
+        default=None,
+        metavar="TEXT",
+        help="Commit message and pull request title (default: `Add <name>`).",
+    )
+    submit_parser.add_argument(
+        "--skip-checks",
+        action="store_true",
+        help=(
+            "Do not run ruff and pytest. CI runs them anyway, so this only "
+            "moves where you find out."
+        ),
+    )
+    submit_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run the checks and stop. Nothing is committed or pushed.",
+    )
+    submit_parser.add_argument(
+        "--yes", action="store_true", help="Do not ask before pushing."
+    )
+    submit_parser.set_defaults(handler=_cmd_plugins_submit)
 
     test_parser = commands.add_parser(
         "test",
@@ -528,6 +776,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             return args.handler(args)
         except PluginError as exc:
             print(f"error: {exc}", file=sys.stderr)
+            return EXIT_REFUSED
+        except KeyboardInterrupt:
+            # Ctrl-C is the other way out of the wizard, and a traceback is a
+            # poor answer to someone who just said stop. What has already
+            # happened has happened; the message says only that this stopped.
+            print("\nStopped.", file=sys.stderr)
             return EXIT_REFUSED
 
     try:
@@ -841,13 +1095,419 @@ def _cmd_rename(registry: LibraryRegistry, args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def _confirm(question: str) -> bool:
-    """Ask for a y/n on stdin. A closed stdin is a no, not a yes."""
+def _confirm(question: str, default: bool = False) -> bool:
+    """Ask for a y/n on stdin, Enter taking *default*.
+
+    *default* is True only where the question follows a full itemised list of
+    what is about to happen, which is the one case where Enter is an informed
+    answer rather than a shrug.
+
+    A closed stdin is a no whatever the default: Enter means a person read the
+    list and pressed a key, and no stdin at all means nobody did.
+    """
     try:
-        answer = input(f"{question} [y/N] ")
+        answer = input(f"{question} {'(Y/n)' if default else '[y/N]'} ").strip().lower()
     except EOFError:
         return False
-    return answer.strip().lower() in ("y", "yes")
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def _ask(question: str, default: str = "") -> str:
+    """Ask one question on stdin, returning *default* on a bare Enter.
+
+    A closed stdin raises rather than silently taking the default: the wizard's
+    questions have no answer that is safe to invent, and a scaffold built from
+    guesses is worse than a refusal that says which question went unanswered.
+    """
+    suffix = f" [{default}]" if default else ""
+    try:
+        answer = input(f"{question}{suffix}: ").strip()
+    except EOFError as exc:
+        raise PluginError(
+            f"no answer to {question!r}, and stdin is closed. Pass the answers "
+            "as options instead — `plugins create --help` lists them."
+        ) from exc
+    return answer or default
+
+
+#: The answer that stops the wizard, wherever one is offered.
+ABORT = "abort"
+
+
+def _ask_choice(question: str, options: dict[str, str]) -> str:
+    """Ask for one of *options* by number, or by name, until an answer fits.
+
+    Numbered because these are line prompts: every answer costs an Enter, so
+    the shortest one worth offering is a single digit.  The names still work,
+    since a reader who has just read `captioning` off the screen should not be
+    told off for typing it.
+    """
+    keys = list(options)
+    width = max(len(key) for key in keys)
+    print(f"\n{question}")
+    for number, key in enumerate(keys, start=1):
+        print(f"  {number}  {key:<{width}}  {options[key]}")
+    while True:
+        answer = _ask("Choose", "1").lower()
+        if answer.isdigit() and 1 <= int(answer) <= len(keys):
+            return keys[int(answer) - 1]
+        if answer in options:
+            return answer
+        print(f"  Choose 1 to {len(keys)}, or type the name.")
+
+
+def _ask_paragraph(question: str) -> str:
+    """Ask for as many lines as the contributor wants, ending on a blank one.
+
+    What a plugin should do is the one answer that does not fit on a line, and
+    it is the answer everything downstream is built from — the README, the
+    class description, the prompt handed to a coding agent. Truncating it to
+    what fits before the Enter key would be the wizard's own fault.
+    """
+    print(f"\n{question}")
+    print("(Several lines are fine. Finish with an empty line.)")
+    lines: list[str] = []
+    while True:
+        try:
+            line = input("  ")
+        except EOFError:
+            break
+        if not line.strip():
+            break
+        lines.append(line.strip())
+    return " ".join(lines)
+
+
+def _ask_name(kind: str, checkout: Path) -> str:
+    """Ask for a plugin name until it is one, explaining each refusal.
+
+    Checked against the checkout, which is why the clone happens before this
+    question rather than after all of them: a name the repository already
+    publishes is the commonest thing to get wrong, and finding out after
+    answering everything means answering everything again.
+    """
+    while True:
+        name = _ask("Name (snake_case, e.g. edge_glow)")
+        try:
+            plugin_create.check_name_free(checkout, name, kind)
+            return name
+        except PluginError as exc:
+            print(f"  {exc}")
+
+
+def _report_readiness(readiness: plugin_create.ForkReadiness) -> bool:
+    """Print what this machine can do about a pull request, and ask if it cannot.
+
+    Asked before anything is cloned, because the answer decides whether the
+    last two steps this command prints are true — and being told at the end
+    that you cannot push is being told too late to do anything about it.
+    """
+    print(f"\n{readiness.explanation}")
+    if readiness.mode != plugin_create.MANUAL:
+        return True
+    print(f"{readiness.remedy}")
+    return _confirm("Carry on and set the plugin up anyway?")
+
+
+def _note_readiness(readiness: plugin_create.ForkReadiness) -> None:
+    """Say how this checkout will reach GitHub, without asking anything.
+
+    The non-interactive half of `_report_readiness`. "origin is the upstream
+    repository" with nothing to explain it reads as something having gone
+    wrong, when for a maintainer it is the expected answer.
+    """
+    print(readiness.explanation)
+
+
+def _plugin_answers(
+    args: argparse.Namespace, checkout: Path, kind: str
+) -> dict[str, object]:
+    """Ask for whatever was not given on the command line."""
+    purpose = args.purpose or _ask_paragraph("What should it do?")
+    name = args.name or _ask_name(kind, checkout)
+    plugin_license = args.plugin_license or _ask(
+        "\nLicence for your own code (SPDX)", "MIT"
+    )
+    return {"purpose": purpose, "name": name, "license": plugin_license}
+
+
+def _ask_kind() -> str | None:
+    """Ask what kind of plugin this is, or None if the answer is to stop.
+
+    The last question asked before anything is created, and so the one that
+    carries the way out: by the time a name is being chosen there is a fork on
+    the contributor's account and a clone on their disk.
+    """
+    answer = _ask_choice(
+        "What kind of plugin is it?",
+        {
+            plugin_install.IMAGE: (
+                "turns a picture into another picture (the Filters menu)"
+            ),
+            plugin_install.CAPTIONING: ("turns an image into tags or a description"),
+            ABORT: "stop here, creating nothing",
+        },
+    )
+    return None if answer == ABORT else answer
+
+
+def _cmd_plugins_create(args: argparse.Namespace) -> int:
+    """Set a plugin up as a branch, asking for whatever was not given."""
+    interactive = not (args.name and args.kind)
+    if interactive and not sys.stdin.isatty():
+        raise PluginError(
+            "a name and --kind are needed, and there is no terminal to ask on. "
+            "Pass them as arguments: `plugins create <name> --kind image`."
+        )
+
+    readiness = (
+        plugin_create.fork_readiness()
+        if args.fork
+        else plugin_create.ForkReadiness(
+            plugin_create.MANUAL,
+            "--no-fork was given, so nothing will be forked.",
+            f"Fork https://github.com/{plugin_install.PLUGINS_REPO} on the web "
+            "and point `origin` at it when you are ready to push.",
+        )
+    )
+    if interactive:
+        if not _report_readiness(readiness):
+            print("Nothing was created.")
+            return EXIT_REFUSED
+    else:
+        _note_readiness(readiness)
+
+    directory = Path(args.directory).expanduser()
+    checkout_state = None
+    kind = args.kind
+    if interactive:
+        # The kind is asked before anything is created, because it is the last
+        # moment at which stopping costs nothing: the step after it forks the
+        # repository onto the contributor's account and clones it.
+        if kind is None:
+            kind = _ask_kind()
+            if kind is None:
+                print("\nStopped. Nothing was forked, cloned or created.")
+                return EXIT_REFUSED
+        # Cloned before the remaining questions, so `_ask_name` can check the
+        # name against what the repository actually publishes and ask again.
+        print("\nFetching the plugins repository...")
+        checkout_state = plugin_create.obtain_checkout(
+            directory, fork=readiness.can_fork
+        )
+    answers = (
+        _plugin_answers(args, directory, kind)
+        if interactive
+        else {
+            "purpose": args.purpose,
+            "name": args.name,
+            "license": args.plugin_license or "MIT",
+        }
+    )
+
+    result = plugin_create.create(
+        answers["name"],
+        kind,
+        directory=directory,
+        example=args.example,
+        branch=args.branch,
+        display_name=args.display_name,
+        description=args.description,
+        purpose=answers["purpose"],
+        author=args.author,
+        plugin_license=answers["license"],
+        readiness=readiness,
+        checkout_state=checkout_state,
+    )
+    _report_created(result)
+
+    agent = args.agent
+    if interactive and agent is None:
+        agent = _ask_choice(
+            "Hand it to a coding agent?",
+            {
+                **{
+                    name: f"print a `{name}` command that writes the plugin"
+                    for name in sorted(plugin_create.AGENTS)
+                },
+                "no": "just show me the steps",
+            },
+        )
+    if agent and agent != "no":
+        _report_agent_command(agent, result)
+    return EXIT_OK
+
+
+def _report_created(result: plugin_create.CreateResult) -> None:
+    """Say what landed on disk, and what has to happen to it."""
+    origin = "your fork" if result.forked else plugin_install.PLUGINS_REPO
+    print()
+    print(
+        f"{'Reused' if result.reused else 'Cloned into'} {result.checkout} "
+        f"(origin: {origin})"
+    )
+    print(f"Branch:  {result.branch}")
+    print(f"Plugin:  {result.folder}  (copied from {result.example})")
+    print()
+
+    for warning in result.warnings:
+        print(f"warning: {warning}")
+    if result.warnings:
+        print()
+
+    # Paths are printed relative to the checkout because every command below
+    # runs from inside it, and an absolute path in step 4 would not paste into
+    # the `git add` in step 5.
+    folder = result.folder.relative_to(result.checkout)
+    # Two steps, because only the first is yours: `plugins submit` runs the
+    # checks, commits, pushes and opens the pull request. A list of the six
+    # commands it runs would be a list of things to get wrong by hand.
+    print("Next:")
+    print(f"  1. cd {result.checkout}")
+    print(f"     Write the plugin:  {result.module.relative_to(result.checkout)}")
+    print(f"     Expand the README: {result.readme.relative_to(result.checkout)}")
+    if result.kind == plugin_install.CAPTIONING:
+        print(f"     Try it:            {invoked_as()} plugins test {folder}")
+    else:
+        # `plugins test` checks captioning plugins only, so pointing an image
+        # plugin at it would send someone to a command that refuses them.
+        print(
+            f"     Try it:            {invoked_as()} plugins install {folder} --force"
+        )
+        print("                        then use it from the Filters menu")
+    print(f"  2. {invoked_as()} plugins submit")
+    print("     Checks it, commits it, pushes it, opens the pull request.")
+
+
+def _report_agent_command(agent: str, result: plugin_create.CreateResult) -> None:
+    """Print the command that hands the plugin to a coding agent.
+
+    Printed rather than run. Starting an agent that edits a checkout is the
+    contributor's decision to make in their own terminal, where they can see
+    what it does, and it belongs to step 2 rather than to this command.
+    """
+    command = plugin_create.agent_command(agent, result)
+    print()
+    print(f"To have {agent} write it, paste this anywhere:")
+    print()
+    print(f"  {command}")
+    print()
+    print(
+        "Read what it writes before you commit it: a plugin runs unsandboxed "
+        "in the server process, and a reviewer will ask what you ran it against."
+    )
+
+
+def _cmd_plugins_submit(args: argparse.Namespace) -> int:
+    """Run the checks, commit the plugin, push it and open the pull request."""
+    submission = plugin_create.find_submission(Path(args.directory), args.name)
+    print(f"Plugin:  {submission.folder}")
+    print(f"Branch:  {submission.branch}")
+
+    if args.skip_checks:
+        print("\nChecks skipped.")
+    else:
+        missing = plugin_create.missing_tools(submission)
+        if missing:
+            raise PluginError(plugin_create.dev_setup_hint(submission, missing))
+        print(f"\nRunning the repository's checks with {submission.python}")
+        failed = plugin_create.run_checks(submission)
+        if failed:
+            # Stopping here is the point of running them: the same failure in
+            # CI costs a red pull request and a force-push to fix.
+            raise PluginError(
+                f"{', '.join(failed)} failed. Fix that and run this again, or "
+                "pass --skip-checks to submit anyway."
+            )
+        print("\nChecks passed.")
+
+    if args.dry_run:
+        print("Stopping here: --dry-run. Nothing was committed or pushed.")
+        return EXIT_OK
+
+    message = args.message or f"Add {submission.name}"
+    tested = args.tested
+    if tested is None:
+        if not sys.stdin.isatty():
+            raise PluginError(
+                "the pull request has to say what you tested the plugin "
+                "against, and there is no terminal to ask on. Pass --tested."
+            )
+        tested = _ask_paragraph(
+            "What did you test it against? (which model, which PixlStash "
+            "version, what hardware)"
+        )
+    if not tested.strip():
+        raise PluginError(
+            "the pull request has to say what you tested the plugin against. "
+            "CI checks the shape of a model-backed plugin and never runs the "
+            "model, so this is what makes it reviewable."
+        )
+
+    print(
+        f"\nAbout to commit {submission.folder.name}, push {submission.branch} "
+        f"to origin, and open a pull request on {plugin_install.PLUGINS_REPO}."
+    )
+    if not args.yes and not _confirm("Go ahead?"):
+        print("Nothing was pushed.")
+        return EXIT_REFUSED
+
+    plugin_create.commit(submission, message)
+    plugin_create.push(submission)
+    url = plugin_create.open_pull_request(
+        submission, message, plugin_create.pull_request_body(submission, tested)
+    )
+    print(f"\n{url}")
+    return EXIT_OK
+
+
+def _report_dependencies(
+    changes: list[plugin_install.DependencyChange], *, force: bool
+) -> bool:
+    """List what pip would install, and say whether it may go ahead.
+
+    Every package is named, transitive ones included: a plugin's
+    requirements.txt asking for one package routinely pulls in dozens, and
+    "pip will install moondream2" is not what is about to happen to the
+    environment PixlStash runs in.
+    """
+    if not changes:
+        print("Everything it needs is already installed.")
+        return True
+
+    print("\nThis operation will install the following Python packages:")
+    width = max(len(change.name) for change in changes)
+    for change in changes:
+        note = f"replaces {change.installed}" if change.moves else "new"
+        print(f"  {change.name:<{width}}  {change.version:<12}  {note}")
+
+    moved = [change for change in changes if change.moves]
+    if not moved:
+        return True
+
+    # The refusal this whole mechanism exists for. PixlStash pins every
+    # dependency it has, so a plugin that replaces one is a plugin that can
+    # stop the application starting, and the damage would not show until the
+    # next boot, long after anyone would connect it to installing a plugin.
+    print()
+    for change in moved:
+        print(
+            f"warning: this replaces {change.name} {change.installed} with "
+            f"{change.version}, which PixlStash itself is using."
+        )
+    if not force:
+        print(
+            "\nRefused: a plugin may add packages, but not change one that is "
+            "already in use. Install it without --with-deps and put its "
+            "dependencies somewhere of your own, or pass --force-deps if you "
+            "accept that PixlStash may stop working.",
+            file=sys.stderr,
+        )
+        return False
+    print("Proceeding anyway: --force-deps.")
+    return True
 
 
 def _cmd_plugins_install(args: argparse.Namespace) -> int:
@@ -866,10 +1526,15 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             "permissions."
         )
 
-        requirements: list[str] = []
+        changes: list[plugin_install.DependencyChange] = []
         if args.with_deps and plan.requirements:
-            requirements = plugin_install.read_requirements(plan.requirements)
-            print("pip will install: " + (", ".join(requirements) or "(nothing)"))
+            # Resolved before anything is copied. pip is asked what it would
+            # do, and it is asked first, so a plugin whose dependencies cannot
+            # be had leaves nothing behind to clean up.
+            print(f"\nResolving {plan.requirements.name}...")
+            changes = plugin_install.resolve_requirements(plan.requirements)
+            if not _report_dependencies(changes, force=args.force_deps):
+                return EXIT_REFUSED
         elif plan.requirements:
             print(
                 f"note: this plugin ships {plan.requirements.name}. It is NOT "
@@ -879,12 +1544,14 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
         if args.dry_run:
             print("Dry run: nothing was written.")
             return EXIT_OK
-        if not args.yes and not _confirm("Install it?"):
+        # Default yes only when the packages have just been listed one by one.
+        question, default = ("Is this OK", True) if changes else ("Install it?", False)
+        if not args.yes and not _confirm(question, default):
             print("Cancelled. Nothing was written.")
             return EXIT_REFUSED
 
         plugin_install.install(plan, force=args.force)
-        if requirements:
+        if changes:
             plugin_install.install_requirements(plan.requirements)
 
     print(f"Installed {plan.name} to {plan.destination}")

--- a/pixlstash/plugin_create.py
+++ b/pixlstash/plugin_create.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 import os
 import re
 import shlex
@@ -48,6 +49,8 @@ from pixlstash.plugin_install import (
     builtin_names,
     read_source,
 )
+
+logger = logging.getLogger(__name__)
 
 #: What each kind is scaffolded from when ``--from`` is not given.  Both load
 #: no model, so a contributor can run the copy before changing a line of it.
@@ -941,6 +944,13 @@ def find_submission(directory: Path, name: str | None = None) -> Submission:
     return Submission(directory, kind, name, folder, branch, _dev_python(directory))
 
 
+#: Where a virtualenv keeps its executables, which is the one thing about one
+#: that differs by platform.  Named once: the setup hint prints these paths for
+#: someone to type, so a Unix-only spelling here is a command that fails on
+#: Windows rather than a wrong path nobody sees.
+VENV_BIN = Path(".venv") / ("Scripts" if os.name == "nt" else "bin")
+
+
 def _dev_python(directory: Path) -> Path:
     """Return the interpreter holding the repository's dev tools.
 
@@ -949,8 +959,7 @@ def _dev_python(directory: Path) -> Path:
     whitespace.  Falling back to ours is what makes the checks runnable at all
     on a machine that has not made one yet.
     """
-    binaries = directory / ".venv" / ("Scripts" if os.name == "nt" else "bin")
-    candidate = binaries / ("python.exe" if os.name == "nt" else "python")
+    candidate = directory / VENV_BIN / ("python.exe" if os.name == "nt" else "python")
     return candidate if candidate.exists() else Path(sys.executable)
 
 
@@ -975,13 +984,13 @@ def missing_tools(submission: Submission) -> list[str]:
 
 def dev_setup_hint(submission: Submission, missing: list[str]) -> str:
     """Return the commands that give the checkout the tools it is missing."""
-    venv = "python -m venv .venv && .venv/bin/pip"
+    pip = VENV_BIN / "pip"
     return (
         f"{submission.python} cannot import {', '.join(missing)}, so the "
         "checks cannot run. Give the checkout its own tools:\n"
         f"  cd {submission.checkout}\n"
-        f"  {venv} install -r requirements-dev.txt\n"
-        "  .venv/bin/pip install --no-deps pixlstash"
+        f"  python -m venv .venv && {pip} install -r requirements-dev.txt\n"
+        f"  {pip} install --no-deps pixlstash"
     )
 
 
@@ -1065,13 +1074,60 @@ def pull_request_body(submission: Submission, tested: str) -> str:
     )
 
 
+#: An `origin` URL, in any of the spellings git accepts, down to its owner.
+_ORIGIN_OWNER_RE = re.compile(r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$")
+
+
+def compare_url(submission: Submission) -> str:
+    """Return the web URL that opens *submission*'s pull request by hand.
+
+    The branch is on whatever ``origin`` is, and for everyone but a maintainer
+    that is a fork — where ``compare/<branch>`` names a branch the upstream
+    repository does not have.  GitHub spells a cross-repository comparison
+    ``main...<owner>:<branch>``, so the owner has to be read off the remote.
+    An unreadable remote falls back to the same-repository form: a URL that
+    might be wrong beats no way out of a failure this branch is already in.
+    """
+    head = submission.branch
+    try:
+        listed = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=submission.checkout,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        # No git on PATH, or a checkout that is no longer there. Neither is
+        # worth raising over -- this URL is itself the handling of a failure --
+        # but it does mean the URL may name the wrong repository, so say so
+        # rather than let a puzzling empty compare page be the first anyone
+        # hears of it.
+        logger.warning(
+            "Could not read `origin` in %s (%s), so the manual pull request "
+            "URL assumes the branch is on %s itself.",
+            submission.checkout,
+            exc,
+            PLUGINS_REPO,
+        )
+        return f"https://github.com/{PLUGINS_REPO}/compare/main...{head}"
+    match = (
+        _ORIGIN_OWNER_RE.search(listed.stdout.strip())
+        if not listed.returncode
+        else None
+    )
+    if match and f"{match[1]}/{match[2]}" != PLUGINS_REPO:
+        head = f"{match[1]}:{submission.branch}"
+    return f"https://github.com/{PLUGINS_REPO}/compare/main...{head}"
+
+
 def open_pull_request(submission: Submission, title: str, body: str) -> str:
     """Open the pull request against the upstream repository, returning its URL."""
     if shutil.which("gh") is None:
         raise PluginError(
             "`gh` is not installed, so the pull request cannot be opened from "
             "here. The branch is pushed, so nothing is lost: open it at "
-            f"https://github.com/{PLUGINS_REPO}/compare/{submission.branch}"
+            f"{compare_url(submission)}"
         )
     return _run(
         [

--- a/pixlstash/plugin_create.py
+++ b/pixlstash/plugin_create.py
@@ -1,0 +1,1091 @@
+"""Start a new plugin as a pull request against the plugins repository.
+
+Backs ``pixlstash-cli plugins create``.  The repository README already
+documents the manual procedure — clone, ``cp -r`` an example, rename the
+folder, rename the module, rewrite the header and the README — and every step
+of it is a place to get it wrong quietly: a folder under the wrong kind, an
+image plugin whose ``.py`` no longer matches its folder, a header still
+crediting the example's author.  This module performs that procedure.
+
+**The skeleton is the example plugin in the checkout, not a copy kept here.**
+A template maintained in this repository would be a second definition of a
+contract owned by another repository, and the two would drift the first time
+its contract tests changed.  The example CI keeps green is the one that gets
+copied, so a scaffold cannot be stale.
+
+Nothing here imports the plugin: the example is read with :mod:`ast` through
+:mod:`pixlstash.plugin_install`, the same way installing reads it.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The private names are the shared definitions of the repository's layout and
+# of what a plugin name may be. Importing them is the point: a second copy of
+# `plugins/<kind>/<slug>` here would be a second thing to get wrong when the
+# repository moves a folder.
+from pixlstash.plugin_install import (
+    CAPTIONING,
+    IMAGE,
+    PLUGINS_REPO,
+    PluginClass,
+    PluginError,
+    _analyse,
+    _declared_name,
+    _NAME_RE,
+    _published_dirs,
+    builtin_names,
+    read_source,
+)
+
+#: What each kind is scaffolded from when ``--from`` is not given.  Both load
+#: no model, so a contributor can run the copy before changing a line of it.
+DEFAULT_EXAMPLES = {
+    CAPTIONING: "hello_world_captioner",
+    IMAGE: "hello_world_stamp",
+}
+
+#: Where a clone lands when ``--dir`` is not given, relative to the working
+#: directory: the name ``git clone`` would have chosen itself.
+DEFAULT_CHECKOUT = "PixlStash-plugins"
+
+CLONE_URL = f"https://github.com/{PLUGINS_REPO}.git"
+
+# "Your Name <you@example.com>" is the shape the repository's contract tests
+# require, so a placeholder has to satisfy it too; it is only ever used when
+# the machine has no git identity to read.
+_PLACEHOLDER_AUTHOR = "Your Name <you@example.com>"
+_PLACEHOLDER_DESCRIPTION = "TODO: one line saying what this plugin does."
+
+
+@dataclass
+class CreateResult:
+    """What ``plugins create`` produced, for the CLI to describe."""
+
+    checkout: Path
+    folder: Path
+    module: Path
+    readme: Path
+    #: The scaffolding brief the agent command points at.
+    brief: Path
+    branch: str
+    kind: str
+    name: str
+    example: str
+    #: True when ``origin`` is the contributor's own fork, so pushing works.
+    forked: bool
+    #: True when the checkout was already there and was reused.
+    reused: bool
+    #: What the contributor said the plugin should do, verbatim. Carried here
+    #: because it is the instruction: the agent prompt needs it, and reading it
+    #: back out of the README means reading it out of a file that also holds
+    #: TODOs the agent then has to tell apart from the brief.
+    purpose: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+# ----------------------------------------------------------------------
+# git and gh
+# ----------------------------------------------------------------------
+
+
+def _run(command: list[str], *, cwd: Path | None = None) -> str:
+    """Run *command*, returning its stdout and turning a failure into a refusal."""
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise PluginError(f"could not run {command[0]}: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        raise PluginError(
+            f"{' '.join(command[:2])} failed (exit {result.returncode})"
+            + (f": {detail[-1]}" if detail else "")
+        )
+    return result.stdout
+
+
+def _have_gh() -> bool:
+    """Return whether a signed-in ``gh`` is available to fork with."""
+    return shutil.which("gh") is not None and _gh("auth", "status") is not None
+
+
+#: How the contributor will get their branch onto GitHub.  Everyone forks,
+#: maintainers included: a plugin arrives as a pull request from a fork, and a
+#: tool that quietly gives some people a shorter route is a tool whose main
+#: path stops being the one anybody tests.
+FORK = "fork"
+MANUAL = "manual"
+
+
+@dataclass
+class ForkReadiness:
+    """Whether a fork can be made, and what to say when it cannot."""
+
+    mode: str
+    #: One line naming the situation, for the wizard to print before it asks.
+    explanation: str
+    #: What the contributor should do about it, when there is anything to do.
+    remedy: str = ""
+    #: The repository that will be created, as ``owner/name``, when one will
+    #: be. Named rather than implied: this command makes a public repository on
+    #: someone's account, and "it will fork it for you" does not say where.
+    fork_target: str = ""
+    #: True when *fork_target* is already there and will be reused rather than
+    #: created, which is the difference between a new repository appearing on
+    #: your account and nothing appearing at all.
+    fork_exists: bool = False
+
+    @property
+    def can_fork(self) -> bool:
+        """Whether a fork can be made, and so whether pushing will work."""
+        return self.mode == FORK
+
+
+def _gh(*arguments: str) -> str | None:
+    """Run a ``gh`` command, returning its stdout or None if it did not work."""
+    try:
+        result = subprocess.run(
+            ["gh", *arguments], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        # No `gh` on this machine. The caller has a fallback for every use of
+        # this, so a missing binary is an answer rather than a failure.
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def fork_readiness() -> ForkReadiness:
+    """Work out how this machine can contribute, before anything is cloned.
+
+    Asked up front rather than discovered by a failed ``gh repo fork`` halfway
+    through, because being told at the end that you cannot push is being told
+    too late to do anything about it.  Both probes are reads, and neither asks
+    what permissions you hold: everyone contributes from a fork, so the answer
+    would not change what happens next.
+    """
+    if shutil.which("gh") is None:
+        return ForkReadiness(
+            MANUAL,
+            "`gh` is not installed, so this cannot fork the repository for you.",
+            f"Clone now and fork https://github.com/{PLUGINS_REPO} on the web "
+            "when you are ready to push, then point `origin` at your fork. Or "
+            "install the GitHub CLI (https://cli.github.com) and run this again.",
+        )
+    if _gh("auth", "status") is None:
+        return ForkReadiness(
+            MANUAL,
+            "`gh` is installed but not signed in, so it cannot fork for you.",
+            "Run `gh auth login`, then run this again. Or clone now and fork "
+            f"https://github.com/{PLUGINS_REPO} on the web later.",
+        )
+
+    login = _gh("api", "user", "--jq", ".login")
+    if not login:
+        # Signed in, but the account will not name itself. The fork will still
+        # work; only the sentence describing it has to admit what it does not
+        # know, rather than inventing an owner.
+        return ForkReadiness(
+            FORK,
+            f"`gh` will fork {PLUGINS_REPO} to your GitHub account. It could "
+            "not tell me which account that is.",
+        )
+
+    target = f"{login}/{PLUGINS_REPO.split('/')[1]}"
+    exists = _gh("repo", "view", target, "--json", "name") is not None
+    if exists:
+        explanation = (
+            f"You already have a fork at https://github.com/{target}, and it "
+            "will be reused. Nothing new is created on your account."
+        )
+    else:
+        explanation = (
+            f"This will create https://github.com/{target}, a public fork of "
+            f"{PLUGINS_REPO} on your account, and clone it."
+        )
+    return ForkReadiness(FORK, explanation, fork_target=target, fork_exists=exists)
+
+
+def obtain_checkout(directory: Path, *, fork: bool) -> tuple[bool, bool]:
+    """Make sure *directory* is a checkout of the plugins repository.
+
+    Returns ``(forked, reused)``.  A fork is how a plugin reaches the
+    repository, so it is the default and the plain clone is the fallback rather
+    than the other way round.  A fork that cannot be made is still worth a
+    checkout: the contributor can write the plugin now and sort the remote out
+    before pushing, which is what the warning tells them to do.
+    """
+    if (directory / ".git").exists():
+        # Reuse rather than refuse: creating a second plugin is a plausible
+        # gesture, and the checkout already has the remotes set up.
+        return _has_fork_remote(directory), True
+    if directory.exists() and any(directory.iterdir()):
+        raise PluginError(
+            f"{directory} already exists and is not a checkout of "
+            f"{PLUGINS_REPO}. Pass --dir to clone somewhere else."
+        )
+
+    directory.parent.mkdir(parents=True, exist_ok=True)
+    if fork and _have_gh():
+        try:
+            # Everything after `--` reaches `git clone`, so this is one command
+            # for fork, clone, `origin` = the fork and `upstream` = here.
+            _run(
+                ["gh", "repo", "fork", PLUGINS_REPO, "--clone", "--", str(directory)],
+                cwd=directory.parent,
+            )
+            return True, False
+        except PluginError:
+            # A fork that cannot be made is not a reason to stop: the clone
+            # below still gives a working checkout, and the caller says so.
+            shutil.rmtree(directory, ignore_errors=True)
+
+    _run(["git", "clone", CLONE_URL, str(directory)])
+    return False, False
+
+
+def _has_fork_remote(directory: Path) -> bool:
+    """Return whether ``origin`` in *directory* is something other than upstream.
+
+    ``gh repo fork`` leaves ``origin`` pointing at the fork and ``upstream`` at
+    the source, so a second remote is what says a push will land somewhere the
+    contributor can push.
+
+    A probe, not a command: a checkout git will not answer for is one we cannot
+    say is a fork, and "no" is the safe answer — it costs a warning telling the
+    contributor to check their remotes, where raising would stop the scaffold.
+    """
+    listed = subprocess.run(
+        ["git", "remote"], cwd=directory, capture_output=True, text=True, check=False
+    )
+    remotes = listed.stdout.split() if listed.returncode == 0 else []
+    return "origin" in remotes and "upstream" in remotes
+
+
+def start_branch(directory: Path, branch: str) -> None:
+    """Create *branch* off the freshest main the checkout can see.
+
+    Branching off ``HEAD`` would be right for a clone made a second ago and
+    wrong for the reused checkout that made last month's plugin, where it
+    quietly bases the pull request on a stale main. ``upstream`` first, because
+    a fork's own ``main`` is the copy that goes stale.
+    """
+    # Checked before branching rather than left to git, because reusing a
+    # checkout is a supported gesture and this is what it hits on the second
+    # run: git's own message names the branch but not the way out.
+    if (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            cwd=directory,
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    ):
+        raise PluginError(
+            f"{directory} already has a branch called {branch!r}, from an "
+            "earlier run. Carry on there (`git switch "
+            f"{branch}`), delete it (`git branch -D {branch}`), or pass "
+            "--branch to use another name."
+        )
+    subprocess.run(["git", "fetch", "--all", "--quiet"], cwd=directory, check=False)
+    for base in ("upstream/main", "origin/main"):
+        if (
+            subprocess.run(
+                ["git", "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}"],
+                cwd=directory,
+                capture_output=True,
+                check=False,
+            ).returncode
+            == 0
+        ):
+            _run(["git", "switch", "-c", branch, base], cwd=directory)
+            return
+    _run(["git", "switch", "-c", branch], cwd=directory)
+
+
+def git_identity(directory: Path) -> str | None:
+    """Return ``Name <email>`` from git config, or None if it is not set.
+
+    The header the repository requires is exactly the shape git already holds,
+    so the one credit a contributor should never have to type is the one they
+    configured years ago.
+    """
+
+    def configured(key: str) -> str:
+        try:
+            return subprocess.run(
+                ["git", "config", key],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+        except OSError:
+            # No git on this machine. Not fatal here: the caller falls back to
+            # the placeholder and the contributor edits one line.
+            return ""
+
+    name, email = configured("user.name"), configured("user.email")
+    return f"{name} <{email}>" if name and email else None
+
+
+# ----------------------------------------------------------------------
+# Scaffolding
+# ----------------------------------------------------------------------
+
+
+def class_name_for(name: str) -> str:
+    """Return the CamelCase class name for a snake_case plugin *name*."""
+    return "".join(part[:1].upper() + part[1:] for part in name.split("_") if part)
+
+
+def display_name_for(name: str) -> str:
+    """Return a readable default label for a snake_case plugin *name*."""
+    return " ".join(part[:1].upper() + part[1:] for part in name.split("_") if part)
+
+
+def first_sentence(text: str | None) -> str:
+    """Return the first sentence of *text*, short enough to be a description.
+
+    The wizard asks what the plugin should do once and puts the answer in two
+    places: the README paragraph whole, and the class's one-line
+    ``description`` trimmed to its first sentence.  Asking twice for the same
+    thing in two lengths is how a wizard starts feeling like a form.
+    """
+    joined = " ".join((text or "").split())
+    if not joined:
+        return ""
+    sentence = re.split(r"(?<=[.!?])\s", joined, maxsplit=1)[0]
+    # ponytail: a plain clamp, matching `plugin_install._summary`. A first
+    # sentence longer than this is one the contributor should shorten anyway.
+    return sentence if len(sentence) <= 200 else sentence[:197] + "..."
+
+
+def check_name(name: str, kind: str) -> None:
+    """Raise unless *name* is one a plugin of *kind* can actually be called.
+
+    The two checks that do not need a checkout, so the wizard can run them
+    while it is still in a position to ask again rather than after a clone.
+    The repository-wide collision needs the checkout and stays in `scaffold`.
+    """
+    if not _NAME_RE.match(name):
+        raise PluginError(
+            f"{name!r} is not a plugin name. Names are lower-case, start with "
+            "a letter, and hold only letters, digits and underscores."
+        )
+    if name in builtin_names(kind):
+        raise PluginError(
+            f"PixlStash already ships a {kind} plugin called {name!r}, and a "
+            "built-in wins the collision, so yours would never load. Pick "
+            "another name."
+        )
+
+
+def taken_names(checkout: Path) -> set[str]:
+    """Return every name the repository already publishes, folder or declared.
+
+    Both, because either one is a collision: the folder name is what a
+    contributor sees in the tree, and the declared name is what the plugin
+    installs and loads under.
+    """
+    published = _published_dirs(checkout)
+    return {_declared_name(entry) for entry in published} | {
+        entry.name for entry in published
+    }
+
+
+def check_name_free(checkout: Path, name: str, kind: str) -> None:
+    """Raise unless *name* is usable and nothing in *checkout* already has it.
+
+    Separate from `check_name` because this one needs the checkout: it is the
+    check the wizard runs against the clone it has just made, so a taken name
+    costs one more question rather than an error after every question.
+    """
+    check_name(name, kind)
+    # Before the collision check, which would otherwise see this very folder as
+    # a plugin the repository publishes and give the less useful of the two
+    # answers: "the name is taken" when what happened is you already made it.
+    folder = checkout / "plugins" / kind / name
+    if folder.exists():
+        raise PluginError(f"{folder} already exists.")
+    if name in taken_names(checkout):
+        raise PluginError(
+            f"the name {name!r} is taken: {PLUGINS_REPO} already publishes a "
+            "plugin called that. Names are unique across the repository, so a "
+            "pull request adding a second one is turned down. Pick another."
+        )
+
+
+def find_example(checkout: Path, kind: str, example: str) -> tuple[Path, PluginClass]:
+    """Return the example folder and the plugin class declared in it."""
+    candidates = [
+        folder
+        for folder in _published_dirs(checkout)
+        if folder.name == example or _declared_name(folder) == example
+    ]
+    if not candidates:
+        published = ", ".join(sorted(f.name for f in _published_dirs(checkout)))
+        raise PluginError(
+            f"{checkout} publishes no plugin called {example!r}. "
+            f"Available: {published or '(none)'}"
+        )
+    folder = candidates[0]
+
+    found = [
+        entry
+        for source in sorted(folder.glob("*.py"))
+        for entry in _analyse(read_source(source), source, strict=False)
+    ]
+    if not found:
+        raise PluginError(f"{folder} declares no plugin class to copy.")
+    primary = found[0]
+    if primary.kind != kind:
+        raise PluginError(
+            f"{example} is a {primary.kind} plugin, so it cannot be the "
+            f"starting point for a {kind} one. Drop --from to use "
+            f"{DEFAULT_EXAMPLES[kind]}."
+        )
+    return folder, primary
+
+
+#: Ruff's default line length, which the plugins repository does not change.
+_LINE_LENGTH = 88
+
+
+def _header_literal(field_name: str, value: str, width: int = _LINE_LENGTH) -> str:
+    """Return ``    field = "value"``, wrapped across lines if it will not fit.
+
+    A description written as a sentence — which is what the wizard asks for —
+    routinely overruns the line length, and ``ruff format`` would then want to
+    reformat a file nobody has touched yet.  Adjacent string literals are one
+    constant to :mod:`ast`, so the header readers see no difference.
+    """
+    single = f"    {field_name} = {json.dumps(value)}"
+    if len(single) <= width:
+        return single
+
+    chunks: list[str] = []
+    current = ""
+    for word in value.split():
+        candidate = f"{current} {word}" if current else word
+        # 8 for the continuation indent; the trailing space joins this chunk to
+        # the next one, and has to fit too.
+        if current and len(json.dumps(f"{candidate} ")) + 8 > width:
+            chunks.append(f"{current} ")
+            current = word
+        else:
+            current = candidate
+    chunks.append(current)
+
+    body = "\n".join(f"        {json.dumps(chunk)}" for chunk in chunks)
+    return f"    {field_name} = (\n{body}\n    )"
+
+
+def _rewrite_header(source: str, values: dict[str, str]) -> tuple[str, list[str]]:
+    """Replace the example's header values with *values*, reporting misses.
+
+    Anchored on the four-space indent of a class body so it cannot touch a
+    module-level constant of the same name.  A field that is not found is a
+    warning rather than a refusal: the scaffold is still usable, and the one
+    thing that must not happen is shipping a pull request that silently credits
+    the example's author.
+    """
+    warnings: list[str] = []
+    for field_name, value in values.items():
+        # `json.dumps` rather than quotes round the value, and a callable
+        # rather than a template: a name holding a quote, a backslash or a
+        # newline would otherwise produce a file that will not parse, and a
+        # `\g` in it would be read as a group reference by `re`.
+        literal = _header_literal(field_name, value)
+        source, count = re.subn(
+            rf"^    {field_name} = .*$",
+            lambda _match, literal=literal: literal,
+            source,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if not count:
+            warnings.append(
+                f"could not find `{field_name}` in the example, so it still "
+                "holds whatever the example declared; set it by hand."
+            )
+    return source, warnings
+
+
+def _replace_docstring(source: str, text: str) -> str:
+    """Replace the module docstring with *text*, or add one if there is none."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+    lines = source.splitlines(keepends=True)
+    docstring = f'"""{text}"""\n'
+    if (
+        tree.body
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    ):
+        node = tree.body[0]
+        return (
+            "".join(lines[: node.lineno - 1])
+            + docstring
+            + "".join(lines[node.end_lineno :])
+        )
+    return docstring + "\n" + source
+
+
+#: What goes under "What it should do" when the wizard did not ask, or the
+#: answer was empty. A TODO is honest: the repository requires a README that
+#: describes the plugin, and nothing here knows what this one will do.
+PURPOSE_TODO = (
+    "TODO: say what this plugin should do, in a sentence or three. Nothing "
+    "else in this folder knows, so an agent sent here will have to ask."
+)
+
+#: The file the agent is pointed at, written into the plugin folder.
+#:
+#: On disk rather than in the command because a prompt has to be pasted, and
+#: nobody pastes four paragraphs: the command stays one short line and the
+#: brief goes where it can be read, re-read and edited before anyone runs
+#: anything. Being a file also makes it worth writing properly, where a shell
+#: argument is only ever worth keeping short.
+BRIEF_NAME = "BRIEF.md"
+
+BRIEF = """# Brief: {name}
+
+A PixlStash {kind} plugin. Build it in this folder.
+
+## Read this first
+
+`AGENTS.md` at the root of this repository, and `CLAUDE.md`, which is the same
+file under the other name, are the general brief for writing a plugin here:
+the contract to follow, which guide in `docs/` covers this kind, the six header
+fields, what a plugin README needs, the dependency rules and the house style.
+That file is maintained and tested by this repository, so it wins wherever
+anything disagrees with it. This brief does not repeat it. It covers only what
+that file cannot know: which plugin this is, and what it is for.
+
+## What it has to do
+
+{purpose}
+
+## Where you are starting from
+
+This folder is a copy of the `{example}` example with the names changed, so
+`{module}` currently does what that example does. Replace it: none of the
+example's behaviour, parameters or constants should survive.
+
+## What done looks like
+
+- `{module}` does what this brief says.
+- `README.md` describes the plugin you built, with no TODO left in it: what it
+  does, its dependencies, one row per parameter, the models it loads and its
+  license.
+- `ruff format .`, `ruff check .` and `pytest` pass from the root of this
+  repository.
+- This file is gone. It is scaffolding, not part of the plugin.
+
+Working code is the deliverable. A README explaining that the plugin is not
+implemented is not.
+"""
+
+#: Written into the brief when nobody said what the plugin is for. Stopping is
+#: the right answer: a plugin invented to fill a silence is worse than none.
+BRIEF_NO_PURPOSE = (
+    "**Nobody said.** Whoever scaffolded this folder did not record what the "
+    "plugin should do, and nothing here knows. Stop and ask rather than "
+    "inventing one."
+)
+
+README = """# {display_name}
+
+> Not written yet. `{brief}` in this folder is the brief, and the code beside
+> it is still the example it was copied from.
+
+## What it should do
+
+{purpose}
+
+## Install
+
+```bash
+pixlstash-cli plugins install {name}
+```
+
+## Dependencies
+
+TODO: what has to be installed into the environment PixlStash runs in, and
+nothing if the answer is nothing. List the same packages in `requirements.txt`.
+
+## Parameters
+
+| Parameter | Type | Default | Meaning |
+|-----------|------|---------|---------|
+| TODO | | | |
+
+## Models
+
+TODO: every model or remote service this plugin loads, and its license. Say
+"none" if it loads none. This is the part a user cannot find out for
+themselves, and your own license says nothing about it.
+
+## License
+
+{license}, see the [LICENSE](../../../LICENSE) at the repository root.
+"""
+
+
+def scaffold(
+    checkout: Path,
+    name: str,
+    kind: str,
+    *,
+    example: str,
+    display_name: str | None = None,
+    description: str | None = None,
+    purpose: str | None = None,
+    author: str | None = None,
+    plugin_license: str = "MIT",
+) -> tuple[Path, Path, Path, Path, list[str]]:
+    """Copy the example into ``plugins/<kind>/<name>/`` and make it *name*'s.
+
+    Returns ``(folder, module, readme, brief, warnings)``.
+    """
+    check_name(name, kind)
+    check_name_free(checkout, name, kind)
+    folder = checkout / "plugins" / kind / name
+    source_folder, primary = find_example(checkout, kind, example)
+    shutil.copytree(
+        source_folder, folder, ignore=shutil.ignore_patterns("__pycache__", "*.pyc")
+    )
+
+    # An image plugin's folder holds one `.py` named after it — the loader
+    # scans for files and never sees the folder — so the rename is part of the
+    # contract rather than tidiness.
+    module = folder / primary.file.name
+    if module.name != "__init__.py":
+        renamed = folder / f"{name}.py"
+        module.rename(renamed)
+        module = renamed
+
+    label = display_name or display_name_for(name)
+    source = read_source(module)
+    source = source.replace(primary.name, name)
+    source = source.replace(primary.class_name, class_name_for(name))
+    # What the contributor said the plugin is for goes here as well as in the
+    # README: this is the file they — or the coding agent they hand it to —
+    # will have open, and a docstring still saying TODO next to a README that
+    # does not is the pair that gets left inconsistent.
+    said = " ".join((purpose or "").split())
+    body = (
+        "\n".join(textwrap.wrap(said, width=79))
+        if said
+        else "TODO: what it does, and how."
+    )
+    source = _replace_docstring(source, f"{label} plugin for PixlStash.\n\n{body}\n")
+    source, warnings = _rewrite_header(
+        source,
+        {
+            "display_name": label,
+            "description": description
+            or first_sentence(purpose)
+            or _PLACEHOLDER_DESCRIPTION,
+            "author": author or git_identity(checkout) or _PLACEHOLDER_AUTHOR,
+            "license": plugin_license,
+        },
+    )
+    module.write_text(source, encoding="utf-8")
+
+    # Written fresh rather than rewritten: the example's README describes the
+    # example, and every sentence of it left in place is a sentence a reviewer
+    # has to notice is a lie.
+    readme = folder / "README.md"
+    readme.write_text(
+        README.format(
+            display_name=label,
+            name=name,
+            brief=BRIEF_NAME,
+            license=plugin_license,
+            purpose=(purpose or "").strip() or PURPOSE_TODO,
+        ),
+        encoding="utf-8",
+    )
+
+    brief = folder / BRIEF_NAME
+    brief.write_text(
+        BRIEF.format(
+            name=name,
+            kind=kind,
+            example=example,
+            module=module.name,
+            purpose=(purpose or "").strip() or BRIEF_NO_PURPOSE,
+        ),
+        encoding="utf-8",
+    )
+    return folder, module, readme, brief, warnings
+
+
+#: The coding agents `plugins create` can hand the job to, by the command that
+#: starts one.  Both take the prompt as a single argument and run in the
+#: working directory, which is why one prompt serves both.
+AGENTS = {
+    "claude": "claude",
+    "codex": "codex",
+}
+
+#: One short line, because it gets pasted. Everything it would otherwise have
+#: had to say is in the brief that `scaffold` writes into the plugin folder:
+#: what to build, that the folder holds a renamed copy of an example rather
+#: than a start, and that code rather than an apology is the deliverable. A
+#: file can be read before it is run and edited before it is obeyed; a shell
+#: argument can only be squinted at.
+AGENT_PROMPT = "Read {brief} and do what it says."
+
+
+def agent_prompt(result: CreateResult) -> str:
+    """Return the prompt that points a coding agent at this plugin's brief."""
+    return AGENT_PROMPT.format(
+        brief=result.brief.relative_to(result.checkout).as_posix()
+    )
+
+
+def agent_command(agent: str, result: CreateResult) -> str:
+    """Return a pasteable shell command running *agent* on this plugin.
+
+    It carries its own ``cd``.  The prompt names the plugin by a path relative
+    to the checkout, and the agent reads the checkout's ``AGENTS.md``, so both
+    are wrong anywhere else; printing the directory as prose above the command
+    put one line between a reader and a paste, and the paste is what gets used.
+    """
+    if agent not in AGENTS:
+        raise PluginError(
+            f"{agent!r} is not an agent this knows how to call. "
+            f"Choose one of: {', '.join(sorted(AGENTS))}."
+        )
+    return (
+        f"cd {shlex.quote(str(result.checkout))} && "
+        f"{AGENTS[agent]} {shlex.quote(agent_prompt(result))}"
+    )
+
+
+def create(
+    name: str,
+    kind: str,
+    *,
+    directory: Path,
+    example: str | None = None,
+    branch: str | None = None,
+    display_name: str | None = None,
+    description: str | None = None,
+    purpose: str | None = None,
+    author: str | None = None,
+    plugin_license: str = "MIT",
+    fork: bool = True,
+    readiness: ForkReadiness | None = None,
+    checkout_state: tuple[bool, bool] | None = None,
+) -> CreateResult:
+    """Clone or reuse a checkout, branch, and scaffold *name* into it.
+
+    *readiness* is passed in by the wizard, which has already probed it and
+    shown the contributor what it found; anything else lets this probe for
+    itself.  It decides both whether to try forking and whether the "you cannot
+    push" warning is true, which is why one value does both rather than a bool
+    saying to fork and a separate guess about what that meant.
+    """
+    check_name(name, kind)
+    directory = directory.expanduser()
+    example = example or DEFAULT_EXAMPLES[kind]
+    branch = branch or f"add-{name}"
+    if readiness is None:
+        readiness = (
+            fork_readiness()
+            if fork
+            else ForkReadiness(MANUAL, "--no-fork was given, so nothing was forked.")
+        )
+
+    forked, reused = (
+        checkout_state
+        if checkout_state is not None
+        else obtain_checkout(directory, fork=readiness.can_fork)
+    )
+    start_branch(directory, branch)
+    folder, module, readme, brief, warnings = scaffold(
+        directory,
+        name,
+        kind,
+        example=example,
+        display_name=display_name,
+        description=description,
+        purpose=purpose,
+        author=author,
+        plugin_license=plugin_license,
+    )
+    if not forked:
+        remedy = readiness.remedy or (
+            f"Fork https://github.com/{PLUGINS_REPO} on the web, then point "
+            "`origin` at your fork before pushing."
+        )
+        warnings.append(
+            "`origin` is the upstream repository rather than your fork, so "
+            f"you cannot push to it. {remedy}"
+        )
+    return CreateResult(
+        checkout=directory,
+        folder=folder,
+        module=module,
+        readme=readme,
+        brief=brief,
+        branch=branch,
+        kind=kind,
+        name=name,
+        example=example,
+        forked=forked,
+        reused=reused,
+        purpose=(purpose or "").strip(),
+        warnings=warnings,
+    )
+
+
+# ----------------------------------------------------------------------
+# Submitting
+# ----------------------------------------------------------------------
+
+
+#: The branch names `create` makes, so `submit` can work out which plugin it is
+#: being asked about without being told twice.
+_BRANCH_PREFIX = "add-"
+
+#: The repository's own checks, in the order its instructions run them:
+#: formatting changes lines, so linting before it reports positions that are
+#: about to move.
+CHECKS = (("ruff", ["format", "."]), ("ruff", ["check", "."]), ("pytest", ["-q"]))
+
+
+@dataclass
+class Submission:
+    """One plugin, ready to be checked, committed and turned into a PR."""
+
+    checkout: Path
+    kind: str
+    name: str
+    folder: Path
+    branch: str
+    #: The interpreter that has the repository's dev tools.
+    python: Path
+
+
+def find_submission(directory: Path, name: str | None = None) -> Submission:
+    """Work out which plugin in *directory* is the one being submitted.
+
+    Derived from the branch when it can be, because `create` named the branch
+    after the plugin, and asking again for something already on disk is how a
+    two-command flow becomes one you have to remember arguments for.  An
+    explicit *name* wins, for a checkout branched by hand.
+    """
+    directory = directory.expanduser()
+    if not (directory / ".git").exists():
+        raise PluginError(
+            f"{directory} is not a checkout of {PLUGINS_REPO}. Pass --dir, or "
+            "run `plugins create` first."
+        )
+
+    branch = _run(["git", "branch", "--show-current"], cwd=directory).strip()
+    if not branch:
+        raise PluginError(
+            f"{directory} is not on a branch (detached HEAD), so there is "
+            "nothing to push. Check out the branch your plugin is on."
+        )
+    if name is None:
+        if not branch.startswith(_BRANCH_PREFIX):
+            raise PluginError(
+                f"{directory} is on {branch!r}, which does not name a plugin. "
+                "Say which with `plugins submit <name>`."
+            )
+        name = branch[len(_BRANCH_PREFIX) :]
+
+    matches = [
+        (kind, directory / "plugins" / kind / name)
+        for kind in (CAPTIONING, IMAGE)
+        if (directory / "plugins" / kind / name).is_dir()
+    ]
+    if not matches:
+        raise PluginError(
+            f"{directory} has no plugin folder called {name!r} under "
+            "plugins/captioning/ or plugins/image/."
+        )
+    if len(matches) > 1:
+        raise PluginError(
+            f"{directory} holds both a captioning and an image plugin called "
+            f"{name!r}. The repository takes one plugin per pull request; "
+            "submit them from separate branches."
+        )
+    kind, folder = matches[0]
+    return Submission(directory, kind, name, folder, branch, _dev_python(directory))
+
+
+def _dev_python(directory: Path) -> Path:
+    """Return the interpreter holding the repository's dev tools.
+
+    Its own virtualenv first: the repository pins its ruff, and a different
+    version formats differently, so borrowing ours could turn its CI red over
+    whitespace.  Falling back to ours is what makes the checks runnable at all
+    on a machine that has not made one yet.
+    """
+    binaries = directory / ".venv" / ("Scripts" if os.name == "nt" else "bin")
+    candidate = binaries / ("python.exe" if os.name == "nt" else "python")
+    return candidate if candidate.exists() else Path(sys.executable)
+
+
+def missing_tools(submission: Submission) -> list[str]:
+    """Return the check modules *submission*'s interpreter cannot import.
+
+    Probed rather than inferred from an exit code: ``python -m nope`` exits 1
+    exactly like a test failure does, and "your plugin is broken" is the wrong
+    thing to tell someone whose only problem is an empty virtualenv.
+    """
+    return [
+        module
+        for module in dict.fromkeys(module for module, _arguments in CHECKS)
+        if subprocess.run(
+            [str(submission.python), "-c", f"import {module}"],
+            capture_output=True,
+            check=False,
+        ).returncode
+        != 0
+    ]
+
+
+def dev_setup_hint(submission: Submission, missing: list[str]) -> str:
+    """Return the commands that give the checkout the tools it is missing."""
+    venv = "python -m venv .venv && .venv/bin/pip"
+    return (
+        f"{submission.python} cannot import {', '.join(missing)}, so the "
+        "checks cannot run. Give the checkout its own tools:\n"
+        f"  cd {submission.checkout}\n"
+        f"  {venv} install -r requirements-dev.txt\n"
+        "  .venv/bin/pip install --no-deps pixlstash"
+    )
+
+
+def run_checks(submission: Submission) -> list[str]:
+    """Run the repository's own checks, returning the ones that failed."""
+    failed: list[str] = []
+    for module, arguments in CHECKS:
+        printable = f"{module} {' '.join(arguments)}"
+        # Flushed, and so is everything buffered behind it: the child writes
+        # straight to the terminal, so without this its output arrives before
+        # the line saying which command produced it.
+        print(f"\n$ {printable}", flush=True)
+        result = subprocess.run(
+            [str(submission.python), "-m", module, *arguments],
+            cwd=submission.checkout,
+            check=False,
+        )
+        if result.returncode != 0:
+            failed.append(printable)
+    return failed
+
+
+def commit(submission: Submission, message: str) -> None:
+    """Stage the plugin folder and nothing else, then commit it.
+
+    Staged by path rather than with ``git add -A``: the checkout is the
+    contributor's, may hold work of their own, and the repository takes one
+    plugin per pull request.
+    """
+    relative = submission.folder.relative_to(submission.checkout).as_posix()
+    _run(["git", "add", "--", relative], cwd=submission.checkout)
+    staged = _run(
+        ["git", "diff", "--cached", "--name-only"], cwd=submission.checkout
+    ).split()
+    if not staged:
+        raise PluginError(
+            f"nothing to commit in {relative}: it is already committed, or "
+            "unchanged since the last commit."
+        )
+    _run(["git", "commit", "-m", message], cwd=submission.checkout)
+
+
+def push(submission: Submission) -> None:
+    """Push the branch to ``origin``, setting it upstream."""
+    _run(
+        ["git", "push", "--set-upstream", "origin", submission.branch],
+        cwd=submission.checkout,
+    )
+
+
+#: The pull request body.  Deliberately short, and deliberately not a summary
+#: of the plugin: the plugin's own README is in the diff and says all of that.
+#: What a reviewer cannot get from the diff is what the contributor actually
+#: ran, which CI can never tell them for a plugin that loads a model.
+PULL_REQUEST_BODY = """\
+Adds `{name}`, {article} {kind} plugin.
+
+See `{readme}` for what it does, its parameters and its licence.
+
+## Tested against
+
+{tested}
+"""
+
+
+def pull_request_body(submission: Submission, tested: str) -> str:
+    """Return the pull request body, given what the contributor tested against.
+
+    *tested* is theirs, verbatim.  Nothing here adds a path, a directory
+    listing or anything else read off this machine: a pull request is public
+    and permanent, and the only thing that belongs in one is what the person
+    opening it chose to write.
+    """
+    readme = (submission.folder / "README.md").relative_to(submission.checkout)
+    return PULL_REQUEST_BODY.format(
+        name=submission.name,
+        article="a" if submission.kind == CAPTIONING else "an",
+        kind=submission.kind,
+        readme=readme.as_posix(),
+        tested=tested.strip(),
+    )
+
+
+def open_pull_request(submission: Submission, title: str, body: str) -> str:
+    """Open the pull request against the upstream repository, returning its URL."""
+    if shutil.which("gh") is None:
+        raise PluginError(
+            "`gh` is not installed, so the pull request cannot be opened from "
+            "here. The branch is pushed, so nothing is lost: open it at "
+            f"https://github.com/{PLUGINS_REPO}/compare/{submission.branch}"
+        )
+    return _run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            PLUGINS_REPO,
+            "--base",
+            "main",
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        cwd=submission.checkout,
+    ).strip()

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -20,6 +20,7 @@ whoever can write to the plugin directory can already install a plugin by hand.
 from __future__ import annotations
 
 import ast
+import json
 import os
 import re
 import shutil
@@ -28,6 +29,8 @@ import sys
 import zipfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as metadata_version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Iterator
@@ -757,6 +760,84 @@ def install(plan: InstallPlan, *, force: bool = False) -> None:
                 staged.unlink(missing_ok=True)
             )
         raise PluginError(f"could not install to {plan.destination}: {exc}") from exc
+
+
+@dataclass
+class DependencyChange:
+    """One package pip would install, and what is there now."""
+
+    name: str
+    version: str
+    #: The version already installed, or None when the package is new here.
+    installed: str | None = None
+
+    @property
+    def moves(self) -> bool:
+        """Whether installing this would change a package already in use.
+
+        The one distinction that matters. Adding a package cannot break what is
+        running; replacing one can, and PixlStash pins every dependency it has,
+        so the thing most likely to be replaced is PixlStash's own torch.
+        """
+        return self.installed is not None and self.installed != self.version
+
+
+def resolve_requirements(requirements: Path) -> list[DependencyChange]:
+    """Return every package installing *requirements* would add or replace.
+
+    Resolved by pip rather than by us: ``--dry-run --report`` runs the real
+    resolver, writes what it would do as JSON, and touches nothing.  The report
+    lists only what is not already satisfied, so an entry is by definition a
+    change, and the entries include transitive dependencies -- which is the
+    point, since a plugin asking for one package can pull in forty.
+
+    Nothing here decides whether the answer is acceptable; it says what would
+    happen, and the caller shows it to the person who has to agree to it.
+    """
+    with TemporaryDirectory(prefix="pixlstash-deps-") as scratch:
+        report = Path(scratch) / "report.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--dry-run",
+                "--quiet",
+                "--report",
+                str(report),
+                "-r",
+                str(requirements),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            raise PluginError(
+                f"pip could not work out what {requirements.name} needs "
+                f"(exit {result.returncode})"
+                + (f": {detail[-1]}" if detail else "")
+                + ". Nothing was installed."
+            )
+        try:
+            entries = json.loads(report.read_text(encoding="utf-8"))["install"]
+        except (OSError, ValueError, KeyError) as exc:
+            raise PluginError(
+                f"pip did not report what it would install: {exc}. "
+                "Nothing was installed."
+            ) from exc
+
+    changes = []
+    for entry in entries:
+        name = entry["metadata"]["name"]
+        try:
+            installed = metadata_version(name)
+        except PackageNotFoundError:
+            installed = None
+        changes.append(DependencyChange(name, entry["metadata"]["version"], installed))
+    return sorted(changes, key=lambda change: change.name.lower())
 
 
 def read_requirements(requirements: Path) -> list[str]:

--- a/tests/test_cli_documentation.py
+++ b/tests/test_cli_documentation.py
@@ -53,8 +53,8 @@ def test_the_walk_reaches_every_command():
     assert "pixlstash-cli libraries backup" in walked
     assert "pixlstash-server" in walked
     assert "pixlstash-cli plugins available" in walked
-    # 2 roots + 2 groups + 8 library verbs + 5 plugin verbs, at least.
-    assert len(walked) >= 17, walked
+    # 2 roots + 2 groups + 8 library verbs + 7 plugin verbs, at least.
+    assert len(walked) >= 19, walked
 
 
 def test_entry_points_are_named_as_they_are_installed():

--- a/tests/test_plugin_create.py
+++ b/tests/test_plugin_create.py
@@ -1,0 +1,1173 @@
+"""`pixlstash-cli plugins create` — scaffolding a plugin pull request.
+
+Nothing here reaches the network or GitHub: the "checkout" is a directory laid
+out like the plugins repository, and the one test that needs real branching
+runs ``git init`` in ``tmp_path``.  What is actually under test is the rewrite
+— the folder, the module filename, the class, the header and the README — plus
+the refusals that stop someone spending an afternoon on a pull request the
+repository would turn down for its name.
+"""
+
+from __future__ import annotations
+
+import ast
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pixlstash import cli, plugin_create
+from pixlstash.plugin_install import CAPTIONING, IMAGE, PluginError
+
+EXAMPLE_STAMP = '''\
+"""Hello-world image plugin for PixlStash: stamps "Hello World" on the image."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pixlstash.image_plugins.base import ImagePlugin
+
+DEFAULT_TEXT = "Hello World"
+
+
+class HelloWorldStamp(ImagePlugin):
+    """Draws a line of magenta text onto every image in the batch."""
+
+    name = "hello_world_stamp"
+    display_name = "Hello World Stamp"
+    description = "Stamps text. Example plugin."
+    author = "PixlStash plugins <https://example.com/plugins>"
+    license = "MIT"
+    models = []
+
+    def parameter_schema(self) -> list[dict[str, Any]]:
+        return []
+
+    def run(self, images, parameters, progress_callback=None, error_callback=None):
+        return images
+'''
+
+EXAMPLE_CAPTIONER = '''\
+"""Hello-world captioner plugin for PixlStash."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pixlstash.tagger_plugins.base import TaggerPlugin
+
+
+class HelloWorldCaptioner(TaggerPlugin):
+    """Captions every image from a template, with no model involved."""
+
+    name = "hello_world_captioner"
+    display_name = "Hello World Captioner"
+    description = "Writes a templated description. Example plugin."
+    author = "PixlStash plugins <https://example.com/plugins>"
+    license = "MIT"
+    models = []
+
+    def parameter_schema(self) -> list[dict[str, Any]]:
+        return []
+
+    def needs_download(self, parameters=None) -> bool:
+        return False
+
+    def init(self, parameters=None) -> None:
+        return None
+
+    def unload(self) -> None:
+        return None
+
+    def is_loaded(self) -> bool:
+        return True
+'''
+
+EXAMPLE_README = "# Hello World Stamp\n\nDraws magenta text on every picture.\n"
+
+
+@pytest.fixture
+def checkout(tmp_path) -> Path:
+    """A directory laid out the way the plugins repository is."""
+    root = tmp_path / "PixlStash-plugins"
+    image = root / "plugins" / "image" / "hello_world_stamp"
+    image.mkdir(parents=True)
+    (image / "hello_world_stamp.py").write_text(EXAMPLE_STAMP, encoding="utf-8")
+    (image / "README.md").write_text(EXAMPLE_README, encoding="utf-8")
+
+    captioning = root / "plugins" / "captioning" / "hello_world_captioner"
+    captioning.mkdir(parents=True)
+    (captioning / "__init__.py").write_text(EXAMPLE_CAPTIONER, encoding="utf-8")
+    (captioning / "README.md").write_text("# Hello World Captioner\n", encoding="utf-8")
+    return root
+
+
+# ----------------------------------------------------------------------
+# Scaffolding
+# ----------------------------------------------------------------------
+
+
+def test_an_image_plugin_is_copied_renamed_and_recredited(checkout):
+    """The whole rewrite, in one place: folder, file, class, header, README."""
+    folder, module, readme, brief, warnings = plugin_create.scaffold(
+        checkout,
+        "magenta_wash",
+        IMAGE,
+        example="hello_world_stamp",
+        author="Ada <ada@example.com>",
+        plugin_license="Apache-2.0",
+    )
+
+    assert warnings == []
+    assert folder == checkout / "plugins" / "image" / "magenta_wash"
+    # The image loader scans for `.py` and never sees the folder, so a module
+    # still called after the example is a plugin that installs under the wrong
+    # name. The rename is the contract, not tidiness.
+    assert module.name == "magenta_wash.py"
+    assert not (folder / "hello_world_stamp.py").exists()
+
+    source = module.read_text(encoding="utf-8")
+    assert "class MagentaWash(ImagePlugin):" in source
+    assert 'name = "magenta_wash"' in source
+    assert 'display_name = "Magenta Wash"' in source
+    assert 'author = "Ada <ada@example.com>"' in source
+    assert 'license = "Apache-2.0"' in source
+    # Nothing of the example's identity may survive into a pull request.
+    assert "hello_world_stamp" not in source
+    assert "HelloWorldStamp" not in source
+    assert "PixlStash plugins" not in source
+
+    assert source.startswith('"""Magenta Wash plugin for PixlStash.')
+    assert "TODO" in readme.read_text(encoding="utf-8")
+    assert "Hello World Stamp" not in readme.read_text(encoding="utf-8")
+
+
+def test_a_captioning_plugin_keeps_its_init_filename(checkout):
+    """A captioning plugin is a package, so `__init__.py` must not be renamed."""
+    folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout,
+        "tiny_vlm",
+        CAPTIONING,
+        example="hello_world_captioner",
+        description="Captions with a tiny VLM.",
+    )
+
+    assert module == folder / "__init__.py"
+    source = module.read_text(encoding="utf-8")
+    assert "class TinyVlm(TaggerPlugin):" in source
+    assert 'description = "Captions with a tiny VLM."' in source
+
+
+def test_the_description_is_a_visible_todo_when_it_is_not_given(checkout):
+    """A placeholder passes the contract tests, so it has to be readable as one."""
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "tiny_vlm", CAPTIONING, example="hello_world_captioner"
+    )
+    assert "TODO" in module.read_text(encoding="utf-8")
+
+
+def test_a_missing_header_field_warns_rather_than_passing_silently(checkout):
+    """Shipping the example's author is the failure this warning exists for."""
+    example = checkout / "plugins" / "image" / "hello_world_stamp"
+    source = (example / "hello_world_stamp.py").read_text(encoding="utf-8")
+    (example / "hello_world_stamp.py").write_text(
+        source.replace(
+            '    author = "PixlStash plugins <https://example.com/plugins>"\n', ""
+        ),
+        encoding="utf-8",
+    )
+
+    _folder, _module, _readme, _brief, warnings = plugin_create.scaffold(
+        checkout, "magenta_wash", IMAGE, example="hello_world_stamp"
+    )
+    assert any("author" in warning for warning in warnings)
+
+
+def test_a_header_value_holding_a_quote_still_parses(checkout):
+    """The values reach a Python literal, so quoting them is not cosmetic."""
+    description = 'Says "hello", and a backslash \\g too.'
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout,
+        "magenta_wash",
+        IMAGE,
+        example="hello_world_stamp",
+        description=description,
+    )
+
+    source = module.read_text(encoding="utf-8")
+    literals = {
+        target.id: node.value.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert literals["description"] == description
+
+
+def test_a_long_description_is_wrapped_so_the_file_needs_no_reformatting(checkout):
+    """A sentence-length description would otherwise make `ruff format` dirty."""
+    sentence = (
+        "Give every picture a soft glow around its edges, much like a bloom filter."
+    )
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "edge_glow", IMAGE, example="hello_world_stamp", purpose=sentence
+    )
+
+    source = module.read_text(encoding="utf-8")
+    assert all(len(line) <= 88 for line in source.splitlines())
+    # Adjacent literals are one constant to `ast`, so the header readers that
+    # never import a plugin still see the whole sentence.
+    literals = {
+        target.id: node.value.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert literals["description"] == sentence
+
+
+def test_the_git_identity_is_the_default_author(checkout, monkeypatch):
+    monkeypatch.setattr(plugin_create, "git_identity", lambda _root: "Ada <a@b.com>")
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "magenta_wash", IMAGE, example="hello_world_stamp"
+    )
+    assert 'author = "Ada <a@b.com>"' in module.read_text(encoding="utf-8")
+
+
+def test_a_machine_with_no_git_identity_still_gets_a_valid_placeholder(
+    checkout, monkeypatch
+):
+    """The repository's tests require `Name <contact>`, placeholder included."""
+    monkeypatch.setattr(plugin_create, "git_identity", lambda _root: None)
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "magenta_wash", IMAGE, example="hello_world_stamp"
+    )
+    assert f'author = "{plugin_create._PLACEHOLDER_AUTHOR}"' in module.read_text(
+        encoding="utf-8"
+    )
+
+
+# ----------------------------------------------------------------------
+# Refusals
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["../evil", "My_Filter", "9lives", "with-dash", ""])
+def test_a_name_that_is_not_a_plugin_name_is_refused(checkout, name):
+    """The name reaches the filesystem, so this is containment, not tidiness."""
+    with pytest.raises(PluginError, match="not a plugin name"):
+        plugin_create.scaffold(checkout, name, IMAGE, example="hello_world_stamp")
+
+
+def test_a_name_the_repository_already_publishes_is_refused(checkout):
+    """Names are unique across the repository, not within one kind."""
+    with pytest.raises(PluginError, match="already publishes"):
+        plugin_create.scaffold(
+            checkout, "hello_world_captioner", IMAGE, example="hello_world_stamp"
+        )
+
+
+def test_a_builtin_name_is_refused(checkout):
+    """A built-in wins the collision, so the plugin would never load."""
+    with pytest.raises(PluginError, match="already ships"):
+        plugin_create.scaffold(checkout, "pixelate", IMAGE, example="hello_world_stamp")
+
+
+def test_an_existing_folder_is_not_overwritten(checkout):
+    (checkout / "plugins" / "image" / "magenta_wash").mkdir(parents=True)
+    with pytest.raises(PluginError, match="already exists"):
+        plugin_create.scaffold(
+            checkout, "magenta_wash", IMAGE, example="hello_world_stamp"
+        )
+
+
+def test_an_example_of_the_other_kind_is_refused(checkout):
+    """Copying a captioner into `plugins/image/` yields a plugin nothing loads."""
+    with pytest.raises(PluginError, match="cannot be the starting point"):
+        plugin_create.scaffold(
+            checkout, "magenta_wash", IMAGE, example="hello_world_captioner"
+        )
+
+
+def test_an_unknown_example_lists_what_there_is(checkout):
+    with pytest.raises(PluginError, match="hello_world_stamp"):
+        plugin_create.scaffold(checkout, "magenta_wash", IMAGE, example="nope")
+
+
+# ----------------------------------------------------------------------
+# The checkout
+# ----------------------------------------------------------------------
+
+
+def test_an_existing_checkout_is_reused(checkout):
+    (checkout / ".git").mkdir()
+    forked, reused = plugin_create.obtain_checkout(checkout, fork=False)
+    assert reused is True
+    assert forked is False
+
+
+def test_a_forked_checkout_is_recognised_by_its_upstream_remote(checkout, monkeypatch):
+    (checkout / ".git").mkdir()
+    listed = subprocess.CompletedProcess([], 0, stdout="origin\nupstream\n", stderr="")
+    monkeypatch.setattr(plugin_create.subprocess, "run", lambda *a, **k: listed)
+    forked, reused = plugin_create.obtain_checkout(checkout, fork=False)
+    assert (forked, reused) == (True, True)
+
+
+def test_a_non_empty_directory_that_is_not_a_checkout_is_refused(tmp_path):
+    directory = tmp_path / "somewhere"
+    directory.mkdir()
+    (directory / "notes.txt").write_text("mine", encoding="utf-8")
+    with pytest.raises(PluginError, match="already exists"):
+        plugin_create.obtain_checkout(directory, fork=True)
+
+
+def test_without_gh_it_clones_instead_of_forking(tmp_path, monkeypatch):
+    commands = []
+    monkeypatch.setattr(plugin_create, "_have_gh", lambda: False)
+    monkeypatch.setattr(
+        plugin_create, "_run", lambda command, cwd=None: commands.append(command) or ""
+    )
+
+    forked, reused = plugin_create.obtain_checkout(tmp_path / "clone", fork=True)
+    assert (forked, reused) == (False, False)
+    assert commands == [
+        ["git", "clone", plugin_create.CLONE_URL, str(tmp_path / "clone")]
+    ]
+
+
+def test_a_fork_that_fails_falls_back_to_a_plain_clone(tmp_path, monkeypatch):
+    """Being unable to fork must not stop the scaffold; it changes the advice."""
+    monkeypatch.setattr(plugin_create, "_have_gh", lambda: True)
+    commands = []
+
+    def run(command, cwd=None):
+        commands.append(command)
+        if command[0] == "gh":
+            raise PluginError("cannot fork your own repository")
+        return ""
+
+    monkeypatch.setattr(plugin_create, "_run", run)
+    forked, _reused = plugin_create.obtain_checkout(tmp_path / "clone", fork=True)
+    assert forked is False
+    assert [command[0] for command in commands] == ["gh", "git"]
+
+
+@pytest.fixture
+def git_checkout(tmp_path) -> Path:
+    """A real one-commit repository on `main`, for the branching tests."""
+    directory = tmp_path / "repo"
+    directory.mkdir()
+    for command in (
+        ["git", "init", "-q", "-b", "main"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "commit", "-q", "--allow-empty", "-m", "first"],
+    ):
+        subprocess.run(command, cwd=directory, check=True)
+    return directory
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_a_branch_from_an_earlier_run_says_what_to_do_about_it(git_checkout):
+    """Reusing a checkout is supported, so its second run must not end at git."""
+    plugin_create.start_branch(git_checkout, "add-edge_glow")
+    subprocess.run(["git", "switch", "-q", "main"], cwd=git_checkout, check=True)
+
+    with pytest.raises(PluginError, match="--branch") as refusal:
+        plugin_create.start_branch(git_checkout, "add-edge_glow")
+    assert "add-edge_glow" in str(refusal.value)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_the_branch_is_created_off_the_freshest_main(git_checkout):
+    """Branching off HEAD would silently base a reused checkout on a stale main."""
+    plugin_create.start_branch(git_checkout, "add-magenta_wash")
+    current = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=git_checkout,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert current == "add-magenta_wash"
+
+
+# ----------------------------------------------------------------------
+# End to end, through the CLI
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def offline(checkout, monkeypatch):
+    """`create` without git or GitHub: the checkout is there, branching is a no-op."""
+    monkeypatch.setattr(
+        plugin_create, "obtain_checkout", lambda directory, *, fork: (True, True)
+    )
+    monkeypatch.setattr(plugin_create, "start_branch", lambda directory, branch: None)
+    monkeypatch.setattr(plugin_create, "git_identity", lambda _root: "Ada <a@b.com>")
+    monkeypatch.setattr(
+        plugin_create,
+        "fork_readiness",
+        lambda: plugin_create.ForkReadiness(plugin_create.FORK, "will fork"),
+    )
+    return checkout
+
+
+def test_create_names_the_branch_after_the_plugin(offline):
+    result = plugin_create.create("magenta_wash", IMAGE, directory=offline)
+    assert result.branch == "add-magenta_wash"
+    assert result.example == "hello_world_stamp"
+
+
+def test_a_checkout_you_cannot_push_to_says_so(offline, monkeypatch):
+    """Without a fork the last two steps printed would simply fail."""
+    monkeypatch.setattr(
+        plugin_create, "obtain_checkout", lambda directory, *, fork: (False, False)
+    )
+    result = plugin_create.create(
+        "magenta_wash",
+        IMAGE,
+        directory=offline,
+        readiness=plugin_create.ForkReadiness(
+            plugin_create.MANUAL, "no gh", "Fork it on the web."
+        ),
+    )
+    assert any("Fork it on the web." in warning for warning in result.warnings)
+
+
+def test_a_maintainer_forks_like_everyone_else(offline, monkeypatch):
+    """No shortcut for write access: a plugin arrives as a pull request or not.
+
+    A path only maintainers take is a path only maintainers test, and it would
+    be the one that quietly rots while the flow everyone else uses moves on.
+    """
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(plugin_create, "_gh", lambda *_arguments: "signed in")
+    assert plugin_create.fork_readiness().mode == plugin_create.FORK
+    assert not hasattr(plugin_create, "PUSH")
+
+
+def test_the_cli_hands_the_rest_to_submit_rather_than_listing_git_commands(
+    offline, capsys
+):
+    """The six manual commands are `plugins submit`; listing them invites typos."""
+    exit_code = cli.main(
+        ["plugins", "create", "magenta_wash", "--kind", "image", "--dir", str(offline)]
+    )
+    assert exit_code == 0
+
+    output = capsys.readouterr().out
+    assert "plugins/image/magenta_wash/magenta_wash.py" in output
+    assert "plugins submit" in output
+    for by_hand in ("git add", "git commit", "git push", "gh pr create"):
+        assert by_hand not in output
+    # `plugins test` checks captioning plugins only, so sending an image plugin
+    # there would send someone to a command that refuses them.
+    assert "plugins test" not in output
+
+
+def test_the_cli_sends_a_captioning_plugin_to_plugins_test(offline, capsys):
+    exit_code = cli.main(
+        ["plugins", "create", "tiny_vlm", "--kind", "captioning", "--dir", str(offline)]
+    )
+    assert exit_code == 0
+    assert "plugins test plugins/captioning/tiny_vlm" in capsys.readouterr().out
+
+
+def test_a_refusal_exits_non_zero_with_a_message(offline, capsys):
+    exit_code = cli.main(
+        ["plugins", "create", "pixelate", "--kind", "image", "--dir", str(offline)]
+    )
+    assert exit_code != 0
+    assert "already ships" in capsys.readouterr().err
+
+
+# ----------------------------------------------------------------------
+# Fork readiness
+# ----------------------------------------------------------------------
+
+
+def test_no_gh_means_a_manual_fork_and_says_how(monkeypatch):
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: None)
+    readiness = plugin_create.fork_readiness()
+    assert readiness.mode == plugin_create.MANUAL
+    assert not readiness.can_fork
+    assert "cli.github.com" in readiness.remedy
+
+
+def test_gh_that_is_not_signed_in_says_to_sign_in(monkeypatch):
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(plugin_create, "_gh", lambda *_a: None)
+    readiness = plugin_create.fork_readiness()
+    assert readiness.mode == plugin_create.MANUAL
+    assert "gh auth login" in readiness.remedy
+
+
+def _fake_gh(asked: list[tuple[str, ...]], **answers: str | None):
+    """Return a `_gh` stand-in recording what was asked of it."""
+
+    def fake_gh(*arguments: str) -> str | None:
+        asked.append(arguments)
+        if arguments[:2] == ("api", "user"):
+            return answers.get("login", "ada")
+        if arguments[:2] == ("repo", "view"):
+            return answers.get("view", None)
+        return "signed in"
+
+    return fake_gh
+
+
+def test_the_fork_that_will_be_created_is_named_in_full(monkeypatch):
+    """It makes a public repository on someone's account, so it has to say which."""
+    asked: list[tuple[str, ...]] = []
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(plugin_create, "_gh", _fake_gh(asked, login="ada"))
+
+    readiness = plugin_create.fork_readiness()
+    assert readiness.mode == plugin_create.FORK
+    assert readiness.fork_target == "ada/PixlStash-plugins"
+    assert readiness.fork_exists is False
+    assert "https://github.com/ada/PixlStash-plugins" in readiness.explanation
+    assert "will create" in readiness.explanation
+    # Never asks what permissions you hold: everyone forks, so the answer
+    # could not change what happens next.
+    assert not any(
+        "viewerPermission" in argument for call in asked for argument in call
+    )
+
+
+def test_an_existing_fork_says_it_will_be_reused_rather_than_created(monkeypatch):
+    """ "Will create" would be a lie, and the difference is the whole warning."""
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        plugin_create, "_gh", _fake_gh([], login="ada", view='{"name": "x"}')
+    )
+
+    readiness = plugin_create.fork_readiness()
+    assert readiness.fork_exists is True
+    assert "reused" in readiness.explanation
+    assert "Nothing new is created" in readiness.explanation
+
+
+def test_an_account_that_will_not_name_itself_admits_it(monkeypatch):
+    """Better than inventing an owner for a repository about to be made."""
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(plugin_create, "_gh", _fake_gh([], login=None))
+
+    readiness = plugin_create.fork_readiness()
+    assert readiness.mode == plugin_create.FORK
+    assert readiness.fork_target == ""
+    assert "could not tell me which account" in readiness.explanation.lower()
+
+
+# ----------------------------------------------------------------------
+# What the contributor said the plugin is for
+# ----------------------------------------------------------------------
+
+
+def test_the_purpose_reaches_the_readme_the_docstring_and_the_description(checkout):
+    """Asked once, used in three places: the wizard must not ask three times."""
+    purpose = "Adds a soft glow to every edge. The strength is adjustable."
+    _folder, module, readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "edge_glow", IMAGE, example="hello_world_stamp", purpose=purpose
+    )
+
+    assert purpose in readme.read_text(encoding="utf-8")
+    source = module.read_text(encoding="utf-8")
+    assert "Adds a soft glow to every edge." in ast.get_docstring(ast.parse(source))
+    # The description is one line in a settings dialog, so it takes the first
+    # sentence rather than the paragraph.
+    assert 'description = "Adds a soft glow to every edge."' in source
+
+
+def test_an_explicit_description_beats_the_purpose(checkout):
+    _folder, module, _readme, _brief, _warnings = plugin_create.scaffold(
+        checkout,
+        "edge_glow",
+        IMAGE,
+        example="hello_world_stamp",
+        purpose="Adds a soft glow.",
+        description="Something else entirely.",
+    )
+    assert 'description = "Something else entirely."' in module.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_no_purpose_leaves_a_todo_in_the_readme(checkout):
+    _folder, _module, readme, _brief, _warnings = plugin_create.scaffold(
+        checkout, "edge_glow", IMAGE, example="hello_world_stamp"
+    )
+    assert plugin_create.PURPOSE_TODO in readme.read_text(encoding="utf-8")
+
+
+# ----------------------------------------------------------------------
+# The agent hand-off
+# ----------------------------------------------------------------------
+
+
+def test_the_command_carries_its_own_directory(offline):
+    """It is pasted, and a paste lands wherever the reader happens to be.
+
+    The prompt names the plugin relative to the checkout and the agent reads
+    the checkout's AGENTS.md, so run anywhere else it finds neither. Printing
+    the directory as prose above the command is what let that happen: the
+    command is what gets copied, so the command has to carry the `cd`.
+    """
+    result = plugin_create.create(
+        "edge_glow", IMAGE, directory=offline, purpose="Adds a glow."
+    )
+    command = plugin_create.agent_command("claude", result)
+    parts = shlex.split(command)
+
+    assert parts[0] == "cd"
+    assert Path(parts[1]) == offline
+    assert parts[2] == "&&"
+    assert parts[3] == "claude"
+    # Still one quoted argument, so a prompt holding quotes survives the shell.
+    assert len(parts) == 5
+
+
+def test_the_prompt_is_short_enough_to_paste(offline):
+    """It is the only part anyone copies, so the brief goes in a file instead."""
+    result = plugin_create.create(
+        "edge_glow", IMAGE, directory=offline, purpose="Adds a soft glow."
+    )
+    prompt = plugin_create.agent_prompt(result)
+
+    assert "\n" not in prompt
+    assert len(prompt) < 80
+    assert "plugins/image/edge_glow/BRIEF.md" in prompt
+
+
+def test_the_brief_says_what_to_build_and_that_the_folder_is_a_scaffold(offline):
+    """The facts AGENTS.md cannot hold, in the file the prompt points at.
+
+    AGENTS.md is written for "deliver one new folder". This folder is not new:
+    it holds a renamed copy of an example. Without being told, an agent has no
+    way to know the code beside it is a placeholder rather than a start, and
+    reads the mismatch with the README as a documentation job.
+    """
+    result = plugin_create.create(
+        "edge_glow", IMAGE, directory=offline, purpose="Adds a soft glow."
+    )
+    brief = result.brief.read_text(encoding="utf-8")
+
+    assert result.brief.name == "BRIEF.md"
+    assert result.brief.parent == result.folder
+    assert "Adds a soft glow." in brief
+    assert "hello_world_stamp" in brief
+    assert "edge_glow.py" in brief
+    # The instruction that answers what actually went wrong.
+    assert "Working code is the deliverable" in brief
+    # And it says to clean itself up.
+    assert "This file is gone" in brief
+
+
+def test_the_brief_sends_the_agent_to_agents_md_for_everything_general(offline):
+    """The contract stays in the repository that maintains and tests it."""
+    result = plugin_create.create("edge_glow", IMAGE, directory=offline)
+    brief = result.brief.read_text(encoding="utf-8")
+
+    assert "AGENTS.md" in brief
+    assert "CLAUDE.md" in brief
+    assert "does not repeat it" in brief
+
+
+def test_a_plugin_with_no_stated_purpose_is_told_to_ask(offline):
+    """Inventing a plugin is worse than stopping, when nobody said what it does."""
+    result = plugin_create.create("edge_glow", IMAGE, directory=offline)
+    assert "Stop and ask" in result.brief.read_text(encoding="utf-8")
+
+
+def test_the_readme_points_at_the_brief(offline):
+    """A reader opening the folder should not have to guess which file is which."""
+    result = plugin_create.create(
+        "edge_glow", IMAGE, directory=offline, purpose="Adds a soft glow."
+    )
+    readme = result.readme.read_text(encoding="utf-8")
+    assert "BRIEF.md" in readme
+    assert "Adds a soft glow." in readme
+
+
+def test_an_agent_this_does_not_know_is_refused(offline):
+    result = plugin_create.create("edge_glow", IMAGE, directory=offline)
+    with pytest.raises(PluginError, match="not an agent"):
+        plugin_create.agent_command("emacs", result)
+
+
+def test_the_cli_prints_the_agent_command_when_asked(offline, capsys):
+    exit_code = cli.main(
+        [
+            "plugins",
+            "create",
+            "edge_glow",
+            "--kind",
+            "image",
+            "--dir",
+            str(offline),
+            "--purpose",
+            "Adds a soft glow to every edge.",
+            "--agent",
+            "claude",
+        ]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "claude " in output
+    assert "Read what it writes before you commit it" in output
+
+
+def test_a_non_interactive_run_still_says_how_it_will_reach_github(offline, capsys):
+    """`origin: <upstream>` with nothing explaining it reads as a failure."""
+    cli.main(
+        ["plugins", "create", "edge_glow", "--kind", "image", "--dir", str(offline)]
+    )
+    assert "will fork" in capsys.readouterr().out
+
+
+def test_the_cli_prints_no_agent_command_by_default(offline, capsys):
+    exit_code = cli.main(
+        ["plugins", "create", "edge_glow", "--kind", "image", "--dir", str(offline)]
+    )
+    assert exit_code == 0
+    assert "codex" not in capsys.readouterr().out
+
+
+# ----------------------------------------------------------------------
+# The wizard
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def answers(monkeypatch):
+    """Feed the wizard's prompts from a list, as a person at a terminal would."""
+
+    def feed(*replies: str) -> list[str]:
+        asked: list[str] = []
+        queued = list(replies)
+
+        def fake_input(prompt: str = "") -> str:
+            asked.append(prompt)
+            if not queued:
+                raise EOFError
+            return queued.pop(0)
+
+        monkeypatch.setattr("builtins.input", fake_input)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        return asked
+
+    return feed
+
+
+def test_the_wizard_asks_for_everything_it_was_not_given(offline, answers, capsys):
+    asked = answers(
+        "y",  # carry on without a fork
+        "image",  # kind
+        "Adds a soft glow to every edge.",  # purpose, first line
+        "",  # purpose, blank line ends it
+        "edge_glow",  # name
+        "",  # licence, Enter takes MIT
+        "no",  # no coding agent
+    )
+    exit_code = cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+
+    assert exit_code == 0
+    assert any("kind of plugin" in prompt or "Choose" in prompt for prompt in asked)
+    readme = offline / "plugins" / "image" / "edge_glow" / "README.md"
+    assert "Adds a soft glow to every edge." in readme.read_text(encoding="utf-8")
+    assert "MIT, see the" in readme.read_text(encoding="utf-8")
+    assert "add-edge_glow" in capsys.readouterr().out
+
+
+def test_the_wizard_re_asks_a_name_it_cannot_use(offline, answers, capsys):
+    """A refused name has to cost a question, not the whole run."""
+    answers(
+        "y",
+        "image",
+        "Adds a soft glow.",
+        "",
+        "Edge Glow",  # not snake_case
+        "pixelate",  # a built-in
+        "edge_glow",
+        "",
+        "no",
+    )
+    assert cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)]) == 0
+    output = capsys.readouterr().out
+    assert "not a plugin name" in output
+    assert "already ships" in output
+
+
+def test_declining_at_the_fork_question_creates_nothing(offline, answers):
+    answers("n")
+    exit_code = cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+    assert exit_code != 0
+    assert not (offline / "plugins" / "image" / "edge_glow").exists()
+
+
+def test_aborting_at_the_kind_question_forks_and_clones_nothing(
+    offline, answers, monkeypatch, capsys
+):
+    """The abort has to come before the fork, or it is an abort of nothing.
+
+    Asked first for exactly this reason: the next step puts a public
+    repository on the contributor's account and a clone on their disk.
+    """
+    obtained: list[object] = []
+    monkeypatch.setattr(
+        plugin_create,
+        "obtain_checkout",
+        lambda directory, *, fork: obtained.append(directory) or (True, True),
+    )
+    answers("y", "abort")
+
+    exit_code = cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+    assert exit_code != 0
+    assert obtained == []
+    assert "Nothing was forked, cloned or created" in capsys.readouterr().out
+
+
+def _choose(monkeypatch, *replies: str) -> str:
+    """Run one `_ask_choice` over a three-option menu, answering with *replies*."""
+    queued = iter(replies)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(queued))
+    return cli._ask_choice(
+        "Which?", {"image": "a picture", "captioning": "words", cli.ABORT: "stop"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("answer", "chosen"),
+    [
+        ("1", "image"),
+        ("2", "captioning"),
+        ("3", cli.ABORT),
+        # Enter takes the first, which is why the safe option is never last by
+        # accident: option 1 is the common case, and abort is chosen on purpose.
+        ("", "image"),
+        # The name is still an answer: a reader who has just read it off the
+        # screen should not be told off for typing it.
+        ("captioning", "captioning"),
+        ("ABORT", cli.ABORT),
+    ],
+)
+def test_an_option_is_chosen_by_number_or_by_name(monkeypatch, answer, chosen):
+    assert _choose(monkeypatch, answer) == chosen
+
+
+@pytest.mark.parametrize("wrong", ["0", "4", "9", "img", "x"])
+def test_an_answer_that_is_not_an_option_asks_again(monkeypatch, wrong, capsys):
+    """Off-by-one at either end included: `0` and `4` are not options."""
+    assert _choose(monkeypatch, wrong, "2") == "captioning"
+    assert "Choose 1 to 3" in capsys.readouterr().out
+
+
+def test_the_kind_question_is_numbered_and_offers_the_way_out(offline, answers, capsys):
+    answers("y", "3")
+    cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+
+    output = capsys.readouterr().out
+    assert "1  image" in output
+    assert "2  captioning" in output
+    assert "3  abort" in output
+
+
+def test_choosing_the_abort_number_forks_and_clones_nothing(
+    offline, answers, monkeypatch, capsys
+):
+    """The number has to do what the word did, or the way out moved silently."""
+    obtained: list[object] = []
+    monkeypatch.setattr(
+        plugin_create,
+        "obtain_checkout",
+        lambda directory, *, fork: obtained.append(directory) or (True, True),
+    )
+    answers("y", "3")
+
+    exit_code = cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+    assert exit_code != 0
+    assert obtained == []
+    assert "Nothing was forked, cloned or created" in capsys.readouterr().out
+
+
+def test_ctrl_c_is_not_a_traceback(offline, monkeypatch, capsys):
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+
+    def interrupt(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", interrupt)
+    exit_code = cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)])
+    assert exit_code != 0
+    assert "Stopped." in capsys.readouterr().err
+
+
+def test_the_wizard_offers_the_agent_command(offline, answers, capsys):
+    answers("y", "image", "Adds a soft glow.", "", "edge_glow", "", "codex")
+    assert cli.main(["plugins", "create", "--no-fork", "--dir", str(offline)]) == 0
+    assert "codex " in capsys.readouterr().out
+
+
+def test_a_missing_answer_with_no_terminal_is_refused_not_guessed(offline, monkeypatch):
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    exit_code = cli.main(["plugins", "create", "--dir", str(offline)])
+    assert exit_code != 0
+
+
+# ----------------------------------------------------------------------
+# Submitting
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def submittable(offline, monkeypatch):
+    """A checkout with a scaffolded plugin on its branch, and git stubbed out."""
+    result = plugin_create.create(
+        "edge_glow", IMAGE, directory=offline, purpose="Adds a soft glow."
+    )
+    (offline / ".git").mkdir(exist_ok=True)
+
+    calls: list[list[str]] = []
+
+    def fake_run(command, *, cwd=None):
+        calls.append(command)
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return f"{result.branch}\n"
+        if command[:3] == ["git", "diff", "--cached"]:
+            return "plugins/image/edge_glow/edge_glow.py\n"
+        if command[:3] == ["gh", "pr", "create"]:
+            return "https://github.com/Pikselkroken/PixlStash-plugins/pull/9\n"
+        return ""
+
+    monkeypatch.setattr(plugin_create, "_run", fake_run)
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: "/usr/bin/gh")
+    monkeypatch.setattr(plugin_create, "missing_tools", lambda _submission: [])
+    monkeypatch.setattr(plugin_create, "run_checks", lambda _submission: [])
+    return offline, calls
+
+
+def test_the_plugin_is_found_from_the_branch_name(submittable):
+    checkout, _calls = submittable
+    submission = plugin_create.find_submission(checkout)
+    assert submission.name == "edge_glow"
+    assert submission.kind == IMAGE
+    assert submission.folder == checkout / "plugins" / "image" / "edge_glow"
+
+
+def test_a_branch_that_names_no_plugin_asks_for_the_name(offline, monkeypatch):
+    (offline / ".git").mkdir(exist_ok=True)
+    monkeypatch.setattr(plugin_create, "_run", lambda *a, **k: "main\n")
+    with pytest.raises(PluginError, match="plugins submit <name>"):
+        plugin_create.find_submission(offline)
+
+
+def test_a_directory_that_is_not_a_checkout_is_refused(tmp_path):
+    with pytest.raises(PluginError, match="not a checkout"):
+        plugin_create.find_submission(tmp_path / "nowhere")
+
+
+def test_only_the_plugin_folder_is_staged(submittable):
+    """The checkout is the contributor's and may hold work of their own."""
+    checkout, calls = submittable
+    plugin_create.commit(plugin_create.find_submission(checkout), "Add edge_glow")
+
+    staging = [command for command in calls if command[:2] == ["git", "add"]]
+    assert staging == [["git", "add", "--", "plugins/image/edge_glow"]]
+
+
+def test_the_pull_request_body_carries_what_was_tested_and_nothing_else(submittable):
+    """A pull request is public and permanent; nothing off this machine goes in."""
+    checkout, _calls = submittable
+    submission = plugin_create.find_submission(checkout)
+    body = plugin_create.pull_request_body(submission, "  moondream2 on a 3090  ")
+
+    assert "moondream2 on a 3090" in body
+    assert "plugins/image/edge_glow/README.md" in body
+    # No absolute path, so no home directory and no clue about this machine.
+    assert str(checkout) not in body
+
+
+def test_a_failing_check_stops_before_anything_is_pushed(submittable, monkeypatch):
+    checkout, calls = submittable
+    monkeypatch.setattr(plugin_create, "run_checks", lambda _s: ["ruff check ."])
+
+    exit_code = cli.main(
+        ["plugins", "submit", "--dir", str(checkout), "--tested", "by hand", "--yes"]
+    )
+    assert exit_code != 0
+    assert not any(command[:2] == ["git", "push"] for command in calls)
+
+
+def test_missing_dev_tools_are_told_apart_from_a_failing_check(
+    submittable, monkeypatch, capsys
+):
+    """`python -m nope` exits 1 like a test failure; saying so would be a lie."""
+    checkout, _calls = submittable
+    monkeypatch.setattr(plugin_create, "missing_tools", lambda _s: ["ruff", "pytest"])
+
+    exit_code = cli.main(
+        ["plugins", "submit", "--dir", str(checkout), "--tested", "by hand", "--yes"]
+    )
+    assert exit_code != 0
+    error = capsys.readouterr().err
+    assert "requirements-dev.txt" in error
+    assert "failed" not in error
+
+
+def test_dry_run_checks_and_stops(submittable):
+    checkout, calls = submittable
+    exit_code = cli.main(
+        ["plugins", "submit", "--dir", str(checkout), "--dry-run", "--tested", "x"]
+    )
+    assert exit_code == 0
+    assert not any(command[:2] == ["git", "commit"] for command in calls)
+    assert not any(command[:2] == ["git", "push"] for command in calls)
+
+
+def test_declining_the_confirmation_pushes_nothing(submittable, answers):
+    checkout, calls = submittable
+    answers("n")
+    exit_code = cli.main(
+        ["plugins", "submit", "--dir", str(checkout), "--tested", "by hand"]
+    )
+    assert exit_code != 0
+    assert not any(command[:2] == ["git", "push"] for command in calls)
+
+
+def test_a_full_submit_commits_pushes_and_opens_the_pull_request(submittable, capsys):
+    checkout, calls = submittable
+    exit_code = cli.main(
+        [
+            "plugins",
+            "submit",
+            "--dir",
+            str(checkout),
+            "--tested",
+            "Pillow 11 on Linux, no model",
+            "--yes",
+        ]
+    )
+    assert exit_code == 0
+
+    ran = [" ".join(command[:3]) for command in calls]
+    assert "git add --" in ran
+    assert "git commit -m" in ran
+    assert "git push --set-upstream" in ran
+    assert "gh pr create" in ran
+    assert "https://github.com/Pikselkroken/PixlStash-plugins/pull/9" in (
+        capsys.readouterr().out
+    )
+
+
+def test_an_empty_tested_answer_is_refused(submittable):
+    """The one thing CI cannot check for a model-backed plugin."""
+    checkout, calls = submittable
+    exit_code = cli.main(
+        ["plugins", "submit", "--dir", str(checkout), "--tested", "   ", "--yes"]
+    )
+    assert exit_code != 0
+    assert not any(command[:2] == ["git", "push"] for command in calls)
+
+
+def test_submit_asks_what_it_was_tested_against(submittable, answers, capsys):
+    checkout, calls = submittable
+    answers("Pillow 11 on Linux, no model", "", "y")
+    exit_code = cli.main(["plugins", "submit", "--dir", str(checkout)])
+
+    assert exit_code == 0
+    assert any(command[:2] == ["git", "push"] for command in calls)
+    assert "pull/9" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_commit_against_real_git_stages_only_the_plugin(tmp_path, monkeypatch):
+    """The stubs above check the sequence; this checks the commands work.
+
+    A wrong flag on `git add` or a misread of `git diff --cached` passes every
+    mocked test and loses someone's unrelated work on the first real run.
+    """
+    directory = tmp_path / "repo"
+    (directory / "plugins" / "image" / "edge_glow").mkdir(parents=True)
+    for command in (
+        ["git", "init", "-q", "-b", "main"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "commit", "-q", "--allow-empty", "-m", "first"],
+        ["git", "switch", "-q", "-c", "add-edge_glow"],
+    ):
+        subprocess.run(command, cwd=directory, check=True)
+
+    (directory / "plugins" / "image" / "edge_glow" / "edge_glow.py").write_text(
+        "x = 1\n", encoding="utf-8"
+    )
+    # Work of the contributor's own, which must survive untouched.
+    (directory / "notes.txt").write_text("mine", encoding="utf-8")
+
+    submission = plugin_create.find_submission(directory)
+    assert submission.name == "edge_glow"
+    assert submission.branch == "add-edge_glow"
+
+    plugin_create.commit(submission, "Add edge_glow")
+    committed = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert committed == ["plugins/image/edge_glow/edge_glow.py"]
+
+    still_untracked = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=directory,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "notes.txt" in still_untracked
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+def test_committing_nothing_says_so_rather_than_making_an_empty_commit(
+    tmp_path,
+):
+    directory = tmp_path / "repo"
+    (directory / "plugins" / "image" / "edge_glow").mkdir(parents=True)
+    (directory / "plugins" / "image" / "edge_glow" / "edge_glow.py").write_text(
+        "x = 1\n", encoding="utf-8"
+    )
+    for command in (
+        ["git", "init", "-q", "-b", "main"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "add", "-A"],
+        ["git", "commit", "-q", "-m", "first"],
+        ["git", "switch", "-q", "-c", "add-edge_glow"],
+    ):
+        subprocess.run(command, cwd=directory, check=True)
+
+    submission = plugin_create.find_submission(directory)
+    with pytest.raises(PluginError, match="nothing to commit"):
+        plugin_create.commit(submission, "Add edge_glow")
+
+
+def test_missing_tools_reports_what_this_interpreter_really_lacks(tmp_path):
+    """Run against a real interpreter, since the point is not trusting exit codes."""
+    submission = plugin_create.Submission(
+        checkout=tmp_path,
+        kind=IMAGE,
+        name="edge_glow",
+        folder=tmp_path / "plugins" / "image" / "edge_glow",
+        branch="add-edge_glow",
+        python=Path(sys.executable),
+    )
+    # This interpreter runs the suite, so pytest is importable by definition.
+    assert "pytest" not in plugin_create.missing_tools(submission)

--- a/tests/test_plugin_create.py
+++ b/tests/test_plugin_create.py
@@ -11,6 +11,7 @@ repository would turn down for its name.
 from __future__ import annotations
 
 import ast
+import os
 import shlex
 import shutil
 import subprocess
@@ -1171,3 +1172,87 @@ def test_missing_tools_reports_what_this_interpreter_really_lacks(tmp_path):
     )
     # This interpreter runs the suite, so pytest is importable by definition.
     assert "pytest" not in plugin_create.missing_tools(submission)
+
+
+def _submission(checkout: Path) -> plugin_create.Submission:
+    return plugin_create.Submission(
+        checkout=checkout,
+        kind=IMAGE,
+        name="edge_glow",
+        folder=checkout / "plugins" / "image" / "edge_glow",
+        branch="add-edge_glow",
+        python=Path(sys.executable),
+    )
+
+
+def test_the_setup_hint_prints_paths_this_platform_can_type(tmp_path, monkeypatch):
+    """The hint is commands for a person to type, so `bin` is wrong on Windows.
+
+    Forced to the other platform's layout rather than read off this one: a
+    Unix-only spelling is invisible to a test that runs on Unix, and this
+    suite is where a Windows-only defect has to be caught.
+    """
+    other = Path(".venv") / ("bin" if os.name == "nt" else "Scripts")
+    monkeypatch.setattr(plugin_create, "VENV_BIN", other)
+    hint = plugin_create.dev_setup_hint(_submission(tmp_path), ["ruff"])
+
+    # Both commands the hint prints: the requirements install and pixlstash.
+    # Two, not one, is what says neither line kept a hardcoded spelling --
+    # the interpreter's own path is in the hint too and is legitimately this
+    # platform's, so the check is on what it tells someone to type.
+    assert hint.count(str(other / "pip")) == 2
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+@pytest.mark.parametrize(
+    "remote, expected",
+    [
+        # The ordinary case: the branch is on the contributor's fork, which is
+        # not a branch the upstream repository has.
+        (
+            "git@github.com:someone/pixlstash-plugins.git",
+            "main...someone:add-edge_glow",
+        ),
+        (
+            "https://github.com/someone/pixlstash-plugins",
+            "main...someone:add-edge_glow",
+        ),
+        # A maintainer pushing to upstream itself compares within the repository.
+        (
+            f"https://github.com/{plugin_create.PLUGINS_REPO}.git",
+            "main...add-edge_glow",
+        ),
+    ],
+)
+def test_the_manual_compare_url_names_the_repository_the_branch_is_on(
+    tmp_path, remote, expected
+):
+    directory = tmp_path / "repo"
+    directory.mkdir()
+    for command in (
+        ["git", "init", "-q", "-b", "main"],
+        ["git", "remote", "add", "origin", remote],
+    ):
+        subprocess.run(command, cwd=directory, check=True)
+
+    assert plugin_create.compare_url(_submission(directory)) == (
+        f"https://github.com/{plugin_create.PLUGINS_REPO}/compare/{expected}"
+    )
+
+
+def test_a_checkout_with_no_origin_still_gets_a_url(tmp_path):
+    """A way out beats no way out: this branch is already handling a failure."""
+    url = plugin_create.compare_url(_submission(tmp_path / "nowhere"))
+    assert url.endswith("/compare/main...add-edge_glow")
+
+
+def test_the_no_gh_message_points_at_the_branch_where_it_actually_is(
+    tmp_path, monkeypatch
+):
+    """The way out of a missing `gh` is that URL, so it has to be the real one."""
+    monkeypatch.setattr(plugin_create.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        plugin_create, "compare_url", lambda _s: "https://example.invalid/compare"
+    )
+    with pytest.raises(PluginError, match=r"https://example\.invalid/compare"):
+        plugin_create.open_pull_request(_submission(tmp_path), "Add edge_glow", "body")

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import ast
 import io
+import json
 import os
 import re
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -794,16 +796,25 @@ def test_requirements_are_never_installed_implicitly(
 
 
 def test_with_deps_says_what_it_will_install(
-    tmp_path, plugin_root, monkeypatch, capsys
+    tmp_path, plugin_root, monkeypatch, pip_report, capsys
 ):
+    """What is listed is what pip resolved, not what the file asked for.
+
+    The two differ whenever a requirement pulls anything in, which is most of
+    the time, and it is the resolved set that lands in the environment.
+    """
     calls = []
     monkeypatch.setattr(plugin_install, "install_requirements", calls.append)
+    pip_report(("something", "1.0"), ("a-dependency-of-it", "2.4"), installed={})
     folder = tmp_path / "pkg"
     _write(folder / "__init__.py", CAPTIONER)
     _write(folder / "requirements.txt", "# a comment\nsomething==1.0\n")
 
     assert _install(folder, "--with-deps") == cli.EXIT_OK
-    assert "something==1.0" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "This operation will install the following Python packages:" in output
+    assert "something" in output
+    assert "a-dependency-of-it" in output
     assert len(calls) == 1
 
 
@@ -1536,3 +1547,191 @@ def test_the_hub_is_read_off_the_command_line_in_both_spellings(monkeypatch):
     assert cli._hub_from_argv() is None
     monkeypatch.setattr(cli.sys, "argv", ["x", "--hub"])
     assert cli._hub_from_argv() is None
+
+
+# ----------------------------------------------------------------------
+# Dependencies
+# ----------------------------------------------------------------------
+#
+# `resolve_requirements` shells out to pip, which needs a network and an index,
+# so the resolver itself is stubbed and what is tested is the rule applied to
+# its answer. The one thing that must not be stubbed away is the shape of the
+# report, so `_report` builds the real thing: pip's `--report` JSON, whose
+# `install` list holds only what is *not* already satisfied.
+
+
+def _report(*packages: tuple[str, str]) -> str:
+    """Return a pip install report naming *packages* as (name, version)."""
+    return json.dumps(
+        {
+            "install": [
+                {"metadata": {"name": name, "version": version}}
+                for name, version in packages
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def pip_report(monkeypatch, tmp_path):
+    """Serve a canned pip `--report`, and record what pip was asked."""
+
+    def serve(*packages: tuple[str, str], installed: dict[str, str] | None = None):
+        calls: list[list[str]] = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            index = command.index("--report")
+            Path(command[index + 1]).write_text(_report(*packages), encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        def fake_version(name: str) -> str:
+            present = installed or {}
+            if name in present:
+                return present[name]
+            raise plugin_install.PackageNotFoundError(name)
+
+        monkeypatch.setattr(plugin_install.subprocess, "run", fake_run)
+        monkeypatch.setattr(plugin_install, "metadata_version", fake_version)
+        return calls
+
+    return serve
+
+
+def test_a_new_package_is_an_addition(pip_report, tmp_path):
+    pip_report(("flask", "3.1.3"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    changes = plugin_install.resolve_requirements(requirements)
+    assert [(c.name, c.version, c.installed) for c in changes] == [
+        ("flask", "3.1.3", None)
+    ]
+    assert not changes[0].moves
+
+
+def test_a_different_version_of_an_installed_package_moves_it(pip_report, tmp_path):
+    """The one case that can stop PixlStash starting."""
+    pip_report(("pillow", "11.0.0"), installed={"pillow": "12.3.0"})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==11.0.0\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.moves
+    assert change.installed == "12.3.0"
+
+
+def test_transitive_packages_are_reported_too(pip_report, tmp_path):
+    """A plugin asking for one package routinely pulls in several."""
+    pip_report(
+        ("Flask", "3.1.3"),
+        ("Werkzeug", "3.1.8"),
+        ("blinker", "1.9.0"),
+        installed={},
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    changes = plugin_install.resolve_requirements(requirements)
+    assert [c.name for c in changes] == ["blinker", "Flask", "Werkzeug"]
+
+
+def test_resolving_asks_pip_not_to_install_anything(pip_report, tmp_path):
+    """It runs before the plugin is copied, so it must change nothing."""
+    calls = pip_report(("flask", "3.1.3"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    plugin_install.resolve_requirements(requirements)
+    assert "--dry-run" in calls[0]
+    assert calls[0][0] == sys.executable
+
+
+def test_a_pip_that_cannot_resolve_is_a_refusal_not_a_crash(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        plugin_install.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command, 1, stdout="", stderr="ERROR: no matching distribution\n"
+        ),
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("nope==1\n", encoding="utf-8")
+
+    with pytest.raises(PluginError, match="no matching distribution"):
+        plugin_install.resolve_requirements(requirements)
+
+
+def test_install_refuses_dependencies_that_replace_a_package_in_use(
+    tmp_path, plugin_root, pip_report, capsys
+):
+    """End to end: the plugin must not be copied when the deps are refused."""
+    source = tmp_path / "dep_filter"
+    source.mkdir()
+    (source / "dep_filter.py").write_text(IMAGE_PLUGIN, encoding="utf-8")
+    (source / "requirements.txt").write_text("pillow==11.0.0\n", encoding="utf-8")
+    pip_report(("pillow", "11.0.0"), installed={"pillow": "12.3.0"})
+
+    exit_code = cli.main(["plugins", "install", str(source), "--with-deps", "--yes"])
+    assert exit_code != 0
+
+    captured = capsys.readouterr()
+    assert "This operation will install the following Python packages:" in captured.out
+    assert "replaces 12.3.0" in captured.out
+    assert "Refused" in captured.err
+    # Nothing copied: the refusal happens before the plugin is written, so
+    # there is no half-installed plugin to clean up.
+    assert not (plugin_install.user_dir(IMAGE) / "my_filter.py").exists()
+
+
+def test_force_deps_installs_anyway_and_says_so(
+    tmp_path, plugin_root, pip_report, monkeypatch, capsys
+):
+    """The owner's machine, the owner's call, once they have been told."""
+    source = tmp_path / "dep_filter"
+    source.mkdir()
+    (source / "dep_filter.py").write_text(IMAGE_PLUGIN, encoding="utf-8")
+    (source / "requirements.txt").write_text("pillow==11.0.0\n", encoding="utf-8")
+    pip_report(("pillow", "11.0.0"), installed={"pillow": "12.3.0"})
+    installed: list[Path] = []
+    monkeypatch.setattr(
+        plugin_install, "install_requirements", lambda path: installed.append(path)
+    )
+
+    exit_code = cli.main(
+        ["plugins", "install", str(source), "--with-deps", "--force-deps", "--yes"]
+    )
+    assert exit_code == cli.EXIT_OK
+    assert "Proceeding anyway: --force-deps." in capsys.readouterr().out
+    assert installed and (plugin_install.user_dir(IMAGE) / "my_filter.py").exists()
+
+
+def test_a_plugin_whose_dependencies_are_all_present_says_so(
+    tmp_path, plugin_root, pip_report, monkeypatch, capsys
+):
+    source = tmp_path / "dep_filter"
+    source.mkdir()
+    (source / "dep_filter.py").write_text(IMAGE_PLUGIN, encoding="utf-8")
+    (source / "requirements.txt").write_text("pillow\n", encoding="utf-8")
+    pip_report(installed={"pillow": "12.3.0"})
+    monkeypatch.setattr(plugin_install, "install_requirements", lambda path: None)
+
+    assert cli.main(["plugins", "install", str(source), "--with-deps", "--yes"]) == 0
+    assert "Everything it needs is already installed." in capsys.readouterr().out
+
+
+def test_without_with_deps_pip_is_never_consulted(
+    tmp_path, plugin_root, monkeypatch, capsys
+):
+    """Resolution costs a network round trip, so it is not done unasked."""
+    source = tmp_path / "dep_filter"
+    source.mkdir()
+    (source / "dep_filter.py").write_text(IMAGE_PLUGIN, encoding="utf-8")
+    (source / "requirements.txt").write_text("flask\n", encoding="utf-8")
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("pip was consulted without --with-deps")
+
+    monkeypatch.setattr(plugin_install, "resolve_requirements", explode)
+    assert cli.main(["plugins", "install", str(source), "--yes"]) == 0
+    assert "It is NOT installed" in capsys.readouterr().out


### PR DESCRIPTION
`pixlstash-cli plugins create` sets up everything a plugin pull request needs, so the only work left is the plugin itself.

Run with no arguments it asks what kind of plugin, what it should do and what to call it; given a name and `--kind` it asks nothing. It then works out whether it can fork the plugins repository, clones, branches, copies one of the repository's own example plugins into `plugins/<kind>/<name>/`, renames the folder, module and class, writes the author and licence into the header, puts the stated purpose into the README, and prints the commands that open the pull request. Last it offers a one-line `claude` or `codex` command pointing the agent at that README — printed, never run.

Nothing is committed, pushed or opened as a PR: at that point the plugin is still the example, and the repository takes one finished plugin per pull request.

The skeleton is the example plugin in the checkout, not a template kept here — a template in this repo would be a second definition of a contract another repository owns, and would drift the first time its contract tests changed. Nothing is imported or executed: the example is read with `ast` through `pixlstash.plugin_install`, the same way installing reads it.

- `pixlstash/plugin_create.py` — the scaffolder
- `pixlstash/cli.py` — the `plugins create` subcommand
- `pixlstash/plugin_install.py` — the layout and name rules it reuses
- `tests/test_plugin_create.py`, plus additions to `tests/test_plugin_install.py`, gated in `.github/workflows/ci.yml`
- `README.md` — documents the command