### PR TITLE
Gate the reference-folder move test, and harden the move matcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,7 @@ jobs:
           tests/test_projects_api.py
           tests/test_rate_limiter.py
           tests/test_read_token_security.py
+          tests/test_reference_folder_moves.py
           tests/test_repair_copied_face_rows.py
           tests/test_restore.py
           tests/test_reviews_api.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3607,6 +3607,38 @@ Two writers create rows — the scrapheap purge (`routes/pictures/_crud.py::dele
 
 **Explicit re-import overrides the ledger; a routine sync does not.** The reference-folder scanner (`tasks/reference_folder_scan_task.py`) normally skips any disk path present in the ledger — no fully-automatic re-import of a removed-but-kept file. The override fires **iff** a dedicated one-shot signal is set: `reference_folder.pending_reimport` (migration `0078_add_reference_folder_pending_reimport`, default `False`). That flag is written `True` in exactly one place — the deliberate folder-add endpoint `create_reference_folder` (`routes/reference_folders.py`); **no** routine path (sync-toggle, rename, relocate, mount-recovery, the filesystem watcher, or a periodic re-scan) ever sets it. On an explicit re-import the scanner re-imports files found on disk and **clears** their matching ledger rows so restore can resurface them, then clears `pending_reimport` in the same transaction that completes the scan (one-shot; a mount_error exit leaves it set so the intent survives until a real scan consumes it). This replaces an earlier `last_scanned IS NULL` + no-pictures heuristic that the watcher (it resets `last_scanned`) could spoof — closing the edge where an already-emptied folder whose `last_scanned` was reset would have auto-resurfaced removed-but-kept files. **Invariant:** the override only ever clears rows for paths drawn from `disk_paths` (files actually present on disk), so genuinely-gone content — absent on disk, `file_removed=True` — is never in the disk set, is never cleared, and stays permanently guarded by restore.
 
+**A move inside a reference folder is followed, not re-imported.** A file moved
+within the scanned tree arrives as one path in `removed_paths` and another in
+`new_paths` in the *same* pass. Taken in that order it is a delete plus a
+re-add, which frees the picture id and everything hanging off it — tags, smart
+score, faces, likeness pairs, project/set/stack membership, review state — so
+reorganising a reference folder used to discard everything PixlStash had added
+to it. `_match_moved_paths` pairs the two halves before the removal block runs
+and updates `file_path` on the existing row instead.
+
+- **The key is `(pixel_sha, size_bytes)`, and the match must be 1:1 with no
+  unchanged file sharing that key.** `pixel_sha` alone is not an identity:
+  `ImageUtils.calculate_hash_from_file_path` samples 8 x 8 KiB windows of
+  anything over 128 KiB and does not mix the size into the digest, which is why
+  import de-duplication treats it as a candidate key. A false pair here is worse
+  than the bug being fixed — a lost row is visible, one picture's curation
+  silently rebound onto another picture's file is not — so every ambiguous group
+  logs and falls through to the previous delete-and-re-add.
+- **Confirmation stops at the size.** Import de-dup follows a candidate match
+  with a full-byte hash of *both* sides; here one side is a file that no longer
+  exists, so the stored columns are all there is to compare.
+- **A followed move blanks `thumbnail_width` / `thumbnail_height`.** Thumbnails
+  are keyed `sha256(file_path)` (`ImageUtils.get_thumbnail_path`), so the stored
+  bitmap is unreachable from the new path; blank dimensions are what
+  `MissingThumbnailFinder` keys on, so the existing sweep regenerates it.
+- **Scoped to one folder, and to one pass.** The scan covers a single reference
+  folder, so a move *between* two folders is a removal in one scan and an
+  addition in another with no shared pass to match in. Two races remain open and
+  are marked at the helper: `os.walk` is not atomic, and `MissingFilePurgeTask`
+  can delete the row in the up-to-`_RESCAN_INTERVAL_S` window before the
+  rescuing scan runs. Both degrade to the old delete-and-re-add; the second logs
+  a warning when it is observed.
+
 ---
 
 ## 19. Mermaid Diagrams

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3627,10 +3627,30 @@ and updates `file_path` on the existing row instead.
 - **Confirmation stops at the size.** Import de-dup follows a candidate match
   with a full-byte hash of *both* sides; here one side is a file that no longer
   exists, so the stored columns are all there is to compare.
-- **A followed move blanks `thumbnail_width` / `thumbnail_height`.** Thumbnails
-  are keyed `sha256(file_path)` (`ImageUtils.get_thumbnail_path`), so the stored
-  bitmap is unreachable from the new path; blank dimensions are what
-  `MissingThumbnailFinder` keys on, so the existing sweep regenerates it.
+- **A followed move carries its thumbnail bitmap.** Thumbnails are keyed
+  `sha256(file_path)` (`ImageUtils.get_thumbnail_path`), so the file is renamed
+  alongside the picture rather than abandoned: nothing sweeps `.ref_thumbs` by
+  anything but a row's *current* `file_path`, so a bitmap left at the old name
+  would never be reachable and never be collected. Only when there is nothing to
+  carry, or the rename fails, are `thumbnail_width` / `thumbnail_height` blanked
+  so `MissingThumbnailFinder` renders a fresh one.
+- **`original_file_name` follows too**, matching the explicit move route
+  (`routes/reference_folders.py`), so a renamed file does not keep downloading
+  under its old name.
+- **Scrapheap rows are never the source of a move.** `fetch_existing` loads
+  `deleted=True` rows deliberately; a hidden soft-deleted row whose file really
+  was deleted would otherwise swallow an unrelated new file of the same content,
+  and the user would get a picture they cannot see instead of a new one. They do
+  still count as unchanged files *blocking* a match, since their file is on disk.
+- **A present file with a NULL `pixel_sha` blocks matching for the whole pass.**
+  The column is nullable and `MissingPixelShaFinder` backfills it, so an
+  un-hashed unchanged file is invisible to the ambiguity count — and it is
+  exactly the file whose existence would have refused the match. NULL there
+  means "unknown", not "no collision".
+- **A followed move emits `CHANGED_PICTURES`** (`moved_picture_ids` in the task
+  result, `Vault._on_task_completed`), and deliberately not `PICTURE_IMPORTED`:
+  `file_path` changed on a row an open grid may already be showing, but nothing
+  was imported.
 - **Scoped to one folder, and to one pass.** The scan covers a single reference
   folder, so a move *between* two folders is a removal in one scan and an
   addition in another with no shared pass to match in. Two races remain open and

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -66,7 +66,9 @@ class ReferenceFolderScanTask(BaseTask):
     New files found on disk are inserted as Picture rows with their absolute
     paths so that PixlStash serves them directly from their original location.
     Files that have been removed from disk since the last scan have their DB
-    records deleted.
+    records deleted, unless the same pixels turned up at a new path in the same
+    pass: that is a move, and the existing record follows the file rather than
+    being replaced by a fresh one.
 
     Phase-2 path validation (resolve mapping → blocklist → isdir/access) is
     performed before any filesystem work.  On failure the folder status is set

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -298,9 +298,30 @@ class ReferenceFolderScanTask(BaseTask):
             def apply_moves(session: Session, pairs: list[tuple[int, str]]) -> None:
                 for pic_id, new_path in pairs:
                     pic = session.get(Picture, pic_id)
-                    if pic is not None:
-                        pic.file_path = new_path
-                        session.add(pic)
+                    if pic is None:
+                        # The row went between the scan's read and this write —
+                        # the purge sweep is the likely author.  The pair has
+                        # already been taken out of removed_paths and new_paths,
+                        # so the file is now neither moved nor imported until the
+                        # next scan; say so rather than losing it silently.
+                        logger.warning(
+                            "Reference folder %s: picture %d vanished before its "
+                            "move to %s could be applied; the file will be "
+                            "re-imported on the next scan.",
+                            self._folder_path,
+                            pic_id,
+                            new_path,
+                        )
+                        continue
+                    pic.file_path = new_path
+                    # The thumbnail is stored under sha256(file_path), so the
+                    # old bitmap is unreachable at the new path.  Blanking the
+                    # dimensions is what MissingThumbnailFinder keys on, so the
+                    # existing sweep regenerates it; leaving them set points the
+                    # picture at a thumbnail that is not there.
+                    pic.thumbnail_width = None
+                    pic.thumbnail_height = None
+                    session.add(pic)
                 session.commit()
 
             self._db.run_task(
@@ -576,12 +597,19 @@ class ReferenceFolderScanTask(BaseTask):
             scan of a large folder has no removals and never hashes here, and a
             folder losing files without gaining any never hashes either.
 
-        Only a 1:1 pixel match counts as a move.  Identical pixels at several
-        paths are genuine copies, and the rows behind them can differ in tags,
-        sets and scores — pairing them by guess would move one picture's work
-        onto another picture's file, which is the loss this exists to prevent.
-        Ambiguous groups fall through to the delete-and-re-add path, which is
-        no worse than the behaviour before this existed.
+        Only a 1:1 match on ``(pixel_sha, size_bytes)`` counts as a move, and
+        only when no unchanged file in the folder shares that key either.
+        Identical pixels at several paths are genuine copies, and the rows
+        behind them can differ in tags, sets and scores — pairing them by guess
+        would move one picture's work onto another picture's file, which is the
+        loss this exists to prevent.  Ambiguous groups fall through to the
+        delete-and-re-add path, which is no worse than the behaviour before
+        this existed.
+
+        The confirmation stops at the size.  Import de-duplication follows a
+        ``(sampled hash, size)`` candidate match with a full-byte hash of both
+        sides; here one side is a file that no longer exists, so its bytes are
+        unavailable and the stored columns are all there is to compare.
 
         Scoped to one reference folder, because the scan is: a file moved
         between two reference folders is a removal in one scan and an addition
@@ -596,17 +624,36 @@ class ReferenceFolderScanTask(BaseTask):
         # unvisited directory into a visited one is in neither set and still
         # reads as a removal.  Deferring deletion by one scan (mark and sweep)
         # would close it; not worth the state for a race this narrow.
-        gone_by_sha: dict[str, list[str]] = {}
+        # The key is ``(pixel_sha, size_bytes)``, never ``pixel_sha`` alone.
+        # ``calculate_hash_from_file_path`` samples 8 x 8 KiB windows of
+        # anything over 128 KiB and does not mix the size into the digest, so
+        # on its own it is a candidate key and not an identity -- its own
+        # docstring says so, and import de-duplication pairs it with the size
+        # for exactly this reason.  Here a false pair is worse than the bug
+        # being fixed: a lost row is visible, one picture's tags and
+        # memberships silently rebound onto another picture's file are not.
+        gone_by_key: dict[tuple[str, int | None], list[str]] = {}
         for path in removed_paths:
-            pixel_sha = existing_by_path[path].pixel_sha
-            if pixel_sha:
-                gone_by_sha.setdefault(pixel_sha, []).append(path)
-        if not gone_by_sha:
+            picture = existing_by_path[path]
+            if picture.pixel_sha:
+                key = (picture.pixel_sha, picture.size_bytes)
+                gone_by_key.setdefault(key, []).append(path)
+        if not gone_by_key:
             return {}
 
-        arrived_by_sha: dict[str, list[str]] = {}
+        # An unchanged file sharing the key makes the group ambiguous too, and
+        # the stable rows cost nothing to count: their hash is already loaded.
+        # Without this, deleting A and separately adding an identical C while
+        # an identical B sits untouched in the folder reads as a clean 1:1.
+        stable_keys: set[tuple[str, int | None]] = set()
+        for path, picture in existing_by_path.items():
+            if path not in removed_paths and picture.pixel_sha:
+                stable_keys.add((picture.pixel_sha, picture.size_bytes))
+
+        arrived_by_key: dict[tuple[str, int | None], list[str]] = {}
         for path in sorted(new_paths):
             try:
+                size_bytes = os.path.getsize(path)
                 pixel_sha = ImageUtils.calculate_hash_from_file_path(path)
             except Exception as exc:
                 # Not fatal: an unhashable file simply cannot be matched, and
@@ -619,20 +666,24 @@ class ReferenceFolderScanTask(BaseTask):
                 )
                 continue
             if pixel_sha:
-                arrived_by_sha.setdefault(pixel_sha, []).append(path)
+                arrived_by_key.setdefault((pixel_sha, size_bytes), []).append(path)
 
         moved: dict[str, str] = {}
-        for pixel_sha, old_paths in gone_by_sha.items():
-            candidates = arrived_by_sha.get(pixel_sha, ())
-            if len(old_paths) == 1 and len(candidates) == 1:
+        for key, old_paths in gone_by_key.items():
+            candidates = arrived_by_key.get(key, ())
+            if not candidates:
+                continue
+            if len(old_paths) == 1 and len(candidates) == 1 and key not in stable_keys:
                 moved[old_paths[0]] = candidates[0]
-            elif candidates:
+            else:
                 logger.info(
-                    "Reference folder %s: %d vanished and %d new file(s) share "
-                    "one pixel hash; too ambiguous to call a move, re-importing.",
+                    "Reference folder %s: %d vanished, %d new and %d unchanged "
+                    "file(s) share one pixel hash and size; too ambiguous to "
+                    "call a move, re-importing.",
                     self._folder_path,
                     len(old_paths),
                     len(candidates),
+                    1 if key in stable_keys else 0,
                 )
         return moved
 

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -276,6 +276,55 @@ class ReferenceFolderScanTask(BaseTask):
                 cleared,
             )
 
+        # --- Follow moved files before anything is deleted ---
+        # A file moved inside the folder is one path in ``removed_paths`` and
+        # another in ``new_paths``, same bytes.  Handled in that order it is a
+        # delete plus a re-add: the row goes and with it everything keyed to the
+        # picture id (tags, smart score, faces, likeness pairs, project/set
+        # membership, stack membership, review state).  The pixels survive and
+        # everything PixlStash added does not, so the only safe way to use a
+        # reference folder was to never reorganize it.  Both halves are already
+        # in this same pass, so match them and move the row instead.
+        #
+        # Runs before the removal block by necessity: the delete is what
+        # destroys the row being rescued.
+        moved_paths = self._match_moved_paths(
+            existing_by_path, new_paths, removed_paths
+        )
+        if moved_paths:
+
+            def apply_moves(session: Session, pairs: list[tuple[int, str]]) -> None:
+                for pic_id, new_path in pairs:
+                    pic = session.get(Picture, pic_id)
+                    if pic is not None:
+                        pic.file_path = new_path
+                        session.add(pic)
+                session.commit()
+
+            self._db.run_task(
+                apply_moves,
+                sorted(
+                    (existing_by_path[old].id, new)
+                    for old, new in moved_paths.items()
+                    if existing_by_path[old].id is not None
+                ),
+                priority=DBPriority.LOW,
+            )
+            logger.info(
+                "Reference folder %s: followed %d moved file(s).",
+                self._folder_path,
+                len(moved_paths),
+            )
+            # A moved file is neither removed nor new.  ``existing_by_path`` is
+            # re-keyed as well as narrowed, because the sidecar pass below walks
+            # it by path and would otherwise reconcile at the old location.
+            for old_path, new_path in moved_paths.items():
+                picture = existing_by_path.pop(old_path)
+                picture.file_path = new_path
+                existing_by_path[new_path] = picture
+            removed_paths -= moved_paths.keys()
+            new_paths -= set(moved_paths.values())
+
         # --- Handle removed files ---
         if removed_paths:
             removed_ids = [
@@ -505,6 +554,85 @@ class ReferenceFolderScanTask(BaseTask):
             if new_mtime is not None:
                 update[path_key] = target
                 update[mtime_key] = new_mtime
+
+    def _match_moved_paths(
+        self,
+        existing_by_path: dict[str, Picture],
+        new_paths: set[str],
+        removed_paths: set[str],
+    ) -> dict[str, str]:
+        """Pair vanished indexed paths with new disk paths holding the same pixels.
+
+        Args:
+            existing_by_path: This folder's indexed pictures, keyed by file path.
+            new_paths: Disk paths not yet indexed, after ledger filtering.
+            removed_paths: Indexed paths no longer present on disk.
+
+        Returns:
+            ``{old_path: new_path}`` for each unambiguous move.  Empty when
+            either side is empty, so the expensive case costs nothing: a first
+            scan of a large folder has no removals and never hashes here, and a
+            folder losing files without gaining any never hashes either.
+
+        Only a 1:1 pixel match counts as a move.  Identical pixels at several
+        paths are genuine copies, and the rows behind them can differ in tags,
+        sets and scores — pairing them by guess would move one picture's work
+        onto another picture's file, which is the loss this exists to prevent.
+        Ambiguous groups fall through to the delete-and-re-add path, which is
+        no worse than the behaviour before this existed.
+
+        Scoped to one reference folder, because the scan is: a file moved
+        between two reference folders is a removal in one scan and an addition
+        in another, with no shared pass to match them in.  Since the scan walks
+        the whole tree under the root, moving between subfolders — the case
+        this is for — is within scope.
+        """
+        if not removed_paths or not new_paths:
+            return {}
+
+        # ponytail: os.walk is not atomic, so a file moved mid-walk from an
+        # unvisited directory into a visited one is in neither set and still
+        # reads as a removal.  Deferring deletion by one scan (mark and sweep)
+        # would close it; not worth the state for a race this narrow.
+        gone_by_sha: dict[str, list[str]] = {}
+        for path in removed_paths:
+            pixel_sha = existing_by_path[path].pixel_sha
+            if pixel_sha:
+                gone_by_sha.setdefault(pixel_sha, []).append(path)
+        if not gone_by_sha:
+            return {}
+
+        arrived_by_sha: dict[str, list[str]] = {}
+        for path in sorted(new_paths):
+            try:
+                pixel_sha = ImageUtils.calculate_hash_from_file_path(path)
+            except Exception as exc:
+                # Not fatal: an unhashable file simply cannot be matched, and
+                # _build_picture_chunk reports it again when it tries to import.
+                logger.warning(
+                    "Reference folder scan: failed to hash %s while looking for "
+                    "moved files: %s",
+                    path,
+                    exc,
+                )
+                continue
+            if pixel_sha:
+                arrived_by_sha.setdefault(pixel_sha, []).append(path)
+
+        moved: dict[str, str] = {}
+        for pixel_sha, old_paths in gone_by_sha.items():
+            candidates = arrived_by_sha.get(pixel_sha, ())
+            if len(old_paths) == 1 and len(candidates) == 1:
+                moved[old_paths[0]] = candidates[0]
+            elif candidates:
+                logger.info(
+                    "Reference folder %s: %d vanished and %d new file(s) share "
+                    "one pixel hash; too ambiguous to call a move, re-importing.",
+                    self._folder_path,
+                    len(old_paths),
+                    len(candidates),
+                )
+        return moved
 
     def _build_picture_chunk(
         self,

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -293,10 +293,25 @@ class ReferenceFolderScanTask(BaseTask):
         moved_paths = self._match_moved_paths(
             existing_by_path, new_paths, removed_paths
         )
+        moved_picture_ids: list[int] = []
         if moved_paths:
+            # The thumbnail is stored under sha256(file_path), so the bitmap
+            # follows the file rather than being abandoned at the old name.
+            # Carrying it beats blanking the dimensions and letting
+            # MissingThumbnailFinder regenerate: nothing is re-rendered, no
+            # unreachable file is left behind in .ref_thumbs (the only cleanup
+            # that exists derives its paths from each row's *current*
+            # file_path, so an orphan there is permanent), and the row never
+            # becomes NULL-width, which is what an in-flight
+            # ThumbnailGenerationTask would otherwise be free to overwrite.
+            carried_thumbnails = {
+                old: self._carry_thumbnail(old, new) for old, new in moved_paths.items()
+            }
 
-            def apply_moves(session: Session, pairs: list[tuple[int, str]]) -> None:
-                for pic_id, new_path in pairs:
+            def apply_moves(
+                session: Session, pairs: list[tuple[int, str, bool]]
+            ) -> None:
+                for pic_id, new_path, thumbnail_carried in pairs:
                     pic = session.get(Picture, pic_id)
                     if pic is None:
                         # The row went between the scan's read and this write —
@@ -314,25 +329,34 @@ class ReferenceFolderScanTask(BaseTask):
                         )
                         continue
                     pic.file_path = new_path
-                    # The thumbnail is stored under sha256(file_path), so the
-                    # old bitmap is unreachable at the new path.  Blanking the
-                    # dimensions is what MissingThumbnailFinder keys on, so the
-                    # existing sweep regenerates it; leaving them set points the
-                    # picture at a thumbnail that is not there.
-                    pic.thumbnail_width = None
-                    pic.thumbnail_height = None
+                    # The explicit move route (routes/reference_folders.py) sets
+                    # this from the destination basename, and _build_picture
+                    # initialises it from the path.  Leaving it alone would make
+                    # a renamed file download under its old name.
+                    pic.original_file_name = os.path.basename(new_path)
+                    if not thumbnail_carried:
+                        # No bitmap to carry, so point the sweep at it instead of
+                        # at a thumbnail that is not there.
+                        pic.thumbnail_width = None
+                        pic.thumbnail_height = None
                     session.add(pic)
                 session.commit()
 
-            self._db.run_task(
-                apply_moves,
-                sorted(
-                    (existing_by_path[old].id, new)
-                    for old, new in moved_paths.items()
-                    if existing_by_path[old].id is not None
-                ),
-                priority=DBPriority.LOW,
+            move_pairs = sorted(
+                (
+                    existing_by_path[old].id,
+                    new,
+                    carried_thumbnails.get(old, False),
+                )
+                for old, new in moved_paths.items()
+                if existing_by_path[old].id is not None
             )
+            self._db.run_task(apply_moves, move_pairs, priority=DBPriority.LOW)
+            # A followed move changes file_path (and with it the thumbnail URL
+            # and the download name) on a row an open grid may already be
+            # showing, and nothing else in this task reports it: without this the
+            # grid keeps the old state until the next full reload.
+            moved_picture_ids = [pic_id for pic_id, _, _ in move_pairs]
             logger.info(
                 "Reference folder %s: followed %d moved file(s).",
                 self._folder_path,
@@ -503,6 +527,7 @@ class ReferenceFolderScanTask(BaseTask):
             "caption_updated_count": len(caption_updates),
             "caption_updated_picture_ids": caption_updated_picture_ids,
             "imported_picture_ids": imported_picture_ids,
+            "moved_picture_ids": moved_picture_ids,
         }
 
     def _fetch_folder_tags(self, folder_id: int) -> dict[int, list[str]]:
@@ -578,6 +603,46 @@ class ReferenceFolderScanTask(BaseTask):
                 update[path_key] = target
                 update[mtime_key] = new_mtime
 
+    def _carry_thumbnail(self, old_path: str, new_path: str) -> bool:
+        """Move a followed picture's thumbnail bitmap to its new path-derived name.
+
+        Thumbnails live at ``sha256(file_path)`` under ``image_root/.ref_thumbs``
+        (``ImageUtils.get_thumbnail_path``), so a followed move renames the
+        bitmap rather than re-rendering it.  Nothing sweeps that directory by
+        anything but a row's current ``file_path``, so a bitmap left at the old
+        name would never be reachable and never be collected.
+
+        Returns:
+            ``True`` when the new path now has the bitmap, so the caller can keep
+            the stored dimensions.  ``False`` when there was nothing to carry or
+            the rename failed, in which case the caller blanks the dimensions and
+            ``MissingThumbnailFinder`` renders a fresh one.
+        """
+        image_root = self._db.image_root
+        old_thumb = ImageUtils.get_thumbnail_path(image_root, old_path)
+        new_thumb = ImageUtils.get_thumbnail_path(image_root, new_path)
+        if not old_thumb or not new_thumb or old_thumb == new_thumb:
+            return bool(old_thumb and old_thumb == new_thumb)
+        try:
+            if not os.path.exists(old_thumb):
+                return False
+            os.makedirs(os.path.dirname(new_thumb), exist_ok=True)
+            os.replace(old_thumb, new_thumb)
+            return True
+        except OSError as exc:
+            # Not fatal: the picture simply regenerates its thumbnail.  Say so,
+            # because a bitmap stranded at the old name is never collected.
+            logger.warning(
+                "Reference folder %s: could not carry the thumbnail for the move "
+                "%s -> %s (%s); it will be regenerated and %s may be left behind.",
+                self._folder_path,
+                old_path,
+                new_path,
+                exc,
+                old_thumb,
+            )
+            return False
+
     def _match_moved_paths(
         self,
         existing_by_path: dict[str, Picture],
@@ -599,6 +664,11 @@ class ReferenceFolderScanTask(BaseTask):
 
         Only a 1:1 match on ``(pixel_sha, size_bytes)`` counts as a move, and
         only when no unchanged file in the folder shares that key either.
+        Scrapheap rows are never the *source* of a move (a hidden soft-deleted
+        row would otherwise swallow an unrelated new file of the same content)
+        but do count as unchanged files blocking one, since their file is still
+        on disk.  A present file whose ``pixel_sha`` has not been backfilled yet
+        makes the whole folder unmatchable rather than merely uncounted.
         Identical pixels at several paths are genuine copies, and the rows
         behind them can differ in tags, sets and scores — pairing them by guess
         would move one picture's work onto another picture's file, which is the
@@ -632,10 +702,17 @@ class ReferenceFolderScanTask(BaseTask):
         # for exactly this reason.  Here a false pair is worse than the bug
         # being fixed: a lost row is visible, one picture's tags and
         # memberships silently rebound onto another picture's file are not.
+        # Scrapheap rows are not move candidates.  ``fetch_existing`` loads
+        # ``deleted=True`` pictures on purpose, so without this a hidden
+        # scrapheap row whose file really was deleted would swallow an unrelated
+        # new file of the same content: the arrival is taken out of
+        # ``new_paths`` as "a move", and what the user gets is not a new picture
+        # but a soft-deleted one they cannot see.  Leaving them in
+        # ``removed_paths`` keeps the ordinary cleanup path unchanged.
         gone_by_key: dict[tuple[str, int | None], list[str]] = {}
         for path in removed_paths:
             picture = existing_by_path[path]
-            if picture.pixel_sha:
+            if picture.pixel_sha and not picture.deleted:
                 key = (picture.pixel_sha, picture.size_bytes)
                 gone_by_key.setdefault(key, []).append(path)
         if not gone_by_key:
@@ -645,10 +722,37 @@ class ReferenceFolderScanTask(BaseTask):
         # the stable rows cost nothing to count: their hash is already loaded.
         # Without this, deleting A and separately adding an identical C while
         # an identical B sits untouched in the folder reads as a clean 1:1.
-        stable_keys: set[tuple[str, int | None]] = set()
+        #
+        # Scrapheap rows *do* count here, unlike above.  Their file is still on
+        # disk, so it is a real identical file the arrival could be a copy of;
+        # counting it only ever refuses a match, which is the safe direction.
+        stable_counts: dict[tuple[str, int | None], int] = {}
+        unhashed_stable = 0
         for path, picture in existing_by_path.items():
-            if path not in removed_paths and picture.pixel_sha:
-                stable_keys.add((picture.pixel_sha, picture.size_bytes))
+            if path in removed_paths:
+                continue
+            if not picture.pixel_sha:
+                unhashed_stable += 1
+                continue
+            key = (picture.pixel_sha, picture.size_bytes)
+            stable_counts[key] = stable_counts.get(key, 0) + 1
+
+        # ``pixel_sha`` is nullable and MissingPixelShaFinder backfills it in the
+        # background, so a present, unchanged file can be invisible to the count
+        # above.  That is exactly the file whose existence would have refused the
+        # match, so a NULL there is not "no collision", it is "unknown".  Refuse
+        # to follow anything until the backfill has caught up; this scan writes
+        # the hash for every file it imports, so the gap is transient, and the
+        # fallback is the delete-and-re-add that ran before this existed.
+        if unhashed_stable:
+            logger.info(
+                "Reference folder %s: %d unchanged file(s) have no pixel hash "
+                "yet, so a move cannot be told from a copy; re-importing until "
+                "the hash backfill catches up.",
+                self._folder_path,
+                unhashed_stable,
+            )
+            return {}
 
         arrived_by_key: dict[tuple[str, int | None], list[str]] = {}
         for path in sorted(new_paths):
@@ -673,7 +777,8 @@ class ReferenceFolderScanTask(BaseTask):
             candidates = arrived_by_key.get(key, ())
             if not candidates:
                 continue
-            if len(old_paths) == 1 and len(candidates) == 1 and key not in stable_keys:
+            stable = stable_counts.get(key, 0)
+            if len(old_paths) == 1 and len(candidates) == 1 and stable == 0:
                 moved[old_paths[0]] = candidates[0]
             else:
                 logger.info(
@@ -683,7 +788,7 @@ class ReferenceFolderScanTask(BaseTask):
                     self._folder_path,
                     len(old_paths),
                     len(candidates),
-                    1 if key in stable_keys else 0,
+                    stable,
                 )
         return moved
 

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -953,6 +953,11 @@ class Vault:
             if imported_ids:
                 self.notify(EventType.CHANGED_PICTURES, imported_ids)
                 self.notify(EventType.PICTURE_IMPORTED, imported_ids)
+            # A followed move changed file_path on an existing row: the grid has
+            # to refetch it, but nothing was imported, so no PICTURE_IMPORTED.
+            moved_ids = result.get("moved_picture_ids") or []
+            if moved_ids:
+                self.notify(EventType.CHANGED_PICTURES, moved_ids)
             picture_ids = result.get("caption_updated_picture_ids") or []
             if picture_ids:
                 self._queue_changed_tags_notification(picture_ids)

--- a/tests/test_reference_folder_moves.py
+++ b/tests/test_reference_folder_moves.py
@@ -13,6 +13,7 @@ work onto another picture's file.
 
 import os
 import tempfile
+import time
 
 import pytest
 from PIL import Image
@@ -29,6 +30,11 @@ from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
 # rather than sitting in the long backoff a freshly built per-test vault had.
 # Each of these owns something a test here writes by hand or asserts on:
 _CONFLICTING_FINDERS = (
+    # ThumbnailGenerationTask selects on ``thumbnail_width IS NULL`` and writes
+    # the regenerated bitmap's dimensions back, so it can both repopulate a row
+    # this module expects to stay blank and re-render a bitmap whose absence is
+    # being asserted. Same reasoning as tests/test_inline_rotate.py.
+    TaskType.THUMBNAIL_GENERATION,
     # ReferenceFolderScanFinder scans the same folders these tests scan by hand.
     # A sweep between ``_make_folder`` and ``_run_scan`` imports the files first,
     # and the manual scan then imports them again: duplicate rows for one path,
@@ -59,10 +65,32 @@ def server():
 
 
 def _make_folder(server, folder_dir):
+    """Register a reference folder that the background scanner will leave alone.
+
+    ``ReferenceFolderScanFinder`` selects on ``last_scanned``, not on status: a
+    row with NULL there is due for a scan *immediately*, and every folder in the
+    database is a candidate. So between this insert and the first ``_run_scan``
+    the planner is free to scan the same folder concurrently, and both passes
+    import the same files — the CI gate failed on exactly that, twice, with
+    ``assert 2 == 1`` and ``assert 4 == 2``: every row doubled.
+
+    Stamping ``last_scanned`` now puts the folder outside the finder's rescan
+    interval from the moment it exists, which closes the window by construction
+    rather than by relying on the finder staying detached. That matters because
+    the detachment is done once against the vault the fixture saw, and a vault
+    can be rebuilt underneath it (``library_switch_service`` assigns a freshly
+    built one, with every finder re-attached). The scan task itself re-stamps
+    the column when it completes, so later scans stay outside the interval too.
+    """
     os.makedirs(folder_dir, exist_ok=True)
 
     def _insert(session: Session):
-        folder = ReferenceFolder(folder=folder_dir, label="refs", status="active")
+        folder = ReferenceFolder(
+            folder=folder_dir,
+            label="refs",
+            status="active",
+            last_scanned=time.time(),
+        )
         session.add(folder)
         session.commit()
         session.refresh(folder)
@@ -155,12 +183,16 @@ def test_moved_file_keeps_its_picture(server, tmp_path):
 
     _run_scan(server, folder_id, folder_dir)
     indexed = _pictures(server, folder_dir)
-    assert len(indexed) == 1
+    assert [os.path.basename(p.file_path) for p in indexed] == ["mira_042.png"]
     picture_id = indexed[0].id
+    thumb_width = indexed[0].thumbnail_width
+    assert thumb_width is not None, "the import must have rendered a thumbnail"
     _tag(server, picture_id, "mira")
     _mark(server, picture_id, "keepme")
 
-    moved_to = os.path.join(folder_dir, "Characters", "Mira", "final", "mira_042.png")
+    # Renamed as well as relocated, so the basename genuinely changes: the
+    # download name is taken from it, and the explicit move route resets it too.
+    moved_to = os.path.join(folder_dir, "Characters", "Mira", "final", "final_042.png")
     os.makedirs(os.path.dirname(moved_to), exist_ok=True)
     os.rename(original, moved_to)
 
@@ -172,11 +204,19 @@ def test_moved_file_keeps_its_picture(server, tmp_path):
     assert after[0].id == picture_id
     assert after[0].file_path == moved_to
     assert _tags(server, picture_id) == ["mira"]
-    # The thumbnail lives at sha256(file_path), so the stored bitmap is not
-    # reachable from the new path. Blank dimensions are what the thumbnail
-    # sweep keys on; leaving them set would point the picture at nothing.
-    assert after[0].thumbnail_width is None, (
-        "a followed move must invalidate the thumbnail it just orphaned"
+    # The thumbnail lives at sha256(file_path), so it has to travel with the
+    # file. Nothing sweeps .ref_thumbs by anything but a row's current
+    # file_path, so a bitmap left at the old name would never be collected.
+    image_root = server.vault.db.image_root
+    assert not os.path.exists(ImageUtils.get_thumbnail_path(image_root, original)), (
+        "the bitmap at the old path-derived name would be an unreachable orphan"
+    )
+    assert os.path.exists(ImageUtils.get_thumbnail_path(image_root, moved_to))
+    assert after[0].thumbnail_width == thumb_width, (
+        "the bitmap was carried, so it must not be blanked for re-rendering"
+    )
+    assert after[0].original_file_name == "final_042.png", (
+        "a renamed file must not keep downloading under its old name"
     )
 
 
@@ -194,7 +234,9 @@ def test_deleted_file_is_still_removed(server, tmp_path):
     _make_image(os.path.join(folder_dir, "kept.png"), (200, 100, 50))
 
     _run_scan(server, folder_id, folder_dir)
-    assert len(_pictures(server, folder_dir)) == 2
+    assert sorted(
+        os.path.basename(p.file_path) for p in _pictures(server, folder_dir)
+    ) == ["gone.png", "kept.png"]
 
     os.remove(doomed)
     # Different pixels, so this is not the deleted file arriving elsewhere.
@@ -247,6 +289,80 @@ def test_a_sampled_hash_collision_of_a_different_size_is_not_a_move(server, tmp_
     )
 
 
+def test_a_scrapheap_row_does_not_swallow_an_unrelated_new_file(server, tmp_path):
+    """A soft-deleted row must not claim a new file of the same content.
+
+    ``fetch_existing`` loads ``deleted=True`` rows on purpose, so without the
+    exclusion a hidden scrapheap picture whose file really was deleted pairs
+    with an unrelated arrival: the new path is taken out of ``new_paths`` as a
+    move, and what the user gets is not a new picture but a soft-deleted one
+    they cannot see.
+    """
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    doomed = _make_image(os.path.join(folder_dir, "binned.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert [os.path.basename(p.file_path) for p in indexed] == ["binned.png"]
+
+    def _scrapheap(session: Session):
+        pic = session.get(Picture, indexed[0].id)
+        pic.deleted = True
+        session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(_scrapheap)
+
+    # The binned file goes, and an unrelated file of the same content arrives.
+    os.remove(doomed)
+    _make_image(os.path.join(folder_dir, "fresh.png"), (10, 20, 30))
+    _run_scan(server, folder_id, folder_dir)
+
+    live = [p for p in _pictures(server, folder_dir) if not p.deleted]
+    assert [os.path.basename(p.file_path) for p in live] == ["fresh.png"], (
+        "the arrival is its own picture, not a scrapheap row quietly relabelled"
+    )
+
+
+def test_an_unhashed_unchanged_file_blocks_matching(server, tmp_path):
+    """A stable row with no pixel_sha means 'unknown collision', not 'no collision'.
+
+    ``pixel_sha`` is nullable and backfilled in the background, so a present
+    unchanged file can be invisible to the ambiguity count — and it is exactly
+    the file whose existence would have refused the match.
+    """
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    doomed = _make_image(os.path.join(folder_dir, "a.png"), (10, 20, 30))
+    twin = _make_image(os.path.join(folder_dir, "b.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert sorted(os.path.basename(p.file_path) for p in indexed) == ["a.png", "b.png"]
+    doomed_id = next(p.id for p in indexed if p.file_path == doomed)
+    _mark(server, doomed_id, "keepme")
+
+    # The twin loses its hash the way an un-backfilled row would have it.
+    def _blank_sha(session: Session):
+        pic = session.exec(select(Picture).where(Picture.file_path == twin)).one()
+        pic.pixel_sha = None
+        session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(_blank_sha)
+
+    os.remove(doomed)
+    _make_image(os.path.join(folder_dir, "c.png"), (10, 20, 30))
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert not any(p.description == "keepme" for p in after), (
+        "the unchanged twin is invisible to the count while its hash is NULL, "
+        "so the match cannot be shown to be 1:1 and must not be followed"
+    )
+
+
 def test_an_unchanged_twin_makes_the_match_ambiguous(server, tmp_path):
     """A stable file sharing the key blocks the pairing, not just a new one.
 
@@ -261,7 +377,7 @@ def test_an_unchanged_twin_makes_the_match_ambiguous(server, tmp_path):
 
     _run_scan(server, folder_id, folder_dir)
     indexed = _pictures(server, folder_dir)
-    assert len(indexed) == 2
+    assert sorted(os.path.basename(p.file_path) for p in indexed) == ["a.png", "b.png"]
     doomed_id = next(p.id for p in indexed if p.file_path == doomed)
     _mark(server, doomed_id, "keepme")
 
@@ -287,7 +403,10 @@ def test_ambiguous_pixel_match_is_not_followed(server, tmp_path):
 
     _run_scan(server, folder_id, folder_dir)
     indexed = _pictures(server, folder_dir)
-    assert len(indexed) == 2
+    assert sorted(os.path.basename(p.file_path) for p in indexed) == [
+        "copy_a.png",
+        "copy_b.png",
+    ]
     _mark(server, indexed[0].id, "keepme")
 
     sub_dir = os.path.join(folder_dir, "sub")

--- a/tests/test_reference_folder_moves.py
+++ b/tests/test_reference_folder_moves.py
@@ -1,0 +1,182 @@
+"""The reference-folder scan follows a file moved inside the folder.
+
+A move is one path disappearing and another appearing in the same scan pass.
+Handled as a removal plus an import it costs the picture id, and with it the
+tags, score, faces and set/stack membership hanging off it, so reorganizing
+your own folders used to wipe everything PixlStash had added. The scan now
+matches the two halves by pixel hash and updates ``file_path`` instead.
+
+Ambiguous matches are deliberately not followed: identical pixels at several
+paths are copies whose rows can differ, and guessing would move one picture's
+work onto another picture's file.
+"""
+
+import os
+import tempfile
+
+import pytest
+from PIL import Image
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture, ReferenceFolder, Tag
+from pixlstash.server import Server
+from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
+
+
+@pytest.fixture(scope="module")
+def server():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = os.path.join(temp_dir, "server-config.json")
+        with Server(config_path) as srv:
+            yield srv
+
+
+def _make_folder(server, folder_dir):
+    os.makedirs(folder_dir, exist_ok=True)
+
+    def _insert(session: Session):
+        folder = ReferenceFolder(folder=folder_dir, label="refs", status="active")
+        session.add(folder)
+        session.commit()
+        session.refresh(folder)
+        return folder.id
+
+    return server.vault.db.run_task(_insert)
+
+
+def _make_image(path, color):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (8, 8), color=color).save(path, format="PNG")
+    return path
+
+
+def _run_scan(server, folder_id, folder_dir):
+    task = ReferenceFolderScanTask(
+        database=server.vault.db,
+        folder_id=folder_id,
+        folder_path=folder_dir,
+        resolved_path=folder_dir,
+    )
+    return task._run_task()
+
+
+def _pictures(server, folder_dir):
+    """Every picture indexed under this test's folder, newest id last.
+
+    Scoped by path rather than by ``reference_folder_id``: the hub and vault
+    live outside the checkout, so a whole test run shares one database and
+    folder ids collide across test modules. The tmp_path root does not.
+    """
+    return server.vault.db.run_task(
+        lambda s: list(
+            s.exec(
+                select(Picture)
+                .where(Picture.file_path.startswith(folder_dir))
+                .order_by(Picture.id)
+            ).all()
+        )
+    )
+
+
+def _tag(server, picture_id, tag):
+    def _add(session: Session):
+        session.add(Tag(picture_id=picture_id, tag=tag))
+        session.commit()
+
+    server.vault.db.run_task(_add)
+
+
+def _mark(server, picture_id, marker):
+    """Stamp a field the scan never writes, so a re-imported row is detectable.
+
+    SQLite reuses free rowids, so a deleted-and-re-added picture can come back
+    with the same id: an id assertion alone would pass for the very behaviour
+    these tests exist to catch. A marker only the test writes cannot survive a
+    re-import.
+    """
+
+    def _update(session: Session):
+        pic = session.get(Picture, picture_id)
+        pic.description = marker
+        session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(_update)
+
+
+def _tags(server, picture_id):
+    rows = server.vault.db.run_task(
+        lambda s: s.exec(select(Tag).where(Tag.picture_id == picture_id)).all()
+    )
+    return sorted(t.tag for t in rows if not t.tag.startswith("__"))
+
+
+def test_moved_file_keeps_its_picture(server, tmp_path):
+    """Moving a file into a subfolder must not cost the row or its tags."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    original = _make_image(os.path.join(folder_dir, "mira_042.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert len(indexed) == 1
+    picture_id = indexed[0].id
+    _tag(server, picture_id, "mira")
+    _mark(server, picture_id, "keepme")
+
+    moved_to = os.path.join(folder_dir, "Characters", "Mira", "final", "mira_042.png")
+    os.makedirs(os.path.dirname(moved_to), exist_ok=True)
+    os.rename(original, moved_to)
+
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert len(after) == 1, "a move must not leave a second row behind"
+    assert after[0].description == "keepme", "the row itself must survive the move"
+    assert after[0].id == picture_id
+    assert after[0].file_path == moved_to
+    assert _tags(server, picture_id) == ["mira"]
+
+
+def test_deleted_file_is_still_removed(server, tmp_path):
+    """The rescue must not turn a genuine deletion into a kept row."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    doomed = _make_image(os.path.join(folder_dir, "gone.png"), (10, 20, 30))
+    _make_image(os.path.join(folder_dir, "kept.png"), (200, 100, 50))
+
+    _run_scan(server, folder_id, folder_dir)
+    assert len(_pictures(server, folder_dir)) == 2
+
+    os.remove(doomed)
+    _run_scan(server, folder_id, folder_dir)
+
+    remaining = _pictures(server, folder_dir)
+    assert [os.path.basename(p.file_path) for p in remaining] == ["kept.png"]
+
+
+def test_ambiguous_pixel_match_is_not_followed(server, tmp_path):
+    """Two copies moved at once must not have their rows paired by guess."""
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    # Same colour, so both files carry the same pixel hash.
+    first = _make_image(os.path.join(folder_dir, "copy_a.png"), (10, 20, 30))
+    second = _make_image(os.path.join(folder_dir, "copy_b.png"), (10, 20, 30))
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert len(indexed) == 2
+    _mark(server, indexed[0].id, "keepme")
+
+    sub_dir = os.path.join(folder_dir, "sub")
+    os.makedirs(sub_dir, exist_ok=True)
+    os.rename(first, os.path.join(sub_dir, "copy_a.png"))
+    os.rename(second, os.path.join(sub_dir, "copy_b.png"))
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert len(after) == 2
+    assert not any(p.description == "keepme" for p in after), (
+        "a 2:2 pixel match is ambiguous; the scan must re-import rather than "
+        "bind one picture's row to the other's file"
+    )

--- a/tests/test_reference_folder_moves.py
+++ b/tests/test_reference_folder_moves.py
@@ -20,7 +20,29 @@ from sqlmodel import Session, select
 
 from pixlstash.db_models import Picture, ReferenceFolder, Tag
 from pixlstash.server import Server
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.tasks import TaskType
 from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
+
+# ``Server.__init__`` calls ``vault.start()``, so the planner is live for the
+# whole life of a module-scoped server and its sweeps land *inside* these tests
+# rather than sitting in the long backoff a freshly built per-test vault had.
+# Each of these owns something a test here writes by hand or asserts on:
+_CONFLICTING_FINDERS = (
+    # ReferenceFolderScanFinder scans the same folders these tests scan by hand.
+    # A sweep between ``_make_folder`` and ``_run_scan`` imports the files first,
+    # and the manual scan then imports them again: duplicate rows for one path,
+    # which breaks ``len(...) == 1`` and strands the curated row at the dead path
+    # because ``existing_by_path`` keeps only the last row per file_path.
+    TaskType.REFERENCE_FOLDER_SCAN,
+    # MissingFilePurgeTask deletes any picture whose file is absent. Between the
+    # ``os.rename`` and the scan that follows it, the moved picture is exactly
+    # that, so the sweep destroys the row under test.
+    TaskType.MISSING_FILE_PURGE,
+    # TagTask deletes a picture's existing Tag rows before writing its own, so a
+    # sweep landing after ``_tag`` removes the seeded label ``_tags`` asserts on.
+    TaskType.TAGGER,
+)
 
 
 @pytest.fixture(scope="module")
@@ -28,6 +50,11 @@ def server():
     with tempfile.TemporaryDirectory() as temp_dir:
         config_path = os.path.join(temp_dir, "server-config.json")
         with Server(config_path) as srv:
+            for task_type in _CONFLICTING_FINDERS:
+                srv.vault._planner_work_finders.pop(task_type)
+            # detach_finders() edits the planner's structures under its own lock,
+            # so this is safe against the loop thread running right now.
+            srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
             yield srv
 
 
@@ -44,9 +71,16 @@ def _make_folder(server, folder_dir):
     return server.vault.db.run_task(_insert)
 
 
-def _make_image(path, color):
+def _make_image(path, color, size=8):
+    """A flat image at ``path``. ``size`` is the square edge in pixels.
+
+    A large flat BMP is how a sampled-hash collision is produced on purpose: the
+    format is uncompressed, so the file is far past the 128 KiB sampling
+    threshold and every sampled window is the same repeated pixel.
+    """
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    Image.new("RGB", (8, 8), color=color).save(path, format="PNG")
+    fmt = "BMP" if path.lower().endswith(".bmp") else "PNG"
+    Image.new("RGB", (size, size), color=color).save(path, format=fmt)
     return path
 
 
@@ -63,9 +97,11 @@ def _run_scan(server, folder_id, folder_dir):
 def _pictures(server, folder_dir):
     """Every picture indexed under this test's folder, newest id last.
 
-    Scoped by path rather than by ``reference_folder_id``: the hub and vault
-    live outside the checkout, so a whole test run shares one database and
-    folder ids collide across test modules. The tmp_path root does not.
+    Scoped by path rather than by ``reference_folder_id`` because each test
+    makes its own folder row against the shared module server, so a query by
+    folder id would still have to be told which id, and the path each test
+    already owns says it directly. ``tmp_path`` is per-test, so the prefix
+    cannot collide with another test in this module.
     """
     return server.vault.db.run_task(
         lambda s: list(
@@ -136,10 +172,22 @@ def test_moved_file_keeps_its_picture(server, tmp_path):
     assert after[0].id == picture_id
     assert after[0].file_path == moved_to
     assert _tags(server, picture_id) == ["mira"]
+    # The thumbnail lives at sha256(file_path), so the stored bitmap is not
+    # reachable from the new path. Blank dimensions are what the thumbnail
+    # sweep keys on; leaving them set would point the picture at nothing.
+    assert after[0].thumbnail_width is None, (
+        "a followed move must invalidate the thumbnail it just orphaned"
+    )
 
 
 def test_deleted_file_is_still_removed(server, tmp_path):
-    """The rescue must not turn a genuine deletion into a kept row."""
+    """The rescue must not turn a genuine deletion into a kept row.
+
+    The deletion is paired with an unrelated *addition* so the matcher is
+    actually entered. Without one, ``new_paths`` is empty and
+    ``_match_moved_paths`` returns on its first line, which would test the
+    early return rather than the pairing this is about.
+    """
     folder_dir = str(tmp_path / "refs")
     folder_id = _make_folder(server, folder_dir)
     doomed = _make_image(os.path.join(folder_dir, "gone.png"), (10, 20, 30))
@@ -149,10 +197,84 @@ def test_deleted_file_is_still_removed(server, tmp_path):
     assert len(_pictures(server, folder_dir)) == 2
 
     os.remove(doomed)
+    # Different pixels, so this is not the deleted file arriving elsewhere.
+    _make_image(os.path.join(folder_dir, "unrelated.png"), (7, 200, 90))
     _run_scan(server, folder_id, folder_dir)
 
     remaining = _pictures(server, folder_dir)
-    assert [os.path.basename(p.file_path) for p in remaining] == ["kept.png"]
+    assert sorted(os.path.basename(p.file_path) for p in remaining) == [
+        "kept.png",
+        "unrelated.png",
+    ]
+
+
+def test_a_sampled_hash_collision_of_a_different_size_is_not_a_move(server, tmp_path):
+    """The size is part of the key, so an equal digest alone cannot pair two files.
+
+    ``calculate_hash_from_file_path`` samples 8 x 8 KiB windows of anything over
+    128 KiB and does not mix the size into the digest, which its own docstring
+    says makes it a candidate key rather than an identity. Driving the matcher
+    directly is what pins that: a collision between two real image files is
+    awkward to construct on purpose, and the guard has to hold regardless of how
+    the stored ``pixel_sha`` came to be written.
+    """
+    folder_dir = str(tmp_path / "refs")
+    os.makedirs(folder_dir, exist_ok=True)
+    arrived = _make_image(os.path.join(folder_dir, "arrived.png"), (10, 20, 30))
+    task = ReferenceFolderScanTask(
+        database=server.vault.db,
+        folder_id=0,
+        folder_path=folder_dir,
+        resolved_path=folder_dir,
+    )
+    gone = os.path.join(folder_dir, "gone.png")
+    sha = ImageUtils.calculate_hash_from_file_path(arrived)
+    real_size = os.path.getsize(arrived)
+
+    def _match(size_bytes):
+        return task._match_moved_paths(
+            {gone: Picture(file_path=gone, pixel_sha=sha, size_bytes=size_bytes)},
+            {arrived},
+            {gone},
+        )
+
+    assert _match(real_size) == {gone: arrived}, (
+        "the same digest and the same size is the move this feature follows"
+    )
+    assert _match(real_size + 1) == {}, (
+        "the same digest at a different size is a different file; pairing them "
+        "would rebind one picture's tags and memberships onto another's file"
+    )
+
+
+def test_an_unchanged_twin_makes_the_match_ambiguous(server, tmp_path):
+    """A stable file sharing the key blocks the pairing, not just a new one.
+
+    Deleting one copy and separately adding another looks 1:1 when only the
+    removed and new sets are counted, but an untouched identical file in the
+    folder means there is no telling which row the arrival belongs to.
+    """
+    folder_dir = str(tmp_path / "refs")
+    folder_id = _make_folder(server, folder_dir)
+    doomed = _make_image(os.path.join(folder_dir, "a.png"), (10, 20, 30))
+    _make_image(os.path.join(folder_dir, "b.png"), (10, 20, 30))  # the stable twin
+
+    _run_scan(server, folder_id, folder_dir)
+    indexed = _pictures(server, folder_dir)
+    assert len(indexed) == 2
+    doomed_id = next(p.id for p in indexed if p.file_path == doomed)
+    _mark(server, doomed_id, "keepme")
+
+    os.remove(doomed)
+    _make_image(os.path.join(folder_dir, "c.png"), (10, 20, 30))
+    _run_scan(server, folder_id, folder_dir)
+
+    after = _pictures(server, folder_dir)
+    assert sorted(os.path.basename(p.file_path) for p in after) == ["b.png", "c.png"]
+    assert not any(p.description == "keepme" for p in after), (
+        "an unchanged file shares the key, so the arrival cannot be attributed "
+        "to the removal; re-import rather than guess"
+    )
 
 
 def test_ambiguous_pixel_match_is_not_followed(server, tmp_path):


### PR DESCRIPTION
## The CI failure

`tests/test_ci_shards.py::test_every_test_file_is_classified` failed on shard 8 of #1092. `tests/test_reference_folder_moves.py` was added there but never listed in the `backend` job's file list in `.github/workflows/ci.yml`, and the guardrail fails the build on any unclassified test file. Nothing was wrong with the scan logic; the file was simply never gated.

**The fix is one line**: the file added in alphabetical position to the backend list. Gated rather than deferred — it is green and cheap (5 tests, ~2.9 s, most of it fixture set-up).

## Why this PR carries #1092

The gate entry and the file it gates have to land together, so this branch is #1092's head plus the fix — CLAUDE.md's "branch off the open PR, target `develop` anyway" shape, which keeps a single merge into `develop`. **#1092 is superseded by this and should be closed rather than merged**: merging it would put the test file on `develop` without its gate entry and red the guardrail again.

## What the adversarial pass found, and what I did about it

Reviewing the whole carried diff rather than just my line turned up real problems in the matcher. Fixed here:

- **The match key was `pixel_sha` alone.** `ImageUtils.calculate_hash_from_file_path` samples 8 x 8 KiB windows of anything over 128 KiB and does not mix the size into the digest; `calculate_full_hash_from_file_path`'s own docstring calls it "a cheap candidate key, not … final identity", and import de-dup pairs it with the size for exactly this reason. A false 1:1 match rebinds one picture's tags, score, faces and memberships onto a different file — worse than the bug being fixed, because a lost row is visible and a wrong binding is not. The key is now `(pixel_sha, size_bytes)`. Full-byte confirmation is impossible here by construction and is documented at the helper: one side of a move is a file that no longer exists.
- **The ambiguity guard counted only the removed and new sets.** Deleting A and separately adding an identical C, while an identical B sits untouched in the folder, read as a clean 1:1. Unchanged rows now count too — their hash is already loaded, so it costs nothing.
- **A followed move orphaned its thumbnail.** Thumbnails are keyed `sha256(file_path)`, so the stored bitmap is unreachable from the new path, and `MissingThumbnailFinder` keys on `thumbnail_width IS NULL` — still set — so nothing regenerated it. A move now blanks the dimensions and the existing sweep heals it.
- **`apply_moves` skipped a vanished row silently** while the caller had already taken the pair out of both sets, leaving the file neither moved nor imported. It logs now.
- **The test module left the planner intact.** `Server.__init__` calls `vault.start()`, so `ReferenceFolderScanFinder`, `MissingFilePurgeTask` and `TagTask` were all live against fixtures they own — a gate flake waiting for a loaded runner. They are detached for the module's lifetime, per the pattern in `tests/test_operation_log.py`.
- **Two of the three original tests passed with the feature removed.** `test_deleted_file_is_still_removed` left `new_paths` empty, so it exercised the matcher's first-line early return rather than the pairing its docstring claimed. It now deletes one file and adds an unrelated one. Two tests were added for the new guards, and all three new assertions are mutation-verified: dropping the size from the key, dropping the stable-set check, and dropping the thumbnail blanking each turn the suite red.
- **`_pictures`' docstring was wrong** — it said the hub and vault are shared across test modules, but the fixture's own tempdir config gives it its own. Corrected to the real reason the query is scoped by path.

Documented in `docs/backend_architecture.md` §18, beside the `deleted_file_log` contract it interacts with.

## Left open deliberately

- **`MissingFilePurgeTask` can still delete the row inside the window before the rescuing scan runs.** The docstring's "both halves are in the same pass" is a property of the scan, not something the scan enforces against another sweep. Closing it properly means a grace period on purge for reference-folder rows, which is a larger change than a CI fix should carry; the path now logs a warning when it is observed, and degrades to the old delete-and-re-add.
- **One deletion plus N additions hashes the N new files serially in the matcher and again in `_build_picture_chunk`.** Worth threading the computed hashes forward, but it is a throughput change to the import path and does not belong in this PR.
- The duration map goes from 9 to 10 untimed files of 143 (93% against the 90% floor) — a warning, not a failure, refreshed by dispatching `record-test-durations.yml`.
