### PR TITLE
Send a model's thumbnail as multipart, and let the chosen tile be seen

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1514,6 +1514,33 @@ The Axios request interceptor rewrites all relative URLs:
 - Fully qualified URLs (`http://...`) are passed through unchanged, except same-origin requests get the share token injected.
 - Share token is injected as `?token=` query param for both relative and same-origin absolute requests.
 
+### Uploads: the transport clears the JSON default
+
+The Axios instance sets `Content-Type: application/json` for every request, and
+Axios 1.x decides in `transformRequest` from **that** header what the body is:
+a `FormData` under a JSON content type is rewritten as
+`JSON.stringify(formDataToJSON(form))`, in which a `File` or `Blob` serialises
+to `{}`. An upload that inherited the default therefore reached the server as
+the literal body `{"file":{}}` and was refused as a validation error, with
+nothing on the wire to suggest a file had been meant.
+
+The request interceptor **deletes** the content type whenever the body is a
+`FormData` (via `AxiosHeaders.delete`, with a plain-object walk behind it for a
+hand-assembled config), so the browser writes it with the boundary only it can
+generate. Deleted in the transport rather than remembered per call: the
+model-icon uploader was the one of four that did not pass
+`{headers: {"Content-Type": "multipart/form-data"}}` itself, which silently
+killed the model shelf's Set Thumbnail verb on both of its routes. The other
+three still pass it and are unaffected — the strip runs first and axios then
+re-derives the type from the body — but a new uploader does not have to.
+
+The alternative was to drop the instance-level JSON default and let Axios set
+`application/json` per request, which it does for any object payload. That is
+the smaller diff and the wider blast radius: it also changes what a POST with
+no body, a string body or a `URLSearchParams` body sends, across every route in
+the app. It is worth doing on its own, deliberately, and not inside a fix for a
+broken upload.
+
 ### `appendShareToken(url)`
 
 For `<img :src="...">` bindings and similar direct browser requests that bypass Axios, call `appendShareToken()` to add `?token=` manually.

--- a/frontend/src/api/modelIcons.test.js
+++ b/frontend/src/api/modelIcons.test.js
@@ -1,0 +1,62 @@
+// The model shelf's icon routes.
+//
+// `setModelIcon` is where the thumbnail verb actually failed: it built the
+// FormData correctly and then let the transport's JSON default rewrite it into
+// `{"file":{}}` (see `utils/apiClient.js`). The transport now clears that
+// header, so what is worth guarding HERE is the half this module owns — the
+// body really is a multipart form, and the bytes really are under the field
+// name the route reads (`file: UploadFile = File(...)`, `routes/model_icons.py`).
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../utils/apiClient", () => ({
+  API_BASE_URL: "/api/v1",
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from "../utils/apiClient";
+import { clearModelIcons, modelIconUrl, setModelIcon } from "./modelIcons";
+
+beforeEach(() => {
+  apiClient.get.mockReset();
+  apiClient.post.mockReset();
+});
+
+describe("api/modelIcons", () => {
+  it("posts a picture's thumbnail bytes as a multipart form", async () => {
+    // A Blob, not a File: the library route sends what
+    // `getPictureThumbnailBlob` returned, which has no name of its own. The
+    // route reads the bytes and sniffs them, so it never needs one.
+    apiClient.post.mockResolvedValue({ data: { model_id: 12, icon_sha256: "ab" } });
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/webp" });
+
+    const body = await setModelIcon(12, blob);
+
+    const [url, form] = apiClient.post.mock.calls[0];
+    expect(url).toBe("/models/12/icon");
+    expect(form).toBeInstanceOf(FormData);
+    expect(form.get("file")).toBeInstanceOf(Blob);
+    expect(form.get("file").size).toBe(3);
+    expect(body).toEqual({ model_id: 12, icon_sha256: "ab" });
+  });
+
+  it("sends a chosen file the same way", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    const file = new File(["x"], "mark.png", { type: "image/png" });
+    await setModelIcon(4, file);
+    expect(apiClient.post.mock.calls[0][1].get("file").name).toBe("mark.png");
+  });
+
+  it("clears by id list, in one request", async () => {
+    apiClient.post.mockResolvedValue({ data: { cleared: [1] } });
+    const body = await clearModelIcons([1, 2]);
+    expect(apiClient.post).toHaveBeenCalledWith("/models/icons/clear", {
+      ids: [1, 2],
+    });
+    expect(body).toEqual({ cleared: [1] });
+  });
+
+  it("addresses a stored icon by content hash", () => {
+    expect(modelIconUrl("abc123")).toContain("/model-icons/abc123");
+  });
+});

--- a/frontend/src/components/widgets/PicturePicker.vue
+++ b/frontend/src/components/widgets/PicturePicker.vue
@@ -140,6 +140,25 @@
               <span v-else class="pp-gone">
                 <v-icon size="18">mdi-image-off-outline</v-icon>
               </span>
+              <!-- The mark that says WHICH tile is chosen, so the edge is not
+                   the only carrier of the state — the lesson the Character
+                   editor's reference grid learned about a thin edge on a
+                   photograph.
+
+                   `aria-hidden`, and real markup rather than a `::before`,
+                   because generated `content` counts towards the accessible
+                   NAME (accname §4.3.2 step 2F, which Chromium implements). The
+                   tile's subtree is one `alt=""` image, i.e. empty, so its name
+                   falls through to `title`; a bare ✓ in there would make the
+                   chosen tile announce as "✓" and lose the picture's name — a
+                   regression on exactly the reader the badge is drawn for.
+                   `aria-pressed` already says chosen. -->
+              <span
+                v-if="chosen?.id === pic.id"
+                class="pp-tick"
+                aria-hidden="true"
+                >✓</span
+              >
             </button>
           </div>
           <p v-if="capped" class="pp-note pp-note--after" role="status">
@@ -631,6 +650,11 @@ watch(
   gap: var(--space-3);
 }
 .pp-cell {
+  position: relative;
+  /* A stacking context of its own, so the tick's z-index below is scoped to
+     this tile rather than escaping into whatever context an ancestor happens
+     to establish. */
+  isolation: isolate;
   aspect-ratio: 1 / 1;
   padding: 0;
   border: 0;
@@ -645,13 +669,54 @@ watch(
   object-fit: cover;
   display: block;
 }
-/* Outline rather than a second box-shadow: the focus ring below is a
-   box-shadow, and two of them at equal specificity means the later rule wins —
-   which hid the chosen state from exactly the reader who has no other way to
-   see it (a focused, chosen tile showed only the ring). */
+/* The chosen tile wears the whole §11 selected vocabulary — `--active-wash`
+   fill AND `--active-bar` edge — not the edge alone. The edge on its own is a
+   2px stroke drawn INSIDE a photograph that can be any colour, so whether it
+   registers depends on the frame behind it: `--active-bar` is `primary` on
+   dark and the `accent` amber on light, and either can land on a picture that
+   already contains it. That is what "the picker doesn't get any selection
+   marker" was — checked in a browser against real thumbnails, in both themes.
+
+   Outline rather than a box-shadow, because the focus ring below is a
+   box-shadow and the two would fight over one property — which is how the
+   chosen state was once hidden from the reader who has no other way to see it
+   (a focused, chosen tile showed only the ring). */
 .pp-cell--on {
-  outline: 2px solid var(--active-bar);
-  outline-offset: -2px;
+  outline: var(--space-1) solid var(--active-bar);
+  outline-offset: calc(-1 * var(--space-1));
+}
+/* The wash, over the image rather than under it — a tile IS its picture, so
+   there is no surface left to tint. A pseudo-element because it carries no
+   text: nothing for the accessibility tree to pick up (unlike the tick, see
+   the template). */
+.pp-cell--on::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--active-wash);
+  pointer-events: none;
+}
+/* The tick. `z-index` to clear the wash, which is an ::after and therefore
+   paints after every child; the elevation is what lifts it off an arbitrary
+   photograph, the same job it does on the image grid's own check badge. */
+.pp-tick {
+  position: absolute;
+  z-index: 1;
+  top: var(--space-2);
+  right: var(--space-2);
+  width: var(--space-6);
+  height: var(--space-6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--active-bar);
+  color: var(--active-text);
+  box-shadow: var(--elevation-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  line-height: 1;
+  pointer-events: none;
 }
 .pp-cell:focus-visible {
   box-shadow: var(--focus-ring);

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -235,9 +235,15 @@ function isMutatingRequest(config) {
 // 422. Cleared HERE rather than remembered at each call site: three uploaders
 // passed `Content-Type: multipart/form-data` themselves and the fourth
 // (`setModelIcon`) did not, which is the whole model-thumbnail verb, both its
-// routes, silently dead. The header is deleted rather than set, so the browser
-// writes it WITH the boundary it generates.
-function stripJsonContentTypeForFormData(config) {
+// routes, silently dead.
+//
+// **Every** content type goes, not only the JSON one, which is why the name
+// does not say `Json`. A hand-written `multipart/form-data` is wrong too: it
+// carries no boundary, and only the thing that serialises the body can know
+// one. Deleting is what hands that decision to the adapter, which then writes
+// the header with the boundary it generated. So a caller cannot set a
+// FormData's content type here — deliberately, because a caller cannot know it.
+function stripContentTypeForFormData(config) {
   if (typeof FormData === 'undefined' || !(config?.data instanceof FormData)) {
     return;
   }
@@ -257,7 +263,7 @@ function stripJsonContentTypeForFormData(config) {
 }
 
 apiClient.interceptors.request.use((config) => {
-  stripJsonContentTypeForFormData(config);
+  stripContentTypeForFormData(config);
 
   const rawUrl = config?.url;
   if (!rawUrl || typeof rawUrl !== 'string') {

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -227,7 +227,38 @@ function isMutatingRequest(config) {
   return MUTATING_METHODS.has(method);
 }
 
+// A multipart body must not inherit this instance's JSON default. Axios 1.x
+// reads the request's own Content-Type in `transformRequest`, and when it says
+// `application/json` it converts a FormData into `JSON.stringify(
+// formDataToJSON(form))` — a File or Blob serialises to `{}`, so
+// `POST /models/{id}/icon` received the literal body `{"file":{}}` and answered
+// 422. Cleared HERE rather than remembered at each call site: three uploaders
+// passed `Content-Type: multipart/form-data` themselves and the fourth
+// (`setModelIcon`) did not, which is the whole model-thumbnail verb, both its
+// routes, silently dead. The header is deleted rather than set, so the browser
+// writes it WITH the boundary it generates.
+function stripJsonContentTypeForFormData(config) {
+  if (typeof FormData === 'undefined' || !(config?.data instanceof FormData)) {
+    return;
+  }
+  const headers = config.headers;
+  if (!headers) return;
+  // `AxiosHeaders.delete` is the public way, and by this point in the pipeline
+  // `config.headers` is one of those. Its own-property store is an
+  // implementation detail, so the plain-object walk is the fallback rather than
+  // the route — it also covers a config assembled by hand, e.g. in a test.
+  if (typeof headers.delete === 'function') {
+    headers.delete('Content-Type');
+    return;
+  }
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'content-type') delete headers[key];
+  }
+}
+
 apiClient.interceptors.request.use((config) => {
+  stripJsonContentTypeForFormData(config);
+
   const rawUrl = config?.url;
   if (!rawUrl || typeof rawUrl !== 'string') {
     return config;

--- a/frontend/src/utils/apiClient.test.js
+++ b/frontend/src/utils/apiClient.test.js
@@ -28,7 +28,6 @@ vi.mock("axios", () => {
   return { default: { create: () => axiosInstance } };
 });
 
-import AxiosHeaders from "axios/unsafe/core/AxiosHeaders.js";
 import {
   API_BASE_URL,
   activateShareToken,
@@ -44,6 +43,11 @@ import {
 } from "./apiClient";
 
 const requestInterceptor = requestInterceptors[0];
+
+// The real `AxiosHeaders`, reached past this file's own `vi.mock("axios")`.
+// It is a named export of the package — `axios/unsafe/...` is a private path
+// and would break on an axios release for no reason to do with this app.
+const { AxiosHeaders } = await vi.importActual("axios");
 
 beforeEach(() => {
   activateShareToken(null);
@@ -327,9 +331,8 @@ describe("a multipart body does not inherit the JSON default", () => {
   // the four uploaders remembered to pass the header and the fourth did not.
   // The header is DELETED, never set: only the browser can write the boundary.
   //
-  // The REAL `AxiosHeaders` is what production hands the interceptor, and this
-  // module's `vi.mock("axios")` above does not cover the subpath it lives on —
-  // so the first case below is the shape that actually ships, not a stand-in
+  // The REAL `AxiosHeaders` is what production hands the interceptor, so the
+  // first case below is the shape that actually ships rather than a stand-in
   // for it. A plain object is covered too, because a hand-assembled config is
   // what every other test in this file passes.
   function interceptForm(headers) {

--- a/frontend/src/utils/apiClient.test.js
+++ b/frontend/src/utils/apiClient.test.js
@@ -28,6 +28,7 @@ vi.mock("axios", () => {
   return { default: { create: () => axiosInstance } };
 });
 
+import AxiosHeaders from "axios/unsafe/core/AxiosHeaders.js";
 import {
   API_BASE_URL,
   activateShareToken,
@@ -311,5 +312,64 @@ describe("backend WebSocket URL normalization", () => {
     expect(appendShareToken("wss://external.example/ws")).toBe(
       "wss://external.example/ws",
     );
+  });
+});
+
+describe("a multipart body does not inherit the JSON default", () => {
+  // The instance sets `Content-Type: application/json` for every request, and
+  // axios 1.x reads THAT in `transformRequest`: a FormData under a JSON content
+  // type is rewritten as `JSON.stringify(formDataToJSON(form))`, in which a File
+  // or Blob serialises to `{}`. `POST /models/{id}/icon` therefore received the
+  // body `{"file":{}}` and answered 422 — the model shelf's Set Thumbnail verb,
+  // both of its routes, silently dead.
+  //
+  // Cleared in the interceptor rather than at each call site because three of
+  // the four uploaders remembered to pass the header and the fourth did not.
+  // The header is DELETED, never set: only the browser can write the boundary.
+  //
+  // The REAL `AxiosHeaders` is what production hands the interceptor, and this
+  // module's `vi.mock("axios")` above does not cover the subpath it lives on —
+  // so the first case below is the shape that actually ships, not a stand-in
+  // for it. A plain object is covered too, because a hand-assembled config is
+  // what every other test in this file passes.
+  function interceptForm(headers) {
+    return requestInterceptor({
+      url: "/models/12/icon",
+      method: "post",
+      data: new FormData(),
+      headers,
+    });
+  }
+
+  it("drops it from the AxiosHeaders production actually sends", () => {
+    const headers = AxiosHeaders.from({
+      Accept: "application/json, text/plain, */*",
+      "Content-Type": "application/json",
+    });
+    const config = interceptForm(headers);
+    expect(config.headers.get("Content-Type")).toBeUndefined();
+    // Everything else survives: this clears one header, it does not reset them.
+    expect(config.headers.get("Accept")).toContain("application/json");
+  });
+
+  it("drops it from a plain headers bag, however it is spelled", () => {
+    expect(
+      interceptForm({ "Content-Type": "application/json" }).headers[
+        "Content-Type"
+      ],
+    ).toBeUndefined();
+    expect(
+      Object.keys(interceptForm({ "content-type": "application/json" }).headers),
+    ).not.toContain("content-type");
+  });
+
+  it("leaves a JSON body's content type alone", () => {
+    const config = requestInterceptor({
+      url: "/models/icons/clear",
+      method: "post",
+      data: { ids: [12] },
+      headers: AxiosHeaders.from({ "Content-Type": "application/json" }),
+    });
+    expect(config.headers.get("Content-Type")).toBe("application/json");
   });
 });


### PR DESCRIPTION
Reported: *"Setting thumbnail for models doesn't actually work. The picker doesn't get any selection marker.. and when you pick something it doesn't change anything"*, plus *"I occasionally get could not set thumbnail"*.

Two separate causes. The first is the whole of "doesn't work"; the second is why the picker looked inert before you got there.

## 1. The upload never carried the image

`utils/apiClient.js` creates the axios instance with a default `Content-Type: application/json`. Axios 1.x reads **that header** in `transformRequest` to decide what the body is, and a `FormData` under a JSON content type is rewritten as `JSON.stringify(formDataToJSON(form))` — in which a `Blob` or `File` serialises to `{}`.

So `POST /models/{id}/icon` was receiving the literal body `{"file":{}}` and refusing it as a validation error. Measured against the repo's own axios 1.18.1:

```
no override (setModelIcon as it shipped)
  content-type: application/json
  body: {"file":{}}
```

That kills **both** routes of the verb — the library picture and `Choose a file…` — because both go through `setModelIcon`. The generic *"Could not set that thumbnail."* is what a caller sees, because a FastAPI 422 answers with `detail` as a list and `errorDetail` returns `""` for anything that is not a string.

`tests/test_model_icons.py` is green and always was: it posts real multipart. The server half was never the problem.

Three of the four uploaders in `src/api/` pass `{headers: {"Content-Type": "multipart/form-data"}}` themselves; `setModelIcon` was the fourth and did not. **Fixed in the transport rather than at that call site**, so the fifth uploader cannot forget either: the request interceptor deletes the content type when the body is a `FormData` (`AxiosHeaders.delete`, with a plain-object walk behind it), and the browser then writes it with the boundary only it can generate. The three explicit callers are unaffected — the strip runs first and axios re-derives the type from the body.

## 2. The chosen tile wore half a selected state

`visual-language.md` §11 defines selected as *"`--active-wash` fill **plus** `--active-bar` edge and `--active-text`"*. The picker had only the edge: a 2px stroke inset **inside** the photograph. Whether it registers depends entirely on the frame behind it — `--active-bar` is `primary` on dark and the `accent` amber on light, and either can land on a picture that already contains that colour.

I reproduced the picker in a real browser (stubbed API, real stylesheets, Playwright) and screenshotted the chosen tile against real thumbnails in both themes before and after; it is now the wash, the edge and a ✓, and it reads at a glance. The ✓ is real markup carrying `aria-hidden="true"`, not a `::before`: generated `content` counts towards the accessible **name**, and the tile's subtree is one `alt=""` image, so a bare ✓ would have made a chosen tile announce as "✓" and drop the picture's name.

## Tests

- `utils/apiClient.test.js` — a FormData body loses the JSON default, on the **real `AxiosHeaders`** production hands the interceptor as well as on a plain bag; a JSON body keeps it. Verified to fail with the strip removed.
- `api/modelIcons.test.js` (new) — `setModelIcon` really posts a `FormData` with the bytes under `file`, for a Blob and for a File. This module had no test at all, which is part of why the bug shipped.
- CSS is not covered by a test; it was checked in a browser instead.

## Answering the review, where I did not do what it asked

An adversarial pass ran before this was pushed. Its findings on the accessible name, the axios-internals access, the missing `modelIcons` test, the badge elevation, the escaping `z-index` and three inaccurate code comments are all fixed above. Four I disagreed with:

- **"Just delete the instance-level JSON default."** Smaller diff, much wider blast radius: it changes what a POST with no body, a string body or a `URLSearchParams` body sends on every route in the app. Worth doing deliberately, not inside a fix for a broken upload. Recorded in the architecture doc.
- **"Root cause 2 is an assumption."** It was checked in a browser against real thumbnails in both themes, not assumed.
- **`--active-text` on a solid fill.** The review measured it: 4.71:1 light, 4.86:1 dark, both AA, and it is what the image grid's own check badge does. Left as is rather than inventing a token.
- **`errorDetail` is blind to a 422 `detail` list, and to a blob-typed error body.** Both true and both pre-existing. With the cause removed there is no 422 here any more, and changing how every notice in the app renders an error is not this fix.

Left alone as out of scope: the `Date.now()` cache-buster in `ModelShelf.onThumbnailPicked` (which `frontend_architecture.md` §361 discourages for thumbnail rendering, though here the bytes are being stored rather than displayed), and `set_model_icon` logging nothing on any path.
