### PR TITLE
Set Thumbnail acts on the whole selection

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2939,8 +2939,9 @@ and at the pointer with them.
 - **The verbs are ICONS with their words in the tooltip and in the menu.** Nine
   labelled buttons was a sentence to re-read on every selection. Tests address
   them by `data-verb`, not by label text.
-- **The two single-item verbs ride along disabled** past one selection rather
-  than disappearing, so the row of buttons never reflows under the pointer.
+- **Rename, the one single-item verb, rides along disabled** past one selection
+  rather than disappearing, so the row of buttons never reflows under the
+  pointer. Set thumbnail used to sit beside it and is now bulk.
 - **Right-click follows the file-manager rule**: right-clicking a row that is
   not selected selects it and acts on it alone; right-clicking one that IS
   selected leaves the selection alone, so a menu opened on any of forty selected
@@ -3211,13 +3212,37 @@ group, and the shelf already treats "not set" as a value rather than an absence.
 The mark is `aria-hidden`: the row's accessible name already says which model it
 is, and a mark announcing "FL" would be the same fact twice, less usefully.
 
-**Set is single-row, clear is bulk.** An icon answers "which one is this?", so
-giving forty rows one mark would remove the only thing telling them apart — Set
-thumbnail is gated to a selection of one, shown-and-disabled like Rename. Clear
-appears only when something in the selection has one. Setting or clearing a
-single row prompts for nothing (both are reconstructable by doing them again); a
-**bulk** clear is not and confirms, the same test the bulk base-model overwrite
-falls on.
+**Both set and clear are bulk.** Set was originally gated to a selection of one,
+on the argument that giving forty rows one mark removes the only thing telling
+them apart; in practice the owner's common case is the opposite — a base model's
+whole family of adapters wearing its logo — and the shelf is where a selection is
+made. So the verb takes whatever is selected. Clear appears only when something
+in the selection has one.
+
+`setIconOnSelected` posts the same bytes once per **model** rather than calling a
+bulk route: the icon store is content-addressed, so N identical uploads collapse
+to one file on disk, and this reuses the single write path all three ways of
+choosing an icon already share (`POST /models/{id}/icon`). It addresses
+`selectedModelIds`, not `selectedRows` — a fully ticked run is one row wearing
+the cover's id, and iterating rows would mark the cover and skip the other
+eleven versions. Set and clear have to agree about what a selection is.
+
+Because the route is per-model, no server cap can see the gesture, so the client
+carries both bounds: `MAX_MODELS_PER_ICON_SET` (500, the clear route's figure)
+refuses the write outright, and the uploads go out six at a time. A wider
+fan-out only queues behind the browser's ~6 sockets per origin while still
+burning the client's own 60 s timeout, which would report as failed writes the
+server had committed. The receipt counts, and names the model only when the
+selection was one — which of a partly failed batch landed is not known
+client-side, so the ids go to `console.warn` beside their reasons.
+
+Setting or clearing a single row prompts for nothing (both are reconstructable
+by doing them again). A **bulk** clear is not reconstructable and confirms, the
+same test the bulk base-model overwrite falls on — and so does a bulk set **over
+rows that already have a mark**: the images survive in the shared store, but
+which model wore which is recorded nowhere else. The prompt is counted on those
+rows only (a selection of forty bare rows loses nothing) and is asked *before*
+the picker opens, so nobody is made to choose a picture and then defend it.
 
 **The verb is `Set Thumbnail…`, and the field is still `icon`.** The vocabulary
 change (workflow plan §3 S3) aligns the user-facing verb with the word the code

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixlstash-desktop",
-  "version": "1.10.1",
+  "version": "1.11.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixlstash-desktop",
-      "version": "1.10.1",
+      "version": "1.11.0-dev.1",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "pixlstash-desktop",
   "productName": "PixlStash",
   "desktopName": "pixlstash.desktop",
-  "version": "1.10.1",
+  "version": "1.11.0-dev.1",
   "description": "PixlStash desktop app: a native window around the local PixlStash server, with downloadable, hardware-matched compute backends.",
   "author": {
     "name": "Gaute Lindkvist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixlstash-frontend",
-  "version": "1.10.1",
+  "version": "1.11.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixlstash-frontend",
-      "version": "1.10.1",
+      "version": "1.11.0-dev.1",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixlstash-frontend",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.11.0-dev.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -154,10 +154,10 @@
       <v-icon size="19">mdi-folder-move-outline</v-icon>
     </button>
 
-    <!-- The two single-item verbs ride along DISABLED rather than disappearing:
-         a row of buttons that reflows as the selection grows is a row you have
-         to re-read, and a disabled button with its reason in the tooltip
-         teaches where the verb lives. -->
+    <!-- Rename rides along DISABLED rather than disappearing: a row of buttons
+         that reflows as the selection grows is a row you have to re-read, and a
+         disabled button with its reason in the tooltip teaches where the verb
+         lives. -->
     <button
       class="selbar-btn"
       type="button"
@@ -175,7 +175,6 @@
       type="button"
       data-verb="set-icon"
       aria-label="Set thumbnail"
-      :disabled="!single"
       :title="iconTitle"
       @click="emit('set-icon')"
     >
@@ -396,10 +395,12 @@ const renameTitle = computed(() =>
   single.value ? "Rename this model" : "Select one model to rename it",
 );
 
+// Counted off `selectedModelIds` rather than the rows, the way the write is: a
+// ticked run is one row and twelve models.
 const iconTitle = computed(() =>
-  single.value
+  store.selectedModelIds.length === 1
     ? "Give this model a picture"
-    : "Select one model to give it a picture",
+    : `Give the same picture to all ${store.selectedModelIds.length} models`,
 );
 
 const withIcons = computed(() =>
@@ -941,19 +942,17 @@ const VerbMenu = (props) => {
           kbd: "F2",
         })
       : null,
-    props.single
-      ? item("mdi-image-outline", "Set thumbnail…", {
-          on: () => props.onVerb("set-icon"),
-          title: props.iconTitle,
-        })
-      : null,
+    item("mdi-image-outline", "Set thumbnail…", {
+      on: () => props.onVerb("set-icon"),
+      title: props.iconTitle,
+    }),
     props.hasIcons
       ? item("mdi-image-off-outline", "Clear thumbnail", {
           on: () => props.onVerb("clear-icons"),
           title: props.clearIconTitle,
         })
       : null,
-    props.single || props.hasIcons ? sep() : null,
+    sep(),
     item("mdi-cube-outline", "Set base model…", {
       on: () => props.onVerb("set-base-model"),
     }),

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -3225,20 +3225,114 @@ describe("the assignment ring (#892, redrawn for #904)", () => {
 });
 
 describe("the thumbnail verb", () => {
-  it("offers Set thumbnail for one model and refuses it for two", async () => {
+  it("marks every selected model with the one picture", async () => {
+    const bytes = new Blob(["webp"], { type: "image/webp" });
+    getPictureThumbnailBlob.mockResolvedValue(bytes);
+    setModelIcon.mockResolvedValue({
+      model_id: 1,
+      icon_sha256: "c".repeat(64),
+    });
     const wrapper = await mountShelf([
       adapter({ id: 1 }),
       adapter({ id: 2, sha256: "b".repeat(64) }),
     ]);
     const store = useModelShelfStore();
     store.toggleSelected(1);
-    await wrapper.vm.$nextTick();
-    const setIcon = () => wrapper.find('[data-verb="set-icon"]');
-    expect(setIcon().attributes("disabled")).toBeUndefined();
-
     store.toggleSelected(2);
     await wrapper.vm.$nextTick();
-    expect(setIcon().attributes("disabled")).toBeDefined();
+
+    await wrapper
+      .findComponent({ name: "PicturePicker" })
+      .vm.$emit("pick", { id: 55 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // One read of the picture, one write per model: the icon store is
+    // content-addressed, so the repeated bytes collapse to one file.
+    expect(getPictureThumbnailBlob).toHaveBeenCalledTimes(1);
+    expect(setModelIcon).toHaveBeenCalledWith(1, bytes);
+    expect(setModelIcon).toHaveBeenCalledWith(2, bytes);
+  });
+
+  it("asks before a bulk set overwrites marks, and opens nothing on no", async () => {
+    // The images survive in the content-addressed store, but which model wore
+    // which does not — the same test the bulk clear falls on.
+    const wrapper = await mountShelf([
+      adapter({ id: 1, icon_sha256: "a".repeat(64) }),
+      adapter({ id: 2, sha256: "b".repeat(64) }),
+    ]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    store.toggleSelected(2);
+    await wrapper.vm.$nextTick();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    // `useConfirm` has no host mounted and falls back to `window.confirm`,
+    // which shows the MESSAGE and nothing else — so the counts have to be
+    // there, not in the title the fallback throws away.
+    expect(confirmSpy.mock.calls[0][0]).toContain("All 2 selected models");
+    expect(confirmSpy.mock.calls[0][0]).toContain("the 1 that already");
+    expect(wrapper.findComponent({ name: "PicturePicker" }).props("open")).toBe(
+      false,
+    );
+
+    // And the other direction: saying yes opens the picker. Over-blocking is
+    // its own regression.
+    confirmSpy.mockReturnValue(true);
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(wrapper.findComponent({ name: "PicturePicker" }).props("open")).toBe(
+      true,
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it("does not ask when the selection has no marks to overwrite", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2, sha256: "b".repeat(64) }),
+    ]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    store.toggleSelected(2);
+    await wrapper.vm.$nextTick();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    await wrapper.find('[data-verb="set-icon"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(wrapper.findComponent({ name: "PicturePicker" }).props("open")).toBe(
+      true,
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it("marks every model in a ticked run, not just its cover", async () => {
+    // A fully-selected stack is ONE row whose id is the cover's. Iterating
+    // rows would silently skip the other two.
+    const bytes = new Blob(["webp"], { type: "image/webp" });
+    getPictureThumbnailBlob.mockResolvedValue(bytes);
+    setModelIcon.mockResolvedValue({
+      model_id: 1,
+      icon_sha256: "e".repeat(64),
+    });
+    const wrapper = await mountShelf([
+      adapter({ id: 1, stack_id: 9, stack_position: 0 }),
+      adapter({ id: 2, sha256: "b".repeat(64), stack_id: 9, stack_position: 1 }),
+      adapter({ id: 3, sha256: "c".repeat(64), stack_id: 9, stack_position: 2 }),
+    ]);
+    const store = useModelShelfStore();
+    store.selectVisible();
+    await wrapper.vm.$nextTick();
+    expect(store.selectedRows).toHaveLength(1);
+
+    await wrapper
+      .findComponent({ name: "PicturePicker" })
+      .vm.$emit("pick", { id: 55 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setModelIcon.mock.calls.map((c) => c[0]).sort()).toEqual([1, 2, 3]);
   });
 
   it("offers Clear thumbnail only when something has one", async () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -2190,15 +2190,55 @@ const thumbnailPickerOpen = ref(false);
  *
  * A row in the `needs-a-name` state has no name by design, so this falls back
  * the same way the receipt does — the reader has to recognise what they are
- * about to change.
+ * about to change. A selection is named by its size instead: the picture is
+ * about to land on all of them, and that is the fact worth stating before the
+ * click rather than after it.
  */
 const thumbnailSubject = computed(() => {
+  const count = store.selectedModelIds.length;
+  if (!count) return "";
+  if (count > 1) return `for ${count} models`;
   const row = store.selectedRows[0];
-  if (!row) return "";
   return `for ${row.name?.text || row.filename || "this model"}`;
 });
 
-function pickIcon() {
+/**
+ * Ask before a bulk set that would REPLACE marks, not before one that adds.
+ *
+ * The shelf's rule is to confirm only where the prior state cannot be
+ * reconstructed, and this falls on the same side of that test as the bulk
+ * clear: the images survive in the content-addressed store, but which model
+ * wore which is not recorded anywhere else. Counted on the models that already
+ * HAVE one, because that is what the verb will actually overwrite — a
+ * selection of forty bare rows loses nothing and is not worth a prompt. Asked
+ * BEFORE the picker opens, so the reader is not made to choose a picture and
+ * then defend the choice.
+ *
+ * Both counts are expanded through `members`, the way the write is: a ticked
+ * run is one row wearing the cover's `icon_sha256`, and prompting on that
+ * would be counting one of twelve.
+ *
+ * Everything material goes in `message`. `useConfirm` has no host mounted yet
+ * and falls back to `window.confirm(message)`, which shows nothing else — a
+ * count parked in `title` would simply not reach the reader.
+ */
+async function pickIcon() {
+  const models = store.selectedRows.flatMap((row) => row.members ?? [row]);
+  const withIcons = models.filter((row) => row.icon_sha256);
+  if (models.length > 1 && withIcons.length) {
+    const ok = await confirm({
+      title: `Replace ${withIcons.length} thumbnails?`,
+      message:
+        `All ${models.length} selected models get the picture you pick next, ` +
+        `replacing the ${withIcons.length} that already have one. The images ` +
+        `themselves are kept, but which model wore which is not recorded ` +
+        `anywhere else, and there is no undo.`,
+      warning: "There is no undo for this.",
+      confirmLabel: "Pick a picture",
+      danger: true,
+    });
+    if (!ok) return;
+  }
   thumbnailPickerOpen.value = true;
 }
 
@@ -2213,6 +2253,9 @@ function pickIcon() {
  * survive. The thumbnail is the copy that gets sent: already WebP, generated on
  * demand for any file the server can still reach, and 384px on the short edge —
  * an icon's size rather than a 40 MB original the store would refuse.
+ *
+ * Read ONCE for the whole selection: every model gets the same bytes, and the
+ * store is content-addressed, so they collapse to one file on disk.
  */
 async function onThumbnailPicked(picture) {
   try {

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -222,6 +222,18 @@ function modelCount(n) {
   return `${Number(n).toLocaleString()} ${n === 1 ? "model" : "models"}`;
 }
 
+// Ceiling on one bulk thumbnail set, mirroring the clear route's
+// `MAX_MODELS_PER_CLEAR` (`pixlstash/routes/model_icons.py`). The set route is
+// per-model, so no server cap can see the gesture: Ctrl+A on a long shelf is
+// one keystroke, and this is where it stops being one.
+const MAX_MODELS_PER_ICON_SET = 500;
+
+// How many of those uploads are in the air at once. A browser gives ~6 sockets
+// per origin, so a wider fan-out only queues — and a queued request still burns
+// the client's own 60 s timeout, which would report as failed writes the server
+// had committed. It also leaves sockets for the row thumbnails.
+const ICON_SET_CONCURRENCY = 6;
+
 /** What each curated column is called in a receipt. */
 const FIELD_WORDS = {
   display_name: "name",
@@ -1818,47 +1830,90 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
   }
 
   /**
-   * Give one model an icon.
+   * Give every selected model the same icon.
    *
-   * Single-row by nature, and gated that way in the bar: an icon answers
-   * "which one is this?", so giving forty rows the same mark would remove the
-   * only thing telling them apart. (Two models legitimately SHARING a logo is
-   * different — that is the owner setting each one, and the content-addressed
-   * store then keeps one file.)
+   * Addressed off `selectedModelIds`, never `selectedRows`: a fully-ticked
+   * stack is ONE row whose `id` is the cover's, so iterating rows would mark
+   * the cover and silently skip the other eleven versions. This is the same
+   * expansion `clearIconsOnSelected` uses, and set and clear have to agree
+   * about what a selection is.
    *
-   * No confirmation: setting an icon is reconstructable by setting it again.
+   * One upload per model rather than one bulk route: the icon store is
+   * content-addressed, so identical bytes collapse to one file on disk however
+   * many times they are posted, and this reuses the write path all three ways
+   * of choosing an icon already share. Windowed rather than fired all at once,
+   * for the socket reason above.
    *
-   * **Refuses a selection that is not exactly one**, rather than taking the
-   * first row. The bar disables the button, but a UI state is not an invariant:
-   * any other caller would silently mark whichever row happened to sort first,
-   * which is the surprise this verb can least afford.
+   * The caller confirms a bulk set that would REPLACE existing marks; this
+   * writes.
    *
    * @param {File|Blob} file
-   * @returns {Promise<boolean>} true when the icon landed; false if it was
-   *   refused or the request failed.
+   * @returns {Promise<boolean>} true when at least one icon landed.
    */
   async function setIconOnSelected(file) {
     const notices = useNoticeStore();
-    if (selectedRows.value.length !== 1 || !file) return false;
-    const row = selectedRows.value[0];
-    try {
-      await setModelIcon(row.id, file);
-      await fetchRows();
-      notices.push({
-        level: "success",
-        // A row in the `needs-a-name` state has no name to say, by design —
-        // its `text` is empty so the shelf can draw it as a field. The receipt
-        // still has to name something the reader can recognise.
-        text: `Set the thumbnail on ${row.name.text || row.filename || "the model"}.`,
-      });
-      return true;
-    } catch (err) {
+    const ids = selectedModelIds.value;
+    if (!ids.length || !file) return false;
+    if (ids.length > MAX_MODELS_PER_ICON_SET) {
       notices.push({
         level: "error",
-        text: errorDetail(err) || "Could not set that thumbnail.",
+        text: `At most ${MAX_MODELS_PER_ICON_SET} models in one thumbnail set.`,
       });
       return false;
     }
+
+    // Captured before the writes: `fetchRows()` below replaces the rows, and
+    // the receipt names the model the reader pointed at.
+    const only = ids.length === 1 ? selectedRows.value[0] : null;
+
+    const failed = [];
+    let done = 0;
+    for (let i = 0; i < ids.length; i += ICON_SET_CONCURRENCY) {
+      const batch = ids.slice(i, i + ICON_SET_CONCURRENCY);
+      const results = await Promise.allSettled(
+        batch.map((id) => setModelIcon(id, file)),
+      );
+      results.forEach((result, offset) => {
+        if (result.status === "rejected") {
+          failed.push([batch[offset], result.reason]);
+        } else {
+          done += 1;
+        }
+      });
+    }
+
+    if (failed.length) {
+      // The ids as well as the reasons: the receipt can only say how many
+      // failed, and without this there is nothing anywhere saying WHICH — and
+      // the only recourse is otherwise to redo the whole selection.
+      console.warn(
+        `[modelShelf] ${failed.length} thumbnail write(s) failed:`,
+        failed.map(([id, reason]) => `${id}: ${errorDetail(reason) || reason}`),
+      );
+    }
+    await fetchRows();
+    if (!done) {
+      notices.push({
+        level: "error",
+        text: errorDetail(failed[0]?.[1]) || "Could not set that thumbnail.",
+      });
+      return false;
+    }
+    const notes = failed.length
+      ? ` ${modelCount(failed.length)} could not be written.`
+      : "";
+    notices.push({
+      level: failed.length ? "warning" : "success",
+      // A row in the `needs-a-name` state has no name to say, by design — its
+      // `text` is empty so the shelf can draw it as a field. The receipt still
+      // has to name something the reader can recognise. Named only when the
+      // selection was one model: which of a partly failed batch landed is not
+      // known here.
+      text: only
+        ? `Set the thumbnail on ${only.name?.text || only.filename || "the model"}.${notes}`
+        : `Set the thumbnail on ${modelCount(done)}.${notes}`,
+    });
+    return true;
   }
 
   /**

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -1363,10 +1363,7 @@ describe("the thumbnail verb", () => {
     expect(setModelIcon).toHaveBeenCalledWith(1, file);
   });
 
-  it("refuses a multi-row selection instead of marking the first row", async () => {
-    // The bar disables the button, but a UI state is not an invariant — any
-    // other caller would otherwise silently mark whichever row happened to sort
-    // first, which is the surprise this verb can least afford.
+  it("marks every selected model, not just the first", async () => {
     const store = useModelShelfStore();
     store.rows = [
       adapter({ id: 1 }),
@@ -1374,9 +1371,87 @@ describe("the thumbnail verb", () => {
     ];
     store.toggleSelected(1);
     store.toggleSelected(2);
+    const file = new Blob(["x"]);
+
+    expect(await store.setIconOnSelected(file)).toBe(true);
+    expect(setModelIcon).toHaveBeenCalledTimes(2);
+    expect(setModelIcon).toHaveBeenCalledWith(1, file);
+    expect(setModelIcon).toHaveBeenCalledWith(2, file);
+    expect(useNoticeStore().notices.at(-1).text).toBe(
+      "Set the thumbnail on 2 models.",
+    );
+  });
+
+  it("counts a partial failure rather than claiming the whole selection", async () => {
+    // The receipt is the only record — there is no undo — so a batch that half
+    // landed must not read like one that landed.
+    const store = useModelShelfStore();
+    store.rows = [
+      adapter({ id: 1 }),
+      adapter({ id: 2, sha256: "b".repeat(64) }),
+    ];
+    store.toggleSelected(1);
+    store.toggleSelected(2);
+    setModelIcon.mockRejectedValueOnce(new Error("nope"));
+
+    expect(await store.setIconOnSelected(new Blob(["x"]))).toBe(true);
+    const notice = useNoticeStore().notices.at(-1);
+    expect(notice.level).toBe("warning");
+    expect(notice.text).toBe(
+      "Set the thumbnail on 1 model. 1 model could not be written.",
+    );
+  });
+
+  it("reports an error when nothing landed", async () => {
+    const store = useModelShelfStore();
+    store.rows = [adapter({ id: 1 })];
+    store.toggleSelected(1);
+    setModelIcon.mockRejectedValue(new Error("nope"));
+
+    expect(await store.setIconOnSelected(new Blob(["x"]))).toBe(false);
+    expect(useNoticeStore().notices.at(-1).level).toBe("error");
+  });
+
+  it("does nothing without a selection, and says nothing either", async () => {
+    // The notice matters as much as the write: without the guard this falls
+    // through to "none landed" and pushes an error about a set nobody asked
+    // for.
+    const store = useModelShelfStore();
+    store.rows = [adapter({ id: 1 })];
+    const before = useNoticeStore().notices.length;
+    expect(await store.setIconOnSelected(new Blob(["x"]))).toBe(false);
+    expect(setModelIcon).not.toHaveBeenCalled();
+    expect(useNoticeStore().notices).toHaveLength(before);
+  });
+
+  it("marks every model in a ticked run, not just its cover", async () => {
+    // A fully-selected stack is ONE selected row, and its id is the cover's.
+    const store = useModelShelfStore();
+    store.rows = [
+      adapter({ id: 1, stack_id: 9, stack_position: 0 }),
+      adapter({ id: 2, sha256: "b".repeat(64), stack_id: 9, stack_position: 1 }),
+      adapter({ id: 3, sha256: "c".repeat(64), stack_id: 9, stack_position: 2 }),
+    ];
+    store.selectVisible();
+    expect(store.selectedRows).toHaveLength(1);
+
+    expect(await store.setIconOnSelected(new Blob(["x"]))).toBe(true);
+    expect(setModelIcon.mock.calls.map((c) => c[0]).sort()).toEqual([1, 2, 3]);
+    expect(useNoticeStore().notices.at(-1).text).toBe(
+      "Set the thumbnail on 3 models.",
+    );
+  });
+
+  it("refuses a selection past the ceiling rather than firing 501 uploads", async () => {
+    const store = useModelShelfStore();
+    store.rows = Array.from({ length: 501 }, (_, i) =>
+      adapter({ id: i + 1, sha256: String(i).padStart(64, "0") }),
+    );
+    store.selectVisible();
 
     expect(await store.setIconOnSelected(new Blob(["x"]))).toBe(false);
     expect(setModelIcon).not.toHaveBeenCalled();
+    expect(useNoticeStore().notices.at(-1).text).toContain("At most 500");
   });
 
   it("does nothing without a file, rather than posting an empty body", async () => {

--- a/pixlstash/routes/model_icons.py
+++ b/pixlstash/routes/model_icons.py
@@ -10,11 +10,18 @@ icon store and a hash in the column". So the client fetches or renders the bytes
 and posts them here; there is no second path that resolves a picture id
 server-side, which is also what keeps the vault out of a hub table.
 
-**No confirmation on set, or on clearing one row.** Both are reconstructable by
+**No confirmation on a single-row set or clear.** Both are reconstructable by
 doing them again, and the shelf's rule is to confirm only where the prior state
 cannot be reconstructed. A **bulk** clear over a selection is not
 reconstructable and falls on the same side of that test as the bulk base-model
-overwrite, so the client confirms it — the route itself stays a plain mutation.
+overwrite, and so does a bulk set over rows that already have a mark; the client
+confirms both — the routes themselves stay plain mutations.
+
+**A bulk set is N calls to this route**, one per model, because the store is
+content-addressed and the same bytes collapse to one file however many times
+they are posted. The client caps and windows that fan-out
+(`MAX_MODELS_PER_ICON_SET`, `useModelShelfStore.js`); this route sees only
+single-model writes and cannot see the gesture.
 
 Authorization: all three are ``OWNER_ONLY``. The store lives beside the hub and
 is written and read by PixlStash alone, so no route here takes, walks or serves
@@ -39,7 +46,9 @@ from pixlstash.services.model_icons import (
 logger = get_logger(__name__)
 
 # Ceiling on one clear. Mirrors the shelf's other bulk verbs rather than
-# inventing a number: a selection is what a person made, not a script.
+# inventing a number: a selection is what a person made, not a script. The
+# client's bulk *set* uses the same figure, enforced there rather than here
+# because a set is N single-model calls this route cannot correlate.
 MAX_MODELS_PER_CLEAR = 500
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixlstash"
-version = "1.11-dev.1"
+version = "1.11.0-dev.1"
 description = "Self-hosted picture library with AI tagging, semantic search, and a clean web UI"
 readme = "README.md"
 license = "GPL-3.0-only AND MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixlstash"
-version = "1.10.1"
+version = "1.11-dev.1"
 description = "Self-hosted picture library with AI tagging, semantic search, and a clean web UI"
 readme = "README.md"
 license = "GPL-3.0-only AND MIT"
@@ -20,7 +20,7 @@ keywords = [
     "comfyui",
 ]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## What

`Set Thumbnail…` on the model shelf was gated to a selection of exactly one
model — shown-and-disabled past that, and refused in the store even if
something called it anyway. It now acts on the whole selection: one picture,
every selected model.

## How

- `setIconOnSelected` addresses **`selectedModelIds`, not `selectedRows`**. A
  fully ticked run is one row wearing the cover's id, so iterating rows would
  have marked the cover and silently skipped the other eleven versions —
  `clearIconsOnSelected` already expands members, and set and clear have to
  agree about what a selection is.
- N calls to `POST /models/{id}/icon` rather than a new bulk route. The icon
  store is content-addressed, so identical bytes collapse to one file on disk
  however many times they are posted, and this reuses the single write path all
  three ways of choosing an icon already share.
- Because that route is per-model, no server cap can see the gesture, so the
  client carries both bounds: `MAX_MODELS_PER_ICON_SET` (500, the clear route's
  figure) refuses outright, and the uploads go out six at a time. A wider
  fan-out only queues behind the browser's ~6 sockets per origin while still
  burning the client's own 60 s timeout, which would report as failed writes the
  server had committed.
- The bar's button and the context-menu item are no longer gated on `single`;
  the tooltip counts models, not rows.
- **A bulk set over rows that already have a mark now confirms**, asked before
  the picker opens. The images survive in the shared store, but which model wore
  which is recorded nowhere else — the same test the bulk clear falls on. A
  selection of bare rows loses nothing and is not prompted. Everything material
  goes in `message`, because `useConfirm` still has no host mounted and falls
  back to `window.confirm(message)`.
- Failures are counted in the receipt and their **ids** logged beside their
  reasons; the receipt names the model only when the selection was one, since
  which of a partly failed batch landed is not known client-side.

Docs updated: `frontend_architecture.md` §9.1 (the paragraph that said set is
single-row and the bar bullet that said two verbs ride along disabled), and the
`model_icons.py` module docstring, which said there is no confirmation on set.

## Tests

Frontend suite green (3639). New coverage: every selected model marked, a ticked
run marking all its members rather than its cover, partial-failure receipt,
error when nothing lands, the ceiling, and both directions of the new confirm.
The stack fix and the confirm's rejected/accepted branches were each proved by
mutation — inverting them reds the suite.

## Reviewer objections answered

An adversarial pass before pushing raised these; both are deliberate:

- *`setIconOnSelected` returns `true` on a partial failure.* Same contract as
  `setAttachment` beside it (`done > 0`); the receipt and the log carry the
  detail, and no caller branches on it.
- *No progress bar, cancel, or in-flight guard.* Out of scope for this card. The
  windowing plus the 500 ceiling bound the worst case; a progress affordance for
  bulk shelf verbs is its own piece of work and would want to cover the other
  bulk verbs too.
