### PR TITLE
Use strict realpath containment for the orientation write sink

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1570,6 +1570,26 @@ never on the read path:
   library's files; never do that. A refused path is reported as unconfirmed, so
   the deletion ledger is corrected to `file_removed=False` and restore can
   still resurrect the row.
+- **The in-place rotate** (`operation_log_service.apply_orientation`, §21.5)
+  contains `Picture.file_path` with `resolve_path_within(image_root, …)` and
+  then reads and writes **the resolved path**, so the value that was checked is
+  the value that is used. Containment here is **strict** rather than
+  `path_is_within` (#1024), and the reason is not the one the function name
+  suggests. A symlink planted inside the library never carried the *write* out
+  of it: `write_orientation` renames a `mkstemp` sibling over the path and
+  `os.replace` replaces a symlink instead of following it. `read_orientation`
+  does follow it, so the lexical check let the outside file's bytes — and, via
+  `_carry_file_identity`, its mode and owner — be copied into the library under
+  the link's name. A read escape reachable through a write sink, which is the
+  hole this closes. A library root that is *itself* a symlink still passes,
+  because both sides are resolved.
+  **The cost is deliberate:** a symlinked **subfolder** inside the library —
+  photos kept on a second disk — is refused too, because realpath cannot tell
+  it from a planted link, and rotate declines those pictures. Pinned in
+  `tests/test_path_containment.py` in all three directions. Do not "fix"
+  `path_is_within` to match: the read paths and the shelf's four sites want the
+  lenient form its docstring promises. If the subfolder case must be allowed
+  again, relax it at this sink.
 - **Sidecar write-backs** funnel through `caption_file_utils.writeback_path`,
   which only honours a recorded `tags_file`/`description_file` value that is
   exactly the image stem plus a safe suffix, so a fabricated column cannot

--- a/pixlstash/services/operation_log_service.py
+++ b/pixlstash/services/operation_log_service.py
@@ -89,7 +89,7 @@ from pixlstash.utils.image_processing.orientation import (
     rotate_orientation,
     write_orientation,
 )
-from pixlstash.utils.path_utils import path_is_within
+from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.service.label_ledger import MANUAL_MODEL_VERSION, UNKNOWN
 from pixlstash.utils.service.smart_score_invalidation import (
     InteractiveRescoreRegistry,
@@ -1250,16 +1250,48 @@ def apply_orientation(
     # ORIGINAL bytes, so it is the last place that should be taking the row's word
     # for it. Reference folders are already refused above, so the vault root is
     # the only legitimate location left.
-    if not image_root or not path_is_within(file_path, image_root):
+    #
+    # Containment here is STRICT — `resolve_path_within`, which realpaths both
+    # sides — and not `path_is_within`, which answers True on a purely lexical
+    # pass before any symlink is resolved (#1024). What that lenience costs is
+    # not what the name suggests: a symlink planted inside the library cannot
+    # carry the *write* out of it, because `write_orientation` renames a
+    # `mkstemp` sibling over the path and `os.replace` replaces a symlink rather
+    # than following it. `read_orientation` does follow it, though, so the
+    # outside file's bytes — and, through `_carry_file_identity`, its mode and
+    # owner — would be copied into the library under the link's name. That is a
+    # read escape wearing a write sink's clothes, and this is the sink that can
+    # close it.
+    #
+    # The price is deliberate and paid here rather than argued away: a symlinked
+    # SUBFOLDER inside the library, photos kept on a second disk, is refused too,
+    # because realpath cannot tell one from a planted link. Rotate declines those
+    # pictures; nothing else about them changes. `path_is_within` itself is left
+    # alone, so every read path and the model shelf keep the lenient form its
+    # docstring promises.
+    if not image_root:
         logger.error(
-            "operation_log: refusing to set orientation %s on picture %s — its "
-            "stored path %r resolves to %s, which is outside the library root %r; "
-            "the file is not touched",
+            "operation_log: refusing to set orientation %s on picture %s — no "
+            "library root was supplied, so its stored path %r cannot be confirmed "
+            "to be inside one; the file is not touched",
             orientation,
             picture_id,
             picture.file_path,
-            file_path,
+        )
+        return False
+    try:
+        file_path = resolve_path_within(image_root, os.path.abspath(file_path))
+    except ValueError as exc:
+        logger.error(
+            "operation_log: refusing to set orientation %s on picture %s — its "
+            "stored path %r resolves through to %s, which is outside the library "
+            "root %r (%s); the file is not touched",
+            orientation,
+            picture_id,
+            picture.file_path,
+            os.path.realpath(file_path),
             image_root,
+            exc,
         )
         return False
 

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -305,10 +305,15 @@ def _add_picture(server, file_path: str, reference_folder_id=None) -> int:
     return server.vault.db.run_task(_do)
 
 
-def _rotate_in_session(server, picture_id: int, orientation: int) -> bool:
+def _rotate_in_session(
+    server, picture_id: int, orientation: int, image_root: str = None
+) -> bool:
     def _do(session):
         turned = apply_orientation(
-            session, picture_id, orientation, image_root=server.vault.image_root
+            session,
+            picture_id,
+            orientation,
+            image_root=image_root or server.vault.image_root,
         )
         session.commit()
         return turned
@@ -369,3 +374,97 @@ def test_rotate_refuses_a_reference_folder_file_at_the_sink(server, tmp_path):
 
     assert _rotate_in_session(server, picture_id, 6) is False
     assert read_orientation(external) == 1
+
+
+def _cleanup(*paths) -> None:
+    """Undo what a test left in the module-scoped vault: `clean_db` wipes rows,
+    not files, and a symlink pointing out of the library must not outlive its
+    test."""
+    for path in paths:
+        if not os.path.lexists(path):
+            continue
+        # Windows removes a directory symlink with rmdir; POSIX with unlink.
+        if os.name == "nt" and os.path.islink(path) and os.path.isdir(path):
+            os.rmdir(path)
+        else:
+            os.unlink(path)
+
+
+def test_rotate_accepts_a_library_root_reached_through_a_symlink(server, tmp_path):
+    """Over-blocking guard for the strict check, not a demonstration of it.
+
+    `path_is_within` already accepted an aliased root, so this passes either
+    way; it is here so that a future tightening cannot refuse every library
+    whose folder is reached through a symlink without a test going red.
+    """
+    linked_root = tmp_path / "linked-root"
+    try:
+        linked_root.symlink_to(server.vault.image_root, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+
+    in_root = os.path.join(server.vault.image_root, "aliased.png")
+    _write_png(in_root)
+    picture_id = _add_picture(server, "aliased.png")
+    try:
+        assert _rotate_in_session(server, picture_id, 6, image_root=str(linked_root))
+        assert read_orientation(in_root) == 6
+    finally:
+        _cleanup(in_root)
+
+
+def test_rotate_refuses_a_symlink_inside_the_root_that_points_outside(server, tmp_path):
+    """The topology `path_is_within` accepts on purpose and a write sink cannot.
+
+    The harm is a read escape, not a write one: `os.replace` replaces a symlink
+    rather than following it, so the outside file is never rewritten — but
+    `read_orientation` follows it, and the rotate then lands a copy of that
+    file's bytes inside the library under the link's name, carrying its mode and
+    owner across. Asserting the link is still a link is what fails on the
+    lexical check; the byte assertion holds either way and is kept as the
+    statement of what must never become true.
+    """
+    victim = tmp_path / "outside" / "theirs.png"
+    _write_png(str(victim))
+    untouched = victim.read_bytes()
+
+    link = os.path.join(server.vault.image_root, "looks-in-root.png")
+    try:
+        os.symlink(str(victim), link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    picture_id = _add_picture(server, "looks-in-root.png")
+
+    try:
+        turned = _rotate_in_session(server, picture_id, 6)
+        assert os.path.islink(link), "the outside file was read into the library"
+        assert victim.read_bytes() == untouched
+        assert turned is False
+    finally:
+        _cleanup(link)
+
+
+def test_rotate_declines_a_symlinked_subfolder_inside_the_root(server, tmp_path):
+    """The deliberate cost of the strict check, pinned so it is not a surprise.
+
+    Realpath containment cannot tell a planted link from photos legitimately
+    kept on a second disk, so both are refused. Rotate declines the picture and
+    logs why; nothing else about it changes. If this ever has to be relaxed,
+    relax it here and not in `path_is_within`.
+    """
+    elsewhere = tmp_path / "second-disk"
+    elsewhere.mkdir()
+    _write_png(str(elsewhere / "beach.png"))
+
+    linked_sub = os.path.join(server.vault.image_root, "2024")
+    try:
+        os.symlink(str(elsewhere), linked_sub, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    picture_id = _add_picture(server, os.path.join("2024", "beach.png"))
+
+    try:
+        assert _rotate_in_session(server, picture_id, 6) is False
+        assert read_orientation(str(elsewhere / "beach.png")) == 1
+    finally:
+        _cleanup(linked_sub)

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -306,7 +306,7 @@ def _add_picture(server, file_path: str, reference_folder_id=None) -> int:
 
 
 def _rotate_in_session(
-    server, picture_id: int, orientation: int, image_root: str = None
+    server, picture_id: int, orientation: int, image_root: str | None = None
 ) -> bool:
     def _do(session):
         turned = apply_orientation(


### PR DESCRIPTION
Closes #1024.

`apply_orientation` now contains `Picture.file_path` with `resolve_path_within(image_root, …)` instead of `path_is_within`, and reads and writes **the resolved path**, so the value that was checked is the value that is used. `path_is_within` is untouched: every read path and the model shelf's four sites keep the lenient form its docstring promises.

## The issue's stated impact is wrong, and the fix is still right

The issue says a symlink planted inside the library would let the sink flip the EXIF orientation of a file outside it. It would not, and I checked rather than assuming: `write_orientation` writes a `tempfile.mkstemp` sibling and `os.replace`s it over the path, and `rename(2)` **replaces** a symlink rather than following it. Measured on `develop` with this change reverted — the outside file's bytes and orientation are unchanged, and it is the *link* that gets replaced.

`read_orientation` does follow the link, though. So what the lexical check actually permitted is the other direction: the outside file's bytes get copied **into** the library under the link's name, carrying its mode and owner across via `_carry_file_identity`. A read escape reachable through a write sink, gated by the PNG/JPEG magic check and `MAX_IN_PLACE_BYTES`. Smaller than "we rewrite your files", still worth closing, and worth writing down accurately — the comment, the tests and `docs/backend_architecture.md` all describe this mechanism, not the one in the issue.

## The cost, which the issue does not mention

**A symlinked *subfolder* inside the library now fails to rotate** — photos kept on a second disk, which is an ordinary setup. Realpath containment cannot distinguish it from a planted link, so strict containment refuses both. This is inherent to what #1024 asks for, not an implementation slip. The affected picture is reported `skipped`; nothing else about it changes.

I have shipped it as asked and pinned it with a test that says so, rather than quietly narrowing the fix. **If that trade is not the one you want, this is the line to change** — relax it at this sink, not in `path_is_within`.

## Tests

`tests/test_path_containment.py`, three directions, all against the real sink:

- a symlink inside the root pointing outside is refused — asserts the link is *still a link*, which is the assertion that fails on the old check, plus the outside bytes;
- a symlinked subfolder is declined, pinning the cost above;
- a library root that is itself a symlink still rotates. This one passes with or without the change and its docstring says so — it is an over-blocking guard for the future, not a demonstration.

Both behavioural tests were confirmed to fail with the sink reverted to `path_is_within`. The file is already in the gated list.

## Also in this diff

- The refusal now logs `resolve_path_within`'s own message and the **realpath**. The previous message printed the lexical path, which under the new check reads as "`<root>/2024/x.png` is outside `<root>`".
- A missing `image_root` gets its own message instead of being folded into "outside the library root".
- `os.path.abspath` before the containment call, so a relative `image_root` cannot double-join.

Reviewed adversarially before pushing; the mechanism error, the subfolder regression and the tautological test above were all findings from that pass and are fixed or documented here. No secrets or private data in the diff.
