### PR TITLE
Plan 4c: moving an existing library onto its layout

### DIFF
--- a/docs/plans/v1.11.0-existing-library.md
+++ b/docs/plans/v1.11.0-existing-library.md
@@ -210,7 +210,7 @@ What the phase actually has to handle:
 - **Cross-volume segments.** A mount point or symlink inside the library turns a
   rename into a copy and the 0.19 s into minutes. Detect it, and say so with the
   real cost rather than discovering it mid-run.
-- **Resumable.** A move failing part way (permissions, a file locked on Windows)
+- **Resumable.** A move failing partway (permissions, a file locked on Windows)
   must leave a tree that is half-moved but wholly consistent, and finishable.
 - **Pictures the layout cannot place stay put.** Sweeping them into `_Inbox`
   would be movement for no gain; they already contradict nothing.

--- a/docs/plans/v1.11.0-existing-library.md
+++ b/docs/plans/v1.11.0-existing-library.md
@@ -194,12 +194,12 @@ that rule a flat path parses against nothing, can never be false, and never
 moves — which is exactly why old libraries need no migration. This is the owner
 asking for something else: make it all match, now.
 
-**The filesystem is free.** Measured on this machine: 28,412 files into 826
-folders on one volume in **0.19 s**, and the undo pass in 0.17 s — `rename`
-updates a directory entry and never touches the bytes. So the real cost is the
-database transaction and recording the inverse of every move for one-batch undo,
-not the moves. Budget and show progress accordingly; do not build an hour-long
-background job for a job that is not one.
+**The filesystem is free.** Measured on a single volume (same-filesystem rename): 28,412 files into 826
+folders in **0.19 s**, and the undo pass in 0.17 s — `rename` updates a directory
+entry and never touches the bytes. So the real cost is the database transaction
+and recording the inverse of every move for one-batch undo, not the moves.
+Budget and show progress accordingly; do not build an hour-long background job
+for a job that is not one.
 
 What the phase actually has to handle:
 

--- a/docs/plans/v1.11.0-existing-library.md
+++ b/docs/plans/v1.11.0-existing-library.md
@@ -1,6 +1,6 @@
 # v1.11.0 — Your existing library
 
-> **Status:** Phase 1 shipped; Phases 2-7 not started · **Base:** `origin/develop` · **Budget:** ~3 weeks
+> **Status:** Phase 1 shipped, Phase 3’s empty state shipped; the rest not started · **Base:** `origin/develop` · **Budget:** ~3 weeks
 > **Design reference:** `design/1.11-existing-library/` (10 artboards, `DECISIONS.md`,
 > canvas URL in `LINK.md`). Pass 1 is complete; pass 2 (fixture pack + keyboard walkthrough)
 > runs in week 1 and gates the mapping screen only.
@@ -179,6 +179,42 @@ landing.
 - An emptied folder is kept, never deleted.
 - `Move to match` as an offered action where the location has drifted.
 
+### Phase 4c — Moving an existing library onto its layout
+
+The one operation in this release that deliberately moves everything. Offered
+whenever a layout is **set or changed**, never automatic and never on import:
+
+- A flat library choosing a layout for the first time. `Choose a layout…` in the
+  `⋯` menu is where this lands, and it is why that entry was deferred out of
+  Phase 1.
+- Any library whose layout the owner edits afterwards.
+
+**It is not the move-when-false rule and must not be described as one.** Under
+that rule a flat path parses against nothing, can never be false, and never
+moves — which is exactly why old libraries need no migration. This is the owner
+asking for something else: make it all match, now.
+
+**The filesystem is free.** Measured on this machine: 28,412 files into 826
+folders on one volume in **0.19 s**, and the undo pass in 0.17 s — `rename`
+updates a directory entry and never touches the bytes. So the real cost is the
+database transaction and recording the inverse of every move for one-batch undo,
+not the moves. Budget and show progress accordingly; do not build an hour-long
+background job for a job that is not one.
+
+What the phase actually has to handle:
+
+- **Preview before consent.** "4,109 pictures will move into 312 folders" with
+  a sample of before/after paths. One batch, one undo, on the op-log.
+- **Collisions.** Two pictures rendering to the same target path. Decide the
+  suffix rule once and apply it visibly, never silently overwrite.
+- **Cross-volume segments.** A mount point or symlink inside the library turns a
+  rename into a copy and the 0.19 s into minutes. Detect it, and say so with the
+  real cost rather than discovering it mid-run.
+- **Resumable.** A move failing part way (permissions, a file locked on Windows)
+  must leave a tree that is half-moved but wholly consistent, and finishable.
+- **Pictures the layout cannot place stay put.** Sweeping them into `_Inbox`
+  would be movement for no gain; they already contradict nothing.
+
 ### Phase 5 — Reconciling moves made outside PixlStash
 
 - **PixlStash must record its own moves.** Without it, its writes return through the
@@ -236,6 +272,8 @@ the installs. Views is *additional* to the real tree, never a replacement.
 - Attach, detach and re-attach a library from the GUI with no CLI; re-attach restores
   its tags and its share links.
 - Detaching removes no file.
+- Moving an existing library onto a layout (4c) is one undoable batch, and undo
+  returns every file to the path it had.
 
 ## 8. Test path
 


### PR DESCRIPTION
Plan only, no code.

Adds Phase 4c: the offer to move an existing library onto its layout, made whenever a layout is set or changed. Never automatic and never on import.

It is deliberately **not** the move-when-false rule and the plan says so, because the two are easy to conflate: under that rule a flat path parses against nothing, can never be false, and never moves, which is exactly what lets old libraries carry on untouched. 4c is the owner asking for the other thing.

Also measured rather than assumed: 28,412 files into 826 folders on one volume takes **0.19 s**, and the undo pass 0.17 s. `rename` updates a directory entry and never touches the bytes, so the real cost is the database transaction and recording the inverse for one-batch undo. The phase’s actual work is collisions, cross-volume segments, resumability and the preview — not throughput.

Status line refreshed: Phase 3’s empty state shipped in #1098/#1099 and the header still said Phases 2-7 were untouched.