### PR TITLE
Call unload() and estimated_vram_mb() on tagger plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,7 @@ jobs:
           tests/test_pictures_stream.py
           tests/test_plugin_create.py
           tests/test_plugin_install.py
+          tests/test_plugin_lifecycle_gaps.py
           tests/test_project_membership_service.py
           tests/test_projects_api.py
           tests/test_rate_limiter.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1311,11 +1311,19 @@ declared":
   passes its `engine_override` so an overridden batch is billed for the plugin it
   dispatches to, and `DetectionTask` — which borrows this estimate but always runs
   Florence-2 — names `florence2` explicitly. Two limits worth naming rather than
-  implying: a plugin that returns 0 (the default) or raises still gets the Florence
-  figure, because the host cannot invent a number for a model it knows nothing about —
-  `plugin_template.py` tells authors that an honest overestimate protects them and 0 does
-  not; and `TaggingWorkflow.estimated_vram_mb` still bills its own constants without
-  asking a tag plugin, which is the same gap on the other surface.
+  implying. **First, 0 is ambiguous and the host resolves it against the plugin.**
+  `TaggerPlugin.estimated_vram_mb` documents 0 as "CPU-only" and 0 is also what the
+  base class returns for a plugin that never overrode it, so a 0 on CUDA is read as *no
+  answer* and charged the Florence figure. For a CPU-only plugin that is a harmless
+  over-charge; for a GPU model that returned 0 merely because it was not resident yet it
+  is the under-charge the budget exists to prevent, which is exactly what
+  `JoyCaptionPlugin` used to do — it now bills its full 8 GB footprint until its weights
+  are actually on the CPU. The three docstrings that authors read (`base.py`,
+  `plugin_template.py`, `docs/writing-tagger-plugins.md`) state the ambiguity rather than
+  leaving it to be discovered. Distinguishing "unknown" from "genuinely zero" would need
+  a new sentinel in the published MIT contract, which is a decision for a separate
+  change. **Second**, `TaggingWorkflow.estimated_vram_mb` still bills its own constants
+  without asking a tag plugin, which is the same gap on the other surface.
 - **`generate_descriptions` gets a `stop_event`** on both paths, so a plugin that honours
   it stops between images instead of running the batch out.
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1282,14 +1282,42 @@ folder's absolute host path needs somewhere to be served from, which is why
 `GET /taggers`, which was `ANY_TOKEN` then and is `OWNER_ONLY` now (the same disclosure `GET /pictures/plugins` and
 `GET /comfyui/workflows` had made all along, now removed from both).
 
-**The plugin lifecycle is not fully wired for third parties, and the guide says so.**
-`ModelLifecycleManager` unloads the four built-in *services* by name and does not walk the
-registry, so nothing calls `TaggerPlugin.unload()` on a user plugin; and
-`DescriptionWorkflow` charges the VRAM budget for Florence-2 only, so
-`estimated_vram_mb()` is never consulted. Closing either is a separate change to the
-workflow, not to discovery. The third gap listed here — `generate_descriptions` being
-called without a `stop_event` — is closed: `DescriptionWorkflow` now passes one on both
-paths, so a plugin that honours it stops between images instead of running the batch out.
+**The lifecycle methods the contract declares are now called (issue #967).** All three
+gaps the guide used to list are closed, each of them "the host ignores a method it
+declared":
+
+- **`unload()` reaches every plugin**, through `unload_loaded_tagger_plugins()` in the
+  registry. Until this, a plugin's model stayed resident for the life of the process and
+  *Keep models in memory = off* could not free it — a multi-GB problem for a VLM
+  captioner. **Where it is called from is the whole design.** The one caller is
+  `Vault._maybe_aggressive_unload`, the setting's own sweep, which fires only once every
+  worker is idle. Hanging it off `ModelLifecycleManager.aggressive_unload` instead reads
+  as the tidier place and is wrong twice over: the registry is process-wide and bound to
+  the *vault's* engine (`_bind_engine_services`), while `InferenceEngine.close()` is also
+  what `DescriptionTask` and `TagTask` call to reap a throwaway CPU spillover engine —
+  on the hot path, before every batch — so a per-engine walk would unload the GPU
+  engine's Florence-2 immediately before captioning with it. Waiting for idle also keeps
+  the walk away from a plugin's in-flight load, which is memory-unsafe rather than merely
+  wrong (`tests/test_model_unload_race.py`); the built-in services hold one lock across
+  load and unload, and a third-party plugin may not. Each plugin is guarded on its own,
+  and `is_loaded()` gates the call — which is also what keeps the walk off a built-in
+  wrapper with no service bound, whose `unload()` would raise. It never builds the
+  registry: a registry nothing has imported is holding nothing.
+- **`estimated_vram_mb()` is consulted on the description path.**
+  `DescriptionWorkflow.estimate_vram_mb` asks the plugin that will actually run the
+  batch, capped at that plugin's own `effective_batch_size` and asked with the parameters
+  it will run with. Charging the Florence figure for a batch that never loads Florence
+  let the scheduler start a second model alongside the plugin's and OOM. `DescriptionTask`
+  passes its `engine_override` so an overridden batch is billed for the plugin it
+  dispatches to, and `DetectionTask` — which borrows this estimate but always runs
+  Florence-2 — names `florence2` explicitly. Two limits worth naming rather than
+  implying: a plugin that returns 0 (the default) or raises still gets the Florence
+  figure, because the host cannot invent a number for a model it knows nothing about —
+  `plugin_template.py` tells authors that an honest overestimate protects them and 0 does
+  not; and `TaggingWorkflow.estimated_vram_mb` still bills its own constants without
+  asking a tag plugin, which is the same gap on the other surface.
+- **`generate_descriptions` gets a `stop_event`** on both paths, so a plugin that honours
+  it stops between images instead of running the batch out.
 
 #### Florence-2 checkpoint selection (issue #512)
 

--- a/docs/writing-tagger-plugins.md
+++ b/docs/writing-tagger-plugins.md
@@ -181,23 +181,28 @@ truth between calls — the settings table polls it.
 | `setup(device)` | optional | **Yes** — via `hasattr`, just before `init()`. The only way to learn the device (`"cuda"`, `"cpu"`, …), so implement it if you use a GPU. |
 | `init(parameters)` | yes | **Yes**, before every batch. Return early when already loaded. |
 | `is_loaded()` | yes | **Yes** — the settings table, and `plugin_schema()`. |
-| `unload()` | yes (abstract) | **No.** See below. |
-| `estimated_vram_mb(image_count, parameters)` | no | **No.** See below. |
-| `effective_batch_size(parameters)` | no | **No** (for description plugins). |
+| `unload()` | yes (abstract) | **Yes** — when the workers go idle with "Keep models in memory" off. See below. |
+| `estimated_vram_mb(image_count, parameters)` | no | **Yes** for a description plugin, before its batch is scheduled. Not yet for a tag plugin. See below. |
+| `effective_batch_size(parameters)` | no | **Yes** — it caps the `image_count` your VRAM estimate is asked about, and sizes a tag batch. |
 
-**Know what the host does not yet do for you.** These are honest gaps in the plugin API
-as it stands, not things to design around:
+**Two of these arrive from outside your batch**, so they are worth reading before you
+implement them (issue #967 wired both; older guides say they are never called):
 
-- **Nothing calls `unload()` on a third-party plugin.** The idle-unload path
-  (`ModelLifecycleManager`) knows the four built-in *services* by name and does not walk
-  the plugin registry. `unload()` is still abstract, so implement it — but a model your
-  plugin loads stays resident for the life of the process, and "Keep models in memory =
-  off" will not free it. If that matters for your model, manage it yourself inside
-  `generate_descriptions`.
-- **Nothing calls `estimated_vram_mb()` on a third-party plugin.** `DescriptionWorkflow`
-  charges the VRAM budget for Florence-2 only. Overriding it is harmless and forward-
-  looking, but it will not currently stop PixlStash scheduling another model alongside
-  yours, so keep your own footprint modest.
+- **`unload()` is called when the user turns "Keep models in memory" off and every worker
+  has gone idle.** The host unloads its own services first and then walks the plugin
+  registry, calling `unload()` on every plugin whose `is_loaded()` returns true. It runs
+  on the sweep's thread, not yours. The idle condition means it will not normally land
+  mid-batch, but it is not a guarantee you should lean on: **serialise unload against
+  load** — the built-in services hold one lock across both — rather than freeing memory
+  another thread is still writing into, which is a segfault and not an exception. A raise
+  here is logged and contained; it will not stop the other plugins being released.
+- **`estimated_vram_mb()` is asked before a description batch runs**, when your plugin is
+  the active description plugin. (A *tag* plugin is not asked yet — `TaggingWorkflow`
+  still bills its own constants.) `image_count` is already capped at your
+  `effective_batch_size(parameters)`. Returning 0 — the default — means "no answer", and
+  the host then charges the Florence-2 figure, which is not your model's: that is exactly
+  the case where it can schedule another model alongside yours and run the card out of
+  memory. An honest overestimate protects you; 0 does not.
 
 ## 5. Inference
 

--- a/docs/writing-tagger-plugins.md
+++ b/docs/writing-tagger-plugins.md
@@ -199,10 +199,24 @@ implement them (issue #967 wired both; older guides say they are never called):
 - **`estimated_vram_mb()` is asked before a description batch runs**, when your plugin is
   the active description plugin. (A *tag* plugin is not asked yet — `TaggingWorkflow`
   still bills its own constants.) `image_count` is already capped at your
-  `effective_batch_size(parameters)`. Returning 0 — the default — means "no answer", and
-  the host then charges the Florence-2 figure, which is not your model's: that is exactly
-  the case where it can schedule another model alongside yours and run the card out of
-  memory. An honest overestimate protects you; 0 does not.
+  `effective_batch_size(parameters)`.
+
+  **0 has two meanings and the host has to guess.** `TaggerPlugin.estimated_vram_mb`
+  documents 0 as "CPU-only", and 0 is also what the default returns for a plugin that
+  never overrode the method. On a CUDA engine the host cannot distinguish them, so it
+  reads any 0 as *no answer* and charges the Florence-2 figure instead — around 900 MB
+  for `base`, 2.6 GB for `large-ft`. Which way that hurts depends on which you meant:
+
+  | You return | You meant | What actually happens |
+  |---|---|---|
+  | 0 (no override) | "I haven't thought about it" | Billed the Florence figure. Fine for a small model, badly wrong for a big one. |
+  | 0 (CPU-only model) | "I need no VRAM" | Billed the Florence figure anyway. Harmless over-charge: your batch may wait, it will not break. |
+  | 0 (GPU model, not loaded yet) | "nothing is resident *right now*" | **The dangerous one.** Billed ~1 GB for the several you are about to allocate, and another model is scheduled alongside you. |
+  | a real figure | "this is what I will occupy" | Budgeted correctly. |
+
+  So charge for the **cold start** as well as the warm one — `JoyCaptionPlugin` bills its
+  full 8 GB footprint until its weights are actually sitting on the CPU — and keep 0 for
+  a model that genuinely holds nothing on the card.
 
 ## 5. Inference
 

--- a/pixlstash/inference/workflows/description.py
+++ b/pixlstash/inference/workflows/description.py
@@ -233,8 +233,13 @@ class DescriptionWorkflow:
 
         return results
 
-    def estimate_vram_mb(self, image_count: int) -> int:
+    def estimate_vram_mb(self, image_count: int, plugin_name: str | None = None) -> int:
         """Estimate incremental VRAM (in MB) required to caption *image_count* images.
+
+        The estimate follows the batch's dispatch: when a plugin other than
+        Florence-2 will run it, that plugin is asked. Charging the Florence
+        figure for a run that never loads Florence lets the scheduler start a
+        second model alongside the plugin's and OOM.
 
         When Florence is already resident in GPU memory only the per-image
         activation scratch is charged, avoiding a false-positive VRAM gate
@@ -244,12 +249,26 @@ class DescriptionWorkflow:
 
         Args:
             image_count: Number of images to be captioned.
+            plugin_name: Plugin the batch will be dispatched to, matching
+                ``generate_batch``'s ``engine_override``. ``None`` means the
+                configured ``active_description_plugin``.
 
         Returns:
             Estimated VRAM in MB, or ``0`` on non-CUDA devices.
         """
         if self._engine.device != "cuda":
             return 0
+        active = (
+            plugin_name
+            if plugin_name is not None
+            else self._engine.tagger_settings.get(
+                "active_description_plugin", "florence2"
+            )
+        )
+        if active and active != "florence2":
+            estimate = self._plugin_estimate_vram_mb(active, image_count)
+            if estimate > 0:
+                return estimate
         service = self._engine.florence_service
         # The gate runs before the load, so charge the variant that is about to
         # be loaded, not whichever one happens to be resident.
@@ -259,3 +278,39 @@ class DescriptionWorkflow:
         if service.is_loaded():
             return int(FLORENCE_PER_IMAGE_VRAM_MB * batch)
         return int(service.base_vram_mb + FLORENCE_PER_IMAGE_VRAM_MB * batch)
+
+    def _plugin_estimate_vram_mb(self, plugin_name: str, image_count: int) -> int:
+        """Ask *plugin_name* what a batch of *image_count* images will cost.
+
+        Returns ``0``, meaning "charge the Florence-2 estimate instead", in two
+        different situations. For a plugin that is missing or cannot caption
+        that is simply correct: ``generate_batch`` falls back to Florence-2, so
+        Florence is what loads. For a plugin that returns 0 (the base class
+        default) or raises it is a known under-charge — that plugin *does* run
+        — kept because the host cannot invent a figure for a model it knows
+        nothing about, and a plugin that overrides the method gets a real
+        budget (issue #967, and ``plugin_template.py`` tells authors so).
+        """
+        from pixlstash.tagger_plugins.registry import get_tagger_plugin_manager
+
+        try:
+            plugin = get_tagger_plugin_manager().get_plugin(plugin_name)
+            if plugin is None or not plugin.supports_descriptions:
+                return 0
+            cfg = self._engine.tagger_settings.get("plugins", {}).get(plugin_name, {})
+            params = {**plugin.default_params(), **(cfg.get("params") or {})}
+            # Capped at the plugin's own batch size for the same reason the
+            # Florence path caps at its own: only one batch is resident at once.
+            batch = min(
+                max(1, int(image_count or 1)),
+                max(1, int(plugin.effective_batch_size(params))),
+            )
+            return max(0, int(plugin.estimated_vram_mb(batch, params)))
+        except Exception as exc:
+            logger.warning(
+                "Description plugin %r could not estimate VRAM; falling back to "
+                "the Florence-2 estimate: %s",
+                plugin_name,
+                exc,
+            )
+            return 0

--- a/pixlstash/inference/workflows/description.py
+++ b/pixlstash/inference/workflows/description.py
@@ -285,11 +285,14 @@ class DescriptionWorkflow:
         Returns ``0``, meaning "charge the Florence-2 estimate instead", in two
         different situations. For a plugin that is missing or cannot caption
         that is simply correct: ``generate_batch`` falls back to Florence-2, so
-        Florence is what loads. For a plugin that returns 0 (the base class
-        default) or raises it is a known under-charge — that plugin *does* run
-        — kept because the host cannot invent a figure for a model it knows
-        nothing about, and a plugin that overrides the method gets a real
-        budget (issue #967, and ``plugin_template.py`` tells authors so).
+        Florence is what loads. For a plugin that returns 0 or raises it is
+        a deliberate charge for the wrong model, because that plugin *does*
+        run. 0 is ambiguous at this seam — it is the base class default, and
+        also its documented "CPU-only" value, and the two cannot be told apart
+        — so the fallback is kept for both: the host cannot invent a figure for
+        a model it knows nothing about, and for the CPU-only reading the error
+        is a harmless over-charge. ``TaggerPlugin.estimated_vram_mb`` tells
+        authors to charge for a cold start rather than rely on this (#967).
         """
         from pixlstash.tagger_plugins.registry import get_tagger_plugin_manager
 

--- a/pixlstash/tagger_plugins/base.py
+++ b/pixlstash/tagger_plugins/base.py
@@ -236,7 +236,21 @@ class TaggerPlugin(ABC):
         """Estimate VRAM (MB) required for *image_count* images.
 
         Used by workflows for sequential VRAM budgeting (max over plugins).
-        Return 0 for CPU-only models.
+        The description workflow asks the active description plugin before it
+        schedules a batch, with *image_count* already capped at
+        :meth:`effective_batch_size`.
+
+        **0 is ambiguous, and the host resolves it against you.** It is both
+        "this model needs no VRAM" and what this default returns for a plugin
+        that never overrode the method, and the two cannot be told apart. On a
+        CUDA engine a 0 is therefore read as *no answer*: the host charges the
+        Florence-2 figure instead, which is not your model's. That is a
+        deliberate over-charge for a CPU-only plugin (harmless — it may delay
+        your batch, never break it) and a serious **under**-charge for a GPU
+        model that returned 0 because it was not resident yet, which is the
+        OOM this budget exists to prevent. So: return a real figure whenever
+        your model will occupy the card, cold start included, and reserve 0
+        for a model that genuinely holds nothing on it.
 
         Args:
             image_count: Number of images to be processed.

--- a/pixlstash/tagger_plugins/joycaption.py
+++ b/pixlstash/tagger_plugins/joycaption.py
@@ -785,6 +785,12 @@ class JoyCaptionPlugin(TaggerPlugin):
     ) -> int:
         """Estimate peak VRAM for processing *image_count* images.
 
+        A model that is *not yet resident* is charged in full, because the host
+        asks this before it loads and only on a CUDA engine: returning 0 for a
+        cold start would bill nothing for the 8 GB that is about to be
+        allocated, which is the OOM the budget exists to prevent (#967). Only a
+        model already sitting on the CPU costs nothing.
+
         Args:
             image_count: Number of images.
             parameters: Plugin parameters (uses ``precision``).
@@ -792,9 +798,7 @@ class JoyCaptionPlugin(TaggerPlugin):
         Returns:
             Estimated VRAM in MB.
         """
-        if self._service is None or self._service._model_device is None:
-            return 0
-        if str(self._service._model_device) == "cpu":
+        if self._service is not None and str(self._service._model_device) == "cpu":
             return 0
         return _BASE_VRAM_MB + _PER_IMAGE_VRAM_MB * max(1, image_count)
 

--- a/pixlstash/tagger_plugins/plugin_template.py
+++ b/pixlstash/tagger_plugins/plugin_template.py
@@ -193,9 +193,18 @@ class MyCaptioner(TaggerPlugin):
 
         The description workflow asks the active plugin before it schedules a
         batch, with *image_count* already capped at your
-        ``effective_batch_size``.  Returning 0 (the default) means "no answer":
-        the host charges the Florence-2 figure instead, which is not your
-        model's, so an honest overestimate protects you better than 0 does.
+        ``effective_batch_size``.
+
+        **Watch the 0.**  The base class documents it as "CPU-only", and it is
+        also what the default returns for a plugin that never overrode this —
+        the host cannot tell those apart, so on a CUDA engine it reads any 0 as
+        "no answer" and charges the Florence-2 figure instead.  For a CPU-only
+        plugin that is a harmless over-charge.  For a GPU model it is not: if
+        you return 0 while your weights are merely *not loaded yet*, you are
+        billed ~1 GB for the several you are about to allocate, and something
+        else gets scheduled alongside you.  Charge for a cold start too —
+        ``JoyCaptionPlugin`` does — and keep 0 for a model that really does
+        hold nothing on the card.
         """
         return 0
 

--- a/pixlstash/tagger_plugins/plugin_template.py
+++ b/pixlstash/tagger_plugins/plugin_template.py
@@ -172,11 +172,13 @@ class MyCaptioner(TaggerPlugin):
     def unload(self) -> None:
         """Release the model.
 
-        Abstract, so you must implement it — but be aware that nothing
-        currently calls it on a third-party plugin: the idle-unload path
-        knows the built-in services by name and does not walk the plugin
-        registry.  A model you load here stays resident for the life of the
-        process.  Manage it yourself if that matters.
+        Called by the host when the user turns *Keep models in memory* off
+        and every worker has gone idle.  That makes a mid-batch unload
+        unlikely rather than impossible, so serialise it against your own load
+        — the built-in services hold one lock across both — rather than
+        freeing memory another thread is still writing into.  It is only
+        called when ``is_loaded()`` is true, and a failure here is logged and
+        contained rather than stopping the other plugins being released.
         """
         self._model = None
 
@@ -189,10 +191,11 @@ class MyCaptioner(TaggerPlugin):
     ) -> int:
         """Estimated VRAM for a batch, in MB.
 
-        Nothing calls this on a third-party plugin yet — the description
-        workflow charges the budget for Florence-2 only — so overriding it
-        is forward-looking rather than protective.  Keep your own footprint
-        modest; another model may be scheduled alongside yours regardless.
+        The description workflow asks the active plugin before it schedules a
+        batch, with *image_count* already capped at your
+        ``effective_batch_size``.  Returning 0 (the default) means "no answer":
+        the host charges the Florence-2 figure instead, which is not your
+        model's, so an honest overestimate protects you better than 0 does.
         """
         return 0
 

--- a/pixlstash/tagger_plugins/registry.py
+++ b/pixlstash/tagger_plugins/registry.py
@@ -168,6 +168,25 @@ class TaggerPluginManager:
         with self._lock:
             return list(self._plugins.values())
 
+    def unload_all(self) -> None:
+        """Call ``unload()`` on every registered plugin that reports loaded.
+
+        Each plugin is guarded on its own: one that raises must not leave the
+        rest of the library resident. Does not load the registry — a plugin
+        that was never imported is holding nothing.
+        """
+        with self._lock:
+            plugins = list(self._plugins.values())
+        for plugin in plugins:
+            name = getattr(plugin, "name", type(plugin).__name__)
+            try:
+                if not plugin.is_loaded():
+                    continue
+                plugin.unload()
+                logger.debug("Released tagger plugin '%s'.", name)
+            except Exception as exc:
+                logger.warning("Tagger plugin '%s' failed to unload: %s", name, exc)
+
     def get_plugin(self, name: str) -> TaggerPlugin | None:
         """Return the plugin with the given name, or ``None`` if not found.
 
@@ -468,6 +487,33 @@ def user_plugin_dir() -> str:
 
 _manager: TaggerPluginManager | None = None
 _manager_lock = Lock()
+
+
+def unload_loaded_tagger_plugins() -> None:
+    """Release every loaded plugin in the process-wide registry.
+
+    The one caller is :meth:`~pixlstash.vault.Vault._maybe_aggressive_unload`,
+    the *Keep models in memory = off* sweep, which runs only once every worker
+    is idle. That is deliberate on both counts:
+
+    * The registry is process-wide, and the vault's engine is the one its
+      plugins are bound to (``Vault._bind_engine_services``). Hanging this off
+      ``InferenceEngine.close()`` instead would mean reaping a throwaway CPU
+      spillover engine — which ``DescriptionTask`` and ``TagTask`` do on the
+      hot path, before every batch — unloading the GPU engine's models.
+    * A plugin's ``unload()`` may arrive while its own load is in flight, which
+      is memory-unsafe rather than merely wrong (``tests/test_model_unload_race.py``).
+      The built-in services hold one lock across load and unload; a third-party
+      plugin may not, and waiting for idle is what keeps that window shut.
+
+    Never triggers a load: a registry nothing has built holds nothing resident,
+    and importing every plugin module in order to free memory would be the
+    opposite of the thing being asked for.
+    """
+    manager = _manager
+    if manager is None or not manager._loaded:
+        return
+    manager.unload_all()
 
 
 def get_tagger_plugin_manager() -> TaggerPluginManager:

--- a/pixlstash/tasks/description_task.py
+++ b/pixlstash/tasks/description_task.py
@@ -105,7 +105,12 @@ class DescriptionTask(BaseTask):
 
     def estimated_vram_mb(self) -> int:
         try:
-            return max(0, self._workflow.estimate_vram_mb(len(self._pictures)))
+            return max(
+                0,
+                self._workflow.estimate_vram_mb(
+                    len(self._pictures), plugin_name=self._engine_override
+                ),
+            )
         except Exception as exc:
             logger.debug(
                 "DescriptionTask: VRAM estimate failed for %d picture(s); "

--- a/pixlstash/tasks/detection_task.py
+++ b/pixlstash/tasks/detection_task.py
@@ -87,11 +87,15 @@ class DetectionTask(BaseTask):
     def estimated_vram_mb(self) -> int:
         # Detection shares Florence-2 with captioning; reuse the description
         # workflow's VRAM estimate (model weights dominate; detection's extra
-        # output tokens are negligible activation scratch).
+        # output tokens are negligible activation scratch). Named explicitly:
+        # detection always runs Florence-2, whatever plugin is configured to
+        # caption, and that estimate now follows the active plugin.
         try:
             return max(
                 0,
-                self._engine.description_workflow.estimate_vram_mb(len(self._pictures)),
+                self._engine.description_workflow.estimate_vram_mb(
+                    len(self._pictures), plugin_name="florence2"
+                ),
             )
         except Exception as exc:
             logger.debug(

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -47,7 +47,10 @@ from . import worker_config
 
 from pixlstash.event_types import EventType
 from pixlstash.utils.service.smart_score_invalidation import InteractiveRescoreRegistry
-from pixlstash.tagger_plugins.registry import get_tagger_plugin_manager
+from pixlstash.tagger_plugins.registry import (
+    get_tagger_plugin_manager,
+    unload_loaded_tagger_plugins,
+)
 from pixlstash.services.set_lock_service import enforce_pictures_not_locked
 from pixlstash.services.scrapheap_service import DEFAULT_RETENTION_DAYS
 from pixlstash.services.snapshot_service import SnapshotService
@@ -1813,6 +1816,14 @@ class Vault:
             self._engine.aggressive_unload()
         except Exception as exc:
             logger.warning("Aggressive unload failed for InferenceEngine: %s", exc)
+        # The engine unloads the services it owns by name; a tagger plugin's
+        # model is reachable only through the registry, and until this it was
+        # not reachable at all — a plugin captioner stayed resident for the
+        # life of the process and this setting could not free it (#967).
+        try:
+            unload_loaded_tagger_plugins()
+        except Exception as exc:
+            logger.warning("Aggressive unload failed for tagger plugins: %s", exc)
         try:
             FaceExtractionTask.release_detection_models()
         except Exception as exc:

--- a/tests/test_description_cancel_blanking.py
+++ b/tests/test_description_cancel_blanking.py
@@ -80,7 +80,7 @@ class _CancelledMidBatchWorkflow:
         self.stop_event = stop_event
         return {first.id: "captioned-before-the-cancel"}
 
-    def estimate_vram_mb(self, image_count):
+    def estimate_vram_mb(self, image_count, plugin_name=None):
         return 0
 
 
@@ -172,7 +172,7 @@ def test_a_genuine_failure_still_clears_the_description():
         def generate_batch(self, pictures, engine_override=None, stop_event=None):
             return {}
 
-        def estimate_vram_mb(self, image_count):
+        def estimate_vram_mb(self, image_count, plugin_name=None):
             return 0
 
     pics = [types.SimpleNamespace(id=failed, description=None)]

--- a/tests/test_picture_set_locking.py
+++ b/tests/test_picture_set_locking.py
@@ -1111,7 +1111,7 @@ def test_description_regeneration_skips_locked_pic():
             def generate_batch(self, pictures, engine_override=None, stop_event=None):
                 return {p.id: "regenerated-caption" for p in pictures}
 
-            def estimate_vram_mb(self, n):
+            def estimate_vram_mb(self, n, plugin_name=None):
                 return 0
 
         pics = [

--- a/tests/test_plugin_lifecycle_gaps.py
+++ b/tests/test_plugin_lifecycle_gaps.py
@@ -1,0 +1,340 @@
+"""The host must actually use the plugin lifecycle methods it declares (#967).
+
+Two gaps this pins, both "the contract declares a method and nothing calls it":
+
+* ``unload()`` is abstract on ``TaggerPlugin`` — every plugin implements it and
+  nothing used to call it, so a plugin's model stayed resident for the life of
+  the process and *Keep models in memory = off* could not free it. That is a
+  multi-GB problem for a VLM captioner. The registry walk now runs from the
+  vault's idle sweep, which is the process-wide decision; hanging it off
+  ``InferenceEngine.close()`` would have made reaping a throwaway CPU spillover
+  engine unload the *GPU* engine's plugins, because the registry is bound to
+  the vault's engine and the spillover reap runs before every batch.
+* ``estimated_vram_mb()`` existed and was never called: the description gate
+  charged the Florence-2 figure whichever plugin was about to run, so it billed
+  for a model that was not loading and nothing for the one that was.
+
+Deliberately Server-free and model-free: stub plugins and a stub engine are
+everything these paths touch (CLAUDE.md, "reuse the environment"), so the file
+costs milliseconds.
+"""
+
+import types
+
+import pytest
+
+from pixlstash.inference.workflows.description import DescriptionWorkflow
+from pixlstash.tagger_plugins import registry
+from pixlstash.tagger_plugins.base import TaggerPlugin
+from pixlstash.tagger_plugins.florence2 import FLORENCE_PER_IMAGE_VRAM_MB
+
+
+class _StubPlugin(TaggerPlugin):
+    """A plugin that records what the host asked of it."""
+
+    def __init__(
+        self,
+        name,
+        loaded=True,
+        raises=False,
+        vram=0,
+        batch=1,
+        supports_descriptions=True,
+    ):
+        self.name = name
+        self.display_name = name
+        self.supports_descriptions = supports_descriptions
+        self.unload_calls = 0
+        self._loaded = loaded
+        self._raises = raises
+        self._vram = vram
+        self._batch = batch
+        self.vram_asked_for = None
+
+    def parameter_schema(self):
+        return [
+            {
+                "name": "precision",
+                "label": "Precision",
+                "type": "string",
+                "default": "nf4",
+            }
+        ]
+
+    def needs_download(self, parameters=None):
+        return False
+
+    def init(self, parameters):
+        self._loaded = True
+
+    def unload(self):
+        self.unload_calls += 1
+        if self._raises:
+            raise RuntimeError(f"{self.name} refuses to unload")
+        self._loaded = False
+
+    def is_loaded(self):
+        return self._loaded
+
+    def effective_batch_size(self, parameters=None):
+        return self._batch
+
+    def estimated_vram_mb(self, image_count, parameters=None):
+        self.vram_asked_for = (image_count, parameters)
+        if self._raises:
+            raise RuntimeError(f"{self.name} cannot estimate")
+        return self._vram
+
+    def generate_descriptions(self, image_paths, parameters, stop_event=None):
+        return {path: "a caption" for path in image_paths}
+
+
+@pytest.fixture
+def install_plugins(monkeypatch):
+    """Install *plugins* as the process-wide registry for one test."""
+
+    def _install(*plugins):
+        manager = registry.TaggerPluginManager(user_dir=None, first_party=[])
+        manager.reload()
+        manager._plugins = {plugin.name: plugin for plugin in plugins}
+        monkeypatch.setattr(registry, "_manager", manager)
+        return manager
+
+    return _install
+
+
+# ----------------------------------------------------------------------
+# 1. unload() reaches third-party plugins
+# ----------------------------------------------------------------------
+
+
+def test_the_idle_sweep_releases_a_loaded_plugin(install_plugins):
+    """The blocker: a resident plugin model that nothing could ever free."""
+    captioner = _StubPlugin("example_captioner")
+    install_plugins(captioner)
+
+    registry.unload_loaded_tagger_plugins()
+
+    assert captioner.unload_calls == 1, (
+        "the registry walk left the plugin resident; 'Keep models in memory = "
+        "off' then cannot free a multi-GB VLM"
+    )
+    assert not captioner.is_loaded()
+
+
+def test_a_plugin_that_holds_nothing_is_not_unloaded(install_plugins):
+    """``is_loaded()`` gates the call, which is what keeps the walk off a
+    built-in wrapper whose service the engine has already released — and off a
+    wrapper with no service bound at all, whose ``unload()`` would raise."""
+    cold = _StubPlugin("example_cold", loaded=False)
+    install_plugins(cold)
+
+    registry.unload_loaded_tagger_plugins()
+
+    assert cold.unload_calls == 0
+
+
+def test_an_unbound_builtin_wrapper_is_skipped_rather_than_raising(install_plugins):
+    """The real shape of the case above: ``WD14Plugin.unload()`` goes through a
+    ``service`` property that raises when nothing is bound, and ``is_loaded()``
+    is what stops it being reached."""
+    from pixlstash.tagger_plugins.wd14 import WD14Plugin
+
+    wrapper = WD14Plugin()
+    assert wrapper._service is None, "an unbound wrapper is the case under test"
+    assert not wrapper.is_loaded()
+    with pytest.raises(RuntimeError):
+        wrapper.unload()  # what the walk must never reach
+
+    install_plugins(wrapper)
+    registry.unload_loaded_tagger_plugins()  # must not raise
+
+
+def test_one_plugin_raising_does_not_strand_the_rest(install_plugins):
+    """Guarded per plugin: one bad plugin must not keep the library resident."""
+    bad = _StubPlugin("example_bad", raises=True)
+    good = _StubPlugin("example_good")
+    install_plugins(bad, good)
+
+    registry.unload_loaded_tagger_plugins()
+
+    assert bad.unload_calls == 1
+    assert good.unload_calls == 1, "the plugin after the raising one was stranded"
+
+
+def test_unload_never_builds_the_registry(monkeypatch):
+    """An unload that imports every plugin module to find something to free is
+    the opposite of the thing being asked for."""
+    monkeypatch.setattr(registry, "_manager", None)
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("the unload walk loaded the plugin registry")
+
+    monkeypatch.setattr(registry, "TaggerPluginManager", _explode)
+
+    registry.unload_loaded_tagger_plugins()
+
+    assert registry._manager is None
+
+
+def test_a_half_built_registry_is_left_alone(install_plugins):
+    """``get_tagger_plugin_manager`` publishes the singleton *before* it loads,
+    so there is a window where the manager exists and holds nothing. Walking it
+    would block on the import lock and then re-enter ``reload()``."""
+    manager = install_plugins(_StubPlugin("example_captioner"))
+    manager._loaded = False
+
+    def _explode():
+        raise AssertionError("the unload walk re-entered reload()")
+
+    manager.reload = _explode
+
+    registry.unload_loaded_tagger_plugins()
+
+
+def test_closing_a_spillover_engine_does_not_touch_the_registry(install_plugins):
+    """``DescriptionTask``/``TagTask`` reap an idle CPU engine before every
+    batch. The registry is bound to the *vault's* engine, so a per-engine
+    unload walk would free the GPU model the batch is about to use."""
+    from pixlstash.inference.model_lifecycle import ModelLifecycleManager
+
+    captioner = _StubPlugin("example_captioner")
+    install_plugins(captioner)
+
+    ModelLifecycleManager(device="cpu").aggressive_unload()
+
+    assert captioner.unload_calls == 0, (
+        "closing one engine unloaded the process-wide registry; that is the "
+        "GPU engine's Florence-2 and JoyCaption on the spillover reap path"
+    )
+
+
+# ----------------------------------------------------------------------
+# 2. estimated_vram_mb() is consulted
+# ----------------------------------------------------------------------
+
+
+def _engine(active_plugin, florence_loaded=False):
+    """A stub with the attributes DescriptionWorkflow.estimate_vram_mb reads."""
+    florence = types.SimpleNamespace(
+        set_model_variant=lambda variant: None,
+        description_batch_size=lambda: 4,
+        is_loaded=lambda: florence_loaded,
+        base_vram_mb=900,
+    )
+    return types.SimpleNamespace(
+        device="cuda",
+        florence_service=florence,
+        florence_model_variant="base",
+        tagger_settings={
+            "active_description_plugin": active_plugin,
+            "plugins": {"example_captioner": {"params": {"precision": "bf16"}}},
+        },
+    )
+
+
+_FLORENCE_COLD_MB = 900 + FLORENCE_PER_IMAGE_VRAM_MB * 4  # base + scratch * batch
+
+
+def test_estimate_asks_the_active_description_plugin(install_plugins):
+    """The blocker: charging the Florence figure for a run that never loads
+    Florence lets the scheduler start a second model alongside and OOM."""
+    plugin = _StubPlugin("example_captioner", vram=7000, batch=2)
+    install_plugins(plugin)
+    workflow = DescriptionWorkflow(_engine("example_captioner"), image_root=None)
+
+    assert workflow.estimate_vram_mb(8) == 7000
+    assert plugin.vram_asked_for[0] == 2, (
+        "the estimate must be capped at the plugin's own batch size; only one "
+        "batch is resident at a time"
+    )
+    assert plugin.vram_asked_for[1]["precision"] == "bf16", (
+        "the plugin must be asked with the parameters it will actually run with"
+    )
+
+
+def test_estimate_follows_an_engine_override(install_plugins):
+    """A batch dispatched to an overridden plugin is billed for that plugin."""
+    plugin = _StubPlugin("example_captioner", vram=7000, batch=8)
+    install_plugins(plugin)
+    workflow = DescriptionWorkflow(_engine("florence2"), image_root=None)
+
+    assert workflow.estimate_vram_mb(4, plugin_name="example_captioner") == 7000
+    assert workflow.estimate_vram_mb(4) == _FLORENCE_COLD_MB, (
+        "with no override the configured active plugin decides, and that is "
+        "Florence-2 here"
+    )
+
+
+def test_detection_is_still_billed_for_florence(install_plugins):
+    """DetectionTask borrows this estimate but always runs Florence-2, whatever
+    plugin is configured to caption — so it names the plugin explicitly."""
+    plugin = _StubPlugin("example_captioner", vram=7000, batch=8)
+    install_plugins(plugin)
+    workflow = DescriptionWorkflow(_engine("example_captioner"), image_root=None)
+
+    assert workflow.estimate_vram_mb(8, plugin_name="florence2") == _FLORENCE_COLD_MB
+    assert plugin.vram_asked_for is None
+
+
+def test_a_plugin_that_cannot_caption_is_billed_for_florence(install_plugins):
+    """``generate_batch`` falls back to Florence-2 for this plugin, so the
+    Florence figure is the one that describes what will actually load."""
+    install_plugins(
+        _StubPlugin("example_captioner", vram=7000, supports_descriptions=False)
+    )
+    workflow = DescriptionWorkflow(_engine("example_captioner"), image_root=None)
+
+    assert workflow.estimate_vram_mb(8) == _FLORENCE_COLD_MB
+
+
+@pytest.mark.parametrize("declines", ["returns_zero", "raises"])
+def test_a_plugin_that_declines_to_answer_leaves_the_old_estimate(
+    install_plugins, declines
+):
+    """Unchanged behaviour, and deliberately so (#967): the plugin *does* run
+    here, so the Florence figure is wrong — but the host cannot invent a number
+    for a model it knows nothing about, and a plugin that overrides the method
+    gets a correct budget. ``plugin_template.py`` says as much to authors."""
+    plugin = _StubPlugin("example_captioner", raises=(declines == "raises"), vram=0)
+    install_plugins(plugin)
+    workflow = DescriptionWorkflow(_engine("example_captioner"), image_root=None)
+
+    assert workflow.estimate_vram_mb(8) == _FLORENCE_COLD_MB
+    assert plugin.vram_asked_for is not None, "the plugin must still be asked"
+
+
+def test_estimate_stays_zero_on_cpu(install_plugins):
+    """No VRAM to budget: the plugin must not be consulted at all."""
+    plugin = _StubPlugin("example_captioner", vram=7000)
+    install_plugins(plugin)
+    engine = _engine("example_captioner")
+    engine.device = "cpu"
+
+    assert DescriptionWorkflow(engine, image_root=None).estimate_vram_mb(8) == 0
+    assert plugin.vram_asked_for is None
+
+
+def test_the_vault_idle_sweep_is_the_caller(install_plugins):
+    """Wiring check: the walk is reached from the *Keep models in memory = off*
+    sweep, and only once every worker is idle — which is what keeps a plugin's
+    unload from landing on top of its own in-flight load."""
+    from pixlstash.vault import Vault
+
+    captioner = _StubPlugin("example_captioner")
+    install_plugins(captioner)
+
+    fake_vault = types.SimpleNamespace(
+        _keep_models_in_memory=False,
+        _engine=types.SimpleNamespace(aggressive_unload=lambda: None),
+        _last_aggressive_unload_at=0.0,
+        AGGRESSIVE_UNLOAD_INTERVAL=Vault.AGGRESSIVE_UNLOAD_INTERVAL,
+        _disable_background_workers=True,
+    )
+    busy = {"tagging": {"running": True, "status": "running", "remaining": 5}}
+
+    Vault._maybe_aggressive_unload(fake_vault, busy)
+    assert captioner.unload_calls == 0, "a busy worker must not lose its model"
+
+    Vault._maybe_aggressive_unload(fake_vault, {})
+    assert captioner.unload_calls == 1

--- a/tests/test_plugin_lifecycle_gaps.py
+++ b/tests/test_plugin_lifecycle_gaps.py
@@ -338,3 +338,26 @@ def test_the_vault_idle_sweep_is_the_caller(install_plugins):
 
     Vault._maybe_aggressive_unload(fake_vault, {})
     assert captioner.unload_calls == 1
+
+
+def test_joycaption_charges_for_a_cold_start():
+    """The shipped VLM is the case the budget exists for: it used to return 0
+    while its weights were merely not loaded yet, which — now that the host
+    reads 0 as "no answer" — would bill ~1 GB of Florence for the 8 GB it is
+    about to allocate."""
+    from pixlstash.tagger_plugins.joycaption import (
+        _BASE_VRAM_MB,
+        JoyCaptionPlugin,
+    )
+
+    cold = JoyCaptionPlugin()
+    assert cold._service is None, "a plugin before setup() is the case under test"
+    assert cold.estimated_vram_mb(1) >= _BASE_VRAM_MB, (
+        "a cold JoyCaption billed nothing for the model it is about to load"
+    )
+
+    cold.setup(device="cpu")
+    cold._service._model_device = "cpu"
+    assert cold.estimated_vram_mb(1) == 0, (
+        "a model already sitting on the CPU occupies no VRAM"
+    )


### PR DESCRIPTION
Closes #967.

Three methods the plugin contract declares that the host never called. Two needed
code; the third turned out to be already fixed.

## 1. `unload()` now reaches a plugin's model

`unload_loaded_tagger_plugins()` (registry) walks the registry and unloads every
plugin whose `is_loaded()` is true, each guarded so one raising plugin cannot leave
the rest resident. Before this a plugin's model stayed resident for the life of the
process and **Keep models in memory = off could not free it** — a multi-GB problem
for a VLM captioner.

**Where it is called from is the design, and the issue's suggested location was
wrong.** The issue proposed hanging this off `ModelLifecycleManager.aggressive_unload`
/ `safe_idle_unload`. I did that first and an adversarial review caught it: the
registry is process-wide and bound to the *vault's* engine (`_bind_engine_services`),
while `InferenceEngine.close()` — which `aggressive_unload` is an alias of — is also
what `DescriptionTask` and `TagTask` call to reap a throwaway **CPU spillover**
engine, on the hot path before every batch. A per-engine walk therefore unloads the
GPU engine's Florence-2 and JoyCaption immediately before captioning with them, and
can do it while another worker is inside `generate_captions_batch`. `safe_idle_unload`
is also dead code — it has no production caller — so half the change would never have
run at all.

The caller is `Vault._maybe_aggressive_unload`, the setting's own sweep, which fires
only once every worker is idle. That is also the safer moment: a plugin's `unload()`
landing on its own in-flight load is memory-unsafe rather than merely wrong
(`tests/test_model_unload_race.py` exists because that took the process down as a
SIGSEGV). The built-in services hold one lock across load and unload; a third-party
plugin may not, and every plugin written against the old template was told in writing
that `unload()` is never called. Waiting for idle is what keeps that window shut, and
`docs/writing-tagger-plugins.md` and `plugin_template.py` now state the requirement.

The walk never *builds* the registry — an unload that imports every plugin module to
find something to free is the opposite of the thing being asked for — and it skips a
half-built one, since `get_tagger_plugin_manager` publishes the singleton before it
loads.

## 2. `estimated_vram_mb()` is now consulted

`DescriptionWorkflow.estimate_vram_mb` asks the plugin that will actually run the
batch, capped at that plugin's own `effective_batch_size` and asked with the
parameters it will run with. Charging the Florence figure for a batch that never loads
Florence lets the scheduler start a second model alongside the plugin's and OOM.

Two callers had to be told which plugin they mean:

* `DescriptionTask` passes its `engine_override`, so an overridden batch is billed for
  the plugin it dispatches to.
* `DetectionTask` borrows this estimate but **always runs Florence-2** whatever plugin
  is configured to caption, so it now names `florence2` explicitly. Without that line
  this change would have mis-billed detection — a regression I introduced and then
  found by grepping the callers.

## 3. `stop_event` on the description path — already fixed

The issue was verified at `dc62306`; PR #969 ("Make Captioning Tasks more cancellable")
landed on `develop` after that and threads the event through `_generate_batch_plugin`
exactly as asked. Only the docs, which still called it a gap, needed changing.

## Answering the adversarial review

Findings I acted on are folded in above (the spillover regression, the dead idle path,
the half-built registry, and a set of test-quality fixes: real `WD14Plugin` coverage
for the unbound-wrapper case, exact assertions instead of `!=`, stubs built per test
rather than at collection time). Two I disagree with:

* **"A plugin that returns 0 or raises is still billed the Florence figure, so the gap
  is only half closed."** True, and deliberate — it is what the issue asks for ("falling
  back to the current behaviour when it returns 0 or raises keeps this safe"). The host
  cannot invent a figure for a model it knows nothing about; inventing one would be a
  guess presented as a budget. A plugin that overrides the method now gets a real budget,
  and `plugin_template.py` tells authors an honest overestimate protects them and 0 does
  not. The docstring and the docs now say this plainly instead of implying it is correct.
* **"`TaggingWorkflow.estimated_vram_mb` still never asks a tag plugin."** Correct, and
  left alone: #967 scopes itself to the description dispatch path. It is named as a
  remaining gap in both `docs/backend_architecture.md` and the plugin guide rather than
  quietly widened here.

## Tests

`tests/test_plugin_lifecycle_gaps.py` — 16 tests, Server-free and model-free (~4 s),
gated in `ci.yml`. Includes a regression test that closing an engine must **not** touch
the registry, and a wiring test that the vault sweep is the caller and does nothing
while a worker is busy. Verified by mutation: reverting either fix reds the file.

The plugins repo's "known gaps" guides still describe the old behaviour and want a
follow-up there — it is a separate repository, not a submodule of this one.


---

## Review round 2 (Copilot, both threads)

Both comments made the same point: `plugin_template.py` and the guide say a 0 from
`estimated_vram_mb()` means "no answer", while `TaggerPlugin.estimated_vram_mb`
documents 0 as the CPU-only sentinel — so the docs contradicted the contract.

Right, and it was live rather than cosmetic. `JoyCaptionPlugin.estimated_vram_mb`
returned 0 whenever `_service is None or _model_device is None` — a **cold start**,
which is exactly when it is about to allocate 8 GB. Under this PR's new fallback that
billed ~900 MB of Florence for the one load the budget exists to gate, so the shipped
VLM would still have been able to OOM the card. Fixed in 8161bafb: it charges its full
footprint until its weights are actually on the CPU, pinned by
`test_joycaption_charges_for_a_cold_start`.

The ambiguity is now stated in all three places an author reads — `base.py` (the
contract), `plugin_template.py`, and the guide, which carries a table of what a 0 might
have meant and what the host does with each. No-override and CPU-only are both charged
the Florence figure; "GPU model, not loaded yet" is named as the dangerous one.

**Not done, deliberately:** giving "unknown" its own sentinel so a deliberate 0 could be
honoured. That changes the published MIT plugin contract and is a decision for a separate
change. Keeping the fallback for every 0 also errs in the safe direction — an over-charge
delays a batch, an under-charge OOMs it.
