### PR TITLE
Show a pasted picture, and file it where you were looking

### DIFF
--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -2564,10 +2564,18 @@ function handleImportFinished(payload) {
   emit("import-finished", payload);
 }
 
-function startLocalImport(files, projectId = null) {
+function startLocalImport(files, projectId = null, target = null) {
   const list = Array.isArray(files) ? files : [];
   if (!list.length) return;
-  const options = projectId != null ? { projectId } : {};
+  // `target` carries the set/character the caller was looking at. Only the
+  // keys `startImport` actually reads are forwarded -- it takes `setId` and
+  // `characterId` and ignores anything else, which is how the grid's
+  // `selectedCharacterId` used to go nowhere.
+  const options = {
+    ...(projectId != null ? { projectId } : {}),
+    ...(target?.setId != null ? { setId: target.setId } : {}),
+    ...(target?.characterId != null ? { characterId: target.characterId } : {}),
+  };
   imageImporterRef.value?.startImport(list, options);
 }
 

--- a/frontend/src/composables/useGridDragDrop.js
+++ b/frontend/src/composables/useGridDragDrop.js
@@ -8,6 +8,7 @@ import {
 import { useNoticeStore } from "../stores/useNoticeStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useProjectStore } from "../stores/useProjectStore";
+import { resolveImportTarget } from "../utils/importTarget.js";
 
 /**
  * Manages all drag-and-drop interactions in the image grid:
@@ -196,12 +197,14 @@ export function useGridDragDrop(
     dragSource.value = null;
     // Trigger import directly in ImageGrid
     if (imageImporterRef.value && files.length) {
+      // `startImport` reads `setId` / `characterId` and nothing else. This
+      // used to pass `selectedCharacterId` (plus the two sentinel ids), none of
+      // which it looks at, so a drop into a character or set view was filed
+      // nowhere despite the comment above claiming it threaded the context.
       imageImporterRef.value.startImport(files, {
         backendUrl: props.backendUrl,
-        selectedCharacterId: selectionStore.selectedCharacter,
-        allPicturesId: "ALL",
-        unassignedPicturesId: "UNASSIGNED",
         projectId: projectStore.selectedProjectId ?? null,
+        ...resolveImportTarget(selectionStore),
       });
     }
   }

--- a/frontend/src/composables/useGridRealtimeSync.js
+++ b/frontend/src/composables/useGridRealtimeSync.js
@@ -402,6 +402,27 @@ export function useGridRealtimeSync(deps) {
   // or that was never ghosted, because the undo came from the toolbar, the
   // lightbox or Ctrl+Z long after the fact — is fetched and re-inserted at its
   // sorted position. One path, both cases, no refetch flash for the live one.
+  /**
+   * Put newly-imported pictures into the grid, for own-origin and foreign-ui
+   * alike. Shared because an own-origin `added` is NOT a true echo: see
+   * `handleOwnOrigin`.
+   */
+  function applyAdded(originLabel, pictureIds) {
+    if (deferWhileOverlayOpen()) {
+      return {
+        action: TARGETED,
+        reason: `${originLabel}-added-overlay-deferred`,
+      };
+    }
+    if (grid.isImagesLoading?.()) {
+      // Streaming fetch owns allGridImages; defer to the pill.
+      enqueueAddPill(pictureIds);
+      return { action: PILL, reason: `${originLabel}-added-during-load` };
+    }
+    enqueueAdded(pictureIds);
+    return { action: TARGETED, reason: `${originLabel}-added` };
+  }
+
   function applyRestored(originLabel, pictureIds) {
     if (!pictureIds.length) {
       // "Restore everything" broadcasts no ids (see the restore endpoint), so
@@ -453,6 +474,18 @@ export function useGridRealtimeSync(deps) {
       for (const id of pictureIds) reconcileServerSortField(id, fields);
       return { action: TARGETED, reason: "own-origin-server-sort-reconcile" };
     }
+    // The second own-origin echo that must NOT be suppressed, and for the same
+    // reason as `restored` above: suppression assumes an optimistic local op
+    // already applied the change, and for an add there cannot have been one.
+    // The grid cannot insert a picture whose id the *server* assigns on commit.
+    // A paste, or a drop outside the grid, goes through the sidebar importer,
+    // which deliberately reports no per-file results because "the grid
+    // refreshes off the WS broadcast" (ImageImporter.vue). Suppressing that
+    // broadcast is exactly what left a pasted picture invisible until the view
+    // was switched away and back.
+    if (changeKind === "added") {
+      return applyAdded("own-origin", pictureIds);
+    }
     return { action: SUPPRESSED, reason: "own-origin-echo" };
   }
 
@@ -476,19 +509,7 @@ export function useGridRealtimeSync(deps) {
       return reloadOrDefer("foreign-ui-untargetable-empty-ids");
     }
     if (changeKind === "added") {
-      if (deferWhileOverlayOpen()) {
-        return {
-          action: TARGETED,
-          reason: "foreign-ui-added-overlay-deferred",
-        };
-      }
-      if (grid.isImagesLoading?.()) {
-        // Streaming fetch owns allGridImages; defer to the pill.
-        enqueueAddPill(pictureIds);
-        return { action: PILL, reason: "foreign-ui-added-during-load" };
-      }
-      enqueueAdded(pictureIds);
-      return { action: TARGETED, reason: "foreign-ui-added" };
+      return applyAdded("foreign-ui", pictureIds);
     }
     // updated
     if (!pictureChangeAffectsView(fields)) {

--- a/frontend/src/composables/useGridRealtimeSync.test.js
+++ b/frontend/src/composables/useGridRealtimeSync.test.js
@@ -243,15 +243,36 @@ describe("useGridRealtimeSync decision table", () => {
     expect(h.grid.insertGridImagesById).toHaveBeenCalledWith([50]);
   });
 
-  it("own-origin import echo (matching id) is suppressed", () => {
+  // Expectation deliberately inverted. This asserted suppression, on the same
+  // assumption the `restored` branch already had to walk back: that an
+  // optimistic local op had applied the change. For an add there cannot have
+  // been one -- the grid cannot insert a picture whose id the server assigns on
+  // commit. A paste, or a drop outside the grid, goes through the sidebar
+  // importer, which reports no per-file results because the grid is supposed to
+  // refresh off this very broadcast. Suppressing it left a pasted picture
+  // invisible until the view was switched away and back.
+  it("own-origin import echo is applied, not suppressed", () => {
     const res = h.sync.handleMessage({
       type: "picture_imported",
       source: "ui",
       origin_client_id: MY_ID,
       picture_ids: [60],
     });
+    expect(res.action).toBe("targeted");
+    expect(res.reason).toBe("own-origin-added");
+    expect(h.grid.insertGridImagesById).toHaveBeenCalledWith([60]);
+  });
+
+  it("still suppresses a genuine own-origin echo of an optimistic update", () => {
+    const res = h.sync.handleMessage({
+      type: "pictures_changed",
+      source: "ui",
+      origin_client_id: MY_ID,
+      picture_ids: [61],
+      change_kind: "updated",
+      fields: ["tags"],
+    });
     expect(res.action).toBe("suppressed");
-    expect(h.grid.insertGridImagesById).not.toHaveBeenCalled();
   });
 
   it("does not refresh the sidebar for a view-irrelevant external update", () => {

--- a/frontend/src/composables/useWindowFileImport.js
+++ b/frontend/src/composables/useWindowFileImport.js
@@ -1,6 +1,8 @@
 import { onMounted, onUnmounted } from "vue";
 import { isInternalImageDrag } from "../utils/media.js";
 import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { resolveImportTarget } from "../utils/importTarget.js";
 
 /**
  * Import media dropped or pasted anywhere in the window.
@@ -16,6 +18,7 @@ import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
  */
 export function useWindowFileImport({ sidebarRef }) {
   const reviewSessionsStore = useReviewSessionsStore();
+  const selectionStore = useSelectionStore();
 
   function isInsideImageGrid(event) {
     const target = event?.target;
@@ -88,7 +91,13 @@ export function useWindowFileImport({ sidebarRef }) {
     if (!mediaFiles.length) return;
     event.preventDefault();
     const projectId = sidebarRef.value?.currentProjectId ?? null;
-    sidebarRef.value?.startLocalImport?.(mediaFiles, projectId);
+    // File it where you are looking. Unlike a drop, a paste has no target
+    // element to read context from, so it takes it from the selection.
+    sidebarRef.value?.startLocalImport?.(
+      mediaFiles,
+      projectId,
+      resolveImportTarget(selectionStore),
+    );
   }
 
   onMounted(() => {

--- a/frontend/src/utils/importTarget.js
+++ b/frontend/src/utils/importTarget.js
@@ -1,0 +1,66 @@
+/**
+ * Where a picture imported "here" should be filed.
+ *
+ * Pasting or dropping while looking at a set or a character should put the
+ * picture in what you are looking at. `openStagingSession` has always accepted
+ * `setId` / `characterId` / `projectId` and applies them server-side on commit,
+ * but neither caller supplied them: the paste handler passed only the project,
+ * and the grid's drop handler passed a `selectedCharacterId` key that
+ * `ImageImporter.startImport` does not read, so the association was silently
+ * dropped on both paths.
+ *
+ * Shared by both callers rather than resolved twice, and kept a pure function
+ * of the selection so it can be tested without mounting anything.
+ *
+ * Virtual views are not destinations. "All Pictures", "Unassigned" and the
+ * scrapheap are filters over the library, not containers, so an import made
+ * while looking at one is filed nowhere in particular -- which is what those
+ * views mean.
+ *
+ * A multi-selection is ambiguous and therefore declined: with two sets on
+ * screen there is no answer to which one the picture joins, and picking the
+ * first would be a coin toss the user cannot see. Filing it nowhere is
+ * recoverable by hand; filing it in the wrong set quietly is not.
+ */
+
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+} from "../stores/useViewStore";
+
+/** Ids that name a filter over the library rather than something to join. */
+const VIRTUAL_VIEW_IDS = new Set([
+  ALL_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+]);
+
+/** The one id in `ids`, or null when there are none or more than one. */
+function soleId(ids, single) {
+  const list = Array.isArray(ids) && ids.length ? ids : [];
+  const candidates = list.length ? list : single != null ? [single] : [];
+  if (candidates.length !== 1) return null;
+  const id = candidates[0];
+  if (
+    id == null ||
+    VIRTUAL_VIEW_IDS.has(id) ||
+    VIRTUAL_VIEW_IDS.has(String(id))
+  )
+    return null;
+  return id;
+}
+
+/**
+ * @param {object} selection The selection store (or a plain stand-in).
+ * @returns {{setId: (string|number|null), characterId: (string|number|null)}}
+ */
+export function resolveImportTarget(selection = {}) {
+  return {
+    setId: soleId(selection.selectedSetIds, selection.selectedSet),
+    characterId: soleId(
+      selection.selectedCharacterIds,
+      selection.selectedCharacter,
+    ),
+  };
+}

--- a/frontend/src/utils/importTarget.test.js
+++ b/frontend/src/utils/importTarget.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveImportTarget } from "./importTarget.js";
+
+describe("resolveImportTarget", () => {
+  it("files into the set you are looking at", () => {
+    expect(resolveImportTarget({ selectedSet: 7 })).toEqual({
+      setId: 7,
+      characterId: null,
+    });
+  });
+
+  it("files into the character you are looking at", () => {
+    expect(resolveImportTarget({ selectedCharacter: 12 })).toEqual({
+      setId: null,
+      characterId: 12,
+    });
+  });
+
+  it("carries both when a character is open inside a set", () => {
+    expect(
+      resolveImportTarget({ selectedSet: 7, selectedCharacter: 12 }),
+    ).toEqual({ setId: 7, characterId: 12 });
+  });
+
+  // The default selection is the "All Pictures" sentinel, not a real character.
+  // Treating it as one would try to file every pasted picture into a character
+  // whose id is the string "ALL".
+  it.each(["ALL", "UNASSIGNED", "SCRAPHEAP"])(
+    "treats the %s view as no destination",
+    (sentinel) => {
+      expect(resolveImportTarget({ selectedCharacter: sentinel })).toEqual({
+        setId: null,
+        characterId: null,
+      });
+    },
+  );
+
+  // Picking the first of several would be a coin toss the user cannot see.
+  // Filing nowhere is recoverable by hand; filing it wrong quietly is not.
+  it("declines an ambiguous multi-selection", () => {
+    expect(resolveImportTarget({ selectedSetIds: [3, 4] })).toEqual({
+      setId: null,
+      characterId: null,
+    });
+  });
+
+  it("accepts a multi-selection that names exactly one", () => {
+    expect(resolveImportTarget({ selectedSetIds: [3] }).setId).toBe(3);
+  });
+
+  it("prefers the multi-select list over the single value", () => {
+    expect(
+      resolveImportTarget({ selectedSetIds: [3, 4], selectedSet: 9 }).setId,
+    ).toBeNull();
+  });
+
+  it("survives an empty selection", () => {
+    expect(resolveImportTarget()).toEqual({ setId: null, characterId: null });
+    expect(resolveImportTarget({})).toEqual({ setId: null, characterId: null });
+  });
+});


### PR DESCRIPTION
Two bugs on the same path, both reported against the Electron app and neither Electron-specific.

## 1. A pasted picture did not appear until you switched views

`ImageImporter` deliberately reports no per-file results because *"the grid refreshes off the WS broadcast"*. That broadcast comes back carrying the pasting tab's own `origin_client_id`, and `handleOwnOrigin` suppressed it:

```js
return { action: SUPPRESSED, reason: "own-origin-echo" };
```

Suppression assumes an optimistic local op already applied the change. **For an add there cannot have been one** — the grid cannot insert a picture whose id the *server* assigns on commit. The `restored` branch directly above already had to walk back this same assumption for scrapheap undo, and its comment says so.

Own-origin adds now go through the branch foreign-ui adds already use, rather than a second copy of it.

**This also affected a drop *outside* the grid**, which takes the same sidebar importer. A drop *into* the grid was unaffected because the grid handles those itself.

## 2. The picture was filed nowhere

`openStagingSession` has always accepted `setId` / `characterId` / `projectId` and applies them server-side on commit. Neither caller passed them:

- the paste handler passed only `projectId`
- the grid's drop handler passed `selectedCharacterId`, `allPicturesId` and `unassignedPicturesId` — **none of which `startImport` reads**, so a drop into a character view was silently unfiled too, despite the comment above it claiming it threaded the context

Both now resolve the destination through one shared `resolveImportTarget()`.

### The two judgement calls in it

**Virtual views are not destinations.** All Pictures, Unassigned and the scrapheap are filters over the library, not containers, so an import made while looking at one is filed nowhere — which is what those views mean. Without this, the default selection (the string sentinel `"ALL"`) would be treated as a character id.

**A multi-selection is declined, not guessed.** With two sets on screen there is no answer to which one the picture joins, and picking the first is a coin toss the user cannot see. Filing nowhere is recoverable by hand; filing it in the wrong set quietly is not.

## Tests

387 pass across `src/composables/` plus the new resolver suite. `test_ci_shards.py` passes (143) — it classifies Python test files only, so the new frontend test needs no `ci.yml` entry.

One existing test is **inverted deliberately**: `"own-origin import echo (matching id) is suppressed"` asserted the behaviour being fixed. Its replacement asserts the add is applied, and a second new test keeps a genuine optimistic-update echo suppressed, so this cannot be misread as disabling echo suppression wholesale.

`SideBar.vue` is not Prettier-clean on `main`, so it is edited in place rather than reformatted — running `--write` on it produced eight unrelated hunks that are not in this diff.

## Not included: auto-assigning faces to characters

Deliberately left out. It needs a threshold policy and a tie-break when two characters score close, but more importantly it collides with **#763**: `characters.py` never filters by `Face.model_pack`, so likeness scores across model packs are meaningless while looking plausible. Auto-filing faces on that number would silently mis-assign them, which is worse than not assigning. #763 should land first.
