### PR TITLE
Follow moved files in reference-folder scans instead of re-importing them

### DIFF
--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -66,7 +66,9 @@ class ReferenceFolderScanTask(BaseTask):
     New files found on disk are inserted as Picture rows with their absolute
     paths so that PixlStash serves them directly from their original location.
     Files that have been removed from disk since the last scan have their DB
-    records deleted.
+    records deleted, unless the same pixels turned up at a new path in the same
+    pass: that is a move, and the existing record follows the file rather than
+    being replaced by a fresh one.
 
     Phase-2 path validation (resolve mapping → blocklist → isdir/access) is
     performed before any filesystem work.  On failure the folder status is set

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -276,6 +276,55 @@ class ReferenceFolderScanTask(BaseTask):
                 cleared,
             )
 
+        # --- Follow moved files before anything is deleted ---
+        # A file moved inside the folder is one path in ``removed_paths`` and
+        # another in ``new_paths``, same bytes.  Handled in that order it is a
+        # delete plus a re-add: the row goes and with it everything keyed to the
+        # picture id (tags, smart score, faces, likeness pairs, project/set
+        # membership, stack membership, review state).  The pixels survive and
+        # everything PixlStash added does not, so the only safe way to use a
+        # reference folder was to never reorganize it.  Both halves are already
+        # in this same pass, so match them and move the row instead.
+        #
+        # Runs before the removal block by necessity: the delete is what
+        # destroys the row being rescued.
+        moved_paths = self._match_moved_paths(
+            existing_by_path, new_paths, removed_paths
+        )
+        if moved_paths:
+
+            def apply_moves(session: Session, pairs: list[tuple[int, str]]) -> None:
+                for pic_id, new_path in pairs:
+                    pic = session.get(Picture, pic_id)
+                    if pic is not None:
+                        pic.file_path = new_path
+                        session.add(pic)
+                session.commit()
+
+            self._db.run_task(
+                apply_moves,
+                sorted(
+                    (existing_by_path[old].id, new)
+                    for old, new in moved_paths.items()
+                    if existing_by_path[old].id is not None
+                ),
+                priority=DBPriority.LOW,
+            )
+            logger.info(
+                "Reference folder %s: followed %d moved file(s).",
+                self._folder_path,
+                len(moved_paths),
+            )
+            # A moved file is neither removed nor new.  ``existing_by_path`` is
+            # re-keyed as well as narrowed, because the sidecar pass below walks
+            # it by path and would otherwise reconcile at the old location.
+            for old_path, new_path in moved_paths.items():
+                picture = existing_by_path.pop(old_path)
+                picture.file_path = new_path
+                existing_by_path[new_path] = picture
+            removed_paths -= moved_paths.keys()
+            new_paths -= set(moved_paths.values())
+
         # --- Handle removed files ---
         if removed_paths:
             removed_ids = [
@@ -505,6 +554,85 @@ class ReferenceFolderScanTask(BaseTask):
             if new_mtime is not None:
                 update[path_key] = target
                 update[mtime_key] = new_mtime
+
+    def _match_moved_paths(
+        self,
+        existing_by_path: dict[str, Picture],
+        new_paths: set[str],
+        removed_paths: set[str],
+    ) -> dict[str, str]:
+        """Pair vanished indexed paths with new disk paths holding the same pixels.
+
+        Args:
+            existing_by_path: This folder's indexed pictures, keyed by file path.
+            new_paths: Disk paths not yet indexed, after ledger filtering.
+            removed_paths: Indexed paths no longer present on disk.
+
+        Returns:
+            ``{old_path: new_path}`` for each unambiguous move.  Empty when
+            either side is empty, so the expensive case costs nothing: a first
+            scan of a large folder has no removals and never hashes here, and a
+            folder losing files without gaining any never hashes either.
+
+        Only a 1:1 pixel match counts as a move.  Identical pixels at several
+        paths are genuine copies, and the rows behind them can differ in tags,
+        sets and scores — pairing them by guess would move one picture's work
+        onto another picture's file, which is the loss this exists to prevent.
+        Ambiguous groups fall through to the delete-and-re-add path, which is
+        no worse than the behaviour before this existed.
+
+        Scoped to one reference folder, because the scan is: a file moved
+        between two reference folders is a removal in one scan and an addition
+        in another, with no shared pass to match them in.  Since the scan walks
+        the whole tree under the root, moving between subfolders — the case
+        this is for — is within scope.
+        """
+        if not removed_paths or not new_paths:
+            return {}
+
+        # ponytail: os.walk is not atomic, so a file moved mid-walk from an
+        # unvisited directory into a visited one is in neither set and still
+        # reads as a removal.  Deferring deletion by one scan (mark and sweep)
+        # would close it; not worth the state for a race this narrow.
+        gone_by_sha: dict[str, list[str]] = {}
+        for path in removed_paths:
+            pixel_sha = existing_by_path[path].pixel_sha
+            if pixel_sha:
+                gone_by_sha.setdefault(pixel_sha, []).append(path)
+        if not gone_by_sha:
+            return {}
+
+        arrived_by_sha: dict[str, list[str]] = {}
+        for path in sorted(new_paths):
+            try:
+                pixel_sha = ImageUtils.calculate_hash_from_file_path(path)
+            except Exception as exc:
+                # Not fatal: an unhashable file simply cannot be matched, and
+                # _build_picture_chunk reports it again when it tries to import.
+                logger.warning(
+                    "Reference folder scan: failed to hash %s while looking for "
+                    "moved files: %s",
+                    path,
+                    exc,
+                )
+                continue
+            if pixel_sha:
+                arrived_by_sha.setdefault(pixel_sha, []).append(path)
+
+        moved: dict[str, str] = {}
+        for pixel_sha, old_paths in gone_by_sha.items():
+            candidates = arrived_by_sha.get(pixel_sha, ())
+            if len(old_paths) == 1 and len(candidates) == 1:
+                moved[old_paths[0]] = candidates[0]
+            elif candidates:
+                logger.info(
+                    "Reference folder %s: %d vanished and %d new file(s) share "
+                    "one pixel hash; too ambiguous to call a move, re-importing.",
+                    self._folder_path,
+                    len(old_paths),
+                    len(candidates),
+                )
+        return moved
 
     def _build_picture_chunk(
         self,

--- a/tests/test_reference_folder_moves.py
+++ b/tests/test_reference_folder_moves.py
@@ -1,0 +1,182 @@
+"""The reference-folder scan follows a file moved inside the folder.
+
+A move is one path disappearing and another appearing in the same scan pass.
+Handled as a removal plus an import it costs the picture id, and with it the
+tags, score, faces and set/stack membership hanging off it, so reorganizing
+your own folders used to wipe everything PixlStash had added. The scan now
+matches the two halves by pixel hash and updates ``file_path`` instead.
+
+Ambiguous matches are deliberately not followed: identical pixels at several
+paths are copies whose rows can differ, and guessing would move one picture's
+work onto another picture's file.
+"""
+
+import os
+import tempfile
+
+import pytest
+from PIL import Image
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture, ReferenceFolder, Tag
+from pixlstash.server import Server
+from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
+
+
+@pytest.fixture(scope="module")
+def server():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = os.path.join(temp_dir, "server-config.json")
+        with Server(config_path) as srv:
+            yield srv
+
+
+def _make_folder(server, folder_dir):
+    os.makedirs(folder_dir, exist_ok=True)
+
+    def _insert(session: Session):
+        folder = ReferenceFolder(folder=folder_dir, label="refs", status="active")
+        session.add(folder)
+        session.commit()
+        session.refresh(folder)
+        return folder.id
+
+    return server.vault.db.run_task(_insert)
+
+
+def _make_image(path, color):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (8, 8), color=color).save(path, format="PNG")
+    return path
+
+
+def _run_scan(server, folder_id, folder_dir):
+    task = ReferenceFolderScanTask(
+        database=server.vault.db,
+        folder_id=folder_id,
+        folder_path=folder_dir,
+        resolved_path=folder_dir,
+    )
+    return task._run_task()
+
+
+def _pictures(server, folder_dir):
+    """Every picture indexed under this test's folder, newest id last.
+
+    Scoped by path rather than by ``reference_folder_id``: the hub and vault
+    live outside the checkout, so a whole test run shares one database and
+    folder ids collide across test modules. The tmp_path root does not.
+    """
+    return server.vault.db.run_task(
+        lambda s: list(
+            s.exec(
+                select(Picture)
+                .where(Picture.file_path.startswith(folder_dir))
+                .order_by(Picture.id)
+            ).all()
+        )
+    )
+
+
+def _tag(server, picture_id, tag):
+    def _add(session: Session):
+        session.add(Tag(picture_id=picture_id, tag=tag))
+        session.commit()
+
+    server.vault.db.run_task(_add)
+
+
+def _mark(server, picture_id, marker):
+    """Stamp a field the scan never writes, so a re-imported row is detectable.
+
+    SQLite reuses free rowids, so a deleted-and-re-added picture can come back
+    with the same id: an id assertion alone would pass for the very behaviour
+    these tests exist to catch. A marker only the test writes cannot survive a
+    re-import.
+    """
+
+    def _update(session: Session):
+        pic = session.get(Picture, picture_id)
+        pic.description = marker
+        session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(_update)
+
+
+def _tags(server, picture_id):
+    rows = server.vault.db.run_task(
+        lambda s: s.exec(select(Tag).where(Tag.picture_id == picture_id)).all()
+    )
+    return sorted(t.tag for t in rows if not t.tag.startswith("__"))
+
+
+def test_moved_file_keeps_its_picture(server, tmp_path):
+    """Moving a file into a subfolder must not cost the row or its tags."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    original = _make_image(os.path.join(folder_dir, "mira_042.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert len(indexed) == 1
+    picture_id = indexed[0].id
+    _tag(server, picture_id, "mira")
+    _mark(server, picture_id, "keepme")
+
+    moved_to = os.path.join(folder_dir, "Characters", "Mira", "final", "mira_042.png")
+    os.makedirs(os.path.dirname(moved_to), exist_ok=True)
+    os.rename(original, moved_to)
+
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert len(after) == 1, "a move must not leave a second row behind"
+    assert after[0].description == "keepme", "the row itself must survive the move"
+    assert after[0].id == picture_id
+    assert after[0].file_path == moved_to
+    assert _tags(server, picture_id) == ["mira"]
+
+
+def test_deleted_file_is_still_removed(server, tmp_path):
+    """The rescue must not turn a genuine deletion into a kept row."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    doomed = _make_image(os.path.join(folder_dir, "gone.png"), (10, 20, 30))
+    _make_image(os.path.join(folder_dir, "kept.png"), (200, 100, 50))
+
+    _run_scan(server, folder_id, folder_dir)
+    assert len(_pictures(server, folder_dir)) == 2
+
+    os.remove(doomed)
+    _run_scan(server, folder_id, folder_dir)
+
+    remaining = _pictures(server, folder_dir)
+    assert [os.path.basename(p.file_path) for p in remaining] == ["kept.png"]
+
+
+def test_ambiguous_pixel_match_is_not_followed(server, tmp_path):
+    """Two copies moved at once must not have their rows paired by guess."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    # Same colour, so both files carry the same pixel hash.
+    first = _make_image(os.path.join(folder_dir, "copy_a.png"), (10, 20, 30))
+    second = _make_image(os.path.join(folder_dir, "copy_b.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert len(indexed) == 2
+    _mark(server, indexed[0].id, "keepme")
+
+    sub_dir = os.path.join(folder_dir, "sub")
+    os.makedirs(sub_dir, exist_ok=True)
+    os.rename(first, os.path.join(sub_dir, "copy_a.png"))
+    os.rename(second, os.path.join(sub_dir, "copy_b.png"))
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert len(after) == 2
+    assert not any(p.description == "keepme" for p in after), (
+        "a 2:2 pixel match is ambiguous; the scan must re-import rather than "
+        "bind one picture's row to the other's file"
+    )


### PR DESCRIPTION
## The bug

A file moved inside a reference folder is one path in `removed_paths` and another in `new_paths` in the same scan pass. Handled in that order it is a delete plus a re-add, so the picture id goes and with it everything keyed to it: tags, smart score, faces, likeness pairs, project and set membership, stack membership, review state.

The pixels survive and everything PixlStash added does not. Reorganising your own folders was the one thing a reference-folder user could not safely do, which is a poor answer for the audience reference folders exist to serve.

## The fix

Both halves of a move are already present in the same pass, so match them by `pixel_sha` before the removal block runs and update `file_path` on the existing row. No new query and no extra state: `fetch_existing` already loads full `Picture` rows, so the hash of every vanished file is in hand.

- **1:1 matches only.** Identical pixels at several paths are genuine copies whose rows can differ in tags and sets, and pairing them by guess would move one picture's work onto another picture's file. Ambiguous groups log and fall through to the previous delete-and-re-add, which is no worse than the behaviour before this change.
- **`existing_by_path` is re-keyed, not just narrowed**, because the sidecar pass further down walks it by path and would otherwise reconcile at the old location.
- **Hashing is skipped unless both sets are non-empty**, so the expensive shape (a first scan of a large folder: many additions, no removals) pays nothing.

## Out of scope, documented at the helper

- **A move between two different reference folders.** The scan is scoped to one folder, so the removal and the addition land in two separate scans with no shared pass to match in. Moves between subfolders of one root are covered, and since the scan walks the whole tree that is the case this is for.
- **A move that races the non-atomic `os.walk`.** A file moved from an unvisited directory into a visited one is in neither set and still reads as a removal. Closing it means deferring deletion by one scan; marked with a `ponytail:` comment rather than built.

## Tests

`tests/test_reference_folder_moves.py`, three cases: a move keeps the row and its tags, a genuine deletion is still removed, and a 2:2 pixel match is not followed. The first fails on the unfixed code and passes with it.

They assert on a marker field rather than on the picture id, because SQLite reuses free rowids: a deleted-and-re-added picture can come back with the same id, so an id assertion alone would have passed for the exact bug under test.

Queries are scoped by path rather than by `reference_folder_id`, since the hub and vault live outside the checkout and a whole run shares one database, so folder ids collide across test modules.
