### PR TITLE
Delete the CORS exception handler that swallowed Retry-After

### DIFF
--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -1204,25 +1204,20 @@ class Server(
         return server_config
 
     def _add_cors_exception_handler(self):
-        @self.api.exception_handler(HTTPException)
-        async def cors_exception_handler(request, exc):
-            origin = request.headers.get("origin")
-            headers = {
-                "Access-Control-Allow-Credentials": "true",
-            }
-            if origin and (
-                origin in self.allow_origins
-                or (
-                    self.allow_origin_regex
-                    and re.match(self.allow_origin_regex, origin)
-                )
-            ):
-                headers["Access-Control-Allow-Origin"] = origin
-            return JSONResponse(
-                status_code=exc.status_code,
-                content={"detail": exc.detail},
-                headers=headers,
-            )
+        # No HTTPException handler here on purpose. One used to rebuild every
+        # HTTPException as a fresh JSONResponse to re-add the CORS pair, and in
+        # doing so dropped exc.headers — so no route's Retry-After ever reached
+        # a client (#1097). It was never needed: FastAPI's default handler
+        # already forwards exc.headers, and CORSMiddleware sits outside
+        # ExceptionMiddleware, so it stamps Access-Control-Allow-Origin and
+        # Vary: Origin on the result anyway. Measured identical on an allowed
+        # origin, a disallowed one and no origin at all.
+        #
+        # The Exception handler below is *not* redundant in the same way: a
+        # 500 is answered by ServerErrorMiddleware, which sits outside
+        # CORSMiddleware and so never gets stamped. The validation handler
+        # probably is redundant, but it takes no headers from its exception,
+        # so it is left alone rather than widened into this fix.
 
         @self.api.exception_handler(Exception)
         async def generic_exception_handler(request, exc):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,5 +1,6 @@
 import logging
 import tempfile
+import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
@@ -1041,3 +1042,54 @@ def test_secure_required_rejects_remote_plaintext(server, monkeypatch):
     # https from the same remote client is allowed (it's over TLS).
     remote_https = SimpleNamespace(url=SimpleNamespace(scheme="https"))
     server.auth.ensure_secure_when_required(remote_https)  # no raise
+
+
+def test_login_lockout_response_carries_retry_after(server):
+    """The 429 backoff must tell the client how long to wait.
+
+    Regression for #1097: a custom CORS exception handler rebuilt every
+    HTTPException as a fresh JSONResponse and dropped exc.headers, so
+    Retry-After never reached a client. Only the login 429 and the authz
+    gate's 503 raise HTTPException(headers=...) — the other backoff paths
+    (rate_limiter, restore, library admission) build their response directly
+    and never pass through an exception handler at all.
+
+    The Origin header matters: it is what makes CORSMiddleware stamp the
+    response, and proving Retry-After survives *alongside* the CORS pair is
+    the whole point of deleting the handler that used to overwrite it.
+    """
+    server.auth._login_lockout_until = time.monotonic() + 30
+
+    client = TestClient(server.api)
+    response = client.post(
+        f"{API_PREFIX}/login",
+        json={"username": "testuser", "password": "testpassword"},
+        headers={"Origin": "http://localhost:5173"},
+    )
+    assert response.status_code == 429
+    # The real backoff, not just any number: the lockout was armed for 30s.
+    assert 28 <= int(response.headers["Retry-After"]) <= 31
+    # CORSMiddleware still answers an allowed origin, Vary included.
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+    assert response.headers["access-control-allow-credentials"] == "true"
+    assert "Origin" in response.headers["vary"]
+
+
+def test_login_lockout_denies_cors_to_a_disallowed_origin(server):
+    """Forwarding exc.headers must not become a way to widen CORS.
+
+    The deleted handler merged a dict of headers into the response; anything
+    that re-adds one has to keep this false, or an error body becomes readable
+    cross-origin with credentials attached.
+    """
+    server.auth._login_lockout_until = time.monotonic() + 30
+
+    client = TestClient(server.api)
+    response = client.post(
+        f"{API_PREFIX}/login",
+        json={"username": "testuser", "password": "testpassword"},
+        headers={"Origin": "https://evil.example"},
+    )
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
Closes #1097.

## What changed

`Server._add_cors_exception_handler` registered an `HTTPException` handler that
rebuilt every exception as a fresh `JSONResponse` purely to re-add the CORS
pair. It never copied `exc.headers`, so no route's `Retry-After` reached a
client.

The issue proposed merging `exc.headers` into the response. I started there,
then measured what the handler was actually contributing and **deleted it
instead**. FastAPI's default `http_exception_handler` already forwards
`exc.headers`, and `CORSMiddleware` sits outside `ExceptionMiddleware`, so it
stamps the error response either way. Measured against a real `Server`, on the
lockout 429, with and without the handler:

| Origin | custom handler | no handler |
|---|---|---|
| allowed | `retry-after` **missing**, ACAO, credentials, `vary: Origin` | `retry-after: 30`, ACAO, credentials, `vary: Origin` |
| disallowed | `retry-after` **missing**, credentials | `retry-after: 30`, credentials |
| none | `retry-after` **missing**, credentials | `retry-after: 30` |

The only thing the handler added was an unconditional
`Access-Control-Allow-Credentials` on requests with no `Origin` — meaningless
without an `Allow-Origin` beside it. Deleting it fixes the bug for every
`HTTPException` at once, removes the bug class rather than patching it, and
drops 19 lines. The `Exception` handler beside it is genuinely needed and stays:
a 500 is answered by `ServerErrorMiddleware`, which is outside `CORSMiddleware`
and never gets stamped.

## Tests

Two in `tests/test_authentication.py`, in the existing warm-server module (no
new fixture, ~1 s): the lockout 429 carries a real `Retry-After` alongside the
CORS pair for an allowed origin, and a disallowed origin still gets
`Retry-After` but **no** `Access-Control-Allow-Origin`. Both were confirmed red
against the old handler before being called done.

## Two corrections to the issue

- **`routes/libraries.py` has no such site.** The issue's table lists a 503 with
  `Retry-After` at `routes/libraries.py:650`; that file is 248 lines and
  contains neither. Only two `HTTPException(headers=...)` sites exist on
  `develop`: `auth.py:2070` and `authz/gate.py:682`.
- **The gate's 503 is usually preempted.** `LibraryAdmissionMiddleware` is added
  last, so it is outermost, and it emits its own raw ASGI 503 with
  `retry-after: 2` without touching any exception handler. So this change fixes
  the login 429 in practice; the gate's is fixed on the paths that reach it.

## Deliberately not in this diff

An adversarial review pass raised these; I judged them out of scope rather than
dropped them.

- **Middleware-emitted responses carry no CORS headers.**
  `LibraryAdmissionMiddleware` (503) and `utils/rate_limiter.py` (429) both
  build responses outside `CORSMiddleware`, so a browser cannot read either
  body cross-origin. Real, but it is a CORS bug, not a dropped-header bug, and
  both already send the `Retry-After` this issue is about.
- **`validation_exception_handler` is probably redundant too.** Same argument as
  the one deleted here, but it takes no headers from its exception, so removing
  it would be an unrelated behaviour change riding along.
- **Forwarding `exc.headers` is a theoretical CORS-widening surface** if a raise
  site ever put an attacker-influenced `Access-Control-Allow-Origin` in them.
  That is FastAPI's documented default behaviour rather than anything this diff
  invents, and the disallowed-origin test above pins the property so a future
  edit that re-adds a header-merging handler goes red.