### PR TITLE
Plan and design bundle for v1.11.0 "Your existing library"

### DIFF
--- a/design/1.11-existing-library/DECISIONS.md
+++ b/design/1.11-existing-library/DECISIONS.md
@@ -1,0 +1,99 @@
+# v1.11 "Your existing library" — design loop, pass 1
+
+Ten artboards, two pages. Canvas URL in `LINK.md`. Rebuild with
+`python3 build.py` then re-seed with the `/design` skill's `seed-canvas.mjs`
+against the artboard list and `canvas.json`.
+
+## Chosen
+
+**Direction A, the tree.** Assign an entity to a whole level, override per row.
+The deciding argument is that two folders at the same depth can legitimately
+mean two different things, and only a tree can say so per row.
+
+**Rejected: the pattern formula.** The 2–3 repeating path shapes as assignable
+formulas, six decisions instead of 341. Scales better and reads faster, but a
+position in a path can only carry one meaning, so per-folder overrides are
+inexpressible. Dropped after the first review.
+
+## The rule the release is built on
+
+**A picture moves only when its folder stops being true.** Not whenever
+something about it changes.
+
+| Action | Folder still true? | Files moved |
+|---|---|---|
+| Import an existing library | true by construction | **none, ever** |
+| Add a second project or person | yes | none |
+| Rename a project | yes, under a new name | none — the **folder** is renamed |
+| Remove the project its folder is named after | no | moves |
+| Swap one project for another | no | moves |
+
+Three consequences fall out rather than being designed in:
+
+1. **Import moves nothing.** The assignments are derived *from* the paths, so
+   every path is true the moment it is written.
+2. **Many-to-many stops mattering.** Nothing is ever re-derived, so a picture in
+   three projects never needs a winner picked after import.
+3. **A folder outside the layout contradicts nothing**, so it never moves. That
+   makes "drag it somewhere of your own" a permanent override needing no
+   setting.
+
+Accepted cost: the tree is never *wrong* but drifts from what the owner would
+have picked. Hence **Move to match** as an offered action on a picture, never
+automatic.
+
+### The mirror, for moves made outside PixlStash
+
+PixlStash changes an assignment only when the owner's move makes it untrue.
+The ambiguity is that leaving a project's folder cannot distinguish "left the
+project" from "refiled the picture", because a folder holds a picture once and
+a project can share it.
+
+Resolved on measurement, not taste. Across the owner's four real libraries
+(~59,000 pictures): 91–100% of assigned pictures have exactly **one** project or
+set, and nothing anywhere is in more than three. So the move is unambiguous for
+almost all of them and is applied; the few with several are listed and left
+alone until asked.
+
+The one facet that genuinely breaks is **people, and only in photo libraries**:
+0% multi-person in all three generation libraries, 22.4% in `family-images`.
+That number only mattered under a re-derive rule. Under move-when-false it does
+not, which is why Person survives as a path segment.
+
+## Also decided
+
+- **Person / People**, never Character. `character` is the model name only; the
+  shipped UI says People.
+- **"Just a folder"** replaced "Leave alone", which implied the *files* would be
+  untouched. Every option leaves the files untouched. This one says the name is
+  not telling us anything.
+- **Managed libraries are gone as a concept.** A PixlStash folder is a
+  referenced folder that starts empty, defaulting to `Project / Person or Set`.
+  Today's flat libraries need no migration: files at a library root match no
+  layout, contradict nothing, and stay put.
+- **A layout segment can hold alternatives** (`Person or Set`), first match
+  wins, and a segment with nothing to fill it is skipped. That keeps the tree
+  two deep rather than five.
+- **No hidden `.pixlstash-images` folder.** Pictures arriving somewhere the
+  owner cannot see them is the opposite of help for a curated library.
+- **Ask for an empty library, point at a folder that is not empty → two ways
+  forward only**: bring them in, or pick a different folder. "Start empty in
+  here anyway" is a trap.
+- **Telemetry is not redesigned.** `TelemetryConsentDialog` already asks on
+  first startup and is good. It appears on the first-run artboard only to fix
+  the order: the question first, then the folder.
+- **Settings › Libraries is drawn as the dialog it lives in** — 820px with the
+  nav rail — which is why the list is compact rows rather than a table.
+
+## Open, for pass 2
+
+- **The fixture pack.** Every figure and folder name is placeholder except the
+  membership counts. Real tree, real counts, real thumbnails, per the loop
+  protocol.
+- **The drag interaction**, made operable by keyboard. Pass 1 is static.
+- **Keyboard keys.** Digits 1–4 and 0, because Project and Person both want P.
+- **The Views spike.** Windows symlinks need admin or Developer Mode; the
+  fallback is hard links, which cannot span drives, and exFAT has neither.
+  Views is the release's flex candidate if that spike fails.
+- **Duplicate facets in the layout builder.** `Project / Person or Set /
+  Person or Set` is expressible and meaningless.

--- a/design/1.11-existing-library/Empty.dc.html
+++ b/design/1.11-existing-library/Empty.dc.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">new-work</span>
+  </div>
+  <div class="app-body">
+
+    <div class="sidebar">
+      <div class="sec">Library<span class="sp"></span></div>
+      <div class="side-scroll">
+        <div class="row on"><span class="lead"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg></span><span class="label">All pictures</span><span class="count">0</span></div>
+        <div class="sec">Projects<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+        <div class="sec">People<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+        <div class="sec">Folders<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+      </div>
+    </div>
+
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">All pictures</span>
+        <span class="tb-sub">0</span>
+      </div>
+      <div class="scroll" style="display:flex;align-items:center;justify-content:center;padding:var(--space-7)">
+        <div style="max-width:640px;width:100%;text-align:center">
+
+          <div class="mosaic" style="width:88px;height:88px;margin:0 auto var(--space-6);opacity:.35">
+            <span></span><span></span><span></span><span></span>
+          </div>
+
+          <h2 class="t">This library is empty</h2>
+          <p class="sub" style="margin:var(--space-3) auto 0;max-width:46ch">
+            <span class="mono">~/Pictures/new-work</span> is yours. Three ways to put something in
+            it, and none of them is more official than the others.
+          </p>
+
+          <div class="stack" style="gap:var(--space-3);margin-top:var(--space-6);text-align:left">
+
+            <div class="opt opt--on" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--project" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Use a folder you already have</h4>
+                <p>Point PixlStash at one and it reads your folder names as the organisation. Nothing
+                  is moved.</p>
+              </span>
+              <button class="btn btn--accent">Choose a folder&hellip;</button>
+            </div>
+
+            <div class="opt" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--set" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3"/><path d="m7 8 5-5 5 5"/><path d="M4 15v4a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-4"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Drop pictures in</h4>
+                <p>Drag them anywhere on this window, or add a folder for PixlStash to watch.</p>
+              </span>
+              <button class="btn btn--outline">Add files&hellip;</button>
+            </div>
+
+            <div class="opt" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--character" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/><circle cx="12" cy="12" r="9"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Connect ComfyUI</h4>
+                <p>Generate straight into this library, with the settings and workflow kept on every
+                  picture.</p>
+              </span>
+              <button class="btn btn--outline">Connect&hellip;</button>
+            </div>
+
+          </div>
+
+          <p class="sub" style="margin:var(--space-6) auto 0;max-width:52ch;font-size:var(--text-xs)">
+            New pictures will be filed under
+            <span class="mono">Project / Person or Set</span>. Change that in Settings whenever.
+          </p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Insights.dc.html
+++ b/design/1.11-existing-library/Insights.dc.html
@@ -1,0 +1,391 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">About this library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">About your library</span>
+        <span class="tb-sub">read only · nothing here has been changed</span>
+        <span class="tb-right"><button class="btn btn--outline">Look again</button></span>
+      </div>
+      <div class="scroll pad">
+
+        <p class="sub" style="margin-top:0">Six things worth knowing about the 28,412 pictures you
+          already had. Each one names the tool that answers it, and none of them has run.</p>
+
+        <div class="stack" style="gap:var(--space-4);margin-top:var(--space-5)">
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>1,678 pictures are in <span class="mono">_unsorted</span> and nowhere else</h4>
+              <p>They are not in a set, a project or a character, and their folder name says nothing
+                about them. This is the largest group in your library with no meaning attached.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Sort them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">rapid triage · about 20 min</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="rowf" style="gap:2px">
+              <span class="mosaic" style="width:26px;height:56px;grid-template-columns:1fr"><span></span><span></span></span>
+              <span class="mosaic" style="width:26px;height:56px;grid-template-columns:1fr"><span></span><span></span></span>
+            </span>
+            <div class="body">
+              <h4><span class="mono">Mira · outdoor/selects</span> and <span class="mono">Mira · outdoor/final</span>
+                are 87% the same pictures</h4>
+              <p>163 of 188 appear in both, at the same pixel dimensions. Most likely a copy you made
+                once and both folders then grew. Stacking them keeps both paths working.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Compare them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">near-duplicate sweep</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>22,208 pictures have no caption</h4>
+              <p>The 6,204 that do are all under <span class="mono">Datasets/</span>, written by
+                whatever you used to build those. Everything outside that folder is uncaptioned, which
+                is what makes it unsearchable by description.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Caption them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">Florence-2 · about 3 hours on your GPU</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="portrait"></span>
+            <div class="body">
+              <h4>Four faces recur across folders that never mention them</h4>
+              <p>One appears in 1,204 pictures spread over 31 folders, including
+                <span class="mono">Client · Nordvik</span>, which your folder names give no way to
+                find. Naming a face makes every one of those reachable at once.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Name the faces</button>
+              <span class="muted" style="font-size:var(--text-2xs)">people review</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>1,880 pictures carry a generation workflow you used exactly once</h4>
+              <p>Of 617 distinct workflows in this library, 70 account for 90% of the pictures. The
+                rest ran once each. Deleting a picture is currently the only way you lose one, and it
+                is silent.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--outline">Coming in 1.12</button>
+              <span class="muted" style="font-size:var(--text-2xs)">workflow library</span>
+            </div>
+          </div>
+
+          <div class="find" style="background:transparent;border-style:dashed">
+            <span class="mosaic" style="opacity:.5"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>Your naming is more consistent than most</h4>
+              <p>337 of 341 folders follow one of the three shapes you named. The four that do not
+                are <span class="mono">temp</span>, <span class="mono">temp2</span>,
+                <span class="mono">new folder</span> and <span class="mono">asdf</span>, holding 61
+                pictures between them. Nothing to fix; you may just want to rename them.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <span class="chip chip--quiet">nothing to do</span>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="note" style="margin-top:var(--space-6)">
+          This screen only ever reads. Every button on it opens the tool with the right pictures
+          already selected, and every one of those tools asks before it changes anything.
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/LINK.md
+++ b/design/1.11-existing-library/LINK.md
@@ -1,0 +1,1 @@
+https://claude.ai/code/artifact/ea0517ec-09b7-4d7a-a3c1-9bfcd2d273f3

--- a/design/1.11-existing-library/Libraries.dc.html
+++ b/design/1.11-existing-library/Libraries.dc.html
@@ -1,0 +1,517 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div style="padding:var(--space-6);display:flex;flex-direction:column;gap:var(--space-7);
+     background:var(--bg);min-height:100%">
+
+  <!-- ── The dialog, Libraries selected ─────────────────────────────────── -->
+  <div>
+    <div class="lbl">Settings &rsaquo; Libraries</div>
+    <div class="panel" style="width:820px;overflow:hidden">
+
+      <div class="rowf" style="gap:var(--space-3);padding:var(--space-4) var(--space-5);
+           border-bottom:1px solid var(--divider)">
+        <span style="font-size:var(--text-lg);font-weight:var(--weight-semibold)">Settings</span>
+        <span class="version">v1.11.0</span>
+        <span class="spacer"></span>
+        <button class="btn" style="height:26px;font-size:var(--text-xs)">Log out</button>
+        <button class="btn" style="height:26px;font-size:var(--text-xs)">&times;</button>
+      </div>
+
+      <div style="display:flex;min-height:430px">
+
+        <nav style="width:186px;flex-shrink:0;padding:var(--space-3);
+             border-right:1px solid var(--divider);background:var(--chrome)">
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Appearance</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Models</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Smart Score &amp; Filters</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Workflows</span></div>
+          <div class="row on"><span class="lead">&#9634;</span><span class="label">Libraries</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Scrapheap</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Snapshots</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Privacy</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Compute</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Account</span></div>
+        </nav>
+
+        <div style="flex:1;min-width:0;padding:var(--space-5)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-5)">
+            <span style="font-size:var(--text-md);font-weight:var(--weight-semibold);flex:1">Libraries</span>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">
+              + Add a library&hellip;
+            </button>
+          </div>
+
+          <div class="stack" style="gap:var(--space-3)">
+
+            <div class="ins-field" style="border-color:var(--accent);background:var(--hover-wash)">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div class="rowf" style="gap:var(--space-3)">
+                    <span style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Generations</span>
+                    <span class="chip" style="height:20px;font-size:var(--text-2xs)">open</span>
+                  </div>
+                  <div class="mono muted" style="margin-top:2px">~/Pictures/Generations</div>
+                  <div class="muted" style="font-size:var(--text-2xs);margin-top:2px">
+                    <span class="num">28,412</span> pictures &middot;
+                    <span class="mono">Project / Person or Set</span>
+                  </div>
+                </div>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+            <div class="ins-field">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Client work</div>
+                  <div class="mono muted" style="margin-top:2px">~/PixlStash/client-work</div>
+                  <div class="muted" style="font-size:var(--text-2xs);margin-top:2px">
+                    <span class="num">4,109</span> pictures &middot;
+                    <span style="color:var(--accent)">flat, no layout chosen</span>
+                  </div>
+                </div>
+                <button class="btn btn--outline" style="height:26px;font-size:var(--text-xs)">Open</button>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+            <div class="ins-field" style="opacity:.65">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px;opacity:.4"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Archive 2022</div>
+                  <div class="mono muted" style="margin-top:2px">/mnt/photos-nas/2022</div>
+                  <div style="font-size:var(--text-2xs);margin-top:2px;color:var(--warning)">
+                    drive not mounted
+                  </div>
+                </div>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5);
+               padding-top:var(--space-4);border-top:1px solid var(--divider)">
+            <span class="muted" style="font-size:var(--text-xs);flex:1">
+              The same four things from a terminal
+            </span>
+            <button class="btn" style="height:24px;font-size:var(--text-2xs)">Show commands &#9662;</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ── The row menu, and detach ────────────────────────────────────────── -->
+  <div class="rowf" style="gap:var(--space-6);align-items:flex-start">
+
+    <div>
+      <div class="lbl">The &ctdot; on a row</div>
+      <div class="panel" style="width:230px;padding:var(--space-2)">
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Open this library</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Rename&hellip;</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Choose a layout&hellip;</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Show in file manager</span></div>
+        <div class="row" style="border-top:1px solid var(--divider);margin-top:var(--space-2);padding-top:var(--space-3)">
+          <span class="lead">&rsaquo;</span><span class="label">Stop using this&hellip;</span>
+        </div>
+      </div>
+      <div class="note" style="margin-top:var(--space-3);max-width:230px">
+        No delete. Nothing in this dialog can remove a picture or a folder.
+      </div>
+    </div>
+
+    <div>
+      <div class="lbl">Stop using it</div>
+      <div class="panel" style="width:440px;padding:var(--space-5)">
+        <h3 class="t" style="font-size:var(--text-md)">Stop using &ldquo;Archive 2022&rdquo;?</h3>
+        <p class="sub" style="margin-top:var(--space-3);font-size:var(--text-sm)">PixlStash forgets
+          it. Every picture and folder inside
+          <span class="mono">/mnt/photos-nas/2022</span> stays exactly where it is.</p>
+        <div class="note" style="margin-top:var(--space-4)">
+          Its tags, scores and people live in that folder too, in
+          <span class="mono">.pixlstash/</span>. Add the folder again later and they come back, and
+          so do any share links pointing at it, which are inert until then.
+        </div>
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5)">
+          <button class="btn btn--outline">Forget it</button>
+          <button class="btn">Cancel</button>
+        </div>
+      </div>
+      <div class="note" style="margin-top:var(--space-3);max-width:440px">
+        The open library has no <b>Stop using this</b> &mdash; switch away first. That refusal is the
+        registry's, not the dialog's.
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Add a library ───────────────────────────────────────────────────── -->
+  <div>
+    <div class="lbl">+ Add a library &mdash; one picker, and the folder answers</div>
+    <div class="panel" style="width:820px;padding:var(--space-5)">
+
+      <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+        <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+          ~/Pictures/Generations
+        </span>
+        <button class="btn btn--outline">Browse&hellip;</button>
+        <button class="btn btn--outline">New folder</button>
+      </div>
+
+      <div class="stack" style="gap:var(--space-3)">
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>28,412 pictures, no library here yet</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                Bring them in and name what your folders mean. Nothing is moved.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Bring them in</button>
+          </div>
+        </div>
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>A library you already made</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                4,109 pictures, last opened in March. Added as it is.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Add it</button>
+          </div>
+        </div>
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Empty</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                A fresh library on <span class="mono">Project / Person or Set</span>.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Start it</button>
+          </div>
+        </div>
+
+        <div class="ins-field" style="border-color:var(--warning)">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--warning)">!</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Inside a library you already have</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                <span class="mono">Generations</span> covers this folder. Two libraries indexing the
+                same pictures would each move them by their own layout, and neither would be wrong.
+              </div>
+            </div>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Open that one</button>
+          </div>
+        </div>
+
+        <div class="ins-field" style="border-color:var(--warning)">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--warning)">!</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Already on the list</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                Added in March as <b style="color:var(--text)">Client work</b>. Nothing to add.
+              </div>
+            </div>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Switch to it</button>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="note" style="margin-top:var(--space-5)">
+        Five outcomes, one picker, no mode to choose first. Three of them are the same
+        <b>Add</b> with a different consequence, and the other two are the registry refusing for
+        reasons it can already name.
+      </div>
+
+    </div>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Main.dc.html
+++ b/design/1.11-existing-library/Main.dc.html
@@ -1,0 +1,359 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">1.11.0</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <div class="rowf" style="gap:var(--space-4);align-items:flex-start">
+          <div style="flex:1">
+            <h2 class="t">Here is what is in that folder</h2>
+            <p class="sub">Nothing has been imported, moved, renamed or written yet, and nothing
+              will be until you say so.</p>
+          </div>
+          <span class="chip mono" style="align-self:center">/home/&hellip;/Pictures/Generations</span>
+        </div>
+
+        <div class="grid4" style="margin-top:var(--space-6)">
+          <div class="stat">
+            <div class="v num">28,412</div>
+            <div class="k">pictures, in 341 folders</div>
+          </div>
+          <div class="stat">
+            <div class="v num">24,110</div>
+            <div class="k">carry generation settings</div>
+          </div>
+          <div class="stat">
+            <div class="v num">6,204</div>
+            <div class="k">already have caption files</div>
+          </div>
+          <div class="stat">
+            <div class="v num">1.24 TB</div>
+            <div class="k">on disk</div>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            Working out what your folders mean
+          </div>
+          <p class="sub" style="margin-bottom:var(--space-5)">Reading 20 pictures from each of the
+            149 folders: who is in them, which have caption files beside them, which names repeat.
+            Worth the wait, because it is the difference between one question on the next screen and
+            four.</p>
+
+          <div class="bar" style="grid-template-columns:1fr">
+            <div class="track"><div class="fill" style="right:36%"></div></div>
+          </div>
+          <div class="muted" style="font-size:var(--text-xs);margin-top:var(--space-3)">
+            96 of 149 folders &middot; about <span class="num">1 min 12 s</span> left
+          </div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+            <button class="btn btn--busy">
+              <svg class="spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+              Set up my library
+            </button>
+            <button class="btn btn--outline">Cancel and organise later</button>
+          </div>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">The same card once the bar finishes</div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>118 folders hold one person each</b></span></div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>31 folders are training sets</b></span></div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>4 names are labels, not things</b></span></div>
+          <div class="worked"><span class="tick muted">&mdash;</span>
+            <span class="muted">14 it narrowed to two answers and could not settle. One question
+              for you.</span></div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5)">
+            <button class="btn btn--commit">Set up my library</button>
+            <button class="btn btn--outline">Cancel and organise later</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/MapTree.dc.html
+++ b/design/1.11-existing-library/MapTree.dc.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Name what your folders are</span>
+  </div>
+  <div class="app-body">
+
+    <div class="sidebar">
+      <div class="sec">What things are<span class="sp"></span></div>
+      <div class="side-scroll stack" style="gap:var(--space-3)">
+
+        <div class="ent ent--project echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>
+          <span class="name">Project</span><span class="have mono">1</span>
+        </div>
+
+        <div class="ent ent--set echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>
+          <span class="name">Set</span><span class="have mono">2</span>
+        </div>
+
+        <div class="ent ent--character echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>
+          <span class="name">Person</span><span class="have mono">3</span>
+        </div>
+
+        <div class="ent ent--tag echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/><circle cx="7.5" cy="7.5" r="1.3"/></svg></span>
+          <span class="name">Tag</span><span class="have mono">4</span>
+        </div>
+
+        <div class="ent ent--ignore echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span>
+          <span class="name">Just a folder</span><span class="have mono">0</span>
+        </div>
+
+        <div class="note" style="margin-top:var(--space-4)">
+          Drag onto a level, or press a number on a row.
+        </div>
+      </div>
+    </div>
+
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">Name what your folders are</span>
+        <span class="tb-sub">from 20 pictures per folder &middot; each row says what answered it</span>
+        <span class="tb-right">
+          <button class="btn btn--outline">Drop this, organise later</button>
+        </span>
+      </div>
+      <div class="scroll" style="padding:var(--space-4) var(--space-5)">
+
+        <div class="tdepth" style="border-top:0">
+          <span class="chev">&rsaquo;</span>Level 1 &middot; 1 folder
+          <span class="ent ent--ignore drop drop--set" style="margin-left:auto">the library itself</span>
+        </div>
+        <div class="tree">
+          <div class="tnode" style="padding-left:26px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Generations</span>
+            <span class="tcount">28,412</span>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&#9662;</span>Level 2 &middot; 14 folders
+          <span class="muted" style="text-transform:none;letter-spacing:0">used once each, so not labels</span>
+          <span class="tfilter">filter&hellip;</span>
+          <span style="margin-left:auto;display:flex;gap:var(--space-2);align-items:center">
+            <span class="muted" style="text-transform:none;letter-spacing:0">one of these:</span>
+            <span class="ent ent--project drop drop--armed">Project</span>
+            <span class="ent ent--set drop drop--armed">Set</span>
+          </span>
+        </div>
+        <div class="tree">
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">2024 Shoots</span><span class="tcount">18,204</span>
+          </div>
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">2023 Shoots</span><span class="tcount">7,918</span>
+          </div>
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Datasets</span><span class="tcount">6,742</span>
+          </div>
+          <div class="tnode ent ent--ignore" style="padding-left:40px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">_unsorted</span><span class="tcount">1,678</span>
+            <span class="etag">just a folder</span>
+          </div>
+          <div class="tmore">
+            10 more
+            <button class="btn btn--outline" style="height:22px;font-size:var(--text-2xs)">Show all 14</button>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&#9662;</span>Level 3 &middot; 149 folders
+          <span class="tfilter" style="color:var(--text);border-color:var(--accent)">mira <span class="muted">6 of 149</span></span>
+          <span class="muted" style="text-transform:none;letter-spacing:0;margin-left:auto">faces</span>
+          <span class="ent ent--character drop drop--set">
+            <span class="etag"><span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>Person</span>
+          </span>
+        </div>
+        <div class="tree" style="position:relative">
+          <div class="tnode ent ent--character" style="padding-left:54px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Mira</span><span class="tcount">2,914</span>
+            <span class="muted" style="font-size:var(--text-2xs)">one face, 20 of 20</span>
+          </div>
+          <div class="tnode ent ent--character" style="padding-left:54px;border-left:2px solid var(--e);background:var(--hover-wash)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Jonas</span><span class="tcount">1,088</span>
+            <span class="muted" style="font-size:var(--text-2xs)">one face, 19 of 20</span>
+            <button class="btn btn--outline" style="height:24px;font-size:var(--text-2xs)">This one is&hellip; &#9662;</button>
+          </div>
+          <div class="tnode ent ent--set" style="padding-left:54px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">mira-lora-v3</span><span class="tcount">2,140</span>
+            <span class="etag">Set</span>
+            <span class="muted" style="font-size:var(--text-2xs)">caption files &middot; 31 rows</span>
+          </div>
+          <div class="tmore">
+            146 more &middot; 31 Set &middot; 28 unclear
+            <button class="btn btn--outline" style="height:22px;font-size:var(--text-2xs)">Show all 149</button>
+          </div>
+
+          <div class="panel" style="position:absolute;right:var(--space-5);top:44px;width:200px;padding:var(--space-2);z-index:2">
+            <div class="ent ent--project row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span><span class="label">Project</span><span class="count mono">1</span></div>
+            <div class="ent ent--set row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span><span class="label">Set</span><span class="count mono">2</span></div>
+            <div class="ent ent--character row on"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span><span class="label">Person</span><span class="count mono">3</span></div>
+            <div class="ent ent--tag row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span><span class="label">Tag</span><span class="count mono">4</span></div>
+            <div class="ent ent--ignore row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span><span class="label">Just a folder</span><span class="count mono">0</span></div>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&rsaquo;</span>Level 4 &middot; 188 folders
+          <span class="muted" style="text-transform:none;letter-spacing:0">4 names under 118 parents</span>
+          <span class="ent ent--tag drop drop--set" style="margin-left:auto">
+            <span class="etag"><span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>Tag</span>
+          </span>
+        </div>
+        <div class="tree">
+          <div class="tnode ent ent--tag" style="padding-left:68px;border-left:2px solid var(--e)">
+            <span class="tname">final &middot; selects &middot; raw &middot; upscaled</span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="inspector">
+      <div class="ins-tabs"><button class="ins-tab on">What this makes</button></div>
+      <div class="ins-body" style="padding-top:var(--space-4)">
+        <div class="stack" style="gap:var(--space-3)">
+
+          <div class="ent ent--project ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">no Projects</span><br><span class="ec">level 2 is yours to call</span></span>
+          </div>
+
+          <div class="ent ent--set ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">31 Sets</span><br><span class="ec">from caption files</span></span>
+          </div>
+
+          <div class="ent ent--character ecard">
+            <span class="portrait" style="width:34px;height:34px"></span>
+            <span style="flex:1"><span class="en">118 People</span><br><span class="ec">4 you already had</span></span>
+          </div>
+
+          <div class="ent ent--tag ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">4 Tags</span><br><span class="ec">from level 4</span></span>
+          </div>
+
+        </div>
+
+        <button class="btn btn--commit" style="width:100%;margin-top:var(--space-6);justify-content:center">
+          Review and import
+        </button>
+        <div class="muted" style="font-size:var(--text-2xs);text-align:center;margin-top:var(--space-2)">
+          one more screen before anything is written
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Moves.dc.html
+++ b/design/1.11-existing-library/Moves.dc.html
@@ -1,0 +1,427 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">After you moved things yourself</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">You moved 312 pictures while PixlStash was closed</span>
+        <span class="tb-sub">nothing has been changed yet</span>
+      </div>
+      <div class="scroll pad">
+
+        <p class="sub" style="margin-top:0">The same rule, the other way round. PixlStash moves a
+          file when its folder stops being true; when <em>you</em> move a file, PixlStash changes an
+          assignment when that assignment stops being true. Nothing else is touched.</p>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--success)">
+          <div class="rowf" style="gap:var(--space-4);margin-bottom:var(--space-5)">
+            <div style="flex:1">
+              <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+                268 said something clear
+              </div>
+              <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+                each had exactly one of the thing it was filed by, so leaving that folder can only
+                mean one thing
+              </div>
+            </div>
+            <button class="btn btn--commit">Apply all 268</button>
+          </div>
+
+          <table class="table">
+            <thead>
+              <tr><th>Moved to</th><th>Which means</th><th class="right">Pictures</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">Client &middot; Nordvik / Mira / 2026-08 /</span></div></td>
+                <td><span class="ent ent--project etag">Project</span>
+                  <span class="muted" style="font-size:var(--text-xs)">2024 Shoots &rarr; Client &middot; Nordvik</span></td>
+                <td class="right num">214</td>
+              </tr>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">2024 Shoots / Jonas / 2026-07 /</span></div></td>
+                <td><span class="ent ent--character etag">Person</span>
+                  <span class="muted" style="font-size:var(--text-xs)">Mira &rarr; Jonas</span></td>
+                <td class="right num">46</td>
+              </tr>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">2024 Shoots / Ines / 2026-08 /</span></div></td>
+                <td><span class="ent ent--character etag">Person</span>
+                  <span class="muted" style="font-size:var(--text-xs)">Ines is new here</span></td>
+                <td class="right num">8</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--warning)">
+          <div class="rowf" style="gap:var(--space-4);margin-bottom:var(--space-4)">
+            <div style="flex:1">
+              <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+                12 could mean two things
+              </div>
+              <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+                these are in more than one project already, so leaving one project's folder does not
+                say whether you left the project or just refiled the picture
+              </div>
+            </div>
+            <button class="btn btn--outline">Go through them</button>
+          </div>
+          <div class="ins-field">
+            <div class="rowf" style="gap:var(--space-4)">
+              <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+              <div style="flex:1;font-size:var(--text-sm)">
+                <span class="mono muted">&hellip; / Client &middot; Nordvik / Mira / 2026-08 /</span><br>
+                <span class="muted">in <b style="color:var(--text)">2024 Shoots</b> and
+                  <b style="color:var(--text)">Client &middot; Nordvik</b></span>
+              </div>
+              <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Only Nordvik now</button>
+              <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Keep both</button>
+            </div>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            A folder can hold a picture once; a project can share it. PixlStash will not turn one
+            into the other by guessing. Untouched until you say, and 12 of 312 is what this costs.
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            32 went somewhere the layout does not describe
+          </div>
+          <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+            already followed, nothing to decide. Their tags, scores, people and projects are exactly
+            as they were &mdash; only the path changed.
+          </div>
+          <div class="chips" style="margin-top:var(--space-4)">
+            <span class="chip">_unsorted <span class="muted num">24</span></span>
+            <span class="chip">Desktop / to sort <span class="muted num">6</span></span>
+            <span class="chip">Datasets / scratch <span class="muted num">2</span></span>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            A folder outside the layout contradicts nothing, so it changes nothing and PixlStash will
+            never move these back. Putting a picture somewhere of your own is how you overrule all of
+            this, and it keeps working.
+          </div>
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Apply the 268</button>
+          <button class="btn btn--outline">Go through all 312</button>
+          <button class="btn">Leave everything as it was</button>
+        </div>
+
+        <div class="grid2" style="margin-top:var(--space-7);gap:var(--space-5);align-items:start">
+          <div class="card card--quiet" style="border-style:dashed">
+            <div class="lbl">The same thing while PixlStash is open</div>
+            <div class="rowf" style="gap:var(--space-4)">
+              <div style="flex:1;font-size:var(--text-sm)">
+                <b>41 pictures moved in your file manager</b>
+                <span class="muted">&mdash; 39 say something clear</span>
+              </div>
+              <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Review</button>
+              <button class="btn" style="height:28px;font-size:var(--text-xs)">Dismiss</button>
+            </div>
+            <div class="note" style="margin-top:var(--space-4)">
+              A strip in the sidebar, a few seconds after the moves stop. Never a dialog and never one
+              per file: reorganising a folder moves hundreds at once, and four hundred prompts is not
+              a question.
+            </div>
+          </div>
+
+          <div class="card card--quiet" style="border-style:dashed">
+            <div class="lbl">Why this never chases its own tail</div>
+            <p class="sub" style="margin:0">PixlStash records every move it makes itself, so when the
+              watcher sees those files land it recognises its own work and says nothing. Only moves it
+              did not make reach this screen. Without that, its writes come back as your intent and
+              the two flip each other forever.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Preview.dc.html
+++ b/design/1.11-existing-library/Preview.dc.html
@@ -1,0 +1,430 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Before anything is written</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">This is what your folders become</span>
+        <span class="tb-sub">nothing written yet</span>
+        <span class="tb-right"><button class="btn btn--outline">Back to the mapping</button></span>
+      </div>
+      <div class="scroll pad">
+
+        <div class="ent ent--project" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>13 Projects</span>
+            <span class="muted" style="font-size:var(--text-xs)">from <span class="mono">Generations/&lt;name&gt;/</span></span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">2024 Shoots</span><br><span class="ec">18,204</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">2023 Shoots</span><br><span class="ec">7,918</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">Client · Nordvik</span><br><span class="ec">1,204</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              10 more
+            </div>
+          </div>
+        </div>
+
+        <div class="ent ent--set" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>31 Sets</span>
+            <span class="muted" style="font-size:var(--text-xs)">from <span class="mono">Datasets/&lt;name&gt;/</span>, the 31 rows you overrode</span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">mira-lora-v3</span><br><span class="ec">2,140</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">jonas-portrait-v2</span><br><span class="ec">880</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">nordvik-interiors</span><br><span class="ec">612</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              28 more
+            </div>
+          </div>
+        </div>
+
+        <div class="ent ent--character" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>118 People</span>
+            <span class="muted" style="font-size:var(--text-xs)">from the third level. Four matched people you already had, by name, and kept their own thumbnails</span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Mira</span><br><span class="ec">500 · already existed</span></span></div>
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Jonas</span><br><span class="ec">288 · already existed</span></span></div>
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Ines</span><br><span class="ec">140 · new</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              115 more
+            </div>
+          </div>
+        </div>
+
+        <div class="grid2" style="margin-bottom:var(--space-6)">
+          <div class="ent ent--tag">
+            <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+              <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>4 Tags</span>
+              <span class="muted" style="font-size:var(--text-xs)">from level 4</span>
+            </div>
+            <div class="chips">
+              <span class="chip">final <span class="muted num">9,104</span></span>
+              <span class="chip">selects <span class="muted num">4,880</span></span>
+              <span class="chip">raw <span class="muted num">3,102</span></span>
+              <span class="chip">upscaled <span class="muted num">1,118</span></span>
+            </div>
+          </div>
+          <div class="ent ent--ignore">
+            <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+              <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span>3,466 arrive ungrouped</span>
+            </div>
+            <div class="muted" style="font-size:var(--text-sm);line-height:1.5">
+              <span class="num">1,678</span> from <span class="mono">_unsorted</span>, which you
+              marked as just folders, and <span class="num">1,788</span> from 191 folders that matched no
+              shape. They are in the library and searchable; they just join nothing.
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="lbl">What happens when you press the button</div>
+          <div class="grid2" style="gap:var(--space-5)">
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>28,412 pictures are indexed where they already are</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>166 projects, sets and people are created</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>6,204 caption files are read, and left on disk</span></div>
+            </div>
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">no file is copied, moved or renamed</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">no folder is created inside your library</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">undo puts the grouping back; the files were never touched</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--accent)">
+          <div class="lbl">One rule from here on, running both ways</div>
+          <div class="grid2" style="gap:var(--space-6)">
+
+            <div>
+              <div style="font-size:var(--text-base);font-weight:var(--weight-semibold)">
+                If you re-organise in PixlStash
+              </div>
+              <p class="sub" style="margin-top:var(--space-2)">A file moves only when its folder
+                stops being true. Adding a second project or a second person moves nothing, because
+                the folder it is in is still correct. Removing the one its folder is named after
+                moves it, because otherwise that folder would be lying. Counted first, one undo.</p>
+            </div>
+
+            <div>
+              <div style="font-size:var(--text-base);font-weight:var(--weight-semibold)">
+                If you move pictures in your file manager
+              </div>
+              <p class="sub" style="margin-top:var(--space-2)">The same rule backwards: PixlStash
+                changes an assignment only when the move makes it untrue. Drag a picture into another
+                project's folder and it belongs to that project now. Drag it somewhere the layout
+                does not describe and nothing changes but the path. New files are imported.</p>
+            </div>
+
+          </div>
+          <div class="note" style="margin-top:var(--space-5)">
+            Which means importing your library moves nothing at all. The folders are where the
+            assignments came from, so every one of them is already true.
+          </div>
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Yes, build this library</button>
+          <button class="btn btn--outline">Back to the mapping</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Storage.dc.html
+++ b/design/1.11-existing-library/Storage.dc.html
@@ -1,0 +1,447 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Settings &rsaquo; Library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">How your folders are laid out</h2>
+        <p class="sub">Where a new picture is written, and the one rule that decides when an existing
+          one is ever moved again.</p>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div class="rowf" style="gap:var(--space-3);flex-wrap:wrap">
+            <span class="muted" style="font-size:var(--text-sm)">Organise by</span>
+            <span class="ent ent--project etag" style="height:28px;padding:0 var(--space-3);font-size:var(--text-xs)">
+              <span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>Project &#9662;
+            </span>
+            <span class="muted">/</span>
+            <span class="rowf" style="gap:var(--space-2);padding:0 var(--space-2);height:28px;
+                 border:1px dashed var(--border);border-radius:var(--radius-sm)">
+              <span class="ent ent--character etag" style="height:22px;padding:0 var(--space-2);font-size:var(--text-2xs)">
+                <span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>Person
+              </span>
+              <span class="muted" style="font-size:var(--text-2xs)">or</span>
+              <span class="ent ent--set etag" style="height:22px;padding:0 var(--space-2);font-size:var(--text-2xs)">
+                <span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>Set
+              </span>
+              <span class="muted" style="font-size:var(--text-2xs)">&#9662;</span>
+            </span>
+            <span class="muted">/</span>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">+ add one</button>
+          </div>
+
+          <div class="grid3" style="margin-top:var(--space-5);gap:var(--space-4)">
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has a project and a person</div>
+              <div class="mono" style="font-size:var(--text-xs)">2024 Shoots / Mira /</div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has a project and a set</div>
+              <div class="mono" style="font-size:var(--text-xs)">2024 Shoots / mira-lora-v3 /</div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has only a set</div>
+              <div class="mono" style="font-size:var(--text-xs)">mira-lora-v3 /</div>
+            </div>
+          </div>
+
+          <div class="note" style="margin-top:var(--space-4)">
+            A segment can hold more than one thing, and the first that applies wins. A segment with
+            nothing to fill it is skipped rather than left as an empty folder, which is what keeps
+            the tree two deep instead of five. <b>A new, empty library starts on exactly this
+            layout</b>, since it has no folders to read a better guess from.
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--accent)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            A picture only moves when its folder stops being true
+          </div>
+          <p class="sub" style="margin-bottom:var(--space-5)">Not whenever something about it
+            changes. Only when the folder it is sitting in would otherwise be saying something that
+            is no longer the case.</p>
+
+          <table class="table">
+            <thead>
+              <tr><th>You do this</th><th>Is the folder still true?</th><th class="right">Files moved</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Import your library</td>
+                <td class="muted">true the moment it is written &mdash; the folder is where the
+                  assignment came from</td>
+                <td class="right"><span class="chip chip--quiet">none, ever</span></td>
+              </tr>
+              <tr>
+                <td>Add a second project, or a second person</td>
+                <td class="muted">yes. It is still in the first one</td>
+                <td class="right"><span class="chip chip--quiet">none</span></td>
+              </tr>
+              <tr>
+                <td>Rename a project</td>
+                <td class="muted">yes, under a new name</td>
+                <td class="right"><span class="chip chip--quiet">none &mdash; the folder is renamed</span></td>
+              </tr>
+              <tr class="on">
+                <td>Remove the project its folder is named after</td>
+                <td>no</td>
+                <td class="right"><span class="chip" style="border-color:var(--accent);color:var(--accent)">moves</span></td>
+              </tr>
+              <tr class="on">
+                <td>Swap one project for another</td>
+                <td>no</td>
+                <td class="right"><span class="chip" style="border-color:var(--accent);color:var(--accent)">moves</span></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="grid2" style="gap:var(--space-5);margin-top:var(--space-5)">
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">was</div>
+              <div class="mono" style="font-size:var(--text-sm);color:var(--text-muted)">
+                Generations / <span style="color:var(--text)">2024 Shoots</span> / Mira / 2026-08 / 0412.png
+              </div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">after removing that project</div>
+              <div class="mono" style="font-size:var(--text-sm);color:var(--text-muted)">
+                Generations / <span style="color:var(--accent)">Client &middot; Nordvik</span> / Mira / 2026-08 / 0412.png
+              </div>
+            </div>
+          </div>
+
+          <div class="stack" style="gap:var(--space-3);margin-top:var(--space-5)">
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>Counted before it happens, and one undo puts every file back</span></div>
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>Two changes in a row are one move, not two</span></div>
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>A folder left empty is kept, never deleted</span></div>
+          </div>
+        </div>
+
+        <div class="grid2" style="margin-top:var(--space-5);gap:var(--space-5);align-items:start">
+
+          <div class="card">
+            <div class="lbl">A folder that does not match the layout is never wrong</div>
+            <p class="sub" style="margin:0 0 var(--space-4)">Drag something into
+              <span class="mono">_unsorted</span> or a folder of your own and there is nothing for
+              PixlStash to contradict, so it stays there. Permanently. That is the override, and it
+              needs no setting.</p>
+            <div class="note">
+              This is also why the rule is safe to leave on. The worst it can do is move a picture
+              out of a folder that has stopped describing it.
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="lbl">Where it drifts, and what you do about it</div>
+            <p class="sub" style="margin:0 0 var(--space-4)">A picture filed under
+              <span class="mono">2024 Shoots</span> that becomes mostly a Nordvik job stays where it
+              is, because that never stopped being true. The tree is never wrong; it is not always
+              what you would have picked.</p>
+            <div class="ins-field">
+              <div class="rowf" style="gap:var(--space-3)">
+                <span style="flex:1;font-size:var(--text-sm)">In folder
+                  <span class="mono">2024 Shoots / Mira / 2026-08</span></span>
+                <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Move to match</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div class="lbl">New pictures with nothing to file them by</div>
+          <p class="sub" style="margin:0 0 var(--space-4)">No project, no person, nothing. They land
+            here, and leave on their own the moment you give them one.</p>
+          <div class="rowf" style="gap:var(--space-3)">
+            <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+              Generations / _Inbox
+            </span>
+            <button class="btn btn--outline">Choose&hellip;</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Views.dc.html
+++ b/design/1.11-existing-library/Views.dc.html
@@ -1,0 +1,375 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Settings › Library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">PixlStash Views</h2>
+        <p class="sub">Your sets, people and projects, as folders you can open in your file
+          manager and point other tools at. They are links, not copies: nothing is duplicated, no
+          original moves, and deleting the whole folder loses nothing.</p>
+
+        <div class="grid2" style="margin-top:var(--space-5);gap:var(--space-5);align-items:start">
+
+          <div class="card">
+            <div class="lbl">What gets published</div>
+            <div class="stack" style="gap:var(--space-3)">
+              <div class="ent ent--character rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">People<span class="muted"> · 4</span></span>
+                <span class="chip">on</span>
+              </div>
+              <div class="ent ent--set rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Sets<span class="muted"> · 96</span></span>
+                <span class="chip">on</span>
+              </div>
+              <div class="ent ent--project rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Projects<span class="muted"> · 14</span></span>
+                <span class="chip chip--quiet">off</span>
+              </div>
+              <div class="ent ent--tag rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Tags<span class="muted"> · 2,140</span></span>
+                <span class="chip chip--quiet">off</span>
+              </div>
+            </div>
+
+            <div class="lbl" style="margin-top:var(--space-6)">Where</div>
+            <div class="rowf" style="gap:var(--space-3)">
+              <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+                Generations / _PixlStash Views
+              </span>
+              <button class="btn btn--outline">Choose…</button>
+            </div>
+
+            <div class="lbl" style="margin-top:var(--space-6)">Keeping up</div>
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span class="radio" style="border:5px solid var(--accent);background:var(--bg)"></span>
+                <span>Rebuild whenever something changes</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="radio"></span>
+                <span>Only when I ask</span></div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="lbl">What appears on disk</div>
+            <div class="tree mono" style="font-size:var(--text-xs)">
+              <div class="tnode"><span class="tname">_PixlStash Views/</span></div>
+              <div class="ent ent--character tnode" style="padding-left:24px;border-left:2px solid var(--e)">
+                <span class="tname">People/</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Mira/</span></div>
+              <div class="tnode muted" style="padding-left:64px">
+                <span class="lead">↗</span><span class="tname">0412.png → ../../2024 Shoots/Mira · outdoor/selects/0412.png</span></div>
+              <div class="tnode muted" style="padding-left:64px">
+                <span class="lead">↗</span><span class="tname">0413.png → ../../2024 Shoots/Mira · studio/final/0413.png</span></div>
+              <div class="tnode muted" style="padding-left:64px"><span class="tname">… 498 more</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Jonas/</span><span class="tcount">288</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Ines/</span><span class="tcount">140</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Ravn/</span><span class="tcount">96</span></div>
+              <div class="ent ent--set tnode" style="padding-left:24px;border-left:2px solid var(--e)">
+                <span class="tname">Sets/</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">mira-lora-v3/</span><span class="tcount">2,140</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Mira · outdoor/</span><span class="tcount">188</span></div>
+              <div class="tnode muted" style="padding-left:44px"><span class="tname">… 94 more</span></div>
+            </div>
+
+            <div class="note" style="margin-top:var(--space-5)">
+              One character appears in two shoot folders on disk and in one folder here. That is the
+              thing your filesystem could not do for you, and the reason this folder is worth having.
+            </div>
+
+            <div class="card card--quiet" style="margin-top:var(--space-4);border-style:dashed;padding:var(--space-4)">
+              <div class="lbl" style="margin-bottom:var(--space-2)">On Windows</div>
+              <p class="sub" style="margin:0;font-size:var(--text-xs)">Symbolic links need
+                administrator rights or developer mode. Without either, PixlStash uses hard links
+                instead, which behave the same for files but cannot span two drives — if your library
+                spans drives, the views for the other drive are skipped and named in the report
+                rather than failing silently.</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/Welcome.dc.html
+++ b/design/1.11-existing-library/Welcome.dc.html
@@ -1,0 +1,393 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}
+
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}
+
+  </style>
+</helmet>
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">first run</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">Where should your pictures live?</h2>
+        <p class="sub">A library is a folder on your disk. PixlStash keeps its index inside that
+          folder, so the whole thing is one thing you can copy, back up or move.</p>
+
+        <div class="grid2" style="margin-top:var(--space-6);gap:var(--space-5)">
+
+          <label class="opt opt--on" style="flex-direction:column;gap:var(--space-4);padding:var(--space-6)">
+            <span class="mark ent ent--project" style="width:36px;height:36px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            </span>
+            <span>
+              <h4 style="font-size:var(--text-lg)">I already have a folder of pictures</h4>
+              <p style="margin-top:var(--space-2)">Point PixlStash at it. Every file stays exactly
+                where it is, and the folder names you already use become the organisation.</p>
+            </span>
+            <span class="chip chip--quiet">nothing is moved, copied or renamed</span>
+          </label>
+
+          <label class="opt" style="flex-direction:column;gap:var(--space-4);padding:var(--space-6)">
+            <span class="mark ent ent--set" style="width:36px;height:36px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+            </span>
+            <span>
+              <h4 style="font-size:var(--text-lg)">Start a new library</h4>
+              <p style="margin-top:var(--space-2)">An empty folder for PixlStash to fill. Bring
+                pictures in whenever you like, or generate straight into it.</p>
+            </span>
+            <span class="chip chip--quiet">you can add the folder you already have later</span>
+          </label>
+
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Choose a folder&hellip;</button>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">Before this, unchanged: the telemetry question that already ships</div>
+          <p class="sub" style="margin:0 0 var(--space-5)">
+            <span class="mono">TelemetryConsentDialog</span> already asks this once, on first
+            startup, and records that it asked however you leave it. It is not redrawn here and it
+            does not need to be. It is on this artboard only so the order is written down: the
+            question comes first, then the folder.
+          </p>
+
+          <div class="panel" style="padding:var(--space-5);max-width:640px">
+            <h3 class="t" style="font-size:var(--text-md)">What may PixlStash send?</h3>
+            <p class="sub" style="margin-top:var(--space-2);font-size:var(--text-xs)">
+              PixlStash can check pixlstash.dev once a day for a new version. Several past releases
+              fixed critical security bugs, so I&rsquo;d suggest leaving this on. You could also help
+              PixlStash improve by sending a random number alongside it.
+            </p>
+            <div class="grid3" style="margin-top:var(--space-5);gap:var(--space-3)">
+              <div class="opt" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">No check</h4>
+                <p style="font-size:var(--text-xs)">Nothing leaves your machine. You&rsquo;ll need to
+                  watch for security releases yourself.</p>
+              </div>
+              <div class="opt" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">Check for updates</h4>
+                <p style="font-size:var(--text-xs)">Sends your version and platform. Nothing else.</p>
+              </div>
+              <div class="opt opt--on" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">Check + random ID</h4>
+                <p style="font-size:var(--text-xs)">Adds a random number, so I can tell ten people
+                  using PixlStash once from one person using it ten times.</p>
+              </div>
+            </div>
+            <p class="sub" style="margin-top:var(--space-4);font-size:var(--text-xs)">
+              <b style="color:var(--text)">Never sent:</b> your images &middot; your tags, captions
+              or filenames &middot; your prompts
+            </p>
+          </div>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">If you asked for an empty library and the folder is not empty</div>
+          <div class="ins-field">
+            <div class="rowf" style="gap:var(--space-4);align-items:flex-start">
+              <span class="mark ent ent--project" style="width:30px;height:30px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+              </span>
+              <div style="flex:1">
+                <div style="font-size:var(--text-sm)">You said <b>start a new library</b>, but there
+                  are <span class="num">28,412</span> pictures in
+                  <span class="mono">~/Pictures/Generations</span>.</div>
+                <div class="muted" style="font-size:var(--text-xs);margin-top:var(--space-2)">
+                  Bring them in and PixlStash reads your folder names as the organisation, without
+                  moving anything. Or point it somewhere else.
+                </div>
+              </div>
+              <div class="stack" style="gap:var(--space-2);flex-shrink:0">
+                <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Bring them in</button>
+                <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Pick a different folder</button>
+              </div>
+            </div>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            There is no third answer, and &ldquo;start empty in here anyway&rdquo; is not one. A
+            library that ignores the 28,412 pictures sitting in its own folder is a trap: the next
+            scan finds them, new pictures get filed in among them, and two ideas of one folder is one
+            too many. Which button was pressed a screen earlier does not get to cause that.
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic { renderVals() { return {}; } }
+</script>
+</body>
+</html>

--- a/design/1.11-existing-library/_extra.css
+++ b/design/1.11-existing-library/_extra.css
@@ -1,0 +1,134 @@
+    /* ---- What this bundle adds on top of the kit -------------------------
+       Two things only: the ENTITY VOCABULARY (one colour and one icon per
+       Project / Set / Character / Tag, so the four are never confused at a
+       glance) and the MAPPING SURFACES, which have no counterpart in the
+       shipped app. Everything else above is the design system as it ships. */
+
+    /* Entity colours are drawn from the kit's existing roles, not invented:
+       project=tertiary, set=accent, character=secondary, tag=primary. */
+    .ent{--e:var(--text-muted)}
+    .ent--project{--e:#46707a}
+    .ent--set{--e:#c47a1e}
+    .ent--character{--e:#bb3566}
+    .ent--tag{--e:#567309}
+    .ent--ignore{--e:rgba(242,229,218,.35)}
+
+    /* The draggable entity chip. Grip + mark + label + what already exists. */
+    .echip{display:flex;align-items:center;gap:var(--space-3);width:100%;
+      padding:var(--space-3);border-radius:var(--radius-md);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);cursor:grab;font-size:var(--text-sm)}
+    .echip .grip{display:grid;grid-template-columns:2px 2px;gap:2px;flex-shrink:0;opacity:.45}
+    .echip .grip i{width:2px;height:2px;background:var(--text);border-radius:50%;display:block}
+    .echip .mark{width:26px;height:26px;border-radius:var(--radius-sm);flex-shrink:0;
+      display:inline-flex;align-items:center;justify-content:center;
+      background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)}
+    .echip .name{flex:1;font-weight:var(--weight-medium)}
+    .echip .have{font-size:var(--text-2xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .echip--drag{box-shadow:var(--elevation-4);border-color:var(--e);cursor:grabbing;
+      transform:rotate(-1.5deg);background:var(--panel)}
+
+    /* The same vocabulary at label size, for anywhere an assignment is shown. */
+    .etag{display:inline-flex;align-items:center;gap:var(--space-2);
+      padding:1px var(--space-2) 1px var(--space-1);border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label)}
+    .etag .mark{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center}
+
+    /* Drop targets. Idle is a dashed ghost; armed is the entity's own colour. */
+    .drop{border:1px dashed var(--border);border-radius:var(--radius-sm);
+      color:var(--text-muted);font-size:var(--text-xs);
+      padding:var(--space-2) var(--space-3);background:transparent}
+    .drop--armed{border-style:solid;border-color:var(--e);color:var(--e);
+      background:color-mix(in srgb,var(--e) 12%,transparent);font-weight:var(--weight-medium)}
+    .drop--set{border-style:solid;border-color:transparent;
+      background:color-mix(in srgb,var(--e) 18%,transparent);color:var(--e);
+      font-weight:var(--weight-semibold)}
+
+    /* A path pattern, the unit Direction B assigns against. */
+    .pattern{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;
+      font-family:var(--font-mono);font-size:var(--text-sm)}
+    .pattern .sep{color:var(--text-muted)}
+    .pattern .lit{color:var(--text-muted)}
+    .pattern .seg{display:inline-flex;flex-direction:column;gap:var(--space-1)}
+
+    /* The tree Direction A assigns against. */
+    .tree{font-size:var(--text-sm)}
+    .tnode{display:flex;align-items:center;gap:var(--space-3);min-height:30px;
+      padding:0 var(--space-3);border-radius:var(--radius-sm)}
+    .tnode:hover{background:var(--hover-wash)}
+    .tnode .tname{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .tnode .tcount{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tdepth{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-top:1px solid var(--divider);font-size:var(--text-2xs);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted)}
+
+    /* Cards, tiles and the stat row, used across most artboards. */
+    .card{background:var(--surface);border:1px solid var(--border);
+      border-radius:var(--radius-lg);padding:var(--space-5)}
+    .card--quiet{background:transparent}
+    .lbl{font-size:var(--text-2xs);font-weight:var(--weight-semibold);text-transform:uppercase;
+      letter-spacing:var(--tracking-label);color:var(--text-muted);margin-bottom:var(--space-3)}
+    .stat{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-4)}
+    .stat .v{font-size:var(--text-xl);font-variant-numeric:tabular-nums;line-height:1.2}
+    .stat .k{font-size:var(--text-xs);color:var(--text-muted);margin-top:var(--space-1)}
+    .mosaic{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:2px;
+      width:56px;height:56px;border-radius:var(--radius-sm);overflow:hidden;flex-shrink:0}
+    .mosaic span{display:block;background:#3a3f46}
+    .portrait{width:56px;height:56px;border-radius:var(--radius-pill);background:#3a3f46;flex-shrink:0}
+    .ecard{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);
+      background:var(--input-bg);border:1px solid var(--border);
+      border-left:3px solid var(--e);border-radius:var(--radius-md)}
+    .ecard .en{font-size:var(--text-sm);font-weight:var(--weight-medium)}
+    .ecard .ec{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+
+    /* A radio card, for the two storage choices and the three library doors. */
+    .opt{display:flex;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-md);
+      border:1px solid var(--border);background:var(--input-bg);cursor:pointer}
+    .opt--on{border-color:var(--accent);background:var(--hover-wash)}
+    .radio{width:16px;height:16px;border-radius:50%;border:1px solid var(--border);
+      flex-shrink:0;margin-top:2px}
+    .opt--on .radio{border:5px solid var(--accent);background:var(--bg)}
+    .opt h4{margin:0 0 var(--space-1);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .opt p{margin:0;font-size:var(--text-sm);color:var(--text-muted)}
+
+    /* A finding, with the feature that answers it. */
+    .find{display:flex;gap:var(--space-4);padding:var(--space-4) var(--space-5);
+      border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface)}
+    .find .body{flex:1;min-width:0}
+    .find h4{margin:0 0 var(--space-2);font-size:var(--text-base);font-weight:var(--weight-semibold)}
+    .find p{margin:0;font-size:var(--text-sm);color:var(--text-muted);line-height:1.5}
+
+    .mono{font-family:var(--font-mono);font-size:var(--text-xs)}
+    .grid2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-4)}
+    .grid3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-4)}
+    .grid4{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--space-3)}
+    .stack{display:flex;flex-direction:column}
+    .rowf{display:flex;align-items:center}
+    .pad{padding:var(--space-6) var(--space-7)}
+    h2.t{margin:0;font-size:var(--text-xl);font-weight:var(--weight-semibold)}
+    h3.t{margin:0;font-size:var(--text-lg);font-weight:var(--weight-semibold)}
+    p.sub{margin:var(--space-2) 0 0;color:var(--text-muted);font-size:var(--text-sm);
+      line-height:1.5;max-width:72ch}
+
+    /* A level band is a disclosure: levels open to show every folder in them,
+       because two folders at the same depth can legitimately mean two
+       different things and the only way to say so is per row. */
+    .tdepth .chev{width:14px;display:inline-flex;justify-content:center;font-size:11px;opacity:.7}
+    .tfilter{height:24px;min-width:200px;padding:0 var(--space-3);border-radius:var(--radius-sm);
+      background:var(--input-bg);border:1px solid var(--border);color:var(--text-muted);
+      font-size:var(--text-xs);display:inline-flex;align-items:center;gap:var(--space-2)}
+    .tmore{display:flex;align-items:center;gap:var(--space-3);min-height:28px;
+      font-size:var(--text-xs);color:var(--text-muted);padding-left:var(--space-3)}
+
+    /* An action that is not available yet because a calculation is still running.
+       Distinct from a refusal: it says what it is waiting for and how long. */
+    .btn--busy{opacity:.6;cursor:default;background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text-muted)}
+    .spin{transform-origin:center;animation:spin 1.1s linear infinite}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .worked{display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);
+      padding:var(--space-2) 0}
+    .worked .tick{width:16px;flex-shrink:0;text-align:center}

--- a/design/1.11-existing-library/_kit.css
+++ b/design/1.11-existing-library/_kit.css
@@ -1,0 +1,120 @@
+    /* PixlStash design system, copied from tokens/colors.css + ui_kits/app/unified.css.
+       Dark is the default theme, exactly as the kit ships it. */
+    :root{
+      --accent:#c47a1e; --accent-on:#f7f1ea; --active-bar:#e08a2a;
+      --hover-wash:rgba(196,122,30,.10); --active-wash:rgba(196,122,30,.20);
+      --primary:#567309; --primary-on:#f7f1ea; --secondary:#bb3566; --tertiary:#46707a;
+      --error:#b0392b; --error-on:#f7f1ea; --warning:#e8912f; --warning-on:#1b1b1b; --success:#2a7d3e;
+      --bg:#1b1f24; --surface:#23282f; --panel:#313337; --chrome:#23282f; --input-bg:#2b3138;
+      --border:#363d45; --divider:#2c323a; --text:#f2e5da; --text-muted:rgba(242,229,218,.55);
+      --active-text:#f2e5da;
+      --space-1:2px; --space-2:4px; --space-3:8px; --space-4:12px; --space-5:16px;
+      --space-6:24px; --space-7:32px;
+      --radius-sm:4px; --radius-md:8px; --radius-lg:12px; --radius-pill:999px;
+      --text-2xs:.6875rem; --text-xs:.75rem; --text-sm:.8125rem; --text-base:.875rem;
+      --text-md:1rem; --text-lg:1.125rem; --text-xl:1.375rem;
+      --weight-medium:500; --weight-semibold:600; --tracking-label:.06em; --leading-body:1.5;
+      --font-ui:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+      --font-mono:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;
+      --font-pixel:"Tiny5",monospace;
+      --titlebar-height:34px; --toolbar-height:48px; --sidebar-width:280px; --stats-width:288px;
+      --elevation-2:0 2px 6px rgba(42,47,54,.18); --elevation-3:0 4px 16px rgba(42,47,54,.22);
+      --elevation-4:0 8px 28px rgba(42,47,54,.30);
+      --dur-1:150ms; --ease-standard:cubic-bezier(.4,0,.2,1);
+      --focus-ring:0 0 0 3px var(--accent);
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font-family:var(--font-ui);
+         font-size:var(--text-base);line-height:var(--leading-body);-webkit-font-smoothing:antialiased}
+    a{color:var(--accent);text-decoration:none}
+    .app{display:flex;flex-direction:column;height:100%;overflow:hidden}
+    .app-body{flex:1;display:flex;min-height:0}
+    .titlebar{height:var(--titlebar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-2) 0 var(--space-4);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .wordmark{font-family:var(--font-pixel);font-size:var(--text-md);letter-spacing:.02em}
+    .spacer{flex:1}
+    .version{font-size:var(--text-2xs);color:var(--text-muted)}
+    .toolbar{height:var(--toolbar-height);flex-shrink:0;display:flex;align-items:center;
+      gap:var(--space-3);padding:0 var(--space-3);background:var(--chrome);
+      border-bottom:1px solid var(--divider)}
+    .tb-title{font-size:var(--text-lg);font-weight:var(--weight-semibold);margin-right:var(--space-2)}
+    .tb-sub{font-size:var(--text-sm);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .tb-right{margin-left:auto;display:flex;align-items:center;gap:var(--space-2)}
+    .vsep{width:1px;height:24px;background:var(--divider);margin:0 var(--space-1)}
+    .btn{height:32px;display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-3);
+      border:1px solid transparent;border-radius:var(--radius-sm);background:transparent;color:var(--text);
+      cursor:pointer;font-family:inherit;font-size:var(--text-sm);white-space:nowrap}
+    .btn--outline{border-color:var(--border)}
+    .btn--accent{background:var(--accent);color:var(--accent-on);font-weight:var(--weight-medium)}
+    .btn--commit{background:var(--primary);color:var(--primary-on);font-weight:var(--weight-medium)}
+    .btn--danger{color:var(--error)}
+    .sidebar{width:var(--sidebar-width);flex-shrink:0;background:var(--chrome);display:flex;
+      flex-direction:column;border-right:1px solid var(--divider)}
+    .side-scroll{flex:1;overflow-y:auto;padding:var(--space-2)}
+    .row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);
+      border-radius:var(--radius-sm);border-left:3px solid transparent;cursor:pointer;
+      font-size:var(--text-sm);min-height:34px}
+    .row.on{background:var(--active-wash);color:var(--active-text);border-left-color:var(--active-bar);
+      font-weight:var(--weight-medium)}
+    .row .lead{width:22px;display:inline-flex;justify-content:center;color:var(--text-muted)}
+    .row.on .lead{color:var(--active-bar)}
+    .row .label{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .row .count{font-size:var(--text-xs);color:var(--text-muted);font-variant-numeric:tabular-nums}
+    .sec{display:flex;align-items:center;gap:var(--space-2);
+      padding:var(--space-4) var(--space-3) var(--space-2);font-size:var(--text-2xs);
+      font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:var(--tracking-label);
+      color:var(--text-muted)}
+    .sec .sp{flex:1}
+    .sec .act,.sec .chev{font-size:16px;opacity:.7}
+    .main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;background:var(--bg)}
+    .scroll{flex:1;overflow-y:auto;position:relative}
+    .muted{color:var(--text-muted)}
+    .num{font-variant-numeric:tabular-nums}
+    .chip{display:inline-flex;align-items:center;gap:var(--space-2);padding:2px var(--space-3);
+      border-radius:var(--radius-sm);font-size:var(--text-xs);background:var(--input-bg);
+      border:1px solid var(--border);color:var(--text)}
+    .chip--quiet{background:transparent;color:var(--text-muted)}
+    .chips{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+    .inspector{width:var(--stats-width);flex-shrink:0;background:var(--chrome);
+      border-left:1px solid var(--divider);display:flex;flex-direction:column;overflow-y:auto}
+    .ins-tabs{display:flex;border-bottom:1px solid var(--divider)}
+    .ins-tab{flex:1;background:none;border:0;cursor:pointer;font-family:inherit;
+      padding:var(--space-3) 0;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      border-bottom:2px solid transparent;display:inline-flex;align-items:center;
+      justify-content:center;gap:var(--space-2)}
+    .ins-tab.on{color:var(--accent);border-bottom-color:var(--accent)}
+    .ins-body{padding:0 var(--space-4) var(--space-5)}
+    .ins-field{background:var(--input-bg);border:1px solid var(--border);
+      border-radius:var(--radius-md);padding:var(--space-3)}
+    .kv{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4) var(--space-3);margin:0}
+    .kv dt{font-size:var(--text-xs);color:var(--text-muted);margin:0}
+    .kv dd{margin:0;font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+    .bars{display:flex;flex-direction:column;gap:var(--space-2)}
+    .bar{display:grid;grid-template-columns:68px 1fr;align-items:center;gap:var(--space-3);
+      font-size:var(--text-xs)}
+    .bar>span:first-child{color:var(--text-muted);text-align:right}
+    .bar .track{height:18px;border-radius:var(--radius-sm);
+      background:color-mix(in srgb,var(--text) 7%,transparent);position:relative;overflow:hidden}
+    .bar .fill{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:var(--radius-sm)}
+    .bar .fill.q1{opacity:.35} .bar .fill.q2{opacity:.55}
+    .bar .fill.q3{opacity:.75} .bar .fill.q4{opacity:1}
+    .bar .v{position:absolute;right:var(--space-3);top:0;line-height:18px;font-size:var(--text-2xs);
+      color:var(--text);font-variant-numeric:tabular-nums}
+    .table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+    .table th{text-align:left;font-size:var(--text-2xs);font-weight:var(--weight-semibold);
+      text-transform:uppercase;letter-spacing:var(--tracking-label);color:var(--text-muted);
+      padding:var(--space-3);border-bottom:1px solid var(--divider);white-space:nowrap}
+    .table td{padding:var(--space-3);border-bottom:1px solid var(--divider);vertical-align:middle}
+    .table tbody tr.on{background:var(--active-wash);box-shadow:inset 3px 0 0 var(--active-bar)}
+    .table .right{text-align:right}
+    .tile{position:relative;border-radius:var(--radius-md);overflow:hidden;aspect-ratio:1/1;
+      background:var(--input-bg)}
+    .facecard{display:flex;align-items:center;gap:var(--space-3)}
+    .facecard .ph{width:44px;height:44px;border-radius:var(--radius-sm);background:#3a3f46;flex-shrink:0}
+    .note{border-left:3px solid var(--accent);padding:var(--space-2) var(--space-4);
+      font-size:var(--text-sm);color:var(--text-muted);background:var(--hover-wash);
+      border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+    .panel{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius-lg);
+      box-shadow:var(--elevation-3)}

--- a/design/1.11-existing-library/bodies/Empty.html
+++ b/design/1.11-existing-library/bodies/Empty.html
@@ -1,0 +1,88 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">new-work</span>
+  </div>
+  <div class="app-body">
+
+    <div class="sidebar">
+      <div class="sec">Library<span class="sp"></span></div>
+      <div class="side-scroll">
+        <div class="row on"><span class="lead"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg></span><span class="label">All pictures</span><span class="count">0</span></div>
+        <div class="sec">Projects<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+        <div class="sec">People<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+        <div class="sec">Folders<span class="sp"></span><span class="act">+</span></div>
+        <div class="row muted"><span class="label" style="font-size:var(--text-xs)">none yet</span></div>
+      </div>
+    </div>
+
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">All pictures</span>
+        <span class="tb-sub">0</span>
+      </div>
+      <div class="scroll" style="display:flex;align-items:center;justify-content:center;padding:var(--space-7)">
+        <div style="max-width:640px;width:100%;text-align:center">
+
+          <div class="mosaic" style="width:88px;height:88px;margin:0 auto var(--space-6);opacity:.35">
+            <span></span><span></span><span></span><span></span>
+          </div>
+
+          <h2 class="t">This library is empty</h2>
+          <p class="sub" style="margin:var(--space-3) auto 0;max-width:46ch">
+            <span class="mono">~/Pictures/new-work</span> is yours. Three ways to put something in
+            it, and none of them is more official than the others.
+          </p>
+
+          <div class="stack" style="gap:var(--space-3);margin-top:var(--space-6);text-align:left">
+
+            <div class="opt opt--on" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--project" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Use a folder you already have</h4>
+                <p>Point PixlStash at one and it reads your folder names as the organisation. Nothing
+                  is moved.</p>
+              </span>
+              <button class="btn btn--accent">Choose a folder&hellip;</button>
+            </div>
+
+            <div class="opt" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--set" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3"/><path d="m7 8 5-5 5 5"/><path d="M4 15v4a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-4"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Drop pictures in</h4>
+                <p>Drag them anywhere on this window, or add a folder for PixlStash to watch.</p>
+              </span>
+              <button class="btn btn--outline">Add files&hellip;</button>
+            </div>
+
+            <div class="opt" style="align-items:center;gap:var(--space-5)">
+              <span class="mark ent ent--character" style="width:34px;height:34px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/><circle cx="12" cy="12" r="9"/></svg>
+              </span>
+              <span style="flex:1">
+                <h4>Connect ComfyUI</h4>
+                <p>Generate straight into this library, with the settings and workflow kept on every
+                  picture.</p>
+              </span>
+              <button class="btn btn--outline">Connect&hellip;</button>
+            </div>
+
+          </div>
+
+          <p class="sub" style="margin:var(--space-6) auto 0;max-width:52ch;font-size:var(--text-xs)">
+            New pictures will be filed under
+            <span class="mono">Project / Person or Set</span>. Change that in Settings whenever.
+          </p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Insights.html
+++ b/design/1.11-existing-library/bodies/Insights.html
@@ -1,0 +1,117 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">About this library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">About your library</span>
+        <span class="tb-sub">read only · nothing here has been changed</span>
+        <span class="tb-right"><button class="btn btn--outline">Look again</button></span>
+      </div>
+      <div class="scroll pad">
+
+        <p class="sub" style="margin-top:0">Six things worth knowing about the 28,412 pictures you
+          already had. Each one names the tool that answers it, and none of them has run.</p>
+
+        <div class="stack" style="gap:var(--space-4);margin-top:var(--space-5)">
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>1,678 pictures are in <span class="mono">_unsorted</span> and nowhere else</h4>
+              <p>They are not in a set, a project or a character, and their folder name says nothing
+                about them. This is the largest group in your library with no meaning attached.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Sort them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">rapid triage · about 20 min</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="rowf" style="gap:2px">
+              <span class="mosaic" style="width:26px;height:56px;grid-template-columns:1fr"><span></span><span></span></span>
+              <span class="mosaic" style="width:26px;height:56px;grid-template-columns:1fr"><span></span><span></span></span>
+            </span>
+            <div class="body">
+              <h4><span class="mono">Mira · outdoor/selects</span> and <span class="mono">Mira · outdoor/final</span>
+                are 87% the same pictures</h4>
+              <p>163 of 188 appear in both, at the same pixel dimensions. Most likely a copy you made
+                once and both folders then grew. Stacking them keeps both paths working.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Compare them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">near-duplicate sweep</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>22,208 pictures have no caption</h4>
+              <p>The 6,204 that do are all under <span class="mono">Datasets/</span>, written by
+                whatever you used to build those. Everything outside that folder is uncaptioned, which
+                is what makes it unsearchable by description.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Caption them</button>
+              <span class="muted" style="font-size:var(--text-2xs)">Florence-2 · about 3 hours on your GPU</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="portrait"></span>
+            <div class="body">
+              <h4>Four faces recur across folders that never mention them</h4>
+              <p>One appears in 1,204 pictures spread over 31 folders, including
+                <span class="mono">Client · Nordvik</span>, which your folder names give no way to
+                find. Naming a face makes every one of those reachable at once.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--accent">Name the faces</button>
+              <span class="muted" style="font-size:var(--text-2xs)">people review</span>
+            </div>
+          </div>
+
+          <div class="find">
+            <span class="mosaic"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>1,880 pictures carry a generation workflow you used exactly once</h4>
+              <p>Of 617 distinct workflows in this library, 70 account for 90% of the pictures. The
+                rest ran once each. Deleting a picture is currently the only way you lose one, and it
+                is silent.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <button class="btn btn--outline">Coming in 1.12</button>
+              <span class="muted" style="font-size:var(--text-2xs)">workflow library</span>
+            </div>
+          </div>
+
+          <div class="find" style="background:transparent;border-style:dashed">
+            <span class="mosaic" style="opacity:.5"><span></span><span></span><span></span><span></span></span>
+            <div class="body">
+              <h4>Your naming is more consistent than most</h4>
+              <p>337 of 341 folders follow one of the three shapes you named. The four that do not
+                are <span class="mono">temp</span>, <span class="mono">temp2</span>,
+                <span class="mono">new folder</span> and <span class="mono">asdf</span>, holding 61
+                pictures between them. Nothing to fix; you may just want to rename them.</p>
+            </div>
+            <div class="stack" style="gap:var(--space-2);align-items:flex-end">
+              <span class="chip chip--quiet">nothing to do</span>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="note" style="margin-top:var(--space-6)">
+          This screen only ever reads. Every button on it opens the tool with the right pictures
+          already selected, and every one of those tools asks before it changes anything.
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Libraries.html
+++ b/design/1.11-existing-library/bodies/Libraries.html
@@ -1,0 +1,243 @@
+<div style="padding:var(--space-6);display:flex;flex-direction:column;gap:var(--space-7);
+     background:var(--bg);min-height:100%">
+
+  <!-- ── The dialog, Libraries selected ─────────────────────────────────── -->
+  <div>
+    <div class="lbl">Settings &rsaquo; Libraries</div>
+    <div class="panel" style="width:820px;overflow:hidden">
+
+      <div class="rowf" style="gap:var(--space-3);padding:var(--space-4) var(--space-5);
+           border-bottom:1px solid var(--divider)">
+        <span style="font-size:var(--text-lg);font-weight:var(--weight-semibold)">Settings</span>
+        <span class="version">v1.11.0</span>
+        <span class="spacer"></span>
+        <button class="btn" style="height:26px;font-size:var(--text-xs)">Log out</button>
+        <button class="btn" style="height:26px;font-size:var(--text-xs)">&times;</button>
+      </div>
+
+      <div style="display:flex;min-height:430px">
+
+        <nav style="width:186px;flex-shrink:0;padding:var(--space-3);
+             border-right:1px solid var(--divider);background:var(--chrome)">
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Appearance</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Models</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Smart Score &amp; Filters</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Workflows</span></div>
+          <div class="row on"><span class="lead">&#9634;</span><span class="label">Libraries</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Scrapheap</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Snapshots</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Privacy</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Compute</span></div>
+          <div class="row"><span class="lead">&#9634;</span><span class="label">Account</span></div>
+        </nav>
+
+        <div style="flex:1;min-width:0;padding:var(--space-5)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-5)">
+            <span style="font-size:var(--text-md);font-weight:var(--weight-semibold);flex:1">Libraries</span>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">
+              + Add a library&hellip;
+            </button>
+          </div>
+
+          <div class="stack" style="gap:var(--space-3)">
+
+            <div class="ins-field" style="border-color:var(--accent);background:var(--hover-wash)">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div class="rowf" style="gap:var(--space-3)">
+                    <span style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Generations</span>
+                    <span class="chip" style="height:20px;font-size:var(--text-2xs)">open</span>
+                  </div>
+                  <div class="mono muted" style="margin-top:2px">~/Pictures/Generations</div>
+                  <div class="muted" style="font-size:var(--text-2xs);margin-top:2px">
+                    <span class="num">28,412</span> pictures &middot;
+                    <span class="mono">Project / Person or Set</span>
+                  </div>
+                </div>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+            <div class="ins-field">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Client work</div>
+                  <div class="mono muted" style="margin-top:2px">~/PixlStash/client-work</div>
+                  <div class="muted" style="font-size:var(--text-2xs);margin-top:2px">
+                    <span class="num">4,109</span> pictures &middot;
+                    <span style="color:var(--accent)">flat, no layout chosen</span>
+                  </div>
+                </div>
+                <button class="btn btn--outline" style="height:26px;font-size:var(--text-xs)">Open</button>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+            <div class="ins-field" style="opacity:.65">
+              <div class="rowf" style="gap:var(--space-4)">
+                <span class="mosaic" style="width:38px;height:38px;opacity:.4"><span></span><span></span><span></span><span></span></span>
+                <div style="flex:1;min-width:0">
+                  <div style="font-size:var(--text-sm);font-weight:var(--weight-medium)">Archive 2022</div>
+                  <div class="mono muted" style="margin-top:2px">/mnt/photos-nas/2022</div>
+                  <div style="font-size:var(--text-2xs);margin-top:2px;color:var(--warning)">
+                    drive not mounted
+                  </div>
+                </div>
+                <button class="btn" style="height:26px;font-size:var(--text-xs)">&ctdot;</button>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5);
+               padding-top:var(--space-4);border-top:1px solid var(--divider)">
+            <span class="muted" style="font-size:var(--text-xs);flex:1">
+              The same four things from a terminal
+            </span>
+            <button class="btn" style="height:24px;font-size:var(--text-2xs)">Show commands &#9662;</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ── The row menu, and detach ────────────────────────────────────────── -->
+  <div class="rowf" style="gap:var(--space-6);align-items:flex-start">
+
+    <div>
+      <div class="lbl">The &ctdot; on a row</div>
+      <div class="panel" style="width:230px;padding:var(--space-2)">
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Open this library</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Rename&hellip;</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Choose a layout&hellip;</span></div>
+        <div class="row"><span class="lead">&rsaquo;</span><span class="label">Show in file manager</span></div>
+        <div class="row" style="border-top:1px solid var(--divider);margin-top:var(--space-2);padding-top:var(--space-3)">
+          <span class="lead">&rsaquo;</span><span class="label">Stop using this&hellip;</span>
+        </div>
+      </div>
+      <div class="note" style="margin-top:var(--space-3);max-width:230px">
+        No delete. Nothing in this dialog can remove a picture or a folder.
+      </div>
+    </div>
+
+    <div>
+      <div class="lbl">Stop using it</div>
+      <div class="panel" style="width:440px;padding:var(--space-5)">
+        <h3 class="t" style="font-size:var(--text-md)">Stop using &ldquo;Archive 2022&rdquo;?</h3>
+        <p class="sub" style="margin-top:var(--space-3);font-size:var(--text-sm)">PixlStash forgets
+          it. Every picture and folder inside
+          <span class="mono">/mnt/photos-nas/2022</span> stays exactly where it is.</p>
+        <div class="note" style="margin-top:var(--space-4)">
+          Its tags, scores and people live in that folder too, in
+          <span class="mono">.pixlstash/</span>. Add the folder again later and they come back, and
+          so do any share links pointing at it, which are inert until then.
+        </div>
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5)">
+          <button class="btn btn--outline">Forget it</button>
+          <button class="btn">Cancel</button>
+        </div>
+      </div>
+      <div class="note" style="margin-top:var(--space-3);max-width:440px">
+        The open library has no <b>Stop using this</b> &mdash; switch away first. That refusal is the
+        registry's, not the dialog's.
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Add a library ───────────────────────────────────────────────────── -->
+  <div>
+    <div class="lbl">+ Add a library &mdash; one picker, and the folder answers</div>
+    <div class="panel" style="width:820px;padding:var(--space-5)">
+
+      <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+        <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+          ~/Pictures/Generations
+        </span>
+        <button class="btn btn--outline">Browse&hellip;</button>
+        <button class="btn btn--outline">New folder</button>
+      </div>
+
+      <div class="stack" style="gap:var(--space-3)">
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>28,412 pictures, no library here yet</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                Bring them in and name what your folders mean. Nothing is moved.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Bring them in</button>
+          </div>
+        </div>
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>A library you already made</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                4,109 pictures, last opened in March. Added as it is.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Add it</button>
+          </div>
+        </div>
+
+        <div class="ins-field">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--success)">&check;</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Empty</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                A fresh library on <span class="mono">Project / Person or Set</span>.
+              </div>
+            </div>
+            <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Start it</button>
+          </div>
+        </div>
+
+        <div class="ins-field" style="border-color:var(--warning)">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--warning)">!</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Inside a library you already have</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                <span class="mono">Generations</span> covers this folder. Two libraries indexing the
+                same pictures would each move them by their own layout, and neither would be wrong.
+              </div>
+            </div>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Open that one</button>
+          </div>
+        </div>
+
+        <div class="ins-field" style="border-color:var(--warning)">
+          <div class="rowf" style="gap:var(--space-4)">
+            <span style="color:var(--warning)">!</span>
+            <div style="flex:1">
+              <div style="font-size:var(--text-sm)"><b>Already on the list</b></div>
+              <div class="muted" style="font-size:var(--text-xs);margin-top:2px">
+                Added in March as <b style="color:var(--text)">Client work</b>. Nothing to add.
+              </div>
+            </div>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Switch to it</button>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="note" style="margin-top:var(--space-5)">
+        Five outcomes, one picker, no mode to choose first. Three of them are the same
+        <b>Add</b> with a different consequence, and the other two are the registry refusing for
+        reasons it can already name.
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/design/1.11-existing-library/bodies/Main.html
+++ b/design/1.11-existing-library/bodies/Main.html
@@ -1,0 +1,85 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">1.11.0</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <div class="rowf" style="gap:var(--space-4);align-items:flex-start">
+          <div style="flex:1">
+            <h2 class="t">Here is what is in that folder</h2>
+            <p class="sub">Nothing has been imported, moved, renamed or written yet, and nothing
+              will be until you say so.</p>
+          </div>
+          <span class="chip mono" style="align-self:center">/home/&hellip;/Pictures/Generations</span>
+        </div>
+
+        <div class="grid4" style="margin-top:var(--space-6)">
+          <div class="stat">
+            <div class="v num">28,412</div>
+            <div class="k">pictures, in 341 folders</div>
+          </div>
+          <div class="stat">
+            <div class="v num">24,110</div>
+            <div class="k">carry generation settings</div>
+          </div>
+          <div class="stat">
+            <div class="v num">6,204</div>
+            <div class="k">already have caption files</div>
+          </div>
+          <div class="stat">
+            <div class="v num">1.24 TB</div>
+            <div class="k">on disk</div>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            Working out what your folders mean
+          </div>
+          <p class="sub" style="margin-bottom:var(--space-5)">Reading 20 pictures from each of the
+            149 folders: who is in them, which have caption files beside them, which names repeat.
+            Worth the wait, because it is the difference between one question on the next screen and
+            four.</p>
+
+          <div class="bar" style="grid-template-columns:1fr">
+            <div class="track"><div class="fill" style="right:36%"></div></div>
+          </div>
+          <div class="muted" style="font-size:var(--text-xs);margin-top:var(--space-3)">
+            96 of 149 folders &middot; about <span class="num">1 min 12 s</span> left
+          </div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+            <button class="btn btn--busy">
+              <svg class="spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+              Set up my library
+            </button>
+            <button class="btn btn--outline">Cancel and organise later</button>
+          </div>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">The same card once the bar finishes</div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>118 folders hold one person each</b></span></div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>31 folders are training sets</b></span></div>
+          <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+            <span><b>4 names are labels, not things</b></span></div>
+          <div class="worked"><span class="tick muted">&mdash;</span>
+            <span class="muted">14 it narrowed to two answers and could not settle. One question
+              for you.</span></div>
+
+          <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-5)">
+            <button class="btn btn--commit">Set up my library</button>
+            <button class="btn btn--outline">Cancel and organise later</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/MapTree.html
+++ b/design/1.11-existing-library/bodies/MapTree.html
@@ -1,0 +1,198 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Name what your folders are</span>
+  </div>
+  <div class="app-body">
+
+    <div class="sidebar">
+      <div class="sec">What things are<span class="sp"></span></div>
+      <div class="side-scroll stack" style="gap:var(--space-3)">
+
+        <div class="ent ent--project echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>
+          <span class="name">Project</span><span class="have mono">1</span>
+        </div>
+
+        <div class="ent ent--set echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>
+          <span class="name">Set</span><span class="have mono">2</span>
+        </div>
+
+        <div class="ent ent--character echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>
+          <span class="name">Person</span><span class="have mono">3</span>
+        </div>
+
+        <div class="ent ent--tag echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/><circle cx="7.5" cy="7.5" r="1.3"/></svg></span>
+          <span class="name">Tag</span><span class="have mono">4</span>
+        </div>
+
+        <div class="ent ent--ignore echip">
+          <span class="grip"><i></i><i></i><i></i><i></i><i></i><i></i></span>
+          <span class="mark"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span>
+          <span class="name">Just a folder</span><span class="have mono">0</span>
+        </div>
+
+        <div class="note" style="margin-top:var(--space-4)">
+          Drag onto a level, or press a number on a row.
+        </div>
+      </div>
+    </div>
+
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">Name what your folders are</span>
+        <span class="tb-sub">from 20 pictures per folder &middot; each row says what answered it</span>
+        <span class="tb-right">
+          <button class="btn btn--outline">Drop this, organise later</button>
+        </span>
+      </div>
+      <div class="scroll" style="padding:var(--space-4) var(--space-5)">
+
+        <div class="tdepth" style="border-top:0">
+          <span class="chev">&rsaquo;</span>Level 1 &middot; 1 folder
+          <span class="ent ent--ignore drop drop--set" style="margin-left:auto">the library itself</span>
+        </div>
+        <div class="tree">
+          <div class="tnode" style="padding-left:26px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Generations</span>
+            <span class="tcount">28,412</span>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&#9662;</span>Level 2 &middot; 14 folders
+          <span class="muted" style="text-transform:none;letter-spacing:0">used once each, so not labels</span>
+          <span class="tfilter">filter&hellip;</span>
+          <span style="margin-left:auto;display:flex;gap:var(--space-2);align-items:center">
+            <span class="muted" style="text-transform:none;letter-spacing:0">one of these:</span>
+            <span class="ent ent--project drop drop--armed">Project</span>
+            <span class="ent ent--set drop drop--armed">Set</span>
+          </span>
+        </div>
+        <div class="tree">
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">2024 Shoots</span><span class="tcount">18,204</span>
+          </div>
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">2023 Shoots</span><span class="tcount">7,918</span>
+          </div>
+          <div class="tnode" style="padding-left:40px">
+            <span class="lead muted"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Datasets</span><span class="tcount">6,742</span>
+          </div>
+          <div class="tnode ent ent--ignore" style="padding-left:40px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">_unsorted</span><span class="tcount">1,678</span>
+            <span class="etag">just a folder</span>
+          </div>
+          <div class="tmore">
+            10 more
+            <button class="btn btn--outline" style="height:22px;font-size:var(--text-2xs)">Show all 14</button>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&#9662;</span>Level 3 &middot; 149 folders
+          <span class="tfilter" style="color:var(--text);border-color:var(--accent)">mira <span class="muted">6 of 149</span></span>
+          <span class="muted" style="text-transform:none;letter-spacing:0;margin-left:auto">faces</span>
+          <span class="ent ent--character drop drop--set">
+            <span class="etag"><span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>Person</span>
+          </span>
+        </div>
+        <div class="tree" style="position:relative">
+          <div class="tnode ent ent--character" style="padding-left:54px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Mira</span><span class="tcount">2,914</span>
+            <span class="muted" style="font-size:var(--text-2xs)">one face, 20 of 20</span>
+          </div>
+          <div class="tnode ent ent--character" style="padding-left:54px;border-left:2px solid var(--e);background:var(--hover-wash)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">Jonas</span><span class="tcount">1,088</span>
+            <span class="muted" style="font-size:var(--text-2xs)">one face, 19 of 20</span>
+            <button class="btn btn--outline" style="height:24px;font-size:var(--text-2xs)">This one is&hellip; &#9662;</button>
+          </div>
+          <div class="tnode ent ent--set" style="padding-left:54px;border-left:2px solid var(--e)">
+            <span class="lead" style="color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>
+            <span class="tname">mira-lora-v3</span><span class="tcount">2,140</span>
+            <span class="etag">Set</span>
+            <span class="muted" style="font-size:var(--text-2xs)">caption files &middot; 31 rows</span>
+          </div>
+          <div class="tmore">
+            146 more &middot; 31 Set &middot; 28 unclear
+            <button class="btn btn--outline" style="height:22px;font-size:var(--text-2xs)">Show all 149</button>
+          </div>
+
+          <div class="panel" style="position:absolute;right:var(--space-5);top:44px;width:200px;padding:var(--space-2);z-index:2">
+            <div class="ent ent--project row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span><span class="label">Project</span><span class="count mono">1</span></div>
+            <div class="ent ent--set row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span><span class="label">Set</span><span class="count mono">2</span></div>
+            <div class="ent ent--character row on"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span><span class="label">Person</span><span class="count mono">3</span></div>
+            <div class="ent ent--tag row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span><span class="label">Tag</span><span class="count mono">4</span></div>
+            <div class="ent ent--ignore row"><span class="lead"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--e)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span><span class="label">Just a folder</span><span class="count mono">0</span></div>
+          </div>
+        </div>
+
+        <div class="tdepth">
+          <span class="chev">&rsaquo;</span>Level 4 &middot; 188 folders
+          <span class="muted" style="text-transform:none;letter-spacing:0">4 names under 118 parents</span>
+          <span class="ent ent--tag drop drop--set" style="margin-left:auto">
+            <span class="etag"><span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>Tag</span>
+          </span>
+        </div>
+        <div class="tree">
+          <div class="tnode ent ent--tag" style="padding-left:68px;border-left:2px solid var(--e)">
+            <span class="tname">final &middot; selects &middot; raw &middot; upscaled</span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="inspector">
+      <div class="ins-tabs"><button class="ins-tab on">What this makes</button></div>
+      <div class="ins-body" style="padding-top:var(--space-4)">
+        <div class="stack" style="gap:var(--space-3)">
+
+          <div class="ent ent--project ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">no Projects</span><br><span class="ec">level 2 is yours to call</span></span>
+          </div>
+
+          <div class="ent ent--set ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">31 Sets</span><br><span class="ec">from caption files</span></span>
+          </div>
+
+          <div class="ent ent--character ecard">
+            <span class="portrait" style="width:34px;height:34px"></span>
+            <span style="flex:1"><span class="en">118 People</span><br><span class="ec">4 you already had</span></span>
+          </div>
+
+          <div class="ent ent--tag ecard">
+            <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+            <span style="flex:1"><span class="en">4 Tags</span><br><span class="ec">from level 4</span></span>
+          </div>
+
+        </div>
+
+        <button class="btn btn--commit" style="width:100%;margin-top:var(--space-6);justify-content:center">
+          Review and import
+        </button>
+        <div class="muted" style="font-size:var(--text-2xs);text-align:center;margin-top:var(--space-2)">
+          one more screen before anything is written
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Moves.html
+++ b/design/1.11-existing-library/bodies/Moves.html
@@ -1,0 +1,153 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">After you moved things yourself</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">You moved 312 pictures while PixlStash was closed</span>
+        <span class="tb-sub">nothing has been changed yet</span>
+      </div>
+      <div class="scroll pad">
+
+        <p class="sub" style="margin-top:0">The same rule, the other way round. PixlStash moves a
+          file when its folder stops being true; when <em>you</em> move a file, PixlStash changes an
+          assignment when that assignment stops being true. Nothing else is touched.</p>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--success)">
+          <div class="rowf" style="gap:var(--space-4);margin-bottom:var(--space-5)">
+            <div style="flex:1">
+              <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+                268 said something clear
+              </div>
+              <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+                each had exactly one of the thing it was filed by, so leaving that folder can only
+                mean one thing
+              </div>
+            </div>
+            <button class="btn btn--commit">Apply all 268</button>
+          </div>
+
+          <table class="table">
+            <thead>
+              <tr><th>Moved to</th><th>Which means</th><th class="right">Pictures</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">Client &middot; Nordvik / Mira / 2026-08 /</span></div></td>
+                <td><span class="ent ent--project etag">Project</span>
+                  <span class="muted" style="font-size:var(--text-xs)">2024 Shoots &rarr; Client &middot; Nordvik</span></td>
+                <td class="right num">214</td>
+              </tr>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">2024 Shoots / Jonas / 2026-07 /</span></div></td>
+                <td><span class="ent ent--character etag">Person</span>
+                  <span class="muted" style="font-size:var(--text-xs)">Mira &rarr; Jonas</span></td>
+                <td class="right num">46</td>
+              </tr>
+              <tr>
+                <td><div class="rowf" style="gap:var(--space-3)">
+                  <span class="mosaic" style="width:28px;height:28px"><span></span><span></span><span></span><span></span></span>
+                  <span class="mono muted">2024 Shoots / Ines / 2026-08 /</span></div></td>
+                <td><span class="ent ent--character etag">Person</span>
+                  <span class="muted" style="font-size:var(--text-xs)">Ines is new here</span></td>
+                <td class="right num">8</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--warning)">
+          <div class="rowf" style="gap:var(--space-4);margin-bottom:var(--space-4)">
+            <div style="flex:1">
+              <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+                12 could mean two things
+              </div>
+              <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+                these are in more than one project already, so leaving one project's folder does not
+                say whether you left the project or just refiled the picture
+              </div>
+            </div>
+            <button class="btn btn--outline">Go through them</button>
+          </div>
+          <div class="ins-field">
+            <div class="rowf" style="gap:var(--space-4)">
+              <span class="mosaic" style="width:34px;height:34px"><span></span><span></span><span></span><span></span></span>
+              <div style="flex:1;font-size:var(--text-sm)">
+                <span class="mono muted">&hellip; / Client &middot; Nordvik / Mira / 2026-08 /</span><br>
+                <span class="muted">in <b style="color:var(--text)">2024 Shoots</b> and
+                  <b style="color:var(--text)">Client &middot; Nordvik</b></span>
+              </div>
+              <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Only Nordvik now</button>
+              <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Keep both</button>
+            </div>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            A folder can hold a picture once; a project can share it. PixlStash will not turn one
+            into the other by guessing. Untouched until you say, and 12 of 312 is what this costs.
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            32 went somewhere the layout does not describe
+          </div>
+          <div class="muted" style="font-size:var(--text-sm);margin-top:var(--space-1)">
+            already followed, nothing to decide. Their tags, scores, people and projects are exactly
+            as they were &mdash; only the path changed.
+          </div>
+          <div class="chips" style="margin-top:var(--space-4)">
+            <span class="chip">_unsorted <span class="muted num">24</span></span>
+            <span class="chip">Desktop / to sort <span class="muted num">6</span></span>
+            <span class="chip">Datasets / scratch <span class="muted num">2</span></span>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            A folder outside the layout contradicts nothing, so it changes nothing and PixlStash will
+            never move these back. Putting a picture somewhere of your own is how you overrule all of
+            this, and it keeps working.
+          </div>
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Apply the 268</button>
+          <button class="btn btn--outline">Go through all 312</button>
+          <button class="btn">Leave everything as it was</button>
+        </div>
+
+        <div class="grid2" style="margin-top:var(--space-7);gap:var(--space-5);align-items:start">
+          <div class="card card--quiet" style="border-style:dashed">
+            <div class="lbl">The same thing while PixlStash is open</div>
+            <div class="rowf" style="gap:var(--space-4)">
+              <div style="flex:1;font-size:var(--text-sm)">
+                <b>41 pictures moved in your file manager</b>
+                <span class="muted">&mdash; 39 say something clear</span>
+              </div>
+              <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Review</button>
+              <button class="btn" style="height:28px;font-size:var(--text-xs)">Dismiss</button>
+            </div>
+            <div class="note" style="margin-top:var(--space-4)">
+              A strip in the sidebar, a few seconds after the moves stop. Never a dialog and never one
+              per file: reorganising a folder moves hundreds at once, and four hundred prompts is not
+              a question.
+            </div>
+          </div>
+
+          <div class="card card--quiet" style="border-style:dashed">
+            <div class="lbl">Why this never chases its own tail</div>
+            <p class="sub" style="margin:0">PixlStash records every move it makes itself, so when the
+              watcher sees those files land it recognises its own work and says nothing. Only moves it
+              did not make reach this screen. Without that, its writes come back as your intent and
+              the two flip each other forever.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Preview.html
+++ b/design/1.11-existing-library/bodies/Preview.html
@@ -1,0 +1,156 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Before anything is written</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="toolbar">
+        <span class="tb-title">This is what your folders become</span>
+        <span class="tb-sub">nothing written yet</span>
+        <span class="tb-right"><button class="btn btn--outline">Back to the mapping</button></span>
+      </div>
+      <div class="scroll pad">
+
+        <div class="ent ent--project" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>13 Projects</span>
+            <span class="muted" style="font-size:var(--text-xs)">from <span class="mono">Generations/&lt;name&gt;/</span></span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">2024 Shoots</span><br><span class="ec">18,204</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">2023 Shoots</span><br><span class="ec">7,918</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">Client · Nordvik</span><br><span class="ec">1,204</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              10 more
+            </div>
+          </div>
+        </div>
+
+        <div class="ent ent--set" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>31 Sets</span>
+            <span class="muted" style="font-size:var(--text-xs)">from <span class="mono">Datasets/&lt;name&gt;/</span>, the 31 rows you overrode</span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">mira-lora-v3</span><br><span class="ec">2,140</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">jonas-portrait-v2</span><br><span class="ec">880</span></span></div>
+            <div class="ecard"><span class="mosaic"><span></span><span></span><span></span><span></span></span>
+              <span style="flex:1"><span class="en">nordvik-interiors</span><br><span class="ec">612</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              28 more
+            </div>
+          </div>
+        </div>
+
+        <div class="ent ent--character" style="margin-bottom:var(--space-6)">
+          <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+            <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>118 People</span>
+            <span class="muted" style="font-size:var(--text-xs)">from the third level. Four matched people you already had, by name, and kept their own thumbnails</span>
+          </div>
+          <div class="grid4">
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Mira</span><br><span class="ec">500 · already existed</span></span></div>
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Jonas</span><br><span class="ec">288 · already existed</span></span></div>
+            <div class="ecard"><span class="portrait"></span>
+              <span style="flex:1"><span class="en">Ines</span><br><span class="ec">140 · new</span></span></div>
+            <div class="ecard" style="justify-content:center;color:var(--text-muted);font-size:var(--text-sm)">
+              115 more
+            </div>
+          </div>
+        </div>
+
+        <div class="grid2" style="margin-bottom:var(--space-6)">
+          <div class="ent ent--tag">
+            <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+              <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>4 Tags</span>
+              <span class="muted" style="font-size:var(--text-xs)">from level 4</span>
+            </div>
+            <div class="chips">
+              <span class="chip">final <span class="muted num">9,104</span></span>
+              <span class="chip">selects <span class="muted num">4,880</span></span>
+              <span class="chip">raw <span class="muted num">3,102</span></span>
+              <span class="chip">upscaled <span class="muted num">1,118</span></span>
+            </div>
+          </div>
+          <div class="ent ent--ignore">
+            <div class="rowf" style="gap:var(--space-3);margin-bottom:var(--space-4)">
+              <span class="etag"><span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M6 6l12 12"/></svg></span>3,466 arrive ungrouped</span>
+            </div>
+            <div class="muted" style="font-size:var(--text-sm);line-height:1.5">
+              <span class="num">1,678</span> from <span class="mono">_unsorted</span>, which you
+              marked as just folders, and <span class="num">1,788</span> from 191 folders that matched no
+              shape. They are in the library and searchable; they just join nothing.
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="lbl">What happens when you press the button</div>
+          <div class="grid2" style="gap:var(--space-5)">
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>28,412 pictures are indexed where they already are</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>166 projects, sets and people are created</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span style="color:var(--success)">✓</span>
+                <span>6,204 caption files are read, and left on disk</span></div>
+            </div>
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">no file is copied, moved or renamed</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">no folder is created inside your library</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="muted">—</span>
+                <span class="muted">undo puts the grouping back; the files were never touched</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--accent)">
+          <div class="lbl">One rule from here on, running both ways</div>
+          <div class="grid2" style="gap:var(--space-6)">
+
+            <div>
+              <div style="font-size:var(--text-base);font-weight:var(--weight-semibold)">
+                If you re-organise in PixlStash
+              </div>
+              <p class="sub" style="margin-top:var(--space-2)">A file moves only when its folder
+                stops being true. Adding a second project or a second person moves nothing, because
+                the folder it is in is still correct. Removing the one its folder is named after
+                moves it, because otherwise that folder would be lying. Counted first, one undo.</p>
+            </div>
+
+            <div>
+              <div style="font-size:var(--text-base);font-weight:var(--weight-semibold)">
+                If you move pictures in your file manager
+              </div>
+              <p class="sub" style="margin-top:var(--space-2)">The same rule backwards: PixlStash
+                changes an assignment only when the move makes it untrue. Drag a picture into another
+                project's folder and it belongs to that project now. Drag it somewhere the layout
+                does not describe and nothing changes but the path. New files are imported.</p>
+            </div>
+
+          </div>
+          <div class="note" style="margin-top:var(--space-5)">
+            Which means importing your library moves nothing at all. The folders are where the
+            assignments came from, so every one of them is already true.
+          </div>
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Yes, build this library</button>
+          <button class="btn btn--outline">Back to the mapping</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Storage.html
+++ b/design/1.11-existing-library/bodies/Storage.html
@@ -1,0 +1,173 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Settings &rsaquo; Library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">How your folders are laid out</h2>
+        <p class="sub">Where a new picture is written, and the one rule that decides when an existing
+          one is ever moved again.</p>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div class="rowf" style="gap:var(--space-3);flex-wrap:wrap">
+            <span class="muted" style="font-size:var(--text-sm)">Organise by</span>
+            <span class="ent ent--project etag" style="height:28px;padding:0 var(--space-3);font-size:var(--text-xs)">
+              <span class="mark"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>Project &#9662;
+            </span>
+            <span class="muted">/</span>
+            <span class="rowf" style="gap:var(--space-2);padding:0 var(--space-2);height:28px;
+                 border:1px dashed var(--border);border-radius:var(--radius-sm)">
+              <span class="ent ent--character etag" style="height:22px;padding:0 var(--space-2);font-size:var(--text-2xs)">
+                <span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>Person
+              </span>
+              <span class="muted" style="font-size:var(--text-2xs)">or</span>
+              <span class="ent ent--set etag" style="height:22px;padding:0 var(--space-2);font-size:var(--text-2xs)">
+                <span class="mark"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>Set
+              </span>
+              <span class="muted" style="font-size:var(--text-2xs)">&#9662;</span>
+            </span>
+            <span class="muted">/</span>
+            <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">+ add one</button>
+          </div>
+
+          <div class="grid3" style="margin-top:var(--space-5);gap:var(--space-4)">
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has a project and a person</div>
+              <div class="mono" style="font-size:var(--text-xs)">2024 Shoots / Mira /</div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has a project and a set</div>
+              <div class="mono" style="font-size:var(--text-xs)">2024 Shoots / mira-lora-v3 /</div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">has only a set</div>
+              <div class="mono" style="font-size:var(--text-xs)">mira-lora-v3 /</div>
+            </div>
+          </div>
+
+          <div class="note" style="margin-top:var(--space-4)">
+            A segment can hold more than one thing, and the first that applies wins. A segment with
+            nothing to fill it is skipped rather than left as an empty folder, which is what keeps
+            the tree two deep instead of five. <b>A new, empty library starts on exactly this
+            layout</b>, since it has no folders to read a better guess from.
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5);border-left:3px solid var(--accent)">
+          <div style="font-size:var(--text-md);font-weight:var(--weight-semibold)">
+            A picture only moves when its folder stops being true
+          </div>
+          <p class="sub" style="margin-bottom:var(--space-5)">Not whenever something about it
+            changes. Only when the folder it is sitting in would otherwise be saying something that
+            is no longer the case.</p>
+
+          <table class="table">
+            <thead>
+              <tr><th>You do this</th><th>Is the folder still true?</th><th class="right">Files moved</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Import your library</td>
+                <td class="muted">true the moment it is written &mdash; the folder is where the
+                  assignment came from</td>
+                <td class="right"><span class="chip chip--quiet">none, ever</span></td>
+              </tr>
+              <tr>
+                <td>Add a second project, or a second person</td>
+                <td class="muted">yes. It is still in the first one</td>
+                <td class="right"><span class="chip chip--quiet">none</span></td>
+              </tr>
+              <tr>
+                <td>Rename a project</td>
+                <td class="muted">yes, under a new name</td>
+                <td class="right"><span class="chip chip--quiet">none &mdash; the folder is renamed</span></td>
+              </tr>
+              <tr class="on">
+                <td>Remove the project its folder is named after</td>
+                <td>no</td>
+                <td class="right"><span class="chip" style="border-color:var(--accent);color:var(--accent)">moves</span></td>
+              </tr>
+              <tr class="on">
+                <td>Swap one project for another</td>
+                <td>no</td>
+                <td class="right"><span class="chip" style="border-color:var(--accent);color:var(--accent)">moves</span></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="grid2" style="gap:var(--space-5);margin-top:var(--space-5)">
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">was</div>
+              <div class="mono" style="font-size:var(--text-sm);color:var(--text-muted)">
+                Generations / <span style="color:var(--text)">2024 Shoots</span> / Mira / 2026-08 / 0412.png
+              </div>
+            </div>
+            <div class="ins-field">
+              <div class="lbl" style="margin-bottom:var(--space-2)">after removing that project</div>
+              <div class="mono" style="font-size:var(--text-sm);color:var(--text-muted)">
+                Generations / <span style="color:var(--accent)">Client &middot; Nordvik</span> / Mira / 2026-08 / 0412.png
+              </div>
+            </div>
+          </div>
+
+          <div class="stack" style="gap:var(--space-3);margin-top:var(--space-5)">
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>Counted before it happens, and one undo puts every file back</span></div>
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>Two changes in a row are one move, not two</span></div>
+            <div class="worked"><span class="tick" style="color:var(--success)">&check;</span>
+              <span>A folder left empty is kept, never deleted</span></div>
+          </div>
+        </div>
+
+        <div class="grid2" style="margin-top:var(--space-5);gap:var(--space-5);align-items:start">
+
+          <div class="card">
+            <div class="lbl">A folder that does not match the layout is never wrong</div>
+            <p class="sub" style="margin:0 0 var(--space-4)">Drag something into
+              <span class="mono">_unsorted</span> or a folder of your own and there is nothing for
+              PixlStash to contradict, so it stays there. Permanently. That is the override, and it
+              needs no setting.</p>
+            <div class="note">
+              This is also why the rule is safe to leave on. The worst it can do is move a picture
+              out of a folder that has stopped describing it.
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="lbl">Where it drifts, and what you do about it</div>
+            <p class="sub" style="margin:0 0 var(--space-4)">A picture filed under
+              <span class="mono">2024 Shoots</span> that becomes mostly a Nordvik job stays where it
+              is, because that never stopped being true. The tree is never wrong; it is not always
+              what you would have picked.</p>
+            <div class="ins-field">
+              <div class="rowf" style="gap:var(--space-3)">
+                <span style="flex:1;font-size:var(--text-sm)">In folder
+                  <span class="mono">2024 Shoots / Mira / 2026-08</span></span>
+                <button class="btn btn--outline" style="height:26px;font-size:var(--text-2xs)">Move to match</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="card" style="margin-top:var(--space-5)">
+          <div class="lbl">New pictures with nothing to file them by</div>
+          <p class="sub" style="margin:0 0 var(--space-4)">No project, no person, nothing. They land
+            here, and leave on their own the moment you give them one.</p>
+          <div class="rowf" style="gap:var(--space-3)">
+            <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+              Generations / _Inbox
+            </span>
+            <button class="btn btn--outline">Choose&hellip;</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Views.html
+++ b/design/1.11-existing-library/bodies/Views.html
@@ -1,0 +1,101 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">Settings › Library</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">PixlStash Views</h2>
+        <p class="sub">Your sets, people and projects, as folders you can open in your file
+          manager and point other tools at. They are links, not copies: nothing is duplicated, no
+          original moves, and deleting the whole folder loses nothing.</p>
+
+        <div class="grid2" style="margin-top:var(--space-5);gap:var(--space-5);align-items:start">
+
+          <div class="card">
+            <div class="lbl">What gets published</div>
+            <div class="stack" style="gap:var(--space-3)">
+              <div class="ent ent--character rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">People<span class="muted"> · 4</span></span>
+                <span class="chip">on</span>
+              </div>
+              <div class="ent ent--set rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="13" height="13" rx="2"/><path d="M4 16V5a1 1 0 0 1 1-1h11"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Sets<span class="muted"> · 96</span></span>
+                <span class="chip">on</span>
+              </div>
+              <div class="ent ent--project rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Projects<span class="muted"> · 14</span></span>
+                <span class="chip chip--quiet">off</span>
+              </div>
+              <div class="ent ent--tag rowf" style="gap:var(--space-3)">
+                <span class="mark" style="width:26px;height:26px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 12 22l-9-9V4a1 1 0 0 1 1-1h8z"/></svg></span>
+                <span style="flex:1;font-size:var(--text-sm)">Tags<span class="muted"> · 2,140</span></span>
+                <span class="chip chip--quiet">off</span>
+              </div>
+            </div>
+
+            <div class="lbl" style="margin-top:var(--space-6)">Where</div>
+            <div class="rowf" style="gap:var(--space-3)">
+              <span class="ins-field mono" style="flex:1;padding:var(--space-3) var(--space-4)">
+                Generations / _PixlStash Views
+              </span>
+              <button class="btn btn--outline">Choose…</button>
+            </div>
+
+            <div class="lbl" style="margin-top:var(--space-6)">Keeping up</div>
+            <div class="stack" style="gap:var(--space-3);font-size:var(--text-sm)">
+              <div class="rowf" style="gap:var(--space-3)"><span class="radio" style="border:5px solid var(--accent);background:var(--bg)"></span>
+                <span>Rebuild whenever something changes</span></div>
+              <div class="rowf" style="gap:var(--space-3)"><span class="radio"></span>
+                <span>Only when I ask</span></div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="lbl">What appears on disk</div>
+            <div class="tree mono" style="font-size:var(--text-xs)">
+              <div class="tnode"><span class="tname">_PixlStash Views/</span></div>
+              <div class="ent ent--character tnode" style="padding-left:24px;border-left:2px solid var(--e)">
+                <span class="tname">People/</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Mira/</span></div>
+              <div class="tnode muted" style="padding-left:64px">
+                <span class="lead">↗</span><span class="tname">0412.png → ../../2024 Shoots/Mira · outdoor/selects/0412.png</span></div>
+              <div class="tnode muted" style="padding-left:64px">
+                <span class="lead">↗</span><span class="tname">0413.png → ../../2024 Shoots/Mira · studio/final/0413.png</span></div>
+              <div class="tnode muted" style="padding-left:64px"><span class="tname">… 498 more</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Jonas/</span><span class="tcount">288</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Ines/</span><span class="tcount">140</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Ravn/</span><span class="tcount">96</span></div>
+              <div class="ent ent--set tnode" style="padding-left:24px;border-left:2px solid var(--e)">
+                <span class="tname">Sets/</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">mira-lora-v3/</span><span class="tcount">2,140</span></div>
+              <div class="tnode" style="padding-left:44px"><span class="tname">Mira · outdoor/</span><span class="tcount">188</span></div>
+              <div class="tnode muted" style="padding-left:44px"><span class="tname">… 94 more</span></div>
+            </div>
+
+            <div class="note" style="margin-top:var(--space-5)">
+              One character appears in two shoot folders on disk and in one folder here. That is the
+              thing your filesystem could not do for you, and the reason this folder is worth having.
+            </div>
+
+            <div class="card card--quiet" style="margin-top:var(--space-4);border-style:dashed;padding:var(--space-4)">
+              <div class="lbl" style="margin-bottom:var(--space-2)">On Windows</div>
+              <p class="sub" style="margin:0;font-size:var(--text-xs)">Symbolic links need
+                administrator rights or developer mode. Without either, PixlStash uses hard links
+                instead, which behave the same for files but cannot span two drives — if your library
+                spans drives, the views for the other drive are skipped and named in the report
+                rather than failing silently.</p>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/bodies/Welcome.html
+++ b/design/1.11-existing-library/bodies/Welcome.html
@@ -1,0 +1,119 @@
+<div class="app">
+  <div class="titlebar">
+    <span class="wordmark">PixlStash</span>
+    <span class="spacer"></span>
+    <span class="version">first run</span>
+  </div>
+  <div class="app-body">
+    <div class="main">
+      <div class="scroll pad">
+
+        <h2 class="t">Where should your pictures live?</h2>
+        <p class="sub">A library is a folder on your disk. PixlStash keeps its index inside that
+          folder, so the whole thing is one thing you can copy, back up or move.</p>
+
+        <div class="grid2" style="margin-top:var(--space-6);gap:var(--space-5)">
+
+          <label class="opt opt--on" style="flex-direction:column;gap:var(--space-4);padding:var(--space-6)">
+            <span class="mark ent ent--project" style="width:36px;height:36px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            </span>
+            <span>
+              <h4 style="font-size:var(--text-lg)">I already have a folder of pictures</h4>
+              <p style="margin-top:var(--space-2)">Point PixlStash at it. Every file stays exactly
+                where it is, and the folder names you already use become the organisation.</p>
+            </span>
+            <span class="chip chip--quiet">nothing is moved, copied or renamed</span>
+          </label>
+
+          <label class="opt" style="flex-direction:column;gap:var(--space-4);padding:var(--space-6)">
+            <span class="mark ent ent--set" style="width:36px;height:36px;border-radius:var(--radius-md);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+            </span>
+            <span>
+              <h4 style="font-size:var(--text-lg)">Start a new library</h4>
+              <p style="margin-top:var(--space-2)">An empty folder for PixlStash to fill. Bring
+                pictures in whenever you like, or generate straight into it.</p>
+            </span>
+            <span class="chip chip--quiet">you can add the folder you already have later</span>
+          </label>
+
+        </div>
+
+        <div class="rowf" style="gap:var(--space-3);margin-top:var(--space-6)">
+          <button class="btn btn--commit">Choose a folder&hellip;</button>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">Before this, unchanged: the telemetry question that already ships</div>
+          <p class="sub" style="margin:0 0 var(--space-5)">
+            <span class="mono">TelemetryConsentDialog</span> already asks this once, on first
+            startup, and records that it asked however you leave it. It is not redrawn here and it
+            does not need to be. It is on this artboard only so the order is written down: the
+            question comes first, then the folder.
+          </p>
+
+          <div class="panel" style="padding:var(--space-5);max-width:640px">
+            <h3 class="t" style="font-size:var(--text-md)">What may PixlStash send?</h3>
+            <p class="sub" style="margin-top:var(--space-2);font-size:var(--text-xs)">
+              PixlStash can check pixlstash.dev once a day for a new version. Several past releases
+              fixed critical security bugs, so I&rsquo;d suggest leaving this on. You could also help
+              PixlStash improve by sending a random number alongside it.
+            </p>
+            <div class="grid3" style="margin-top:var(--space-5);gap:var(--space-3)">
+              <div class="opt" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">No check</h4>
+                <p style="font-size:var(--text-xs)">Nothing leaves your machine. You&rsquo;ll need to
+                  watch for security releases yourself.</p>
+              </div>
+              <div class="opt" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">Check for updates</h4>
+                <p style="font-size:var(--text-xs)">Sends your version and platform. Nothing else.</p>
+              </div>
+              <div class="opt opt--on" style="flex-direction:column;gap:var(--space-2);padding:var(--space-4)">
+                <h4 style="font-size:var(--text-sm)">Check + random ID</h4>
+                <p style="font-size:var(--text-xs)">Adds a random number, so I can tell ten people
+                  using PixlStash once from one person using it ten times.</p>
+              </div>
+            </div>
+            <p class="sub" style="margin-top:var(--space-4);font-size:var(--text-xs)">
+              <b style="color:var(--text)">Never sent:</b> your images &middot; your tags, captions
+              or filenames &middot; your prompts
+            </p>
+          </div>
+        </div>
+
+        <div class="card card--quiet" style="margin-top:var(--space-6);border-style:dashed">
+          <div class="lbl">If you asked for an empty library and the folder is not empty</div>
+          <div class="ins-field">
+            <div class="rowf" style="gap:var(--space-4);align-items:flex-start">
+              <span class="mark ent ent--project" style="width:30px;height:30px;border-radius:var(--radius-sm);display:inline-flex;align-items:center;justify-content:center;background:color-mix(in srgb,var(--e) 22%,transparent);color:var(--e);flex-shrink:0">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+              </span>
+              <div style="flex:1">
+                <div style="font-size:var(--text-sm)">You said <b>start a new library</b>, but there
+                  are <span class="num">28,412</span> pictures in
+                  <span class="mono">~/Pictures/Generations</span>.</div>
+                <div class="muted" style="font-size:var(--text-xs);margin-top:var(--space-2)">
+                  Bring them in and PixlStash reads your folder names as the organisation, without
+                  moving anything. Or point it somewhere else.
+                </div>
+              </div>
+              <div class="stack" style="gap:var(--space-2);flex-shrink:0">
+                <button class="btn btn--accent" style="height:28px;font-size:var(--text-xs)">Bring them in</button>
+                <button class="btn btn--outline" style="height:28px;font-size:var(--text-xs)">Pick a different folder</button>
+              </div>
+            </div>
+          </div>
+          <div class="note" style="margin-top:var(--space-4)">
+            There is no third answer, and &ldquo;start empty in here anyway&rdquo; is not one. A
+            library that ignores the 28,412 pictures sitting in its own folder is a trap: the next
+            scan finds them, new pictures get filed in among them, and two ideas of one folder is one
+            too many. Which button was pressed a screen earlier does not get to cause that.
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/design/1.11-existing-library/build.py
+++ b/design/1.11-existing-library/build.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Assemble the .dc.html artboards from bodies/ + the shared design kit.
+
+The kit is inlined into every artboard because a .dc.html cannot link a
+stylesheet: the canvas runtime serves each artboard in its own sandboxed
+iframe with no egress. `_kit.css` is a copy of the design system's
+tokens/colors.css + ui_kits/app/unified.css and follows it, never the
+other way round.
+
+`_extra.css` holds only what this bundle adds on top of the kit: the
+entity vocabulary (icon/colour per Project, Set, Character, Tag) and the
+mapping surfaces, which have no counterpart in the shipped app yet.
+
+    python3 build.py
+"""
+
+import pathlib
+
+HERE = pathlib.Path(__file__).parent
+KIT = (HERE / "_kit.css").read_text()
+EXTRA = (HERE / "_extra.css").read_text()
+
+TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+{kit}
+{extra}
+  </style>
+</helmet>
+{body}
+</x-dc>
+<script data-dc-script data-props='{{}}'>
+class Component extends DCLogic {{ renderVals() {{ return {{}}; }} }}
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    bodies = sorted((HERE / "bodies").glob("*.html"))
+    if not bodies:
+        raise SystemExit("no bodies/*.html to build")
+    for body_path in bodies:
+        out = HERE / f"{body_path.stem}.dc.html"
+        out.write_text(
+            TEMPLATE.format(kit=KIT, extra=EXTRA, body=body_path.read_text().rstrip())
+        )
+        print(f"{out.name}  {out.stat().st_size // 1024} KB")
+
+
+if __name__ == "__main__":
+    main()

--- a/design/1.11-existing-library/canvas.json
+++ b/design/1.11-existing-library/canvas.json
@@ -1,0 +1,182 @@
+{
+  "artboards": [
+    {
+      "file": "Main.dc.html",
+      "title": "2 \u00b7 What we found",
+      "page": "bringing-in",
+      "x": 1260,
+      "y": 0,
+      "w": 1240,
+      "h": 900
+    },
+    {
+      "file": "MapTree.dc.html",
+      "title": "3 \u00b7 Name what your folders are",
+      "page": "bringing-in",
+      "x": 2600,
+      "y": 0,
+      "w": 1440,
+      "h": 860
+    },
+    {
+      "file": "Preview.dc.html",
+      "title": "4 \u00b7 Before anything is written",
+      "page": "bringing-in",
+      "x": 4140,
+      "y": 0,
+      "w": 1300,
+      "h": 1300
+    },
+    {
+      "file": "Storage.dc.html",
+      "title": "How your folders are laid out",
+      "page": "living-in",
+      "x": 0,
+      "y": 0,
+      "w": 1160,
+      "h": 1400
+    },
+    {
+      "file": "Views.dc.html",
+      "title": "PixlStash Views",
+      "page": "living-in",
+      "x": 2600,
+      "y": 0,
+      "w": 1300,
+      "h": 960
+    },
+    {
+      "file": "Insights.dc.html",
+      "title": "About your library",
+      "page": "living-in",
+      "x": 4000,
+      "y": 0,
+      "w": 1240,
+      "h": 1160
+    },
+    {
+      "file": "Libraries.dc.html",
+      "title": "Settings > Libraries: attach and detach",
+      "page": "living-in",
+      "x": 5340,
+      "y": 0,
+      "w": 900,
+      "h": 1780
+    },
+    {
+      "file": "Moves.dc.html",
+      "title": "When you move things yourself",
+      "page": "living-in",
+      "x": 1260,
+      "y": 0,
+      "w": 1240,
+      "h": 1420
+    },
+    {
+      "file": "Welcome.dc.html",
+      "page": "bringing-in",
+      "title": "1 \u00b7 First run",
+      "x": 0,
+      "y": 0,
+      "w": 1160,
+      "h": 1520
+    },
+    {
+      "file": "Empty.dc.html",
+      "page": "bringing-in",
+      "title": "1a \u00b7 A new library, before anything is in it",
+      "x": 0,
+      "y": 1700,
+      "w": 1160,
+      "h": 900
+    }
+  ],
+  "annotations": [
+    {
+      "id": "pass-one",
+      "page": "bringing-in",
+      "x": 640,
+      "y": -300,
+      "w": 600,
+      "text": "Loop pass 1. Static mockups: the drag interaction gets built and operated by keyboard in pass 2.\n\nDIRECTION A IS PICKED. The pattern-formula alternative is dropped and recorded in DECISIONS.md; the deciding argument is that two folders at the same depth can legitimately mean two different things, and only the tree can say so per row.\n\nEvery figure and folder name is PLACEHOLDER, except the membership counts behind the single-valued argument, which were measured on the owner's four real libraries. The protocol's fixture pack replaces the rest before this is state-complete."
+    },
+    {
+      "id": "what-is-derivable",
+      "page": "bringing-in",
+      "x": 1260,
+      "y": -300,
+      "w": 600,
+      "text": "The screen is pre-filled, and NOTHING in it is a guess at a folder name. That was the review's concern and this is the answer to it: no LLM ships with PixlStash, so a name is a string. What can be computed locally is:\n\nCARDINALITY \u2014 four names repeating under 118 of 149 parents is a facet, not a thing. Fills Tag. Costs nothing.\n\nFILES BESIDE THE PICTURES \u2014 a caption .txt next to every image is a training set. Fills Set. Costs nothing.\n\nFACES \u2014 one identity across a folder's pictures is a person. Fills Person. This one costs real time, and SAMPLING is what makes it affordable: 20 pictures per folder, not 28,412. Two minutes rather than an hour, and the full pass later can only add.\n\nNAME MATCHES AN EXISTING ENTITY \u2014 a lookup, not an inference.\n\nWhat none of them can do is call level 2. Cardinality rules out Tag, so those 14 are things rather than labels, and the screen offers exactly the two candidates left. Narrowed, not guessed, and the last step is the user's."
+    },
+    {
+      "id": "vocabulary",
+      "page": "bringing-in",
+      "x": 2600,
+      "y": -300,
+      "w": 560,
+      "text": "One colour and one drawn icon per entity, reused on every artboard: Project teal, Set amber, Person magenta, Tag olive, Just-a-folder grey. All four are existing roles in the kit rather than new colours.\n\nPerson, not Character \u2014 the shipped UI says People and Person; character is the internal model name only.\n\n\"Just a folder\" replaced \"Leave alone\", which read as though the FILES would be untouched. Every option leaves the files untouched. What this one says is that the name is not telling us anything.\n\nThe number on each chip is its keyboard key. Letters collide (Project and Person both want P), so digits until someone finds better."
+    },
+    {
+      "id": "living",
+      "page": "living-in",
+      "x": 0,
+      "y": -270,
+      "w": 640,
+      "text": "THE RULE, settled after the many-to-many problem nearly sank this: a picture moves only when its folder STOPS BEING TRUE. Not whenever something about it changes.\n\nAdd a second project or a second person and nothing moves, because the folder it is in is still correct. Remove the one its folder is named after and it moves, because otherwise the folder lies. Rename a project and the FOLDER is renamed, not 18,000 files moved.\n\nThree things fall out rather than being designed in. Importing a library moves NOTHING, because the assignments came from the folders and are true the moment they are written. Multiplicity stops mattering, because nothing is ever re-derived. And a folder outside the layout contradicts nothing, so it never moves, which makes dragging a picture somewhere of your own a permanent override that needs no setting.\n\nMANAGED LIBRARIES ARE GONE as a concept. A PixlStash folder is just this, starting empty, on a default of Project / Person or Set. Today's flat libraries need no migration: files at a library root match no layout, contradict nothing, and stay put.\n\nThe honest cost: the tree is never wrong but it drifts from what you would have picked. Hence \"Move to match\" as an offered action.\n\nForced to build: renaming an entity renames its folder, and the check is debounced or a remove-then-add becomes two moves via the fallback."
+    },
+    {
+      "id": "external-moves",
+      "page": "living-in",
+      "x": 1260,
+      "y": 850,
+      "w": 620,
+      "text": "THE MIRROR RULE, and the answer to \"maybe it will have to be a popup\": no, and never per file. PixlStash changes an assignment only when your move makes it untrue.\n\nThe one judgement call is when a move is ambiguous. Moving OUT of a project's folder cannot distinguish \"left the project\" from \"refiled the picture\", because a folder holds a picture once and a project can share it. Resolved on the owner's real data: 91-100% of assigned pictures have exactly one project or set, so a move is unambiguous for almost all of them and is applied. The few with several are listed and left alone until asked.\n\nShape is the house rule from the 1.9 sweep: batch, propose, act-then-report. A screen on next start, a sidebar strip a few seconds after the moves stop while running.\n\nHARD REQUIREMENT: PixlStash must record its own moves, or its writes return through the watcher as user intent and the two flip each other forever."
+    },
+    {
+      "id": "consent",
+      "page": "bringing-in",
+      "x": 2880,
+      "y": -270,
+      "w": 600,
+      "text": "The last screen of the import states the rule in both directions, because it is the moment the owner agrees to let PixlStash keep the folders.\n\nThe line that matters most is underneath: importing your library moves nothing at all. For somebody handing over a tree they curated by hand over years, that is the whole pitch, and under this rule it is simply true rather than a promise."
+    },
+    {
+      "id": "first-run",
+      "page": "bringing-in",
+      "x": 0,
+      "y": -300,
+      "w": 620,
+      "text": "TWO OPTIONS AT FIRST RUN, AND THEY ARE FRAMING RATHER THAN MECHANISM. Both lead to the same folder picker; the folder decides what actually happens. Option 2 goes straight into artboards 2-4.\n\nThe rule the bottom of the artboard pins down: ask for an empty library, point at a folder that is not empty, and there are exactly TWO ways forward. Bring them in, or pick a different folder. \"Start empty in here anyway\" is not offered, because a library that ignores the pictures in its own folder is a trap: the next scan finds them, new pictures get filed in among them, and two ideas of one folder is one too many.\n\nThe options exist for comprehension, not to fork the code. A bare folder picker gives a new user no hint that pointing at an existing library is supported at all, and that discoverability failure is the leak this whole release is aimed at.\n\nTELEMETRY IS NOT REDESIGNED HERE. TelemetryConsentDialog already asks on first startup, with three exclusive options, a live payload preview, a never-sent list, and consent recorded however the user leaves. It is reproduced on the artboard only to fix the ORDER: the question first, then the folder.\n\nWhich also corrects an earlier read of the 5 opted-in installs. The prompt is not missing, so the number is explained by something else: installs predating it, headless and Docker installs that never load the SPA, or people choosing one of the first two options. Worth finding out which before anyone touches this dialog, because it is good and the low number is not evidence against it."
+    },
+    {
+      "id": "empty-landing",
+      "page": "bringing-in",
+      "x": 0,
+      "y": 1080,
+      "w": 620,
+      "text": "1a is the other branch's ending, and it is the screen that started all of this. Today it reads \"No pictures in the database. Add pictures by dragging them here.\" on the first run of every install: the word database on the first screen, and one route in, the one that suits a curated library least.\n\nThree routes now, none of them presented as the official one, and the folder route first. It also states where new pictures will be filed, so the layout is never a surprise discovered later in Settings."
+    },
+    {
+      "id": "libraries",
+      "page": "living-in",
+      "x": 5340,
+      "y": -300,
+      "w": 620,
+      "text": "DRAWN AS THE DIALOG IT ACTUALLY LIVES IN. The first pass drew this as a full-width page; it is a section of UserSettingsDialog, 820px wide with a nav rail beside it, which is why the list is compact rows rather than a table.\n\nTHE ONLY REAL GAP IN THE RELEASE, and it is thinner than it looks. The hub registry already has attach(), register_pending() for a folder whose vault does not exist yet, detach() that clears a flag rather than deleting the row so share links survive, overlap detection, and typed errors for every refusal. What is missing is HTTP routes over it: today routes/libraries.py has GET /libraries and POST /libraries/active and nothing else.\n\nFour routes: GET /libraries/inspect?path= (new, and the one that makes \"the folder answers the question\" work), POST /libraries, DELETE /libraries/{id}, and /filesystem/browse which already exists.\n\nThe two refusals at the top are the registry's own errors made visible. The overlap one matters most: two libraries indexing the same pictures would each move them by their own layout, and neither would be wrong."
+    }
+  ],
+  "launch": {
+    "view": "canvas",
+    "page": "bringing-in"
+  },
+  "pages": [
+    {
+      "id": "bringing-in",
+      "name": "Bringing it in"
+    },
+    {
+      "id": "living-in",
+      "name": "Living in it"
+    }
+  ]
+}

--- a/design/1.11-existing-library/update_canvas.py
+++ b/design/1.11-existing-library/update_canvas.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Keep canvas.json in step with the artboards. Re-runnable."""
+
+import json
+import pathlib
+
+p = pathlib.Path(__file__).parent / "canvas.json"
+c = json.loads(p.read_text())
+
+# Page 1 reads left to right as the first run actually goes.
+LAYOUT = {
+    "Welcome.dc.html": ("bringing-in", "1 · First run", 0, 0, 1160, 1520),
+    "Empty.dc.html": ("bringing-in", "1a · A new library, before anything is in it",
+                      0, 1700, 1160, 900),
+    "Main.dc.html": ("bringing-in", "2 · What we found", 1260, 0, 1240, 900),
+    "MapTree.dc.html": ("bringing-in", "3 · Name what your folders are", 2600, 0, 1440, 860),
+    "Preview.dc.html": ("bringing-in", "4 · Before anything is written", 4140, 0, 1300, 1300),
+    "Storage.dc.html": ("living-in", "How your folders are laid out", 0, 0, 1160, 1400),
+    "Moves.dc.html": ("living-in", "When you move things yourself", 1260, 0, 1240, 1420),
+    "Views.dc.html": ("living-in", "PixlStash Views", 2600, 0, 1300, 960),
+    "Insights.dc.html": ("living-in", "About your library", 4000, 0, 1240, 1160),
+    "Libraries.dc.html": ("living-in", "Settings > Libraries: attach and detach",
+                          5340, 0, 900, 1780),
+}
+
+by_file = {a["file"]: a for a in c["artboards"]}
+for name, (page, title, x, y, w, h) in LAYOUT.items():
+    a = by_file.get(name)
+    if a is None:
+        a = {"file": name}
+        c["artboards"].append(a)
+    a.update(page=page, title=title, x=x, y=y, w=w, h=h)
+
+NOTES = {
+    "pass-one": (
+        "Loop pass 1. Static mockups: the drag interaction gets built and operated by keyboard in "
+        "pass 2.\n\n"
+        "DIRECTION A IS PICKED. The pattern-formula alternative is dropped and recorded in "
+        "DECISIONS.md; the deciding argument is that two folders at the same depth can legitimately "
+        "mean two different things, and only the tree can say so per row.\n\n"
+        "Every figure and folder name is PLACEHOLDER, except the membership counts behind the "
+        "single-valued argument, which were measured on the owner's four real libraries. The "
+        "protocol's fixture pack replaces the rest before this is state-complete."
+    ),
+    "first-run": (
+        "TWO OPTIONS AT FIRST RUN, AND THEY ARE FRAMING RATHER THAN MECHANISM. Both lead to the "
+        "same folder picker; the folder decides what actually happens. Option 2 goes straight into "
+        "artboards 2-4.\n\n"
+        "The rule the bottom of the artboard pins down: ask for an empty library, point at a folder "
+        "that is not empty, and there are exactly TWO ways forward. Bring them in, or pick a "
+        "different folder. \"Start empty in here anyway\" is not offered, because a library that "
+        "ignores the pictures in its own folder is a trap: the next scan finds them, new pictures "
+        "get filed in among them, and two ideas of one folder is one too many.\n\n"
+        "The options exist for comprehension, not to fork the code. A bare folder picker gives a "
+        "new user no hint that pointing at an existing library is supported at all, and that "
+        "discoverability failure is the leak this whole release is aimed at.\n\n"
+        "TELEMETRY IS NOT REDESIGNED HERE. TelemetryConsentDialog already asks on first startup, "
+        "with three exclusive options, a live payload preview, a never-sent list, and consent "
+        "recorded however the user leaves. It is reproduced on the artboard only to fix the ORDER: "
+        "the question first, then the folder.\n\n"
+        "Which also corrects an earlier read of the 5 opted-in installs. The prompt is not missing, "
+        "so the number is explained by something else: installs predating it, headless and Docker "
+        "installs that never load the SPA, or people choosing one of the first two options. Worth "
+        "finding out which before anyone touches this dialog, because it is good and the low number "
+        "is not evidence against it."
+    ),
+    "empty-landing": (
+        "1a is the other branch's ending, and it is the screen that started all of this. Today it "
+        "reads \"No pictures in the database. Add pictures by dragging them here.\" on the first "
+        "run of every install: the word database on the first screen, and one route in, the one "
+        "that suits a curated library least.\n\n"
+        "Three routes now, none of them presented as the official one, and the folder route first. "
+        "It also states where new pictures will be filed, so the layout is never a surprise "
+        "discovered later in Settings."
+    ),
+    "living": (
+        "THE RULE, settled after the many-to-many problem nearly sank this: a picture moves only "
+        "when its folder STOPS BEING TRUE. Not whenever something about it changes.\n\n"
+        "Add a second project or a second person and nothing moves, because the folder it is in is "
+        "still correct. Remove the one its folder is named after and it moves, because otherwise "
+        "the folder lies. Rename a project and the FOLDER is renamed, not 18,000 files moved.\n\n"
+        "Three things fall out rather than being designed in. Importing a library moves NOTHING, "
+        "because the assignments came from the folders and are true the moment they are written. "
+        "Multiplicity stops mattering, because nothing is ever re-derived. And a folder outside the "
+        "layout contradicts nothing, so it never moves, which makes dragging a picture somewhere of "
+        "your own a permanent override that needs no setting.\n\n"
+        "MANAGED LIBRARIES ARE GONE as a concept. A PixlStash folder is just this, starting empty, "
+        "on a default of Project / Person or Set. Today's flat libraries need no migration: files "
+        "at a library root match no layout, contradict nothing, and stay put.\n\n"
+        "The honest cost: the tree is never wrong but it drifts from what you would have picked. "
+        "Hence \"Move to match\" as an offered action.\n\n"
+        "Forced to build: renaming an entity renames its folder, and the check is debounced or a "
+        "remove-then-add becomes two moves via the fallback."
+    ),
+    "external-moves": (
+        "THE MIRROR RULE, and the answer to \"maybe it will have to be a popup\": no, and never per "
+        "file. PixlStash changes an assignment only when your move makes it untrue.\n\n"
+        "The one judgement call is when a move is ambiguous. Moving OUT of a project's folder cannot "
+        "distinguish \"left the project\" from \"refiled the picture\", because a folder holds a "
+        "picture once and a project can share it. Resolved on the owner's real data: 91-100% of "
+        "assigned pictures have exactly one project or set, so a move is unambiguous for almost all "
+        "of them and is applied. The few with several are listed and left alone until asked.\n\n"
+        "Shape is the house rule from the 1.9 sweep: batch, propose, act-then-report. A screen on "
+        "next start, a sidebar strip a few seconds after the moves stop while running.\n\n"
+        "HARD REQUIREMENT: PixlStash must record its own moves, or its writes return through the "
+        "watcher as user intent and the two flip each other forever."
+    ),
+    "consent": (
+        "The last screen of the import states the rule in both directions, because it is the moment "
+        "the owner agrees to let PixlStash keep the folders.\n\n"
+        "The line that matters most is underneath: importing your library moves nothing at all. For "
+        "somebody handing over a tree they curated by hand over years, that is the whole pitch, and "
+        "under this rule it is simply true rather than a promise."
+    ),
+}
+
+NOTES["libraries"] = (
+    "DRAWN AS THE DIALOG IT ACTUALLY LIVES IN. The first pass drew this as a full-width page; it "
+    "is a section of UserSettingsDialog, 820px wide with a nav rail beside it, which is why the "
+    "list is compact rows rather than a table.\n\n"
+    "THE ONLY REAL GAP IN THE RELEASE, and it is thinner than it looks. The hub registry already "
+    "has attach(), register_pending() for a folder whose vault does not exist yet, detach() that "
+    "clears a flag rather than deleting the row so share links survive, overlap detection, and "
+    "typed errors for every refusal. What is missing is HTTP routes over it: today "
+    "routes/libraries.py has GET /libraries and POST /libraries/active and nothing else.\n\n"
+    "Four routes: GET /libraries/inspect?path= (new, and the one that makes \"the folder answers "
+    "the question\" work), POST /libraries, DELETE /libraries/{id}, and /filesystem/browse which "
+    "already exists.\n\n"
+    "The two refusals at the top are the registry's own errors made visible. The overlap one "
+    "matters most: two libraries indexing the same pictures would each move them by their own "
+    "layout, and neither would be wrong."
+)
+
+NEW_NOTES = {
+    "libraries": ("living-in", 5340, -300, 620),
+    "first-run": ("bringing-in", 0, -300, 620),
+    "empty-landing": ("bringing-in", 0, 1560, 620),
+    "consent": ("bringing-in", 4140, -300, 600),
+}
+
+by_id = {n["id"]: n for n in c["annotations"]}
+for nid, text in NOTES.items():
+    n = by_id.get(nid)
+    if n is None:
+        page, x, y, w = NEW_NOTES[nid]
+        n = {"id": nid, "page": page, "x": x, "y": y, "w": w}
+        c["annotations"].append(n)
+    n["text"] = text
+
+# The vocabulary note moves out of the way of the widened first page.
+for n in c["annotations"]:
+    if n["id"] == "vocabulary":
+        n.update(x=2600, y=-300, w=560)
+    if n["id"] == "what-is-derivable":
+        n.update(x=1260, y=-300, w=600)
+    if n["id"] == "pass-one":
+        n.update(x=640, y=-300, w=600)
+
+c["launch"] = {"view": "canvas", "page": "bringing-in"}
+p.write_text(json.dumps(c, indent=2) + "\n")
+print(f"canvas.json updated: {len(c['artboards'])} artboards, "
+      f"{len(c['annotations'])} notes")

--- a/docs/plans/v1.11.0-existing-library.md
+++ b/docs/plans/v1.11.0-existing-library.md
@@ -1,0 +1,217 @@
+# v1.11.0 — Your existing library
+
+> **Status:** planned, not started · **Base:** `origin/develop` · **Budget:** ~3 weeks
+> **Design reference:** `design/1.11-existing-library/` (10 artboards, `DECISIONS.md`,
+> canvas URL in `LINK.md`). Pass 1 is complete; pass 2 (fixture pack + keyboard walkthrough)
+> runs in week 1 and gates the mapping screen only.
+> **Scheduling authority** remains `pixlstash-master-release-plan.md` in the business repo.
+> That plan's v1.11 (Workflows) moves to v1.12; see §9.
+
+## 1. Why this release exists
+
+The North Star has been flat for five months — 12.8, 17.1, 13.6, 10.3, 10.3 daily
+version-checks — while reach roughly tripled. Stickiness halved in June→July and
+stayed there. Whatever we are losing, we are losing it *after* people arrive, not
+before.
+
+The hypothesis this release tests: **PixlStash is built for someone whose images are
+a mess, and it has nothing to say to someone who already organised them.** The
+evidence is in the code, not in a survey:
+
+- The first screen of every install reads *"No pictures in the database. Add pictures
+  by dragging them here."* There is no onboarding anywhere in the frontend.
+- Reference folders index in place and work well, but they are a sidebar accessory
+  nobody is pointed at.
+- Nothing maps a folder tree onto projects, sets or people, so an owner who spent
+  years building `2024 Shoots/Mira/final/` is asked to rebuild it by hand in our
+  vocabulary.
+- Every line of website copy addresses the other persona: *"a smarter home for your
+  images"*, *"anyone drowning in images"*, *"bring order to the chaos"*.
+
+The release makes the curated-library owner a first-class case: point PixlStash at
+the folder, it reads the folder names as the organisation, nothing moves, and the
+folders keep working afterwards.
+
+## 2. The rule
+
+Everything below is downstream of one sentence.
+
+> **A picture moves only when its folder stops being true.**
+
+Not whenever something about it changes. `DECISIONS.md` has the case table and the
+argument; the three properties that matter for scheduling are:
+
+1. **Import moves zero files.** Assignments are derived from paths, so the paths are
+   true the moment they are written. This is the release's headline and under this
+   rule it is a fact rather than a promise.
+2. **Nothing is ever re-derived**, so a picture in several projects never needs a
+   winner picked. The many-to-many problem does not arise.
+3. **A path that does not parse against the layout can never be false**, so it never
+   moves. Existing flat libraries need **no migration**, and a hand-placed file is a
+   permanent override.
+
+The mirror, for moves the owner makes in their file manager: **an assignment changes
+only when the move makes it untrue**, applied when the old assignment was
+single-valued and queued for review when it was not.
+
+## 3. What is already on `develop` and stays
+
+Do not revert these. They are additive and cost nothing to carry:
+
+- `0106_add_picture_workflow_hashes` and the hub workflow tables (`6a2637ff`,
+  `eaa824ee`, `84da173f`). The workflow *view* moves to v1.12; the storage stays.
+- The model-shelf picture picker (`Set Thumbnail…`), shipped 2026-08-22.
+- **PR #1092**, `fix/reference-folder-move-tracking`: the reference-folder scan now
+  follows a moved file by `pixel_sha` instead of deleting its row. **This release
+  depends on it.** Land it first, or Phase 3 has nothing to build on.
+
+## 4. Phases
+
+Ordered by dependency. Each is a PR against `develop`.
+
+### Phase 0 — Land the move fix (already written)
+
+PR #1092. Nothing else starts until it is on `develop`.
+
+### Phase 1 — Library lifecycle in the GUI
+
+`routes/libraries.py` today has exactly `GET /libraries` and
+`POST /libraries/active`. Create, attach and detach are CLI-only. The hub registry
+already implements all of it (`registry.attach`, `register_pending`, `detach`, the
+overlap check, and typed errors), so this is routes over a specified service layer.
+
+| Route | Backs onto |
+|---|---|
+| `GET /libraries/inspect?path=` | **new.** Returns which of five things a folder is: a vault, a folder of pictures, empty, inside an attached library, already attached |
+| `POST /libraries` | `attach()` for a vault, `register_pending()` for an empty folder |
+| `DELETE /libraries/{id}` | `detach()` — clears the flag, never deletes the row, so share links survive |
+| `GET /filesystem/browse` | exists |
+
+`inspect` is what lets one picker answer the question instead of asking the owner to
+choose a mode first. Every refusal is an error the registry already raises; surface
+it, do not re-derive it.
+
+Frontend: `LibrariesSection.vue` gains the list rows, the `⋯` menu and the picker.
+It is an 820px dialog with a nav rail — see the artboard, and do not build a table.
+Keep the CLI disclosure, demoted.
+
+**Authz:** new routes need registry declarations and a coverage-matrix row. `DELETE`
+is a destructive verb on a caller-supplied path; it goes through the same
+`validate_reference_folder_path` chokepoint as the rest.
+
+### Phase 2 — The folder-structure read
+
+The two-minute pass behind the mapping screen. Deterministic, local, no LLM.
+
+- **Cardinality.** Few names repeating under many parents is a facet, not a thing →
+  Tag. Costs nothing.
+- **Sidecars.** A caption `.txt` beside every picture → Set. A filesystem fact.
+- **Faces.** One identity across a folder's pictures → Person. **Sampled at 20
+  pictures per folder**, which is what makes it two minutes instead of an hour. The
+  full pass runs later in the background and can only add.
+- **Name matches an existing entity** → a lookup, not an inference.
+- **Nothing else.** A folder name is a string; `Mira` could be a person, a project or
+  a client. Where the signals only narrow the answer (used once each, so not a Tag),
+  offer the remaining candidates and let the owner choose.
+
+Every filled row carries its evidence in the UI. If a signal cannot state its
+reason, it does not fill the row.
+
+### Phase 3 — Import and mapping
+
+The wizard: `Welcome → Main → MapTree → Preview`, plus `Empty` as the other branch's
+landing.
+
+- Level assignment with per-row and per-branch override, levels expandable with a
+  filter, keyboard via digits and a per-row menu.
+- The preview commits nothing until accepted, and **moves no files**.
+- `Cancel and organise later` at every step. The screen stays reachable from the
+  sidebar afterwards, and the Phase 2 working is kept so picking it up later costs
+  nothing twice.
+- Fix the grid empty state (`ImageGrid.vue:6744-6766`). Drop the word "database";
+  three routes out, folder first.
+
+### Phase 4 — The layout, and move-when-false
+
+- A layout is an ordered list of segments; a segment holds one or more facets, first
+  match wins, absent segments are skipped.
+- New-library default: `Project / Person or Set`.
+- Placement on write, and the truth check on assignment change. **Debounced** — a
+  remove-then-add must be one move, not two via the fallback.
+- **Renaming an entity renames its folder**, it does not move its files.
+- Batched, counted before it happens, one undo (rides the op-log).
+- An emptied folder is kept, never deleted.
+- `Move to match` as an offered action where the location has drifted.
+
+### Phase 5 — Reconciling moves made outside PixlStash
+
+- **PixlStash must record its own moves.** Without it, its writes return through the
+  watcher as owner intent and the two flip each other forever. This is a hard
+  requirement, not a nicety.
+- Batched review: a screen on next start, a sidebar strip a few seconds after the
+  moves stop while running. **Never a dialog, never one per file** — reorganising a
+  folder moves hundreds at once and the app is often closed when it happens.
+- Three outcomes: unambiguous (applied), ambiguous because the picture has several of
+  that thing (listed, untouched), off-layout (path followed, assignments untouched).
+
+### Phase 6 — About your library
+
+Read-only findings over the imported library, each naming the tool that answers it
+and opening it with the right pictures selected. Uses the dedup tiers, scoring and
+taggers that already ship. This is the release's screenshot.
+
+### Phase 7 — PixlStash Views *(flex candidate)*
+
+Sets, people and projects as folders of links. **Spike first:** Windows symlinks
+need admin or Developer Mode, hard links cannot span drives, exFAT has neither, and
+cloud-sync clients do not sync links. If the spike fails, cut this and say so in the
+release notes rather than shipping a Views tree that silently does not exist on half
+the installs. Views is *additional* to the real tree, never a replacement.
+
+## 5. Explicitly out
+
+- Any "never move my files" mode. The rule is safe enough not to need one; revisit as
+  a Settings switch if owners ask.
+- Duplicating files to represent multi-membership.
+- Deriving meaning from a folder name by language. No LLM ships with PixlStash.
+- Redesigning `TelemetryConsentDialog`. It already asks on first startup and is good.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| The whole release rests on an inferred diagnosis | Ship the empty-state fix (Phase 3, hours) early and watch reference-folder creation before the expensive phases land |
+| Move-when-false has a bug and moves the wrong files | Counted before, one undo, an emptied folder never deleted, and off-layout files are structurally exempt |
+| Sampled face pass calls a folder one person wrongly | Every row shows its evidence (`one face, 19 of 20`); the owner overrules on the same screen |
+| Views does not work on Windows / exFAT | Spike in week 1; flex candidate |
+| 2 minutes of waiting on first run reads as slow | The bar names what it is buying and Cancel stays live |
+
+## 7. Acceptance
+
+- Importing a real library of ~28k pictures **moves, renames and copies zero files**.
+  Assert it, do not eyeball it.
+- Adding a second project or person to a picture moves nothing.
+- Removing the project a picture's folder is named after moves exactly that picture,
+  and one undo returns it.
+- Renaming a project renames one folder and moves no files.
+- A file moved by hand into another project's folder is reconciled without a dialog,
+  and one moved off-layout keeps every assignment.
+- A file moved by PixlStash never appears in the reconciliation queue.
+- Attach, detach and re-attach a library from the GUI with no CLI; re-attach restores
+  its tags and its share links.
+- Detaching removes no file.
+
+## 8. Test path
+
+Real libraries exist on this machine and are the fixture pack. **Copy one; do not
+test against the original.**
+
+## 9. Feeding back to the master plan
+
+- v1.11 becomes this. Workflows moves to **v1.12**, keeping the hub tables and
+  migration 0106 already merged; its design bundle is done and banked.
+- The recipes block splits to **v1.13** and Datasets to **v1.14**, which the master
+  plan already flagged as a call to make before that window opened.
+- v2.0 slips by roughly this window. Workflows is upstream of recipe ingest, which is
+  upstream of the honest offload round-trip.
+- §8's MAU gate is unchanged. This release is aimed at the denominator.


### PR DESCRIPTION
Adds `docs/plans/v1.11.0-existing-library.md` and the design bundle at `design/1.11-existing-library/` (pass 1 of the loop: ten artboards, `DECISIONS.md`, canvas URL in `LINK.md`).

No code. The plan is the handoff for the implementation sessions; the bundle is what they are pointed at.

**The rule everything is downstream of:** a picture moves only when its folder stops being true. Adding a second project or person moves nothing; removing the one its folder is named after does. Importing an existing library therefore moves zero files, multi-membership never needs a winner picked, and a path that does not match the layout can never be false — so existing flat libraries need no migration and a hand-placed file is a permanent override.

Phase 0 is PR #1092, which this depends on.