### PR TITLE
Answer the empty-library review: one accept for every import input

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -406,7 +406,19 @@ to agree with `isSupportedImportFile`, and it did not: this card shipped as
 supports and left them reachable only through the picker's "All Files". Advisory
 or not, `accept` is what the route *looks like it takes*, so a narrow one hides
 a feature rather than rejecting a file. `media.test.js` asserts the offer
-against the predicate rather than against a copy of the string.
+against the predicate in **both** directions — every named extension is one the
+importer takes, and every type the importer takes is named or covered by a
+wildcard — because a subset check alone stays green when a supported type is
+dropped from the offer, which is the drift that matters.
+
+**A `:accept` bound to a name the `<script setup>` never imported renders no
+`accept` at all**, so the picker silently offers every file on the disk while
+the markup still reads correctly. This shipped in review: two of the three
+inputs were pointed at the shared constant without importing it. Two guards now
+close it — `vue/no-undef-properties` is an **error** in `eslint.config.js`
+(repo-wide, for every undeclared name a template references, not just this one),
+and `TbImportPanel.test.js` asserts the *rendered* attribute rather than the
+binding.
 
 **Three conditions stop it appearing, and two are about not lying:**
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -395,7 +395,18 @@ hands the chosen files up **unfiltered**. `ImageGrid.importChosenFiles` drops
 what PixlStash cannot read, against the same `isSupportedImportFile` and under
 the same `import-unsupported-files` notice key the two drop paths use — an OS
 picker's `accept` is advisory, so a button that skipped it would be the one
-import route that took anything silently.
+import route that took anything silently. It normalises with `Array.from`
+before filtering, so a caller handing it an `<input>`'s `FileList` gets an
+import rather than a `TypeError` raised a long way from the mistake.
+
+**`accept` is one constant, `IMPORT_FILE_ACCEPT` in `utils/media.js`, for all
+three import inputs** (this card, `PhotosImportDialog`, `TbImportPanel`). It has
+to agree with `isSupportedImportFile`, and it did not: this card shipped as
+`image/*,video/*`, which greyed out the zip and caption-file imports the app
+supports and left them reachable only through the picker's "All Files". Advisory
+or not, `accept` is what the route *looks like it takes*, so a narrow one hides
+a feature rather than rejecting a file. `media.test.js` asserts the offer
+against the predicate rather than against a copy of the string.
 
 **Three conditions stop it appearing, and two are about not lying:**
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -39,6 +39,13 @@ export default [
       ],
       "no-useless-assignment": "warn",
       "vue/no-unused-vars": "warn",
+      // A template that names something `<script setup>` never declared renders
+      // NOTHING for it and warns nowhere: `:accept="IMPORT_FILE_ACCEPT"` with
+      // the import missing produced an <input> with no `accept` at all, so the
+      // picker offered every file on the disk and the markup still read
+      // correctly. An error rather than a warning because the failure is
+      // invisible in review and in the running app alike.
+      "vue/no-undef-properties": "error",
       "vue/no-use-v-if-with-v-for": "warn",
       "vue/multi-word-component-names": "off",
     },

--- a/frontend/src/components/io/PhotosImportDialog.vue
+++ b/frontend/src/components/io/PhotosImportDialog.vue
@@ -265,7 +265,7 @@ watch(dialogOpen, (isOpen) => {
                     class="local-import-input"
                     type="file"
                     multiple
-                    accept="image/*,video/*,.zip,application/zip,application/x-zip-compressed,.txt,text/plain"
+                    :accept="IMPORT_FILE_ACCEPT"
                     @change="handleLocalChange"
                   />
                   <v-btn variant="outlined" @click="openLocalPicker">

--- a/frontend/src/components/io/PhotosImportDialog.vue
+++ b/frontend/src/components/io/PhotosImportDialog.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref, watch } from "vue";
 import {
   extractSupportedImportFilesFromDataTransfer,
   isSupportedImportFile,
+  IMPORT_FILE_ACCEPT,
 } from "../../utils/media.js";
 import { listProjects } from "../../api/projects.js";
 import { listImportFolders } from "../../api/folders.js";

--- a/frontend/src/components/panels/TbImportPanel.test.js
+++ b/frontend/src/components/panels/TbImportPanel.test.js
@@ -14,6 +14,7 @@ vi.mock("../../api/projects", () => ({
 
 import { listProjects } from "../../api/projects";
 import TbImportPanel from "./TbImportPanel.vue";
+import { IMPORT_FILE_ACCEPT } from "../../utils/media.js";
 
 function mountPanel() {
   return mount(TbImportPanel, {
@@ -34,6 +35,21 @@ afterEach(() => {
 });
 
 describe("TbImportPanel hardening", () => {
+  it("offers the picker the shared import accept, not an undefined binding", async () => {
+    // A `:accept` bound to a name the <script setup> never imported renders no
+    // `accept` attribute at all — the picker then offers every file on the
+    // disk, and nothing about the markup looks wrong. This asserts the rendered
+    // attribute rather than the binding, because that is the difference.
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    expect(wrapper.get(".tb-import-file-input").attributes("accept")).toBe(
+      IMPORT_FILE_ACCEPT,
+    );
+
+    wrapper.unmount();
+  });
+
   it("labels the project selector and exposes complete tab relationships", async () => {
     const wrapper = mountPanel();
     await flushPromises();

--- a/frontend/src/components/panels/TbImportPanel.vue
+++ b/frontend/src/components/panels/TbImportPanel.vue
@@ -161,6 +161,7 @@ import { API_BASE_URL } from "../../utils/apiClient";
 import {
   extractSupportedImportFilesFromDataTransfer,
   isSupportedImportFile,
+  IMPORT_FILE_ACCEPT,
 } from "../../utils/media.js";
 
 const props = defineProps({

--- a/frontend/src/components/panels/TbImportPanel.vue
+++ b/frontend/src/components/panels/TbImportPanel.vue
@@ -99,7 +99,7 @@
         class="tb-import-file-input"
         type="file"
         multiple
-        accept="image/*,video/*,.zip,application/zip,application/x-zip-compressed,.txt,text/plain"
+        :accept="IMPORT_FILE_ACCEPT"
         @change="onLocalChange"
       />
       <div class="tb-import-actions">

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -6773,6 +6773,16 @@ const canShowAllPicturesButton = computed(() => {
 //     sidebar dialogs; the importer refuses a read-only token outright), and
 //     the count they get is the one the summary route refused them, not a fact
 //     about the library. They keep the plain card.
+const showLibraryEmptyState = computed(
+  () =>
+    showEmptyState.value &&
+    totalAllPicturesCountLoaded.value &&
+    totalAllPicturesCount.value === 0 &&
+    !isReadOnly.value &&
+    !isScrapheapView.value &&
+    !isSetOverlapView.value,
+);
+
 /**
  * Files chosen through the empty library's "Add files…".
  *
@@ -6783,7 +6793,13 @@ const canShowAllPicturesButton = computed(() => {
  * defaults it to the one being looked at.
  */
 function importChosenFiles(chosen) {
-  const files = (chosen ?? []).filter((file) => isSupportedImportFile(file));
+  // `Array.from` rather than a bare `.filter`: the one caller emits a real
+  // Array today, but the natural thing to hand a function named this is the
+  // `FileList` off an `<input>`, which has no `.filter` and would throw here
+  // rather than anywhere near the mistake. It also gives `offered` a length to
+  // compare against below, so nothing reads the argument twice.
+  const offered = Array.from(chosen ?? []);
+  const files = offered.filter((file) => isSupportedImportFile(file));
   if (!files.length) {
     noticeStore.warning(
       "None of those files are a supported image, video or archive.",
@@ -6791,7 +6807,7 @@ function importChosenFiles(chosen) {
     );
     return;
   }
-  if (files.length !== chosen.length) {
+  if (files.length !== offered.length) {
     noticeStore.warning(
       "Some of those files are not a supported image, video or archive, and were skipped.",
       { key: "import-unsupported-files" },
@@ -6799,16 +6815,6 @@ function importChosenFiles(chosen) {
   }
   emit("local-import", { files });
 }
-
-const showLibraryEmptyState = computed(
-  () =>
-    showEmptyState.value &&
-    totalAllPicturesCountLoaded.value &&
-    totalAllPicturesCount.value === 0 &&
-    !isReadOnly.value &&
-    !isScrapheapView.value &&
-    !isSetOverlapView.value,
-);
 
 const emptyStateTitle = computed(() => {
   if (isSetOverlapView.value) {

--- a/frontend/src/components/views/ImageGridLibraryEmptyState.test.js
+++ b/frontend/src/components/views/ImageGridLibraryEmptyState.test.js
@@ -184,6 +184,34 @@ describe("an install with nothing in it", () => {
     expect(wrapper.emitted("local-import")[0][0]).toEqual({ files: [keep] });
   });
 
+  it("takes a FileList as readily as an array", async () => {
+    // The card emits a real Array, but `importChosenFiles` is the obvious place
+    // to hand the `FileList` off an <input>, which has no `.filter`. Taking
+    // both means a future caller gets an import rather than a TypeError thrown
+    // a long way from the mistake.
+    const wrapper = await settleEmpty(mountGrid());
+    const keep = new File(["x"], "one.jpg", { type: "image/jpeg" });
+    // jsdom will not construct a FileList, so this is its array-like shape:
+    // indexed keys, a length and `item()`, but no Array methods.
+    const fileList = {
+      0: keep,
+      length: 1,
+      item: (i) => (i === 0 ? keep : null),
+    };
+
+    await emptyState(wrapper).vm.$emit("add-files", fileList);
+
+    expect(wrapper.emitted("local-import")[0][0]).toEqual({ files: [keep] });
+  });
+
+  it("takes nothing at all without reading a length off it", async () => {
+    const wrapper = await settleEmpty(mountGrid());
+
+    await emptyState(wrapper).vm.$emit("add-files", undefined);
+
+    expect(wrapper.emitted("local-import")).toBeFalsy();
+  });
+
   it("starts no import at all when nothing chosen is readable", async () => {
     const wrapper = await settleEmpty(mountGrid());
     const drop = new File(["y"], "notes.docx", { type: "application/msword" });

--- a/frontend/src/components/views/LibraryEmptyState.test.js
+++ b/frontend/src/components/views/LibraryEmptyState.test.js
@@ -13,6 +13,7 @@ vi.mock("vuetify/components", () => ({
 }));
 
 import LibraryEmptyState from "./LibraryEmptyState.vue";
+import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
 function mountState() {
   return mount(LibraryEmptyState, {
@@ -122,6 +123,16 @@ describe("what the buttons do", () => {
     await input.trigger("change");
 
     expect(wrapper.emitted("add-files")[0][0]).toEqual(files);
+  });
+
+  it("offers the picker everything the importer takes, not just media", async () => {
+    // This shipped as `image/*,video/*`, which is narrower than the app: a zip
+    // and a caption file are both supported imports, and the picker greyed them
+    // out. `accept` is advisory rather than a filter, so the cost of getting it
+    // wrong is not a rejected file — it is a route nobody finds.
+    const input = mountState().find(".library-empty__file-input");
+
+    expect(input.attributes("accept")).toBe(IMPORT_FILE_ACCEPT);
   });
 
   it("clears the input so the same files can be chosen twice", async () => {

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -14,6 +14,7 @@ import { ref } from "vue";
 import { VIcon } from "vuetify/components";
 
 import AppButton from "../widgets/AppButton.vue";
+import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
 const emit = defineEmits(["choose-folder", "add-files", "connect-comfyui"]);
 
@@ -117,7 +118,7 @@ function filesChosen(event) {
         class="library-empty__file-input"
         type="file"
         multiple
-        accept="image/*,video/*"
+        :accept="IMPORT_FILE_ACCEPT"
         tabindex="-1"
         aria-hidden="true"
         @change="filesChosen"

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -100,6 +100,24 @@ const ARCHIVE_EXTENSIONS = ["zip"];
 
 const CAPTION_EXTENSIONS = ["txt"];
 
+/**
+ * The `accept` for every `<input type="file">` that feeds the picture importer.
+ *
+ * One constant rather than a literal per input, because it has to agree with
+ * `isSupportedImportFile` and there is now more than one place to forget: the
+ * empty-library card shipped with `image/*,video/*` alone, which hid zip and
+ * caption imports behind an "All Files" the picker only offers if you look for
+ * it. `accept` remains advisory — the grid still filters what comes back — so
+ * this decides what the picker *offers*, not what the app will take.
+ *
+ * Both spellings of each non-media type are listed because browsers disagree
+ * about which one they match on: Windows reports a zip as
+ * `application/x-zip-compressed`, and a file with no registered handler
+ * reports no type at all, leaving only the extension.
+ */
+export const IMPORT_FILE_ACCEPT =
+  "image/*,video/*,.zip,application/zip,application/x-zip-compressed,.txt,text/plain";
+
 /** What the model shelf catalogues — `pixlstash/routes/model_files.py`. */
 const MODEL_FILE_EXTENSION = ".safetensors";
 

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -96,9 +96,9 @@ export const IMPORT_MEDIA_EXTENSIONS = [
   "mkv",
 ];
 
-const ARCHIVE_EXTENSIONS = ["zip"];
+export const ARCHIVE_EXTENSIONS = ["zip"];
 
-const CAPTION_EXTENSIONS = ["txt"];
+export const CAPTION_EXTENSIONS = ["txt"];
 
 /**
  * The `accept` for every `<input type="file">` that feeds the picture importer.

--- a/frontend/src/utils/media.test.js
+++ b/frontend/src/utils/media.test.js
@@ -7,7 +7,9 @@ import {
   isInternalImageDrag,
   isPictureDrag,
   setInternalDragPayload,
+  isSupportedImportFile,
   FACE_DRAG_MIME,
+  IMPORT_FILE_ACCEPT,
   PICTURE_DRAG_MIME,
 } from './media.js'
 
@@ -196,5 +198,33 @@ describe('displayedAspectRatio', () => {
   it('falls back to square rather than dividing by zero', () => {
     expect(displayedAspectRatio(null)).toBe(1)
     expect(displayedAspectRatio({ width: 0, height: 0 })).toBe(1)
+  })
+})
+
+describe('IMPORT_FILE_ACCEPT', () => {
+  // The empty-library card shipped with `image/*,video/*` and nothing else, so
+  // a zip or a caption file could only be reached through the picker's "All
+  // Files" — an import route the app supports and its own dialog hid. These
+  // assert the offer against the predicate rather than against a copy of the
+  // string, so the two cannot drift apart silently again.
+
+  it('offers every file extension the importer will actually take', () => {
+    const offered = IMPORT_FILE_ACCEPT.split(',')
+      .filter((entry) => entry.startsWith('.'))
+      .map((entry) => entry.slice(1))
+
+    expect(offered.length).toBeGreaterThan(0)
+    for (const ext of offered) {
+      expect(isSupportedImportFile({ name: `sample.${ext}` })).toBe(true)
+    }
+  })
+
+  it('names the two types the media wildcards cannot cover', () => {
+    // `image/*` and `video/*` carry the media list between them; an archive and
+    // a caption file match neither wildcard and have to be named outright.
+    expect(isSupportedImportFile({ name: 'shoot.zip' })).toBe(true)
+    expect(isSupportedImportFile({ name: 'shoot.txt' })).toBe(true)
+    expect(IMPORT_FILE_ACCEPT).toContain('.zip')
+    expect(IMPORT_FILE_ACCEPT).toContain('.txt')
   })
 })

--- a/frontend/src/utils/media.test.js
+++ b/frontend/src/utils/media.test.js
@@ -8,6 +8,8 @@ import {
   isPictureDrag,
   setInternalDragPayload,
   isSupportedImportFile,
+  ARCHIVE_EXTENSIONS,
+  CAPTION_EXTENSIONS,
   FACE_DRAG_MIME,
   IMPORT_FILE_ACCEPT,
   PICTURE_DRAG_MIME,
@@ -219,12 +221,21 @@ describe('IMPORT_FILE_ACCEPT', () => {
     }
   })
 
-  it('names the two types the media wildcards cannot cover', () => {
-    // `image/*` and `video/*` carry the media list between them; an archive and
-    // a caption file match neither wildcard and have to be named outright.
-    expect(isSupportedImportFile({ name: 'shoot.zip' })).toBe(true)
-    expect(isSupportedImportFile({ name: 'shoot.txt' })).toBe(true)
-    expect(IMPORT_FILE_ACCEPT).toContain('.zip')
-    expect(IMPORT_FILE_ACCEPT).toContain('.txt')
+  it('advertises every type the importer takes, the other direction', () => {
+    // The check above is a subset check: it would stay green if a supported
+    // type were dropped from the offer, which is the drift that actually
+    // matters. So walk the predicate's own lists instead.
+    //
+    // Media is carried by the two wildcards rather than named extension by
+    // extension, so those are asserted outright — removing either would hide
+    // every picture and every video while leaving the subset check green.
+    expect(IMPORT_FILE_ACCEPT).toContain('image/*')
+    expect(IMPORT_FILE_ACCEPT).toContain('video/*')
+
+    // Everything else matches neither wildcard and has to be named.
+    for (const ext of [...ARCHIVE_EXTENSIONS, ...CAPTION_EXTENSIONS]) {
+      expect(isSupportedImportFile({ name: `shoot.${ext}` })).toBe(true)
+      expect(IMPORT_FILE_ACCEPT).toContain(`.${ext}`)
+    }
   })
 })


### PR DESCRIPTION
## What this changes

Answers the two review comments on #1098, plus one comment-placement slip the
review did not catch.

**Every `<input type="file">` that feeds the importer now offers the same
thing.** The empty-library card shipped with `accept="image/*,video/*"`, which
is narrower than the app: a zip and a caption file are both supported imports,
and the picker greyed them out. `accept` is advisory rather than a filter, so
the cost of getting it wrong is not a rejected file — it is a route nobody
finds. The string was already duplicated verbatim in `PhotosImportDialog` and
`TbImportPanel`, so it is now one exported constant, `IMPORT_FILE_ACCEPT` in
`utils/media.js`, and all three point at it.

**`ImageGrid.importChosenFiles` takes any file collection.** It normalises with
`Array.from` before filtering, so the `FileList` off an `<input>` — the obvious
thing to hand a function with that name — imports instead of throwing, and the
argument is read once rather than twice.

**The empty-state guard comment sits on the computed again.** #1098 inserted
`importChosenFiles` between the ten-line comment explaining
`showLibraryEmptyState`'s two extra guards and the computed itself, leaving the
comment stranded above an unrelated function. The function moved below the
computed; no logic changed.

**`vue/no-undef-properties` is now an error.** See the correction below for why.

## Why

Two review comments on #1098, one of which needed a correction:

- **`accept` is inconsistent with `isSupportedImportFile`** — correct, and fixed
  as above.
- **"`importChosenFiles` guards `chosen` when filtering, but later reads
  `chosen.length`; a `null`/`undefined` call will throw"** — the throw described
  cannot happen: `(chosen ?? [])` makes `files` empty, and the `if
  (!files.length)` branch returns before `chosen.length` is reached. The
  *non-array* half of that comment was real, though — a `FileList` has no
  `.filter` and would have thrown one line earlier, at the filter rather than
  anywhere near the caller. `Array.from` fixes the real defect and removes the
  second read the comment objected to.

## Correction: this PR shipped a regression in review, now fixed

The first version of this branch pointed `PhotosImportDialog` and
`TbImportPanel` at `IMPORT_FILE_ACCEPT` **without importing it**, which an
earlier draft of this description wrongly called "unchanged in behaviour; only
the literal moved". A `:accept` bound to an undeclared name renders **no
`accept` attribute at all**, so both pickers were offering every file on the
disk — the opposite of this PR's point, and invisible in review because the
markup still reads correctly.

Caught by Copilot, fixed in `06f3dd9`, and closed twice over:

- `vue/no-undef-properties` is an **error** in `eslint.config.js`. It flags the
  exact line with the import missing, and the repo is otherwise clean under it,
  so it covers every template that names something `<script setup>` never
  declared.
- `TbImportPanel.test.js` asserts the *rendered* `accept` attribute rather than
  the binding.

The two suppressed comments about `media.test.js` testing only one direction
were also right, and are fixed in `a66d4ec` — see the PR comment for detail.

## How it was verified

- `npx vitest run` — the full frontend suite, **200 files / 3690 tests, green**.
- `npx eslint .` — no errors, with the new rule active (one pre-existing
  unused-var warning in `AppDialog.test.js`, untouched here).
- Every new assertion re-run against the unfixed code to prove it goes red, then
  each mutation reverted:
  - Removing the import again reds the `TbImportPanel` attribute test with
    `expected undefined`, and reds the lint rule.
  - Narrowing the constant reds the two `media.test.js` guards; removing
    `image/*`, `video/*` or `.zip` each reds the reverse-direction guard.
  - Hardcoding the card's old `accept` reds the `LibraryEmptyState` assertion.
  - Removing `Array.from` reds the `FileList` case in
    `ImageGridLibraryEmptyState.test.js`, which drives the real grid with a
    `FileList`-shaped argument (jsdom will not construct a real one).

Based on #1098's branch so it carried that work; now that #1098 has merged, its
commits have dropped out of this diff by themselves.

## Contributor licence agreement

Not applicable: this change is frontend and docs only, nothing under
`pixlstash/**`.

- [ ] I have read and agree to the CLA in `pixlstash/CLA.md`.