### PR TITLE
Publish ID-bearing check-ins per install type from the telemetry Worker

### DIFF
--- a/website/telemetry-worker/README.md
+++ b/website/telemetry-worker/README.md
@@ -148,6 +148,17 @@ column is stored. Two consequences for the consumer:
 - A bit is a ping *day*. Two pings on one UTC day count once here and twice in a
   raw request count, so this is a floor on requests. The client throttles to one
   check per day (`pixlstash/telemetry/sender.py`), so in practice they agree.
+- It is a **rolling 28-day total republished every day**, not a daily figure.
+  Consecutive snapshots overlap almost completely, so they must never be summed
+  or plotted as a time series — read one snapshot, and divide it by the *same*
+  28 days of zone-analytics check-ins. A rolling total was chosen over a
+  per-day count because a missed cron then costs accuracy rather than a
+  permanently absent day, which suits a Worker whose slices can be delayed. The
+  cost is that it cannot be decomposed back into days.
+- `null` rather than an object when a scan resumed from a checkpoint written
+  before this field existed: those rows' check-ins are unrecoverable and the
+  snapshot is never backfilled, so the day is reported as uncountable rather
+  than as a confident undercount.
 
 **Resurrection rate** is the metric that answers pause-versus-churn directly: a
 silence of 14 days or more that a later ping closes. `first_seen`/`last_seen`

--- a/website/telemetry-worker/README.md
+++ b/website/telemetry-worker/README.md
@@ -148,17 +148,24 @@ column is stored. Two consequences for the consumer:
 - A bit is a ping *day*. Two pings on one UTC day count once here and twice in a
   raw request count, so this is a floor on requests. The client throttles to one
   check per day (`pixlstash/telemetry/sender.py`), so in practice they agree.
-- It is a **rolling 28-day total republished every day**, not a daily figure.
-  Consecutive snapshots overlap almost completely, so they must never be summed
-  or plotted as a time series — read one snapshot, and divide it by the *same*
-  28 days of zone-analytics check-ins. A rolling total was chosen over a
+- It is a **rolling total republished every day**, not a daily figure. The
+  window is `ACTIVE_WINDOW_DAYS` days *plus the snapshot date itself* — 29 days
+  inclusive — because it is deliberately the same window as
+  `active_installs_by_type`, whose predicate is
+  `daysBetween(last_seen, today) <= ACTIVE_WINDOW_DAYS`. Pairing a numerator
+  and a denominator taken over different spans is the error this field exists
+  to remove, so the two are kept identical rather than rounded to a tidy 28.
+  Consecutive snapshots overlap by 28 of those 29 days, so they must never be
+  summed or plotted as a time series — read one snapshot, and divide it by the
+  *same* 29 days of zone-analytics check-ins. A rolling total was chosen over a
   per-day count because a missed cron then costs accuracy rather than a
   permanently absent day, which suits a Worker whose slices can be delayed. The
   cost is that it cannot be decomposed back into days.
-- `null` rather than an object when a scan resumed from a checkpoint written
-  before this field existed: those rows' check-ins are unrecoverable and the
-  snapshot is never backfilled, so the day is reported as uncountable rather
-  than as a confident undercount.
+- `null` rather than an object when a scan resumed from a checkpoint that was
+  written before this field existed *and had already folded in rows*: their
+  check-ins are unrecoverable and the snapshot is never backfilled, so the day
+  is reported as uncountable rather than as a confident undercount. A pre-field
+  checkpoint that had scanned nothing yet lost nothing, and still counts.
 
 **Resurrection rate** is the metric that answers pause-versus-churn directly: a
 silence of 14 days or more that a later ping closes. `first_seen`/`last_seen`

--- a/website/telemetry-worker/README.md
+++ b/website/telemetry-worker/README.md
@@ -132,6 +132,23 @@ missing cells, not a month to be reconstructed later.
 Desktop and pip installs ping when someone runs them, so a weekend-only user
 misses an exact day-7 check and would read as churned.
 
+**ID-bearing check-ins per type** (`id_bearing_checkins_by_type`) is the
+numerator for the MAU coverage ratio computed in `pixlstash-metrics`. The
+denominator there is *all* version check-ins from Cloudflare zone analytics,
+which this Worker never sees — it only ever receives the ID-bearing ones. It
+does, however, know each one's install type, so it publishes the split and the
+metrics side does the division per bucket instead of pooling.
+
+It is derived from the activity bitmap, over the same rolling window and the
+same buckets as `active_installs_by_type`, so no request is logged and no new
+column is stored. Two consequences for the consumer:
+
+- These are check-in **counts**, not distinct installs. Dividing them by a
+  distinct-install denominator is a unit error.
+- A bit is a ping *day*. Two pings on one UTC day count once here and twice in a
+  raw request count, so this is a floor on requests. The client throttles to one
+  check per day (`pixlstash/telemetry/sender.py`), so in practice they agree.
+
 **Resurrection rate** is the metric that answers pause-versus-churn directly: a
 silence of 14 days or more that a later ping closes. `first_seen`/`last_seen`
 alone give a decay curve and cannot distinguish the two. Once observed, that

--- a/website/telemetry-worker/src/aggregate.js
+++ b/website/telemetry-worker/src/aggregate.js
@@ -196,19 +196,31 @@ export function serializeAccumulator(state) {
   });
 }
 
-/** Restore an accumulator written by serializeAccumulator. */
-export function deserializeAccumulator(serialized) {
+/**
+ * Restore an accumulator written by serializeAccumulator.
+ *
+ * @param {string} serialized Checkpointed accumulator JSON.
+ * @param {boolean} pristine True when the checkpoint has folded in no rows yet,
+ *   i.e. its run still has an empty cursor. It decides what a checkpoint
+ *   written before `checkinsByType` existed means: nothing was lost if nothing
+ *   was scanned, so the day stays countable rather than being nulled for the
+ *   whole scan. runScheduledSlice persists an initial accumulator before it
+ *   reads a single row, so a crash or a redeploy in that gap is exactly the
+ *   reachable case.
+ * @returns {object}
+ */
+export function deserializeAccumulator(serialized, pristine = false) {
   const value = JSON.parse(serialized);
   return {
     ...createAccumulator(),
     ...value,
-    // A checkpoint written before this field existed has already folded in rows
-    // whose check-ins were never counted, so this day's total can no longer be
-    // completed. Null, not the partial count: the snapshot is immutable and
-    // never backfilled, so a confident wrong number here would be permanent.
-    // Same reasoning as resurrection_rate below -- "cannot say" and "zero" must
-    // not look alike. Null is sticky through the rest of the scan.
-    checkinsByType: value.checkinsByType ?? null,
+    // A partial pre-field checkpoint has already folded in rows whose check-ins
+    // were never counted, so this day's total can no longer be completed. Null,
+    // not the partial count: the snapshot is immutable and never backfilled, so
+    // a confident wrong number here would be permanent. Same reasoning as
+    // resurrection_rate below -- "cannot say" and "zero" must not look alike.
+    // Null is sticky through the rest of the scan.
+    checkinsByType: value.checkinsByType ?? (pristine ? emptyBuckets() : null),
     cohorts: new Map(value.cohorts ?? []),
   };
 }

--- a/website/telemetry-worker/src/aggregate.js
+++ b/website/telemetry-worker/src/aggregate.js
@@ -202,6 +202,13 @@ export function deserializeAccumulator(serialized) {
   return {
     ...createAccumulator(),
     ...value,
+    // A checkpoint written before this field existed has already folded in rows
+    // whose check-ins were never counted, so this day's total can no longer be
+    // completed. Null, not the partial count: the snapshot is immutable and
+    // never backfilled, so a confident wrong number here would be permanent.
+    // Same reasoning as resurrection_rate below -- "cannot say" and "zero" must
+    // not look alike. Null is sticky through the rest of the scan.
+    checkinsByType: value.checkinsByType ?? null,
     cohorts: new Map(value.cohorts ?? []),
   };
 }
@@ -220,12 +227,15 @@ export function deserializeAccumulator(serialized) {
 export function accumulateRow(state, row, today) {
   if (daysBetween(row.last_seen, today) <= ACTIVE_WINDOW_DAYS) {
     state.active += 1;
-    // Independent defaults: a checkpoint written before checkinsByType existed
-    // can carry a bucket in byType that the restored map has never seen.
     state.byType[row.install_type] ??= 0;
-    state.checkinsByType[row.install_type] ??= 0;
     state.byType[row.install_type] += 1;
-    state.checkinsByType[row.install_type] += checkinsInActiveWindow(row, today);
+    // Null means a legacy resume already lost part of this day; see
+    // deserializeAccumulator. Independent default because a checkpoint can
+    // carry a bucket in byType that the restored map has never seen.
+    if (state.checkinsByType) {
+      state.checkinsByType[row.install_type] ??= 0;
+      state.checkinsByType[row.install_type] += checkinsInActiveWindow(row, today);
+    }
   }
 
   if (daysBetween(row.first_seen, today) >= RESURRECTION_GAP_DAYS) {
@@ -291,6 +301,7 @@ export function finalizeAggregate(state, today) {
     active_installs_by_type: state.byType,
     // Same window and same buckets as active_installs_by_type, but check-ins
     // rather than installs. Aggregate counts only; no identifier leaves here.
+    // Null when a legacy checkpoint made the day uncountable.
     id_bearing_checkins_by_type: state.checkinsByType,
     new_installs_last_7d: state.newLast7d,
     // Null rather than 0 when there is nothing to divide by: a rate of "0%"

--- a/website/telemetry-worker/src/aggregate.js
+++ b/website/telemetry-worker/src/aggregate.js
@@ -54,6 +54,51 @@ function anyBitInRange(bits, lo, hi) {
 }
 
 /**
+ * Count the set bits in the inclusive day-ago range [lo, hi].
+ *
+ * @param {bigint} bits Bitmap relative to the install's last_seen.
+ * @param {number} lo Low day-ago bound.
+ * @param {number} hi High day-ago bound.
+ * @returns {number}
+ */
+function countBitsInRange(bits, lo, hi) {
+  const from = Math.max(0, lo);
+  const to = Math.min(ACTIVITY_BITS - 1, hi);
+  let count = 0;
+  for (let b = from; b <= to; b++) {
+    if (((bits >> BigInt(b)) & 1n) === 1n) count += 1;
+  }
+  return count;
+}
+
+/**
+ * How many days this install pinged inside the active window ending `today`.
+ *
+ * This is the ID-bearing check-in COUNT, the numerator that pairs with the
+ * check-in denominator Cloudflare zone analytics supplies. The Worker never
+ * sees ID-less check-ins and so cannot compute coverage itself, but it does see
+ * every ID-bearing one and already knows its install type.
+ *
+ * The bitmap is relative to last_seen, so a window expressed in days before
+ * *today* has to be shifted by the gap between the two before it can be read.
+ *
+ * One caveat for the consumer: a bit is a ping *day*, so two pings on the same
+ * UTC day count once here and twice in a raw request count. The client throttles
+ * to one check per day, so this is a floor on requests rather than an identity.
+ *
+ * @param {{last_seen: string, activity: bigint|number|string}} row
+ * @param {string} today UTC aggregation date, YYYY-MM-DD.
+ * @returns {number}
+ */
+export function checkinsInActiveWindow(row, today) {
+  // Clamp a negative gap to 0. A last_seen in the future is clock skew, and
+  // widening the window for it would count bits from before the window opened.
+  const gap = Math.max(0, daysBetween(row.last_seen, today));
+  if (gap > ACTIVE_WINDOW_DAYS) return 0;
+  return countBitsInRange(decodeActivity(row.activity) & MASK, 0, ACTIVE_WINDOW_DAYS - gap);
+}
+
+/**
  * Was an install active during week N of its own life?
  *
  * Life-week N covers days first_seen+7N .. first_seen+7N+6. The bitmap is
@@ -119,20 +164,17 @@ export function hasResurrected(activity) {
   return false;
 }
 
-/**
- * Build the day's publishable aggregate.
- *
- * @param {Array<{install_id: string, first_seen: string, last_seen: string,
- *   activity: bigint|number|string, has_resurrected: number,
- *   is_new_install: number, install_type: string}>} rows
- * @param {string} today UTC date, YYYY-MM-DD.
- * @returns {object} JSON-safe aggregate. Contains counts and percentages only:
- *   no ids, no dates finer than a week, nothing per-install.
- */
+function emptyBuckets() {
+  return { docker: 0, pip: 0, electron: 0, other: 0 };
+}
+
 export function createAccumulator() {
   return {
     active: 0,
-    byType: { docker: 0, pip: 0, electron: 0, other: 0 },
+    byType: emptyBuckets(),
+    // Check-in counts, not distinct installs: this is a numerator for a
+    // check-in denominator, and mixing the two units is the bug it fixes.
+    checkinsByType: emptyBuckets(),
     newLast7d: 0,
     resurrectionEligible: 0,
     resurrected: 0,
@@ -146,6 +188,7 @@ export function serializeAccumulator(state) {
   return JSON.stringify({
     active: state.active,
     byType: state.byType,
+    checkinsByType: state.checkinsByType,
     newLast7d: state.newLast7d,
     resurrectionEligible: state.resurrectionEligible,
     resurrected: state.resurrected,
@@ -156,7 +199,11 @@ export function serializeAccumulator(state) {
 /** Restore an accumulator written by serializeAccumulator. */
 export function deserializeAccumulator(serialized) {
   const value = JSON.parse(serialized);
-  return { ...value, cohorts: new Map(value.cohorts ?? []) };
+  return {
+    ...createAccumulator(),
+    ...value,
+    cohorts: new Map(value.cohorts ?? []),
+  };
 }
 
 /**
@@ -173,10 +220,12 @@ export function deserializeAccumulator(serialized) {
 export function accumulateRow(state, row, today) {
   if (daysBetween(row.last_seen, today) <= ACTIVE_WINDOW_DAYS) {
     state.active += 1;
-    if (state.byType[row.install_type] === undefined) {
-      state.byType[row.install_type] = 0;
-    }
+    // Independent defaults: a checkpoint written before checkinsByType existed
+    // can carry a bucket in byType that the restored map has never seen.
+    state.byType[row.install_type] ??= 0;
+    state.checkinsByType[row.install_type] ??= 0;
     state.byType[row.install_type] += 1;
+    state.checkinsByType[row.install_type] += checkinsInActiveWindow(row, today);
   }
 
   if (daysBetween(row.first_seen, today) >= RESURRECTION_GAP_DAYS) {
@@ -240,6 +289,9 @@ export function finalizeAggregate(state, today) {
     date: today,
     active_installs: state.active,
     active_installs_by_type: state.byType,
+    // Same window and same buckets as active_installs_by_type, but check-ins
+    // rather than installs. Aggregate counts only; no identifier leaves here.
+    id_bearing_checkins_by_type: state.checkinsByType,
     new_installs_last_7d: state.newLast7d,
     // Null rather than 0 when there is nothing to divide by: a rate of "0%"
     // and "we cannot say yet" are different claims and must not look alike.

--- a/website/telemetry-worker/src/index.js
+++ b/website/telemetry-worker/src/index.js
@@ -408,7 +408,9 @@ export async function runScheduledSlice(db, date = today(), limits = {}) {
   if (!run) return { phase: "idle", date };
 
   if (run.phase === "scan") {
-    const state = deserializeAccumulator(run.accumulator);
+    // An empty cursor means no row has been folded in yet: the accumulator is
+    // still the one persisted before the scan began, in the same transaction.
+    const state = deserializeAccumulator(run.accumulator, run.cursor === "");
     let cursor = run.cursor;
     let scanned = 0;
     for (let pageNumber = 0; pageNumber < scanPagesPerSlice; pageNumber++) {

--- a/website/telemetry-worker/test/worker.test.js
+++ b/website/telemetry-worker/test/worker.test.js
@@ -27,8 +27,12 @@ import {
 } from "../src/activity.js";
 import {
   buildAggregate,
+  checkinsInActiveWindow,
+  createAccumulator,
+  deserializeAccumulator,
   hasResurrected,
   activeInLifeWeek,
+  ACTIVE_WINDOW_DAYS,
   MIN_COHORT,
 } from "../src/aggregate.js";
 import { D1Stub, allowAll, denyAll, pingRequest } from "./d1-stub.js";
@@ -296,6 +300,51 @@ describe("buildAggregate", () => {
     ];
 
     assert.equal(buildAggregate(rows, "2026-07-20").resurrection_rate, 100);
+  });
+
+  it("counts ID-bearing check-ins per type, not distinct installs", () => {
+    const rows = [
+      // Pinged on three days inside the window.
+      { ...cohortRows(1, "2026-06-01", "2026-07-20", encodeActivity(0b1011n))[0] },
+      // One electron install, one ping.
+      {
+        ...cohortRows(1, "2026-07-20", "2026-07-20", encodeActivity(1n))[0],
+        install_type: "electron",
+      },
+    ];
+    const agg = buildAggregate(rows, "2026-07-20");
+    assert.deepEqual(agg.active_installs_by_type, {
+      docker: 0,
+      pip: 1,
+      electron: 1,
+      other: 0,
+    });
+    assert.deepEqual(agg.id_bearing_checkins_by_type, {
+      docker: 0,
+      pip: 3,
+      electron: 1,
+      other: 0,
+    });
+  });
+
+  it("keeps dev in its own check-in bucket", () => {
+    const rows = cohortRows(1, "2026-07-19", "2026-07-20", encodeActivity(0b11n)).map(
+      (r) => ({ ...r, install_type: "dev" }),
+    );
+    const agg = buildAggregate(rows, "2026-07-20");
+    assert.equal(agg.id_bearing_checkins_by_type.dev, 2);
+    assert.equal(agg.active_installs_by_type.dev, 1);
+  });
+
+  it("excludes check-ins from installs that fell out of the active window", () => {
+    const stale = cohortRows(1, "2026-01-01", "2026-02-01", encodeActivity(0b111n));
+    const agg = buildAggregate(stale, "2026-07-20");
+    assert.deepEqual(agg.id_bearing_checkins_by_type, {
+      docker: 0,
+      pip: 0,
+      electron: 0,
+      other: 0,
+    });
   });
 
   it("publishes no identifiers", () => {
@@ -726,5 +775,45 @@ describe("scheduled", () => {
     await worker.scheduled({}, e);
     await worker.scheduled({}, e);
     assert.equal(e.DB.snapshots.size, 1);
+  });
+});
+
+describe("checkinsInActiveWindow", () => {
+  const row = (lastSeen, bits) => ({
+    last_seen: lastSeen,
+    activity: encodeActivity(bits),
+  });
+
+  it("shifts the window by the gap between last_seen and today", () => {
+    // Bits 0 and 1 are two days before last_seen, which is itself
+    // ACTIVE_WINDOW_DAYS - 1 days before today: both still inside the window.
+    const lastSeen = "2026-06-23"; // 27 days before 2026-07-20
+    assert.equal(daysBetween(lastSeen, "2026-07-20"), ACTIVE_WINDOW_DAYS - 1);
+    assert.equal(checkinsInActiveWindow(row(lastSeen, 0b11n), "2026-07-20"), 2);
+  });
+
+  it("drops the bits that fall out of the far edge of the window", () => {
+    // last_seen sits exactly on the window edge, so only bit 0 is inside it.
+    const lastSeen = "2026-06-22"; // ACTIVE_WINDOW_DAYS days before
+    assert.equal(daysBetween(lastSeen, "2026-07-20"), ACTIVE_WINDOW_DAYS);
+    assert.equal(checkinsInActiveWindow(row(lastSeen, 0b111n), "2026-07-20"), 1);
+  });
+
+  it("counts nothing once the install is past the window", () => {
+    assert.equal(checkinsInActiveWindow(row("2026-06-21", 0b111n), "2026-07-20"), 0);
+  });
+
+  it("restores a checkpoint written before the field existed", () => {
+    const legacy = JSON.stringify({
+      active: 4,
+      byType: { docker: 0, pip: 4, electron: 0, other: 0, dev: 1 },
+      newLast7d: 0,
+      resurrectionEligible: 0,
+      resurrected: 0,
+      cohorts: [],
+    });
+    const state = deserializeAccumulator(legacy);
+    assert.deepEqual(state.checkinsByType, createAccumulator().checkinsByType);
+    assert.equal(state.active, 4);
   });
 });

--- a/website/telemetry-worker/test/worker.test.js
+++ b/website/telemetry-worker/test/worker.test.js
@@ -26,10 +26,13 @@ import {
   ACTIVITY_BITS,
 } from "../src/activity.js";
 import {
+  accumulateRow,
   buildAggregate,
   checkinsInActiveWindow,
   createAccumulator,
   deserializeAccumulator,
+  finalizeAggregate,
+  serializeAccumulator,
   hasResurrected,
   activeInLifeWeek,
   ACTIVE_WINDOW_DAYS,
@@ -803,7 +806,53 @@ describe("checkinsInActiveWindow", () => {
     assert.equal(checkinsInActiveWindow(row("2026-06-21", 0b111n), "2026-07-20"), 0);
   });
 
-  it("restores a checkpoint written before the field existed", () => {
+  it("does not widen the window for a last_seen in the future", () => {
+    // Clock skew. Without the clamp the negative gap reads bits from before the
+    // window opened, so all three would count instead of the one inside it.
+    const skewed = { last_seen: "2026-07-22", activity: encodeActivity(0b111n) };
+    assert.equal(daysBetween(skewed.last_seen, "2026-07-20"), -2);
+    assert.equal(
+      checkinsInActiveWindow(skewed, "2026-07-20"),
+      3,
+      "bits at or inside the clamped window still count",
+    );
+    // The clamp is what stops the window from extending past ACTIVE_WINDOW_DAYS.
+    const wide = {
+      last_seen: "2026-07-22",
+      activity: encodeActivity((1n << 40n) - 1n),
+    };
+    assert.equal(checkinsInActiveWindow(wide, "2026-07-20"), ACTIVE_WINDOW_DAYS + 1);
+  });
+});
+
+describe("the aggregation checkpoint", () => {
+  const row = {
+    install_id: "checkpointed",
+    first_seen: "2026-06-01",
+    last_seen: "2026-07-20",
+    activity: encodeActivity(0b1011n),
+    has_resurrected: 0,
+    is_new_install: 0,
+    install_type: "pip",
+  };
+
+  it("carries counted check-ins across a slice boundary", () => {
+    const state = createAccumulator();
+    accumulateRow(state, row, "2026-07-20");
+    assert.equal(state.checkinsByType.pip, 3, "guard: the row was counted");
+
+    const resumed = deserializeAccumulator(serializeAccumulator(state));
+    // The scan is split across five-minute slices, so anything not serialised
+    // here is silently dropped from every day that needs more than one slice.
+    assert.deepEqual(resumed.checkinsByType, state.checkinsByType);
+
+    accumulateRow(resumed, { ...row, install_id: "second" }, "2026-07-20");
+    assert.equal(resumed.checkinsByType.pip, 6);
+  });
+
+  it("publishes null, not a partial count, when resuming a legacy checkpoint", () => {
+    // Written by a Worker deployed before checkinsByType existed: byType carries
+    // its prefix, and those rows' check-ins can never be recovered.
     const legacy = JSON.stringify({
       active: 4,
       byType: { docker: 0, pip: 4, electron: 0, other: 0, dev: 1 },
@@ -813,7 +862,18 @@ describe("checkinsInActiveWindow", () => {
       cohorts: [],
     });
     const state = deserializeAccumulator(legacy);
-    assert.deepEqual(state.checkinsByType, createAccumulator().checkinsByType);
-    assert.equal(state.active, 4);
+    assert.equal(state.active, 4, "the rest of the checkpoint still resumes");
+    assert.equal(state.checkinsByType, null);
+
+    // Still null after folding in the remaining rows, and still null through a
+    // further checkpoint: a partial count must never look like a real one.
+    accumulateRow(state, row, "2026-07-20");
+    assert.equal(state.byType.pip, 5, "byType keeps accumulating");
+    const resumed = deserializeAccumulator(serializeAccumulator(state));
+    assert.equal(resumed.checkinsByType, null);
+    assert.equal(
+      finalizeAggregate(resumed, "2026-07-20").id_bearing_checkins_by_type,
+      null,
+    );
   });
 });

--- a/website/telemetry-worker/test/worker.test.js
+++ b/website/telemetry-worker/test/worker.test.js
@@ -788,8 +788,9 @@ describe("checkinsInActiveWindow", () => {
   });
 
   it("shifts the window by the gap between last_seen and today", () => {
-    // Bits 0 and 1 are two days before last_seen, which is itself
-    // ACTIVE_WINDOW_DAYS - 1 days before today: both still inside the window.
+    // Bits 0 and 1 are the day of last_seen and the day before it. last_seen is
+    // itself ACTIVE_WINDOW_DAYS - 1 days before today, so those two days sit
+    // ACTIVE_WINDOW_DAYS - 1 and ACTIVE_WINDOW_DAYS days back: both inside.
     const lastSeen = "2026-06-23"; // 27 days before 2026-07-20
     assert.equal(daysBetween(lastSeen, "2026-07-20"), ACTIVE_WINDOW_DAYS - 1);
     assert.equal(checkinsInActiveWindow(row(lastSeen, 0b11n), "2026-07-20"), 2);
@@ -807,16 +808,20 @@ describe("checkinsInActiveWindow", () => {
   });
 
   it("does not widen the window for a last_seen in the future", () => {
-    // Clock skew. Without the clamp the negative gap reads bits from before the
-    // window opened, so all three would count instead of the one inside it.
+    // Clock skew. A sparse bitmap cannot tell the two apart -- clamped or not,
+    // these three bits are inside either window -- so this is only a control
+    // that skew does not lose ordinary counts.
     const skewed = { last_seen: "2026-07-22", activity: encodeActivity(0b111n) };
     assert.equal(daysBetween(skewed.last_seen, "2026-07-20"), -2);
     assert.equal(
       checkinsInActiveWindow(skewed, "2026-07-20"),
       3,
-      "bits at or inside the clamped window still count",
+      "bits inside the window still count",
     );
-    // The clamp is what stops the window from extending past ACTIVE_WINDOW_DAYS.
+    // This is the assertion that proves the clamp. A bitmap dense enough to
+    // reach past the window edge counts ACTIVE_WINDOW_DAYS + 1 days clamped and
+    // two more than that unclamped, because a negative gap would widen the
+    // window backwards into days before it opened.
     const wide = {
       last_seen: "2026-07-22",
       activity: encodeActivity((1n << 40n) - 1n),
@@ -848,6 +853,29 @@ describe("the aggregation checkpoint", () => {
 
     accumulateRow(resumed, { ...row, install_id: "second" }, "2026-07-20");
     assert.equal(resumed.checkinsByType.pip, 6);
+  });
+
+  it("still counts a pre-field checkpoint that had scanned nothing", () => {
+    // runScheduledSlice persists an initial accumulator before it reads a row,
+    // so an old Worker that crashed in that gap leaves a pre-field checkpoint
+    // with an empty cursor. Nothing was lost, so the day stays countable.
+    const pristine = JSON.stringify({
+      active: 0,
+      byType: { docker: 0, pip: 0, electron: 0, other: 0 },
+      newLast7d: 0,
+      resurrectionEligible: 0,
+      resurrected: 0,
+      cohorts: [],
+    });
+    const state = deserializeAccumulator(pristine, true);
+    assert.deepEqual(state.checkinsByType, createAccumulator().checkinsByType);
+
+    accumulateRow(state, row, "2026-07-20");
+    assert.equal(
+      finalizeAggregate(state, "2026-07-20").id_bearing_checkins_by_type.pip,
+      3,
+      "a complete total, not null",
+    );
   });
 
   it("publishes null, not a partial count, when resuming a legacy checkpoint", () => {


### PR DESCRIPTION
Adds `id_bearing_checkins_by_type` to the Worker's daily aggregate snapshot, so
`pixlstash-metrics` can compute the MAU coverage ratio per install type instead
of scaling an all-electron numerator by a mostly-pip denominator.

## The problem this fixes

Coverage is `ID-bearing check-ins ÷ all check-ins`. The denominator comes from
Cloudflare zone analytics and is already split per install type; the numerator
was a pooled count of `/v1/ping` hits with no split. Every opted-in install is
electron while the check-in traffic is mostly pip, so the ratio is biased low —
far enough that an independent floor derived from "at most one check-in per
install per day" now reads *above* the ratio's central estimate.

The Worker cannot compute coverage itself and should not: it never sees the
ID-less check-ins, so it has no denominator. But it does see every ID-bearing
ping and already knows each one's install type, so it can supply the numerator
split, which is the only missing piece.

## How

No schema change, no write-path change, no new request logging. The 63-bit
activity bitmap already records which days each install pinged, so the count is
a popcount over the bits inside the active window — the same rolling window and
the same buckets as the existing `active_installs_by_type`.

The bitmap is stored relative to each install's `last_seen` rather than to the
snapshot date, so the window is shifted by the gap between the two before it is
read. A negative gap (a `last_seen` in the future, from clock skew) is clamped
to zero rather than allowed to widen the window backwards.

Additive: the collector ignores unknown snapshot keys, so this cannot disturb
the existing pipeline.

## Units, deliberately

Check-in **counts**, not distinct installs — it pairs with a check-in
denominator, and mixing the two units is the bug being fixed. `dev` stays its
own bucket so its size remains visible; the metrics side excludes it from the
totals. Aggregate counts only; no identifier leaves the Worker.

One caveat now recorded in the README: a bit is a ping *day*, so two pings on
one UTC day count once here and twice in a raw request count. The client
throttles to one check per day, so in practice they agree, but the field is a
floor on requests rather than an identity.

## Answering the pre-merge review

An adversarial pass over the diff raised five things. Four are fixed here; the
fifth I disagree with and am recording rather than silently dropping.

**Fixed:**

1. **A legacy resume published a silent undercount.** The scan is checkpointed
   across five-minute slices. A checkpoint written by the currently deployed
   Worker carries `byType`'s prefix but no check-in counts, so resuming it
   folded the remaining rows into a zeroed map and published a confidently
   wrong number — into a snapshot that is immutable and never backfilled. It
   now publishes `null`, matching the precedent `resurrection_rate` already
   sets three lines below: "cannot say" and "zero" must not look alike.
2. **The only new checkpointed state had no round-trip coverage.** Deleting
   `checkinsByType` from `serializeAccumulator` left the suite green, which
   would have made every multi-slice day publish only the final slice's count.
   Now covered, and verified by mutation.
3. **The negative-gap clamp had no test.** Now covered, likewise verified.
4. **The README did not warn about the trap a consumer will actually hit** —
   this is a rolling 28-day total republished daily, so consecutive snapshots
   overlap by 28 of 29 days and must never be summed or plotted as a series.
   The denominator has to be summed over the matching 28 days.

**Not taken:** the review argued for counting only the snapshot date's bit —
one bit test instead of a loop, directly divisible by a daily zone-analytics
figure, and composable into any window. That is true, but it makes a missed or
delayed cron a permanently absent day, and this Worker is built around bounded
slices that can be delayed ("compute daily, never backfill"). A rolling total
absorbs that; the cost is that it cannot be decomposed back into days. The
trade-off is now stated in the README rather than left implicit.

The review also read `validate.js`'s note that `dev` is "excluded downstream"
as a promise that `dev` is never published, and flagged the bucket as a leak.
"Downstream" is the metrics side's totals, which is where the exclusion
happens; keeping the bucket visible in the snapshot is the requested behaviour,
and the destination repo is private.

Bit arithmetic, performance inside the Worker's CPU budget, and the removal of
a stale JSDoc block were attacked and cleared.

## Tests

`node --test test/config.test.js test/worker.test.js` — 82 pass, 0 fail.
Six new assertions: the per-type split, the `dev` bucket, exclusion once an
install leaves the window, the window shift at both edges, the clock-skew
clamp, and both checkpoint paths. Each new guard was mutation-checked: the
mutant fails the suite, the restored file passes.

`npm test` additionally runs the Miniflare D1 suite, which needs `npm ci` in
`website/telemetry-worker/` first; it is untouched by this change.
