### PR TITLE
Tell the frontend its install type in the document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
           tests/test_image_embedding_worker.py
           tests/test_import_scrapheap_match.py
           tests/test_impossible_clear_authz.py
+          tests/test_index_install_type.py
           tests/test_inline_rotate.py
           tests/test_insightface_relocation.py
           tests/test_install_type_buckets.py

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,15 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>PixlStash</title>
+    <!--
+      Substituted by the server with the install type it detected, so the
+      frontend knows the channel synchronously at page load. The version check
+      fires from a child component's onMounted, before GET /version can answer,
+      and stamps its 24h throttle before the request -- so a value that arrives
+      later is not reported that day. Left as the literal placeholder by the
+      Vite dev server, which `defaultInstallType` treats as absent.
+    -->
+    <meta name="pixlstash-install-type" content="__PIXLSTASH_INSTALL_TYPE__" />
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,6 +14,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useReviewRoute } from "./composables/useReviewRoute";
 import { isReadOnly, sessionContext } from "./utils/apiClient";
 import { getInstallId } from "./api/telemetry";
+import { defaultInstallType } from "./utils/telemetryPayload";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useGridStore } from "./stores/useGridStore";
@@ -65,14 +66,14 @@ import { toPx } from "./utils/floatingBottom.js";
 
 // These surfaces are mutually exclusive with the primary grid (or explicitly
 // opened on demand), so keep their heavier feature code out of app startup.
-const DuplicateQueue = defineAsyncComponent(() =>
-  import("./components/views/DuplicateQueue.vue"),
+const DuplicateQueue = defineAsyncComponent(
+  () => import("./components/views/DuplicateQueue.vue"),
 );
-const ModelShelf = defineAsyncComponent(() =>
-  import("./components/views/ModelShelf.vue"),
+const ModelShelf = defineAsyncComponent(
+  () => import("./components/views/ModelShelf.vue"),
 );
-const ReviewSessionsOverlay = defineAsyncComponent(() =>
-  import("./components/views/ReviewSessionsOverlay.vue"),
+const ReviewSessionsOverlay = defineAsyncComponent(
+  () => import("./components/views/ReviewSessionsOverlay.vue"),
 );
 
 // --- Stores ---
@@ -132,7 +133,11 @@ const telemetryConsentOpen = ref(false);
 const telemetryConsentIsUpgrade = ref(false);
 const telemetryInstallIsNew = ref(false);
 const photosDialogOpen = ref(false);
-const installType = ref("pip");
+// Seeded from the marker the server substituted into the document, not from
+// "pip" -- see `defaultInstallType` for why the value held here before
+// `/version` answers is the one that actually gets reported. The fetch below
+// still refreshes it for everything else that reads this ref.
+const installType = ref(defaultInstallType());
 const appVersion = ref("");
 const dockerVariant = ref("gpu");
 const loading = ref(null);

--- a/frontend/src/utils/telemetryPayload.js
+++ b/frontend/src/utils/telemetryPayload.js
@@ -22,7 +22,7 @@ const TELEMETRY_HOST = "https://t.pixlstash.dev";
  * not told the truth.
  *
  * @param {string} version Running app version, e.g. "1.9.0".
- * @param {string} installType One of docker, pip, electron, other.
+ * @param {string} installType One of docker, pip, electron, other, dev.
  * @returns {{method: string, url: string}}
  */
 /** Token left in `index.html` when nothing substituted it (Vite dev server). */

--- a/frontend/src/utils/telemetryPayload.js
+++ b/frontend/src/utils/telemetryPayload.js
@@ -25,6 +25,49 @@ const TELEMETRY_HOST = "https://t.pixlstash.dev";
  * @param {string} installType One of docker, pip, electron, other.
  * @returns {{method: string, url: string}}
  */
+/** Token left in `index.html` when nothing substituted it (Vite dev server). */
+const INSTALL_TYPE_PLACEHOLDER = "__PIXLSTASH_INSTALL_TYPE__";
+
+/**
+ * The install type to assume before `GET /version` has answered.
+ *
+ * This is not cosmetic. The version check fires from `TitleBar`'s `onMounted`,
+ * and Vue mounts children before parents, so it runs before `App.vue`'s own
+ * `onMounted` has started the `/version` fetch. `checkForUpdatesNow` also
+ * stamps its 24h throttle before the request, so whatever is assumed here is
+ * what gets reported, and a wrong guess is not corrected until the next
+ * interval tick -- i.e. only if the app stays running. Assuming "pip"
+ * unconditionally filed every restarted desktop and Docker install under
+ * `pip`.
+ *
+ * The server substitutes `Server.detect_install_type()` into the
+ * `pixlstash-install-type` meta tag when it hands out the document, which
+ * covers every channel at once: docker, the `other` the Windows installer
+ * declares, the `dev` a development machine declares, and electron -- the
+ * desktop shell only ever reaches this SPA through `loadURL` against its own
+ * backend, and that backend is started with `PIXLSTASH_INSTALL_TYPE=electron`.
+ * (The `index.html` bundled in the shell is the splash screen, which never
+ * mounts this app.) So there is no second detection path here on purpose.
+ *
+ * Passed through unvalidated: the backend already constrains it to
+ * `Server.INSTALL_TYPES`, and re-listing the buckets here would add a sixth
+ * copy of a list that `tests/test_install_type_buckets.py` exists to keep in
+ * sync. Only the un-substituted placeholder is rejected, which is the Vite dev
+ * server, where "pip" is the historical answer and a real dev machine is
+ * declared through `PIXLSTASH_TELEMETRY_DEV` anyway.
+ *
+ * @returns {string} The install type to report on the first version check.
+ */
+export function defaultInstallType() {
+  const injected =
+    typeof document !== "undefined"
+      ? document
+          .querySelector('meta[name="pixlstash-install-type"]')
+          ?.getAttribute("content")
+      : null;
+  return injected && injected !== INSTALL_TYPE_PLACEHOLDER ? injected : "pip";
+}
+
 export function buildVersionCheckRequest(version, installType) {
   return {
     method: "GET",
@@ -117,11 +160,13 @@ export function buildPayloadLegend(variant, context) {
     legend.push(
       {
         term: "install_id",
-        meaning: "random and replaceable; not derived from you or your computer",
+        meaning:
+          "random and replaceable; not derived from you or your computer",
       },
       {
         term: "is_new_install",
-        meaning: "whether telemetry began on a fresh install or was enabled later",
+        meaning:
+          "whether telemetry began on a fresh install or was enabled later",
       },
       { term: "install_type", meaning: "the same install method shown above" },
     );

--- a/frontend/src/utils/telemetryPayload.test.js
+++ b/frontend/src/utils/telemetryPayload.test.js
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   buildInstallPingRequest,
   buildPayloadForChoice,
   buildPayloadLegend,
   buildVersionCheckRequest,
+  defaultInstallType,
 } from "./telemetryPayload";
 
 const CONTEXT = {
@@ -120,5 +121,40 @@ describe("buildPayloadLegend", () => {
       installType: "docker",
     });
     expect(legend.map((entry) => entry.term)).toEqual(["2.0.1", "docker"]);
+  });
+});
+
+describe("defaultInstallType", () => {
+  const META = 'meta[name="pixlstash-install-type"]';
+  const setMeta = (content) => {
+    document.querySelector(META)?.remove();
+    const el = document.createElement("meta");
+    el.setAttribute("name", "pixlstash-install-type");
+    el.setAttribute("content", content);
+    document.head.appendChild(el);
+  };
+
+  afterEach(() => document.querySelector(META)?.remove());
+
+  // Regression guard. This value is what the version check reports, because it
+  // fires from TitleBar's onMounted before App.vue's GET /version resolves and
+  // stamps its 24h throttle before the request. Assuming "pip" emptied the
+  // `electron` bucket when 1.10.1 shipped and every desktop user restarted, and
+  // had been undercounting docker the same way all along.
+  it.each(["docker", "electron", "other", "dev"])(
+    "reports the %s the server substituted in",
+    (installType) => {
+      setMeta(installType);
+      expect(defaultInstallType()).toBe(installType);
+    },
+  );
+
+  it("ignores the placeholder the dev server leaves behind", () => {
+    setMeta("__PIXLSTASH_INSTALL_TYPE__");
+    expect(defaultInstallType()).toBe("pip");
+  });
+
+  it("falls back to pip when the document carries no marker at all", () => {
+    expect(defaultInstallType()).toBe("pip");
   });
 });

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -316,6 +316,16 @@ class Server(
     # tests/test_install_type_buckets.py, which fails if they drift.
     INSTALL_TYPES = ("docker", "pip", "electron", "other", "dev")
 
+    #: Token in ``frontend/index.html`` replaced with the detected install type
+    #: when the server hands the SPA out. The frontend cannot wait for
+    #: ``GET /version``: the version check runs from a child component's
+    #: ``onMounted`` and stamps its 24h throttle before the request, so whatever
+    #: it knows at that instant is what gets reported for the day. Passing the
+    #: value in the document removes the race for every channel at once, and
+    #: keeps the backend the single source of truth -- no bucket list is
+    #: duplicated frontend-side (see tests/test_install_type_buckets.py).
+    INSTALL_TYPE_PLACEHOLDER = "__PIXLSTASH_INSTALL_TYPE__"
+
     #: Marks the host as a development machine, whatever channel it runs.
     #:
     #: Needed because ``PIXLSTASH_INSTALL_TYPE`` is not only a telemetry label:
@@ -1326,6 +1336,34 @@ class Server(
             return None
         return index_path
 
+    def _index_html_response(self):
+        """Return the SPA document with the install type substituted in.
+
+        ``None`` when there is no built frontend, so callers fall back the same
+        way they did when this served the file straight off disk.
+
+        Cached on ``(path, install_type)`` rather than re-read per request: the
+        SPA entry point is hit on every cold navigation, and the substitution is
+        the same string every time until one of those two changes.
+        """
+        index_path = self._get_frontend_index_path()
+        if not index_path:
+            return None
+
+        install_type = Server.detect_install_type()
+        key = (index_path, install_type)
+        if (
+            getattr(self, "_index_html_cache", None) is None
+            or self._index_html_cache[0] != key
+        ):
+            with open(index_path, encoding="utf-8") as handle:
+                html = handle.read()
+            self._index_html_cache = (
+                key,
+                html.replace(Server.INSTALL_TYPE_PLACEHOLDER, install_type),
+            )
+        return HTMLResponse(content=self._index_html_cache[1])
+
     def _setup_routes(self):
         ###############################
         # Rate limiting              ##
@@ -1375,9 +1413,9 @@ class Server(
 
         @self.api.get("/", include_in_schema=False)
         async def read_root():
-            index_path = self._get_frontend_index_path()
-            if index_path:
-                return FileResponse(index_path)
+            index_response = self._index_html_response()
+            if index_response:
+                return index_response
             version = self._get_version()
             return {"message": "PixlStash REST API", "version": version}
 
@@ -1725,7 +1763,7 @@ class Server(
             if candidate.startswith(dist_dir) and os.path.isfile(candidate):
                 return FileResponse(candidate)
 
-            index_path = self._get_frontend_index_path()
-            if not index_path:
+            index_response = self._index_html_response()
+            if not index_response:
                 raise HTTPException(status_code=404, detail="Not Found")
-            return FileResponse(index_path)
+            return index_response

--- a/tests/test_index_install_type.py
+++ b/tests/test_index_install_type.py
@@ -1,0 +1,63 @@
+"""The SPA document must carry the install type the backend detected.
+
+The frontend cannot ask for it in time. Its version check runs from a child
+component's ``onMounted`` -- Vue mounts children before parents -- so it fires
+before ``App.vue`` has even started ``GET /version``, and
+``checkForUpdatesNow`` stamps its 24h throttle before the request. Whatever the
+document says at load is therefore what gets reported for the day. Assuming
+"pip" filed every restarted Docker and desktop install under ``pip``; see
+``pixlstash-metrics/CLAUDE.md`` for the bucket swap that exposed it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pixlstash.server import Server
+
+
+class _Stub:
+    """Minimal stand-in: ``_index_html_response`` only needs these two."""
+
+    def __init__(self, index_path):
+        self._index_path = index_path
+        self._index_html_cache = None
+
+    def _get_frontend_index_path(self):
+        return self._index_path
+
+
+def _write_index(tmp_path):
+    index = tmp_path / "index.html"
+    index.write_text(
+        '<html><head><meta name="pixlstash-install-type" '
+        f'content="{Server.INSTALL_TYPE_PLACEHOLDER}" /></head></html>',
+        encoding="utf-8",
+    )
+    return index
+
+
+@pytest.mark.parametrize("install_type", Server.INSTALL_TYPES)
+def test_placeholder_is_replaced_with_every_declared_bucket(
+    tmp_path, monkeypatch, install_type
+):
+    monkeypatch.setattr(Server, "detect_install_type", staticmethod(lambda: install_type))
+    body = Server._index_html_response(_Stub(str(_write_index(tmp_path)))).body.decode()
+
+    assert f'content="{install_type}"' in body
+    assert Server.INSTALL_TYPE_PLACEHOLDER not in body
+
+
+def test_no_built_frontend_returns_none(tmp_path):
+    assert Server._index_html_response(_Stub(None)) is None
+
+
+def test_cache_follows_a_changed_install_type(tmp_path, monkeypatch):
+    """The cache keys on the install type, so a change is not served stale."""
+    stub = _Stub(str(_write_index(tmp_path)))
+
+    monkeypatch.setattr(Server, "detect_install_type", staticmethod(lambda: "docker"))
+    assert 'content="docker"' in Server._index_html_response(stub).body.decode()
+
+    monkeypatch.setattr(Server, "detect_install_type", staticmethod(lambda: "electron"))
+    assert 'content="electron"' in Server._index_html_response(stub).body.decode()


### PR DESCRIPTION
Hotfix onto `main`. Targets `main` only; `develop` picks it up when main is merged down.

## The bug

Every install channel has been under-reporting itself on the first version check, `docker` and `electron` worst of all.

`App.vue` seeded `installType` to `"pip"` and corrected it once `GET /version` answered. The version check does not wait: it runs from `TitleBar`'s `onMounted`, and Vue mounts children before parents, so it fires before `App.vue`'s own `onMounted` has even started the fetch. `checkForUpdatesNow` then stamps its 24h throttle *before* the request, so the wrong value is not corrected until the next interval tick — i.e. only if the app stays running.

## How it surfaced

Invisible while instances stayed up, because the 24h interval path did report the real type. It showed when v1.10.1 shipped on 2026-08-21 and everyone restarted to upgrade:

```
          8/17  8/18  8/19  8/20 | 8/21  8/22  8/23
electron     8    11    16    10 |    3     2     1
pip          5     7    24     9 |   17    26    16
```

Totals hold while the buckets swap — relabelling, not behaviour. The telemetry ping, which carries install type in the request *body* from the server rather than from this ref, kept reporting the same five desktop installs throughout.

## The fix

Fix it where the answer already exists. `Server.detect_install_type()` resolves this correctly at runtime (dev marker → `PIXLSTASH_INSTALL_TYPE` override → Docker detection → pip), so substitute that value into a meta tag when the server hands out the SPA. The frontend then knows its channel synchronously at load.

```js
-const installType = ref("pip");
+const installType = ref(defaultInstallType());   // reads the substituted meta tag
```

**One mechanism, every bucket:** docker, the `other` the Windows installer declares, the `dev` a development machine declares, and electron — the shell only reaches this SPA via `loadURL` against its own backend, which is started with `PIXLSTASH_INSTALL_TYPE=electron`. (The `index.html` bundled in the shell is the splash screen; it never mounts this app.)

### Why not bake it in at build time

Considered and rejected. All three Dockerfiles build the frontend, so a build constant would work for Docker — but `electron/package.json`'s `build` is `sync-version && tsc && copy-assets` and never runs a Vue build. The desktop app serves the same `frontend/dist` bundled in the wheel a pip user installs, so a build-time constant has nothing to tell those two apart. Making it work would mean adding a dedicated Vue build to the Electron pipeline and shipping a second dist, and would still leave `other` and `dev` wrong.

The frontend validates nothing beyond rejecting the un-substituted placeholder: the backend already constrains the value, and a bucket list here would be a sixth copy for `tests/test_install_type_buckets.py` to police.

## Tests

- 4 frontend cases over the injected value, plus placeholder and no-marker fallbacks
- Backend substitution parametrised over every `Server.INSTALL_TYPES` bucket, plus no-frontend and cache-invalidation cases
- The five-holder drift test still passes; no new bucket list was introduced

## Scope

- **No user-visible change.** `pip.json` and `electron.json` currently carry identical contents and `upgrade.html` ignores the install-type parameter. The buckets exist so they *can* diverge; this protects that.
- **Caching changes slightly.** The SPA entry point was served with `FileResponse`, which sets ETag/Last-Modified and so allowed a 304 on revalidation. It is now `HTMLResponse`, which sets no validators, so those ~1.1 kB are re-sent on each cold navigation. The document is no longer a static file — its content depends on the detected install type — so the validators would have been wrong to keep anyway. Assets are untouched and still served by `FileResponse`.
- **The `electron` and `docker` buckets will step up on release.** That step is the bug being fixed, not growth — worth annotating the release date in `pixlstash-metrics` so it is not read as a launch effect later.

Background and the matching measurement caveats are in `pixlstash-metrics/CLAUDE.md`.
