### PR TITLE
Phase 4a: the library layout model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,7 @@ jobs:
           tests/test_libraries_routes.py
           tests/test_library_backup.py
           tests/test_library_generation_coordinator.py
+          tests/test_library_layout.py
           tests/test_library_restore_cli.py
           tests/test_library_settings.py
           tests/test_library_switch.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1400,6 +1400,7 @@ This rule is enforced by **`tests/test_architecture_guardrails.py::test_services
 | [utils/watermark.py](../pixlstash/utils/watermark.py) | Seeded watermark rendering + cache |
 | [utils/caption_file_utils.py](../pixlstash/utils/caption_file_utils.py) | Sidecar `.txt` caption I/O |
 | [utils/face_tags.py](../pixlstash/utils/face_tags.py) | Face-derived tag helpers |
+| [utils/library_layout.py](../pixlstash/utils/library_layout.py) | The library layout model — `render` / `is_true` (§13) |
 | [utils/path_mapper.py](../pixlstash/utils/path_mapper.py) | Host↔container path translation |
 | [utils/host_path_utils.py](../pixlstash/utils/host_path_utils.py) | Host-aware path resolution |
 | [utils/reference_folder_watcher.py](../pixlstash/utils/reference_folder_watcher.py) | watchdog-based folder monitoring |
@@ -2879,6 +2880,57 @@ this record and needs its own independent adversarial sign-off.
 | Quality stats | In-memory (≈60 s TTL) | Used by aggregate endpoints |
 | Anomaly regions | In-memory bounded LRU | Cleared on library switch |
 | Models | `~/.cache/huggingface/` + VRAM | Lazy load, idle unload |
+
+### The library layout (v1.11 Phase 4a)
+
+`utils/library_layout.py` is the model of **where a picture belongs and whether
+it still belongs there**. Model only: no move engine, no file writes, no UI —
+see Phase 4b for those.
+
+A `Layout` is an ordered list of segments, one folder level each. A segment
+holds one or more `Facet`s (`PROJECT`, `PERSON`, `SET`, `TAG`) and the first the
+picture has a value for wins; a segment nothing fills is **skipped rather than
+left as an empty folder**, which keeps the tree two deep instead of five. A new
+library starts on `DEFAULT_LAYOUT`, `Project / Person or Set`.
+
+Two pure functions:
+
+| Function | Answers |
+|---|---|
+| `render(facets, layout)` | The folder path the picture should have, relative to the library root. A picture nothing files goes to `layout.unfiled` (`_Inbox`), never the root. |
+| `is_true(path, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. |
+
+The release rests on `is_true`, and on one property of it: **a path that does
+not parse against the layout can never be false.** A file at the library root
+matches no segment, so an existing flat library needs no migration; a file the
+owner dragged into `_unsorted` contradicts nothing, so it stays there
+permanently and the override needs no setting.
+
+Three things follow from how it is written:
+
+- **Truth is membership, not equality with `render`.** The folder `Mira/` says
+  "this is a Mira picture" and stays true while Mira is one of the picture's
+  people, whoever `render` would pick today. That is what makes adding a second
+  project or person move nothing.
+- **`known_names` is not optional.** Only the library's whole vocabulary
+  separates *this folder names a project the picture is no longer in* (false, it
+  moves) from *this folder names nothing PixlStash knows* (unparseable, it never
+  moves). Deleting an entity takes its name out of the language and freezes the
+  folders named after it; a caller that wants those judged one last time passes
+  the name it is deleting in `known_names`.
+- **Skipping is not re-validated, and neither is anything below the layout.** A
+  set-only picture filed one level deep stays there when it gains a project
+  (nothing is ever re-derived), and `2024 Shoots/Mira/2026-08/` is judged on its
+  first two components only — the third is the owner's own.
+
+Where a component could be read as more than one facet, any reading that is
+still true wins. This decides whether a file moves, so it errs towards leaving
+it alone. Entity names are written down through `folder_name()`, which is the
+chokepoint that stops a name like `Mira/2024` from inventing a folder level or
+escaping the root, and comparison is case-folded and NFC-normalised because
+Windows and macOS are case-insensitive and macOS decomposes accents.
+
+`tests/test_library_layout.py` covers it, unparseable-path cases first.
 
 ---
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2885,28 +2885,28 @@ this record and needs its own independent adversarial sign-off.
 
 `utils/library_layout.py` is the model of **where a picture belongs and whether
 it still belongs there**. Model only: no move engine, no file writes, no UI —
-see Phase 4b for those.
+see Phase 4b for those. The rule it implements, and its case table, are in
+`design/1.11-existing-library/DECISIONS.md`; the module docstring carries the
+detail, so this section is the map rather than a second copy of it.
 
 A `Layout` is an ordered list of segments, one folder level each. A segment
 holds one or more `Facet`s (`PROJECT`, `PERSON`, `SET`, `TAG`) and the first the
 picture has a value for wins; a segment nothing fills is **skipped rather than
 left as an empty folder**, which keeps the tree two deep instead of five. A new
-library starts on `DEFAULT_LAYOUT`, `Project / Person or Set`.
-
-Two pure functions:
+library starts on `DEFAULT_LAYOUT`, `Project` then `Person or Set`.
 
 | Function | Answers |
 |---|---|
-| `render(facets, layout)` | The folder path the picture should have, relative to the library root. A picture nothing files goes to `layout.unfiled` (`_Inbox`), never the root. |
-| `is_true(path, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. |
+| `render(facets, layout)` | The folder the picture should be in, relative to the library root. A picture nothing files goes to `layout.unfiled`, defaulting to `_Inbox` — never the library root, which is where an unmigrated flat library lives. |
+| `is_true(folder, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. Takes the **folder**, not the file path: guessing which trailing component was a file name would silently flip the answer for a path written with a trailing separator. |
 
 The release rests on `is_true`, and on one property of it: **a path that does
 not parse against the layout can never be false.** A file at the library root
 matches no segment, so an existing flat library needs no migration; a file the
-owner dragged into `_unsorted` contradicts nothing, so it stays there
+owner dragged into a folder of their own contradicts nothing, so it stays there
 permanently and the override needs no setting.
 
-Three things follow from how it is written:
+The three properties a reader is most likely to get wrong:
 
 - **Truth is membership, not equality with `render`.** The folder `Mira/` says
   "this is a Mira picture" and stays true while Mira is one of the picture's
@@ -2916,19 +2916,19 @@ Three things follow from how it is written:
   separates *this folder names a project the picture is no longer in* (false, it
   moves) from *this folder names nothing PixlStash knows* (unparseable, it never
   moves). Deleting an entity takes its name out of the language and freezes the
-  folders named after it; a caller that wants those judged one last time passes
-  the name it is deleting in `known_names`.
-- **Skipping is not re-validated, and neither is anything below the layout.** A
-  set-only picture filed one level deep stays there when it gains a project
-  (nothing is ever re-derived), and `2024 Shoots/Mira/2026-08/` is judged on its
-  first two components only — the third is the owner's own.
+  folders named after it.
+- **Reading stops at the first component the vocabulary cannot read**, and it is
+  not positional. Everything from that component down is the owner's own, so
+  `2024 Shoots/Mira/2026-08` is judged on its first two components while
+  `Holiday/2024 Shoots` is judged on none of them.
 
-Where a component could be read as more than one facet, any reading that is
-still true wins. This decides whether a file moves, so it errs towards leaving
-it alone. Entity names are written down through `folder_name()`, which is the
-chokepoint that stops a name like `Mira/2024` from inventing a folder level or
-escaping the root, and comparison is case-folded and NFC-normalised because
-Windows and macOS are case-insensitive and macOS decomposes accents.
+Every name reaching a path goes through `folder_name()` — including
+`Layout.unfiled`, which is validated against it on construction because it is
+the one field a settings screen will let a user type and it reaches `render`'s
+output verbatim. It is a many-to-one map (`A/B`, `A:B` and `A_B` all become
+`A_B`), which is the collision the filesystem would force anyway; comparison is
+additionally case-folded and NFC-normalised for Windows and macOS. Every
+ambiguity here resolves towards *not* moving a file.
 
 `tests/test_library_layout.py` covers it, unparseable-path cases first.
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2898,7 +2898,7 @@ library starts on `DEFAULT_LAYOUT`, `Project` then `Person or Set`.
 | Function | Answers |
 |---|---|
 | `render(facets, layout)` | The folder the picture should be in, relative to the library root. A picture nothing files goes to `layout.unfiled`, defaulting to `_Inbox` — never the library root, which is where an unmigrated flat library lives. |
-| `is_true(folder, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. Takes the **folder**, not the file path: guessing which trailing component was a file name would silently flip the answer for a path written with a trailing separator. |
+| `is_true(folder, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. Takes the **folder**, not the file path: guessing which trailing component was a file name would silently flip the answer for a path written with a trailing separator. A path carrying `.` or `..` is refused whole rather than normalised — tidying one would fabricate a level the path does not have. |
 
 The release rests on `is_true`, and on one property of it: **a path that does
 not parse against the layout can never be false.** A file at the library root

--- a/docs/plans/v1.11.0-existing-library.md
+++ b/docs/plans/v1.11.0-existing-library.md
@@ -133,6 +133,11 @@ landing.
 
 ### Phase 4 — The layout, and move-when-false
 
+Split in two: **4a is the model** — `pixlstash/utils/library_layout.py`, `render` and
+`is_true`, pure and shipped — and **4b is everything that moves a file**. 4b also
+shares `reference_folder_scan_task.py` with Phase 5, so those two run as one
+sequential track.
+
 - A layout is an ordered list of segments; a segment holds one or more facets, first
   match wins, absent segments are skipped.
 - New-library default: `Project / Person or Set`.

--- a/pixlstash/utils/library_layout.py
+++ b/pixlstash/utils/library_layout.py
@@ -1,0 +1,266 @@
+"""The library layout model: where a picture belongs, and whether it still does.
+
+A layout is an ordered list of segments, one folder level each. A segment holds
+one or more facets and the first that applies wins; a segment with nothing to
+fill it is skipped rather than left as an empty folder, which is what keeps the
+tree two deep instead of five. A new library starts on ``DEFAULT_LAYOUT``,
+``Project / Person or Set``.
+
+Two pure functions do the work, and the second one is the release:
+
+``render``
+    The folder path a picture should have under a layout.
+
+``is_true``
+    Whether the folder a picture is *actually* sitting in still describes it.
+    **A path that does not parse against the layout can never be false**, so a
+    hand-placed file is a permanent override and an existing flat library needs
+    no migration: a file at the library root matches no segment, contradicts
+    nothing, and stays put.
+
+Truth is membership, not equality with ``render``. The folder ``Mira/`` says
+"this is a Mira picture"; it stays true while Mira is one of the picture's
+people, whoever ``render`` would pick today. That is what makes adding a second
+project or person move nothing.
+
+Neither function touches the database or the filesystem. The caller supplies
+the picture's own names per facet, and — for ``is_true`` — the library's whole
+vocabulary of names per facet. The vocabulary is what separates *this folder
+names a project the picture is no longer in* (false, it moves) from *this
+folder names nothing PixlStash knows about* (unparseable, it never moves), and
+there is no way to tell those apart without it.
+
+Nothing here moves a file. See v1.11.0 Phase 4b for that.
+"""
+
+import unicodedata
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+# Characters that cannot appear in a path component on some supported OS, plus
+# the separators, which would otherwise let an entity name invent folder levels.
+_ILLEGAL_IN_FOLDER_NAME = set('/\\:*?"<>|') | {chr(code) for code in range(32)}
+
+# Names Windows refuses whatever the extension, so a project called ``CON`` has
+# to be written down as something else or its folder cannot exist.
+_WINDOWS_RESERVED = frozenset(
+    ["con", "prn", "aux", "nul"]
+    + [f"com{digit}" for digit in range(1, 10)]
+    + [f"lpt{digit}" for digit in range(1, 10)]
+)
+
+# What a name collapses to when sanitising leaves nothing of it at all.
+_EMPTY_FOLDER_NAME = "_unnamed"
+
+
+class Facet(str, Enum):
+    """A kind of thing a folder level can be named after.
+
+    The vocabulary the design bundle uses throughout: ``person`` is the user-
+    facing word for what the database calls a character.
+    """
+
+    PROJECT = "project"
+    PERSON = "person"
+    SET = "set"
+    TAG = "tag"
+
+
+_FACET_LABELS = {
+    Facet.PROJECT: "Project",
+    Facet.PERSON: "Person",
+    Facet.SET: "Set",
+    Facet.TAG: "Tag",
+}
+
+# A picture's own names per facet, in the order they should be preferred, and
+# the library's whole set of names per facet. Both are plain mappings so that
+# callers can build them straight out of a query without a wrapper type.
+FacetValues = Mapping[Facet, Sequence[str]]
+FacetVocabulary = Mapping[Facet, Collection[str]]
+
+
+@dataclass(frozen=True)
+class Layout:
+    """An ordered list of folder levels.
+
+    Attributes:
+        segments: One tuple of facets per folder level. Within a segment the
+            first facet the picture has a value for wins.
+        unfiled: The folder a picture with nothing to file it by is written to.
+            It has to be a real name rather than the library root, because the
+            root is exactly where an unmigrated flat library lives and those
+            files must never move.
+    """
+
+    segments: tuple[tuple[Facet, ...], ...]
+    unfiled: str = "_Inbox"
+
+    def __str__(self) -> str:
+        """Render the layout the way the Storage screen shows it."""
+        return " / ".join(
+            " or ".join(_FACET_LABELS[facet] for facet in segment)
+            for segment in self.segments
+        )
+
+
+DEFAULT_LAYOUT = Layout(segments=((Facet.PROJECT,), (Facet.PERSON, Facet.SET)))
+
+
+def folder_name(name: str) -> str:
+    """Return the folder name an entity name is written down as.
+
+    Anything that cannot be a path component is replaced rather than dropped,
+    so two different names stay two different folders. In particular the path
+    separators go: without this an entity called ``Mira/2024`` would invent a
+    folder level and a rendered path would escape the library root.
+
+    Args:
+        name: The entity name as the owner typed it.
+
+    Returns:
+        A single path component, never empty and never a separator.
+    """
+    cleaned = "".join(
+        "_" if character in _ILLEGAL_IN_FOLDER_NAME else character for character in name
+    )
+    # Windows silently drops trailing dots and spaces, which would make the
+    # written folder a different name from the one matched against later.
+    cleaned = cleaned.strip().rstrip(". ")
+    if not cleaned or set(cleaned) == {"."}:
+        return _EMPTY_FOLDER_NAME
+    if cleaned.split(".")[0].lower() in _WINDOWS_RESERVED:
+        return f"_{cleaned}"
+    return cleaned
+
+
+def _match_key(name: str) -> str:
+    """Return the form two folder names are compared in.
+
+    Case-folded because Windows and macOS are case-insensitive, and NFC-
+    normalised because macOS hands back decomposed accents, so an unnormalised
+    comparison would find a person's own folder untrue on their own machine.
+    """
+    return unicodedata.normalize("NFC", name).casefold()
+
+
+def _segment_value(segment: Iterable[Facet], facets: FacetValues) -> str | None:
+    """Return the name that fills a segment, or ``None`` if nothing does."""
+    for facet in segment:
+        values = facets.get(facet) or ()
+        for value in values:
+            if value:
+                return value
+    return None
+
+
+def render(facets: FacetValues, layout: Layout) -> str:
+    """Return the folder path a picture should have, relative to the library root.
+
+    Args:
+        facets: The picture's own names per facet, most-preferred first. A
+            facet that is missing or empty simply does not fill a segment.
+        layout: The layout to place it under.
+
+    Returns:
+        A ``/``-separated relative folder path, never absolute and never empty:
+        a picture that fills no segment at all gets ``layout.unfiled``.
+        Components never contain ``/`` themselves, so splitting is safe.
+    """
+    parts = []
+    for segment in layout.segments:
+        value = _segment_value(segment, facets)
+        if value is not None:
+            parts.append(folder_name(value))
+    return "/".join(parts) if parts else layout.unfiled
+
+
+def _folder_components(path: str) -> tuple[str, ...]:
+    """Return the folder components of a relative picture path, file name dropped."""
+    normalised = path.replace("\\", "/")
+    components = [part for part in normalised.split("/") if part and part != "."]
+    return tuple(components[:-1])
+
+
+def _segment_keys(
+    segment: Iterable[Facet], names: Mapping[Facet, Collection[str]]
+) -> set[str]:
+    """Return the match keys of every name that could fill a segment."""
+    return {
+        _match_key(folder_name(name))
+        for facet in segment
+        for name in names.get(facet) or ()
+    }
+
+
+def is_true(
+    path: str,
+    facets: FacetValues,
+    layout: Layout,
+    known_names: FacetVocabulary,
+) -> bool:
+    """Return whether the folder a picture sits in still describes it.
+
+    A component is read against the layout left to right, skipping segments the
+    path does not use — a picture filed by set alone under ``Project / Person or
+    Set`` sits one level deep, not two. Components below the last one the layout
+    accounts for are the owner's own subfolders and are not judged. Where a
+    component could be read as more than one facet, any reading that is still
+    true wins: this decides whether a file moves, so it errs towards leaving it
+    alone.
+
+    Args:
+        path: The picture's path relative to the library root, file name
+            included — only its folder components are examined.
+        facets: The picture's own names per facet.
+        layout: The layout to judge against.
+        known_names: Every entity name in the library, per facet. A component
+            naming nothing in here is not part of the layout's language, so the
+            path does not parse and can never be false. Deleting an entity
+            therefore takes its name out of the language and freezes the
+            folders named after it; a caller that wants those judged one last
+            time passes the name it is deleting in here.
+
+    Returns:
+        ``True`` while the folder is still true, including every case where the
+        path does not parse against the layout at all. ``False`` only when a
+        component names something of the layout's that the picture no longer is.
+    """
+    components = _folder_components(path)
+    if not components:
+        # The library root. It matches no segment, so it contradicts nothing —
+        # this is why an existing flat library needs no migration.
+        return True
+
+    if _match_key(components[0]) == _match_key(layout.unfiled):
+        # The unfiled folder is part of the layout's language: it says "nothing
+        # files this picture", and stops being true the moment something does.
+        return render(facets, layout) == layout.unfiled
+
+    vocab = [_segment_keys(segment, known_names) for segment in layout.segments]
+    mine = [_segment_keys(segment, facets) for segment in layout.segments]
+
+    next_segment = 0
+    for component in components:
+        key = _match_key(component)
+        parses = False
+        for index in range(next_segment, len(layout.segments)):
+            if key not in vocab[index]:
+                continue
+            parses = True
+            if key in mine[index]:
+                # Still true here. Consume this segment and move on.
+                next_segment = index + 1
+                break
+        else:
+            if parses:
+                # It names something of the layout's, in every reading, and the
+                # picture is none of them any more. The folder has stopped
+                # being true.
+                return False
+            # Nothing the layout knows about: the owner's own folder, and the
+            # rest of the path below it is theirs too.
+            break
+
+    return True

--- a/pixlstash/utils/library_layout.py
+++ b/pixlstash/utils/library_layout.py
@@ -2,45 +2,40 @@
 
 A layout is an ordered list of segments, one folder level each. A segment holds
 one or more facets and the first that applies wins; a segment with nothing to
-fill it is skipped rather than left as an empty folder, which is what keeps the
-tree two deep instead of five. A new library starts on ``DEFAULT_LAYOUT``,
-``Project / Person or Set``.
+fill it is skipped rather than left as an empty folder. A new library starts on
+``DEFAULT_LAYOUT``, ``Project`` then ``Person or Set``.
 
-Two pure functions do the work, and the second one is the release:
-
-``render``
-    The folder path a picture should have under a layout.
-
-``is_true``
-    Whether the folder a picture is *actually* sitting in still describes it.
-    **A path that does not parse against the layout can never be false**, so a
-    hand-placed file is a permanent override and an existing flat library needs
-    no migration: a file at the library root matches no segment, contradicts
-    nothing, and stays put.
+``render`` gives the folder a picture should be in. ``is_true`` says whether the
+folder it *is* in still describes it, and that one is the release: **a path that
+does not parse against the layout can never be false**, so a hand-placed file is
+a permanent override and an existing flat library needs no migration.
 
 Truth is membership, not equality with ``render``. The folder ``Mira/`` says
-"this is a Mira picture"; it stays true while Mira is one of the picture's
+"this is a Mira picture" and stays true while Mira is one of the picture's
 people, whoever ``render`` would pick today. That is what makes adding a second
 project or person move nothing.
 
-Neither function touches the database or the filesystem. The caller supplies
-the picture's own names per facet, and — for ``is_true`` — the library's whole
-vocabulary of names per facet. The vocabulary is what separates *this folder
-names a project the picture is no longer in* (false, it moves) from *this
-folder names nothing PixlStash knows about* (unparseable, it never moves), and
-there is no way to tell those apart without it.
+Neither function touches the database or the filesystem. The caller passes the
+picture's own names per facet and, for ``is_true``, the library's whole
+vocabulary of names per facet. The vocabulary is the only thing that separates
+*this folder names a project the picture is no longer in* (false, it moves) from
+*this folder names nothing PixlStash knows about* (unparseable, it never moves).
 
-Nothing here moves a file. See v1.11.0 Phase 4b for that.
+Nothing here moves a file. See v1.11.0 Phase 4b for that. The rule and its case
+table live in ``design/1.11-existing-library/DECISIONS.md``.
 """
 
+import re
 import unicodedata
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 
-# Characters that cannot appear in a path component on some supported OS, plus
-# the separators, which would otherwise let an entity name invent folder levels.
-_ILLEGAL_IN_FOLDER_NAME = set('/\\:*?"<>|') | {chr(code) for code in range(32)}
+# The character class from ``utils/service/export_utils.py``, which solves the
+# same problem for zip member names. Not that function itself: it takes the last
+# component of a name, so ``Mira/2024`` becomes ``2024``, and here two entities
+# that differ only above a separator must not become the same folder.
+_UNSAFE_FOLDER_CHARS_RE = re.compile(r'[\x00-\x1f\x7f<>:"|?*/\\]')
 
 # Names Windows refuses whatever the extension, so a project called ``CON`` has
 # to be written down as something else or its folder cannot exist.
@@ -57,8 +52,8 @@ _EMPTY_FOLDER_NAME = "_unnamed"
 class Facet(str, Enum):
     """A kind of thing a folder level can be named after.
 
-    The vocabulary the design bundle uses throughout: ``person`` is the user-
-    facing word for what the database calls a character.
+    The vocabulary the design bundle uses throughout: ``person`` is the
+    user-facing word for what the database calls a character.
     """
 
     PROJECT = "project"
@@ -67,18 +62,40 @@ class Facet(str, Enum):
     TAG = "tag"
 
 
-_FACET_LABELS = {
-    Facet.PROJECT: "Project",
-    Facet.PERSON: "Person",
-    Facet.SET: "Set",
-    Facet.TAG: "Tag",
-}
-
 # A picture's own names per facet, in the order they should be preferred, and
 # the library's whole set of names per facet. Both are plain mappings so that
 # callers can build them straight out of a query without a wrapper type.
 FacetValues = Mapping[Facet, Sequence[str]]
 FacetVocabulary = Mapping[Facet, Collection[str]]
+
+
+def folder_name(name: str) -> str:
+    """Return the folder name an entity name is written down as.
+
+    Every character that cannot appear in a path component becomes ``_``. That
+    is a many-to-one map — ``A/B``, ``A:B`` and ``A_B`` all become ``A_B`` — so
+    two entities whose names differ only in punctuation share a folder, and a
+    picture in either of them reads as true there. That is the same collision
+    the filesystem would force anyway, and it errs towards not moving files.
+
+    What it must not do is let a name invent a folder level: without the
+    separator replacement an entity called ``Mira/2024`` would render two
+    folders deep and one called ``../..`` would escape the library root.
+
+    Args:
+        name: The entity name as the owner typed it.
+
+    Returns:
+        A single path component, never empty and never a separator.
+    """
+    # Windows silently drops trailing dots and spaces, which would make the
+    # written folder a different name from the one matched against later.
+    cleaned = _UNSAFE_FOLDER_CHARS_RE.sub("_", name).strip().rstrip(". ")
+    if not cleaned:
+        return _EMPTY_FOLDER_NAME
+    if cleaned.split(".")[0].lower() in _WINDOWS_RESERVED:
+        return f"_{cleaned}"
+    return cleaned
 
 
 @dataclass(frozen=True)
@@ -87,52 +104,32 @@ class Layout:
 
     Attributes:
         segments: One tuple of facets per folder level. Within a segment the
-            first facet the picture has a value for wins.
-        unfiled: The folder a picture with nothing to file it by is written to.
-            It has to be a real name rather than the library root, because the
-            root is exactly where an unmigrated flat library lives and those
-            files must never move.
+            first facet the picture has a value for wins. A facet repeated
+            across segments is expressible and meaningless — that is still open
+            in ``DECISIONS.md`` and is deliberately not resolved here.
+        unfiled: The single folder a picture with nothing to file it by is
+            written to. It has to be a real name rather than the library root,
+            because the root is exactly where an unmigrated flat library lives
+            and those files must never move.
+
+    Raises:
+        ValueError: If ``unfiled`` is not already a safe single path component.
+            It reaches ``render``'s output verbatim, so it is the one field that
+            could otherwise escape the library root.
     """
 
     segments: tuple[tuple[Facet, ...], ...]
     unfiled: str = "_Inbox"
 
-    def __str__(self) -> str:
-        """Render the layout the way the Storage screen shows it."""
-        return " / ".join(
-            " or ".join(_FACET_LABELS[facet] for facet in segment)
-            for segment in self.segments
-        )
+    def __post_init__(self) -> None:
+        if self.unfiled != folder_name(self.unfiled):
+            raise ValueError(
+                f"unfiled must be a single safe path component, "
+                f"got {self.unfiled!r} (try {folder_name(self.unfiled)!r})"
+            )
 
 
 DEFAULT_LAYOUT = Layout(segments=((Facet.PROJECT,), (Facet.PERSON, Facet.SET)))
-
-
-def folder_name(name: str) -> str:
-    """Return the folder name an entity name is written down as.
-
-    Anything that cannot be a path component is replaced rather than dropped,
-    so two different names stay two different folders. In particular the path
-    separators go: without this an entity called ``Mira/2024`` would invent a
-    folder level and a rendered path would escape the library root.
-
-    Args:
-        name: The entity name as the owner typed it.
-
-    Returns:
-        A single path component, never empty and never a separator.
-    """
-    cleaned = "".join(
-        "_" if character in _ILLEGAL_IN_FOLDER_NAME else character for character in name
-    )
-    # Windows silently drops trailing dots and spaces, which would make the
-    # written folder a different name from the one matched against later.
-    cleaned = cleaned.strip().rstrip(". ")
-    if not cleaned or set(cleaned) == {"."}:
-        return _EMPTY_FOLDER_NAME
-    if cleaned.split(".")[0].lower() in _WINDOWS_RESERVED:
-        return f"_{cleaned}"
-    return cleaned
 
 
 def _match_key(name: str) -> str:
@@ -141,26 +138,53 @@ def _match_key(name: str) -> str:
     Case-folded because Windows and macOS are case-insensitive, and NFC-
     normalised because macOS hands back decomposed accents, so an unnormalised
     comparison would find a person's own folder untrue on their own machine.
+
+    ``render`` writes the name as the owner typed it and only the comparison
+    folds, so on a case-sensitive filesystem two entities differing only in case
+    get two folders and each reads as true in both. Again: the same collision
+    the other two platforms force, in the direction that does not move files.
     """
     return unicodedata.normalize("NFC", name).casefold()
+
+
+def _names_of(facet: Facet, names: Mapping[Facet, Collection[str]]) -> Collection[str]:
+    """Return one facet's names, refusing a bare string handed in for a list."""
+    values = names.get(facet) or ()
+    if isinstance(values, str):
+        raise TypeError(
+            f"{facet} must map to a sequence of names, not the string "
+            f"{values!r} — a str would be read one character per name"
+        )
+    return values
 
 
 def _segment_value(segment: Iterable[Facet], facets: FacetValues) -> str | None:
     """Return the name that fills a segment, or ``None`` if nothing does."""
     for facet in segment:
-        values = facets.get(facet) or ()
-        for value in values:
+        for value in _names_of(facet, facets):
             if value:
                 return value
     return None
 
 
+def _segment_keys(
+    segment: Iterable[Facet], names: Mapping[Facet, Collection[str]]
+) -> set[str]:
+    """Return the match keys of every name that could fill a segment."""
+    return {
+        _match_key(folder_name(name))
+        for facet in segment
+        for name in _names_of(facet, names)
+        if name
+    }
+
+
 def render(facets: FacetValues, layout: Layout) -> str:
-    """Return the folder path a picture should have, relative to the library root.
+    """Return the folder a picture should be in, relative to the library root.
 
     Args:
-        facets: The picture's own names per facet, most-preferred first. A
-            facet that is missing or empty simply does not fill a segment.
+        facets: The picture's own names per facet, most-preferred first. A facet
+            that is missing or empty simply does not fill a segment.
         layout: The layout to place it under.
 
     Returns:
@@ -176,66 +200,64 @@ def render(facets: FacetValues, layout: Layout) -> str:
     return "/".join(parts) if parts else layout.unfiled
 
 
-def _folder_components(path: str) -> tuple[str, ...]:
-    """Return the folder components of a relative picture path, file name dropped."""
-    normalised = path.replace("\\", "/")
-    components = [part for part in normalised.split("/") if part and part != "."]
-    return tuple(components[:-1])
-
-
-def _segment_keys(
-    segment: Iterable[Facet], names: Mapping[Facet, Collection[str]]
-) -> set[str]:
-    """Return the match keys of every name that could fill a segment."""
-    return {
-        _match_key(folder_name(name))
-        for facet in segment
-        for name in names.get(facet) or ()
-    }
+def _components(folder: str) -> tuple[str, ...]:
+    """Split a relative folder path into components, either separator."""
+    return tuple(
+        part
+        for part in folder.replace("\\", "/").split("/")
+        if part and part not in (".", "..")
+    )
 
 
 def is_true(
-    path: str,
+    folder: str,
     facets: FacetValues,
     layout: Layout,
     known_names: FacetVocabulary,
 ) -> bool:
     """Return whether the folder a picture sits in still describes it.
 
-    A component is read against the layout left to right, skipping segments the
-    path does not use — a picture filed by set alone under ``Project / Person or
-    Set`` sits one level deep, not two. Components below the last one the layout
-    accounts for are the owner's own subfolders and are not judged. Where a
+    Components are read against the layout left to right, skipping segments the
+    path does not use — a picture filed by set alone under ``Project`` then
+    ``Person or Set`` sits one level deep, not two. Reading **stops** at the
+    first component the layout's vocabulary cannot read: everything from there
+    down is the owner's own, so ``2024 Shoots/Mira/2026-08`` is judged on its
+    first two components and ``Holiday/2024 Shoots`` on none of them. Where a
     component could be read as more than one facet, any reading that is still
     true wins: this decides whether a file moves, so it errs towards leaving it
     alone.
 
     Args:
-        path: The picture's path relative to the library root, file name
-            included — only its folder components are examined.
+        folder: The folder the picture is in, relative to the library root, and
+            **not** including the file name — a caller holding a relative file
+            path passes ``os.path.dirname`` of it. Guessing which trailing
+            component was a file name would silently flip the answer for a path
+            written with a trailing separator.
         facets: The picture's own names per facet.
         layout: The layout to judge against.
         known_names: Every entity name in the library, per facet. A component
             naming nothing in here is not part of the layout's language, so the
             path does not parse and can never be false. Deleting an entity
-            therefore takes its name out of the language and freezes the
-            folders named after it; a caller that wants those judged one last
-            time passes the name it is deleting in here.
+            therefore takes its name out of the language and freezes the folders
+            named after it.
 
     Returns:
         ``True`` while the folder is still true, including every case where the
         path does not parse against the layout at all. ``False`` only when a
         component names something of the layout's that the picture no longer is.
     """
-    components = _folder_components(path)
+    components = _components(folder)
     if not components:
         # The library root. It matches no segment, so it contradicts nothing —
         # this is why an existing flat library needs no migration.
         return True
 
-    if _match_key(components[0]) == _match_key(layout.unfiled):
+    if len(components) == 1 and _match_key(components[0]) == _match_key(layout.unfiled):
         # The unfiled folder is part of the layout's language: it says "nothing
         # files this picture", and stops being true the moment something does.
+        # Only at this exact depth. Anything nested below a folder of that name
+        # is a tree of the owner's own that happens to share the name, and the
+        # override has to survive that.
         return render(facets, layout) == layout.unfiled
 
     vocab = [_segment_keys(segment, known_names) for segment in layout.segments]

--- a/pixlstash/utils/library_layout.py
+++ b/pixlstash/utils/library_layout.py
@@ -201,12 +201,19 @@ def render(facets: FacetValues, layout: Layout) -> str:
 
 
 def _components(folder: str) -> tuple[str, ...]:
-    """Split a relative folder path into components, either separator."""
-    return tuple(
-        part
-        for part in folder.replace("\\", "/").split("/")
-        if part and part not in (".", "..")
-    )
+    """Split a relative folder path into components, either separator.
+
+    A path carrying ``.`` or ``..`` is refused whole rather than tidied up.
+    Dropping the ``..`` from ``2024 Shoots/../Mira`` would fabricate a project
+    level the path does not have and could return ``False`` — a move — for a
+    picture that is only ever in ``Mira``. An unnormalised path is a caller
+    mistake, and the safe reading of one is the same as any path the layout
+    cannot read: no components, and never false.
+    """
+    parts = folder.replace("\\", "/").split("/")
+    if any(part in (".", "..") for part in parts):
+        return ()
+    return tuple(part for part in parts if part)
 
 
 def is_true(
@@ -248,8 +255,9 @@ def is_true(
     """
     components = _components(folder)
     if not components:
-        # The library root. It matches no segment, so it contradicts nothing —
-        # this is why an existing flat library needs no migration.
+        # The library root, or a path this cannot read at all. It matches no
+        # segment, so it contradicts nothing — this is why an existing flat
+        # library needs no migration.
         return True
 
     if len(components) == 1 and _match_key(components[0]) == _match_key(layout.unfiled):

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -1,0 +1,218 @@
+"""The layout model: where a picture belongs and whether it still does.
+
+Pure functions, so there is no ``Server`` and no vault here — every case is a
+dict of names and a string path.
+"""
+
+import unicodedata
+
+import pytest
+
+from pixlstash.utils.library_layout import (
+    DEFAULT_LAYOUT,
+    Facet,
+    Layout,
+    folder_name,
+    is_true,
+    render,
+)
+
+# The library the cases below are judged against: two projects, two people, one
+# set. Names, not rows — the model never sees the database.
+KNOWN = {
+    Facet.PROJECT: ["2024 Shoots", "Client Nordvik"],
+    Facet.PERSON: ["Mira", "Aled"],
+    Facet.SET: ["mira-lora-v3"],
+}
+
+
+def facets(*, projects=(), people=(), sets=(), tags=()):
+    """Build the per-facet names of one picture."""
+    return {
+        Facet.PROJECT: list(projects),
+        Facet.PERSON: list(people),
+        Facet.SET: list(sets),
+        Facet.TAG: list(tags),
+    }
+
+
+# --- The case that makes the release safe, tested first ---------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "0412.png",  # a flat library, everything at the root
+        "_unsorted/0412.png",  # a folder of the owner's own
+        "Holiday/best/0412.png",  # two of them
+        "Mira and Aled/0412.png",  # nearly a person's name, but not one
+    ],
+)
+def test_a_path_the_layout_cannot_read_is_never_false(path):
+    """A path that does not parse can never be false, whatever the picture is.
+
+    This is what makes a hand-placed file a permanent override and what means
+    an existing flat library needs no migration.
+    """
+    picture = facets(projects=["Client Nordvik"], people=["Aled"])
+    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_an_unreadable_path_stays_true_even_with_nothing_to_file_it_by():
+    picture = facets()
+    assert is_true("_unsorted/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+# --- render -----------------------------------------------------------------
+
+
+def test_render_fills_both_segments():
+    picture = facets(projects=["2024 Shoots"], people=["Mira"])
+    assert render(picture, DEFAULT_LAYOUT) == "2024 Shoots/Mira"
+
+
+def test_a_segment_with_nothing_to_fill_it_is_skipped_not_left_empty():
+    """No empty folder level: the set picture sits one deep, not two."""
+    assert render(facets(sets=["mira-lora-v3"]), DEFAULT_LAYOUT) == "mira-lora-v3"
+    assert render(facets(projects=["2024 Shoots"]), DEFAULT_LAYOUT) == "2024 Shoots"
+
+
+def test_the_first_facet_that_applies_wins_within_a_segment():
+    picture = facets(projects=["2024 Shoots"], people=["Mira"], sets=["mira-lora-v3"])
+    assert render(picture, DEFAULT_LAYOUT) == "2024 Shoots/Mira"
+
+
+def test_the_first_value_of_a_facet_wins():
+    picture = facets(projects=["2024 Shoots", "Client Nordvik"])
+    assert render(picture, DEFAULT_LAYOUT) == "2024 Shoots"
+
+
+def test_a_picture_with_nothing_to_file_it_by_goes_to_the_unfiled_folder():
+    """Never the library root: that is where an unmigrated flat library lives."""
+    assert render(facets(), DEFAULT_LAYOUT) == DEFAULT_LAYOUT.unfiled
+
+
+def test_render_never_escapes_the_library_root():
+    """A name is one folder level however many separators the owner typed."""
+    picture = facets(projects=["../../etc"], people=["Mira/2024"])
+    rendered = render(picture, DEFAULT_LAYOUT)
+    assert rendered.split("/") == [".._.._etc", "Mira_2024"]
+
+
+# --- is_true: the case table from DECISIONS.md ------------------------------
+
+
+def test_import_moves_nothing_because_the_path_is_where_the_assignment_came_from():
+    picture = facets(projects=["2024 Shoots"], people=["Mira"])
+    path = render(picture, DEFAULT_LAYOUT) + "/0412.png"
+    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_adding_a_second_project_leaves_the_folder_true():
+    """It is still in the first one, whichever ``render`` would pick today."""
+    picture = facets(projects=["Client Nordvik", "2024 Shoots"], people=["Mira"])
+    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_removing_the_project_the_folder_is_named_after_makes_it_false():
+    picture = facets(projects=["Client Nordvik"], people=["Mira"])
+    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
+def test_swapping_the_person_the_folder_is_named_after_makes_it_false():
+    picture = facets(projects=["2024 Shoots"], people=["Aled"])
+    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
+def test_a_folder_of_the_owners_own_below_the_layout_is_not_judged():
+    """``2024 Shoots / Mira / 2026-08`` is still a Mira picture in that project."""
+    picture = facets(projects=["2024 Shoots"], people=["Mira"])
+    path = "2024 Shoots/Mira/2026-08/0412.png"
+    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_a_skipped_segment_stays_skipped_when_the_picture_gains_one():
+    """Nothing is re-derived: gaining a project does not move the set picture."""
+    picture = facets(projects=["2024 Shoots"], sets=["mira-lora-v3"])
+    assert is_true("mira-lora-v3/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_a_deeper_segment_is_judged_even_when_an_earlier_one_was_skipped():
+    picture = facets(sets=["mira-lora-v3"], people=["Aled"])
+    assert is_true("Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
+def test_where_a_component_can_be_read_two_ways_a_true_reading_wins():
+    """A name that is both a project and a person errs towards leaving it alone."""
+    known = {Facet.PROJECT: ["Mira"], Facet.PERSON: ["Mira"], Facet.SET: []}
+    picture = facets(people=["Mira"])
+    assert is_true("Mira/0412.png", picture, DEFAULT_LAYOUT, known) is True
+
+
+def test_a_name_the_library_no_longer_knows_freezes_its_folder():
+    """Delete the entity and its name leaves the layout's language."""
+    picture = facets(people=["Mira"])
+    without_the_project = {**KNOWN, Facet.PROJECT: ["Client Nordvik"]}
+    path = "2024 Shoots/Mira/0412.png"
+    assert is_true(path, picture, DEFAULT_LAYOUT, without_the_project) is True
+    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
+# --- is_true: the unfiled folder --------------------------------------------
+
+
+def test_the_unfiled_folder_stops_being_true_the_moment_something_files_it():
+    empty = facets()
+    filed = facets(people=["Mira"])
+    path = f"{DEFAULT_LAYOUT.unfiled}/0412.png"
+    assert is_true(path, empty, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true(path, filed, DEFAULT_LAYOUT, KNOWN) is False
+
+
+# --- folder names -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("Client Nordvik", "Client Nordvik"),
+        ("Mira/2024", "Mira_2024"),
+        ("back\\slash", "back_slash"),
+        ("colon:name", "colon_name"),
+        ("trailing dot.", "trailing dot"),
+        ("  padded  ", "padded"),
+        ("..", "_unnamed"),
+        ("///", "___"),
+        ("", "_unnamed"),
+        ("CON", "_CON"),
+        ("com4.raw", "_com4.raw"),
+        ("Connor", "Connor"),
+    ],
+)
+def test_folder_name(name, expected):
+    assert folder_name(name) == expected
+
+
+def test_matching_ignores_case_and_unicode_form():
+    """Windows and macOS are case-insensitive, and macOS decomposes accents."""
+    composed = unicodedata.normalize("NFC", "Ren\u00e9e")
+    decomposed = unicodedata.normalize("NFD", composed)
+    assert composed != decomposed
+    known = {Facet.PERSON: [composed]}
+    picture = facets(people=[composed])
+    layout = Layout(segments=((Facet.PERSON,),))
+    assert is_true(f"{decomposed.upper()}/0412.png", picture, layout, known) is True
+
+
+def test_windows_separators_in_the_path_are_read_as_folder_levels():
+    picture = facets(projects=["Client Nordvik"], people=["Mira"])
+    path = "2024 Shoots\\Mira\\0412.png"
+    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
+# --- the layout itself ------------------------------------------------------
+
+
+def test_the_new_library_default_is_project_then_person_or_set():
+    assert str(DEFAULT_LAYOUT) == "Project / Person or Set"
+    assert DEFAULT_LAYOUT.segments == ((Facet.PROJECT,), (Facet.PERSON, Facet.SET))

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -1,7 +1,7 @@
 """The layout model: where a picture belongs and whether it still does.
 
 Pure functions, so there is no ``Server`` and no vault here — every case is a
-dict of names and a string path.
+dict of names and a folder path.
 """
 
 import unicodedata
@@ -40,27 +40,27 @@ def facets(*, projects=(), people=(), sets=(), tags=()):
 
 
 @pytest.mark.parametrize(
-    "path",
+    "folder",
     [
-        "0412.png",  # a flat library, everything at the root
-        "_unsorted/0412.png",  # a folder of the owner's own
-        "Holiday/best/0412.png",  # two of them
-        "Mira and Aled/0412.png",  # nearly a person's name, but not one
+        "",  # a flat library, everything at the root
+        "_unsorted",  # a folder of the owner's own
+        "Holiday/best",  # two of them
+        "Mira and Aled",  # nearly a person's name, but not one
+        "Holiday/2024 Shoots",  # a project name, but not where the layout looks
     ],
 )
-def test_a_path_the_layout_cannot_read_is_never_false(path):
+def test_a_path_the_layout_cannot_read_is_never_false(folder):
     """A path that does not parse can never be false, whatever the picture is.
 
     This is what makes a hand-placed file a permanent override and what means
     an existing flat library needs no migration.
     """
     picture = facets(projects=["Client Nordvik"], people=["Aled"])
-    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true(folder, picture, DEFAULT_LAYOUT, KNOWN) is True
 
 
 def test_an_unreadable_path_stays_true_even_with_nothing_to_file_it_by():
-    picture = facets()
-    assert is_true("_unsorted/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true("_unsorted", facets(), DEFAULT_LAYOUT, KNOWN) is True
 
 
 # --- render -----------------------------------------------------------------
@@ -95,8 +95,20 @@ def test_a_picture_with_nothing_to_file_it_by_goes_to_the_unfiled_folder():
 def test_render_never_escapes_the_library_root():
     """A name is one folder level however many separators the owner typed."""
     picture = facets(projects=["../../etc"], people=["Mira/2024"])
-    rendered = render(picture, DEFAULT_LAYOUT)
-    assert rendered.split("/") == [".._.._etc", "Mira_2024"]
+    assert render(picture, DEFAULT_LAYOUT).split("/") == [".._.._etc", "Mira_2024"]
+
+
+def test_an_unfiled_folder_that_could_escape_the_root_is_refused():
+    """``unfiled`` reaches ``render``'s output verbatim, so it is validated once."""
+    for bad in ["../../etc", "/etc/passwd", "Generations/_Inbox", ""]:
+        with pytest.raises(ValueError):
+            Layout(segments=DEFAULT_LAYOUT.segments, unfiled=bad)
+
+
+def test_a_bare_string_where_a_list_of_names_belongs_is_refused():
+    """``str`` is a ``Sequence[str]``, so this would silently render ``M/``."""
+    with pytest.raises(TypeError):
+        render({Facet.PROJECT: "Mira"}, DEFAULT_LAYOUT)
 
 
 # --- is_true: the case table from DECISIONS.md ------------------------------
@@ -104,69 +116,76 @@ def test_render_never_escapes_the_library_root():
 
 def test_import_moves_nothing_because_the_path_is_where_the_assignment_came_from():
     picture = facets(projects=["2024 Shoots"], people=["Mira"])
-    path = render(picture, DEFAULT_LAYOUT) + "/0412.png"
-    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true(render(picture, DEFAULT_LAYOUT), picture, DEFAULT_LAYOUT, KNOWN)
 
 
 def test_adding_a_second_project_leaves_the_folder_true():
     """It is still in the first one, whichever ``render`` would pick today."""
     picture = facets(projects=["Client Nordvik", "2024 Shoots"], people=["Mira"])
-    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, KNOWN) is True
 
 
 def test_removing_the_project_the_folder_is_named_after_makes_it_false():
     picture = facets(projects=["Client Nordvik"], people=["Mira"])
-    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
 
 
 def test_swapping_the_person_the_folder_is_named_after_makes_it_false():
     picture = facets(projects=["2024 Shoots"], people=["Aled"])
-    assert is_true("2024 Shoots/Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
 
 
 def test_a_folder_of_the_owners_own_below_the_layout_is_not_judged():
     """``2024 Shoots / Mira / 2026-08`` is still a Mira picture in that project."""
     picture = facets(projects=["2024 Shoots"], people=["Mira"])
-    path = "2024 Shoots/Mira/2026-08/0412.png"
-    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true("2024 Shoots/Mira/2026-08", picture, DEFAULT_LAYOUT, KNOWN) is True
+
+
+def test_a_component_below_the_last_segment_is_not_judged_even_when_known():
+    """The layout has run out of segments, so ``Aled`` here is the owner's own."""
+    picture = facets(projects=["2024 Shoots"], people=["Mira"])
+    assert is_true("2024 Shoots/Mira/Aled", picture, DEFAULT_LAYOUT, KNOWN) is True
 
 
 def test_a_skipped_segment_stays_skipped_when_the_picture_gains_one():
     """Nothing is re-derived: gaining a project does not move the set picture."""
     picture = facets(projects=["2024 Shoots"], sets=["mira-lora-v3"])
-    assert is_true("mira-lora-v3/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true("mira-lora-v3", picture, DEFAULT_LAYOUT, KNOWN) is True
 
 
 def test_a_deeper_segment_is_judged_even_when_an_earlier_one_was_skipped():
     picture = facets(sets=["mira-lora-v3"], people=["Aled"])
-    assert is_true("Mira/0412.png", picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
 
 
 def test_where_a_component_can_be_read_two_ways_a_true_reading_wins():
     """A name that is both a project and a person errs towards leaving it alone."""
     known = {Facet.PROJECT: ["Mira"], Facet.PERSON: ["Mira"], Facet.SET: []}
-    picture = facets(people=["Mira"])
-    assert is_true("Mira/0412.png", picture, DEFAULT_LAYOUT, known) is True
+    assert is_true("Mira", facets(people=["Mira"]), DEFAULT_LAYOUT, known) is True
 
 
 def test_a_name_the_library_no_longer_knows_freezes_its_folder():
     """Delete the entity and its name leaves the layout's language."""
     picture = facets(people=["Mira"])
     without_the_project = {**KNOWN, Facet.PROJECT: ["Client Nordvik"]}
-    path = "2024 Shoots/Mira/0412.png"
-    assert is_true(path, picture, DEFAULT_LAYOUT, without_the_project) is True
-    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, without_the_project)
 
 
 # --- is_true: the unfiled folder --------------------------------------------
 
 
 def test_the_unfiled_folder_stops_being_true_the_moment_something_files_it():
-    empty = facets()
-    filed = facets(people=["Mira"])
-    path = f"{DEFAULT_LAYOUT.unfiled}/0412.png"
-    assert is_true(path, empty, DEFAULT_LAYOUT, KNOWN) is True
-    assert is_true(path, filed, DEFAULT_LAYOUT, KNOWN) is False
+    unfiled = DEFAULT_LAYOUT.unfiled
+    assert is_true(unfiled, facets(), DEFAULT_LAYOUT, KNOWN) is True
+    assert is_true(unfiled, facets(people=["Mira"]), DEFAULT_LAYOUT, KNOWN) is False
+
+
+def test_a_tree_below_a_folder_that_happens_to_be_named_like_the_unfiled_one():
+    """The owner's own folders keep the override even under that name."""
+    picture = facets(people=["Mira"])
+    folder = f"{DEFAULT_LAYOUT.unfiled}/2019/holiday"
+    assert is_true(folder, picture, DEFAULT_LAYOUT, KNOWN) is True
 
 
 # --- folder names -----------------------------------------------------------
@@ -179,6 +198,8 @@ def test_the_unfiled_folder_stops_being_true_the_moment_something_files_it():
         ("Mira/2024", "Mira_2024"),
         ("back\\slash", "back_slash"),
         ("colon:name", "colon_name"),
+        ("bell\x07name", "bell_name"),
+        ("del\x7fname", "del_name"),
         ("trailing dot.", "trailing dot"),
         ("  padded  ", "padded"),
         ("..", "_unnamed"),
@@ -194,25 +215,29 @@ def test_folder_name(name, expected):
 
 
 def test_matching_ignores_case_and_unicode_form():
-    """Windows and macOS are case-insensitive, and macOS decomposes accents."""
-    composed = unicodedata.normalize("NFC", "Ren\u00e9e")
+    """Windows and macOS are case-insensitive, and macOS decomposes accents.
+
+    Asserted on a folder that must come out **false**: a decomposed name that
+    simply failed to match would read as an unparseable path and pass either
+    way, which is no test of the normalisation at all.
+    """
+    composed = unicodedata.normalize("NFC", "Renée")
     decomposed = unicodedata.normalize("NFD", composed)
     assert composed != decomposed
-    known = {Facet.PERSON: [composed]}
-    picture = facets(people=[composed])
+    known = {Facet.PERSON: [composed, "Aled"]}
     layout = Layout(segments=((Facet.PERSON,),))
-    assert is_true(f"{decomposed.upper()}/0412.png", picture, layout, known) is True
+    assert is_true(decomposed.upper(), facets(people=[composed]), layout, known) is True
+    assert is_true(decomposed.upper(), facets(people=["Aled"]), layout, known) is False
 
 
-def test_windows_separators_in_the_path_are_read_as_folder_levels():
+def test_windows_separators_are_read_as_folder_levels():
     picture = facets(projects=["Client Nordvik"], people=["Mira"])
-    path = "2024 Shoots\\Mira\\0412.png"
-    assert is_true(path, picture, DEFAULT_LAYOUT, KNOWN) is False
+    assert is_true("2024 Shoots\\Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
 
 
 # --- the layout itself ------------------------------------------------------
 
 
 def test_the_new_library_default_is_project_then_person_or_set():
-    assert str(DEFAULT_LAYOUT) == "Project / Person or Set"
     assert DEFAULT_LAYOUT.segments == ((Facet.PROJECT,), (Facet.PERSON, Facet.SET))
+    assert DEFAULT_LAYOUT.unfiled == "_Inbox"

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -63,6 +63,23 @@ def test_an_unreadable_path_stays_true_even_with_nothing_to_file_it_by():
     assert is_true("_unsorted", facets(), DEFAULT_LAYOUT, KNOWN) is True
 
 
+@pytest.mark.parametrize(
+    "folder",
+    ["2024 Shoots/../Mira", "./2024 Shoots/Mira", "2024 Shoots/Mira/..", ".."],
+)
+def test_an_unnormalised_path_is_refused_whole_rather_than_tidied_up(folder):
+    """Dropping the ``..`` would fabricate a level the path does not have.
+
+    ``2024 Shoots/../Mira`` is a picture in ``Mira`` and nothing else; reading a
+    project level out of it would return false — a move — for a picture that
+    never left one.
+    """
+    picture = facets(projects=["Client Nordvik"], people=["Mira"])
+    assert is_true(folder, picture, DEFAULT_LAYOUT, KNOWN) is True
+    # The same path without the traversal is read, and is false.
+    assert is_true("2024 Shoots/Mira", picture, DEFAULT_LAYOUT, KNOWN) is False
+
+
 # --- render -----------------------------------------------------------------
 
 


### PR DESCRIPTION
Phase 4a of v1.11.0 "Your existing library": **the layout model, and nothing else**. No move engine, no file writes, no UI — that is 4b.

## What this adds

`pixlstash/utils/library_layout.py`, two pure functions and the types they need. Neither touches the database or the filesystem; the caller passes the picture's own names per facet, and — for `is_true` — the library's whole vocabulary of names.

| | |
|---|---|
| `render(facets, layout)` | The folder the picture should be in, relative to the library root. |
| `is_true(folder, facets, layout, known_names)` | Whether the folder it *is* in still describes it. |

A `Layout` is an ordered list of segments, one folder level each. A segment holds one or more `Facet`s and the first that applies wins; a segment with nothing to fill it is skipped rather than left as an empty folder. `DEFAULT_LAYOUT` is `Project` then `Person or Set`, per the Storage artboard.

## Why `is_true` is written the way it is

**A path that does not parse against the layout can never be false.** That single property is the release: a file at the library root matches no segment, so an existing flat library needs no migration, and a file the owner dragged into a folder of their own contradicts nothing, so it stays there permanently and the override needs no setting. `tests/test_library_layout.py` tests that case first, before anything else.

Two consequences worth reading the code for, because they are the parts most likely to be got wrong later:

**Truth is membership, not `render(...) == folder`.** The folder `Mira/` says "this is a Mira picture" and stays true while Mira is one of the picture's people, whoever `render` would pick today. That is exactly what makes the `DECISIONS.md` case table's *"add a second project or person → none moved"* row come out right, and it is why the two functions are not one.

**`is_true` takes a fourth argument, `known_names`.** Only the library's whole vocabulary separates *this folder names a project the picture is no longer in* (false → 4b moves it) from *this folder names nothing PixlStash knows about* (unparseable → it never moves). There is no way to tell those apart from the picture alone, so the load-bearing property is unimplementable without it. The deviation from the brief's three-argument sketch is deliberate.

Deleting an entity therefore takes its name out of the language and freezes the folders named after it. That is the conservative direction and it is documented, not accidental.

## Adversarial pass

One pass, before the push. Clean on secrets and privacy — the diff adds no address, path, login or host name, and `Mira` / `Aled` / `Client Nordvik` / `2024 Shoots` are the design bundle's own placeholders, already on `develop`. Everything below is from that pass.

**Fixed in `0f3ce8b0`:**

- `Layout.unfiled` was an unvalidated `str` returned verbatim by `render`, so `unfiled="../../../etc"` escaped the library root. It is now validated against `folder_name()` on construction — the one field a settings screen will let a user type.
- The unfiled branch judged `components[0]` alone, so an owner who already had an `_Inbox` folder had **its whole subtree** made movable — a hole straight through the property this release rests on. It now fires only at exactly that depth; anything nested below keeps the override.
- `is_true` took a file path and dropped the last component as a file name, so `2024 Shoots/Mira/` and `2024 Shoots/Mira/x.png` returned opposite verdicts. It takes the **folder** now and guesses nothing; 4b passes `os.path.dirname`.
- `render({Facet.PROJECT: "Mira"})` returned `"M"`, because `str` is a `Sequence[str]`. Now a `TypeError`.
- `folder_name` re-derived the control-character class by hand and dropped `\x7f`. It now uses the same regex as `utils/service/export_utils.py`, with a comment on why it cannot call that function (it takes the *last* component, so `Mira/2024` would become `2024` and two entities differing above a separator would collide).
- A dead branch (`set(cleaned) == {"."}`, unreachable after the preceding `rstrip(". ")`).
- **The unicode test tested nothing** — it asserted `True`, and an unrecognised component returns `True` whether or not the normalisation exists, so it passed with `_match_key` deleted. It now asserts a *different* person's decomposed folder comes out **false**. Verified: stubbing `_match_key` to the identity now fails it, and stubbing out the unfiled guard fails its test too.
- A test named for "below the layout is not judged" exercised the wrong branch (unknown component, not ran-out-of-segments). Both branches are now covered.
- Three claims in the `backend_architecture.md` addition were false against the code — `folder_name` as "the chokepoint" (true only now that `unfiled` goes through it), "never the root", and describing the read as positional when it stops at the first unreadable component. Rewritten, and trimmed so it points at the module docstring instead of being a third copy of `DECISIONS.md`.
- Cut `Layout.__str__` and its label table: UI rendering in a no-UI brief, with only a test using it.

**Not fixed, with reasons:**

- *"Rename then reuse the old name moves files, so the model needs entity ids."* It cannot: the path holds **names**, so matching a folder always compares names, and an id has nothing to compare against. The rename row of the case table is satisfied in 4b by renaming the folder — the spec's own wording, *"the folder is renamed"* — after which no stale name is on disk to be reused. Worth a test in 4b; there is nothing for 4a to do.
- *"The artboard shows the unfiled destination as `Generations / _Inbox`, so it must be multi-component."* `Generations` is the library root name throughout that artboard (`Generations / 2024 Shoots / Mira / …` in the drift example immediately above it), not a path level. `unfiled` is correctly a single component, and is now validated as one.
- *"`folder_name` collides `A/B`, `A:B` and `A_B`."* True of any fixed-replacement sanitiser, `_safe_archive_stem` included. The docstring claimed injectivity; that claim is what was wrong, and it is now corrected to state the collision and note it errs towards not moving files — which is the same collision the filesystem forces anyway.
- *"Duplicate facets across segments are accepted silently."* `DECISIONS.md` lists that as open for pass 2. Resolving it here would be deciding a design question by implementation accident; the docstring says so instead.
- *"`Facet.TAG` is unused."* It is the fourth term of the design's entity vocabulary and costs one enum member; a three-member `Facet` would misdescribe the layout builder 4b and the UI work build against.
- *"Several `never false` tests pass against `def is_true(): return True`."* Individually yes — that is what they assert. The suite as a whole does not: inverting the parse guard reds six of them.

## Testing

`tests/test_library_layout.py`, 43 tests, gated in `ci.yml` in alphabetical position. No `Server`, no vault, no fixtures — every case is a dict of names and a folder path, so it runs in 0.16 s.
