### PR TITLE
Rename the ownerpass1 fixture password onto the stand-in convention

### DIFF
--- a/tests/multi_project_authz/conftest.py
+++ b/tests/multi_project_authz/conftest.py
@@ -65,7 +65,8 @@ def _module_env():
         client = TestClient(server.api, raise_server_exceptions=True)
         anon = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 
@@ -150,7 +151,7 @@ def env(_module_env, request):
     _reset_domain_state(server, m.baseline)
 
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, (
         f"owner re-login failed — the shared environment is dirty: {r.text}"

--- a/tests/test_anomaly_region_scope.py
+++ b/tests/test_anomaly_region_scope.py
@@ -83,7 +83,7 @@ def _setup_server_with_pictures():
     client = TestClient(server.api, raise_server_exceptions=True)
 
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
 

--- a/tests/test_async_import_staging.py
+++ b/tests/test_async_import_staging.py
@@ -94,7 +94,8 @@ def owner_server():
         with Server(config_path) as srv:
             client = TestClient(srv.api, raise_server_exceptions=True)
             r = client.post(
-                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                f"{API}/login",
+                json={"username": "owner", "password": "example-owner-password"},
             )
             assert r.status_code == 200, r.text
             yield srv, client

--- a/tests/test_auth_read_path.py
+++ b/tests/test_auth_read_path.py
@@ -94,7 +94,7 @@ def owner_client(server):
 
     client = TestClient(server.api)
     response = client.post(
-        "/login", json={"username": "owner651", "password": "ownerpass1"}
+        "/login", json={"username": "owner651", "password": "example-owner-password"}
     )
     assert response.status_code == 200, response.text
     yield client

--- a/tests/test_authz_gate_step3.py
+++ b/tests/test_authz_gate_step3.py
@@ -74,7 +74,8 @@ def _owner_env():
     try:
         client = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 

--- a/tests/test_authz_gate_step4.py
+++ b/tests/test_authz_gate_step4.py
@@ -489,7 +489,8 @@ def env():
         client = TestClient(server.api, raise_server_exceptions=True)
         anon = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 

--- a/tests/test_authz_host_capability_16_3.py
+++ b/tests/test_authz_host_capability_16_3.py
@@ -324,7 +324,8 @@ def _owner_env():
     try:
         client = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
         yield {"server": server, "owner": client, "tmp": tmp}
@@ -834,7 +835,8 @@ def _test_hooks_owner_env():
     try:
         client = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
         yield {"server": server, "owner": client, "tmp": tmp}

--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -61,7 +61,7 @@ def _owner_client(server) -> TestClient:
     """A client logged in as the owner."""
     client = TestClient(server.api)
     response = client.post(
-        "/login", json={"username": "pinowner", "password": "pinownerpass1"}
+        "/login", json={"username": "pinowner", "password": "example-pinowner-password"}
     )
     assert response.status_code == 200, response.text
     return client

--- a/tests/test_batch_character_likeness_scope.py
+++ b/tests/test_batch_character_likeness_scope.py
@@ -63,7 +63,7 @@ def _setup_server_with_pictures():
     client = TestClient(server.api, raise_server_exceptions=True)
 
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
 

--- a/tests/test_comfyui_recipe_route.py
+++ b/tests/test_comfyui_recipe_route.py
@@ -110,7 +110,8 @@ def env():
     try:
         client = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 

--- a/tests/test_dedup_mixed_stacks.py
+++ b/tests/test_dedup_mixed_stacks.py
@@ -170,7 +170,8 @@ def _env():
     client = TestClient(server.api)
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )

--- a/tests/test_dedup_sweep_api.py
+++ b/tests/test_dedup_sweep_api.py
@@ -132,7 +132,8 @@ def _env():
     client = TestClient(server.api)
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -107,7 +107,8 @@ def _env():
     client = TestClient(server.api)
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )
@@ -1580,7 +1581,7 @@ def test_two_clients_cannot_interleave_inside_an_atomic_verdict_gesture(
         assert (
             client_b.post(
                 f"{API}/login",
-                json={"username": "owner", "password": "ownerpass1"},
+                json={"username": "owner", "password": "example-owner-password"},
             ).status_code
             == 200
         )

--- a/tests/test_detections_scope.py
+++ b/tests/test_detections_scope.py
@@ -66,7 +66,7 @@ def _setup_server_with_pictures():
     client = TestClient(server.api, raise_server_exceptions=True)
 
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
 

--- a/tests/test_import_scrapheap_match.py
+++ b/tests/test_import_scrapheap_match.py
@@ -68,7 +68,8 @@ def owner_server():
         with Server(config_path) as srv:
             client = TestClient(srv.api, raise_server_exceptions=True)
             r = client.post(
-                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                f"{API}/login",
+                json={"username": "owner", "password": "example-owner-password"},
             )
             assert r.status_code == 200, r.text
             yield srv, client

--- a/tests/test_impossible_clear_authz.py
+++ b/tests/test_impossible_clear_authz.py
@@ -90,7 +90,8 @@ def _env():
     client = TestClient(server.api)
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )

--- a/tests/test_insightface_relocation.py
+++ b/tests/test_insightface_relocation.py
@@ -125,7 +125,8 @@ def face_env(tmp_path, data_dir, monkeypatch):
     try:
         owner = TestClient(server.api, raise_server_exceptions=True)
         r = owner.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
         yield _FaceEnv(

--- a/tests/test_keep_cover_only.py
+++ b/tests/test_keep_cover_only.py
@@ -188,7 +188,8 @@ def _env():
     client = TestClient(server.api)
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )

--- a/tests/test_libraries_routes.py
+++ b/tests/test_libraries_routes.py
@@ -82,7 +82,7 @@ def _owner(server, client_ip: str | None = None) -> TestClient:
     """
     client = TestClient(server.api)
     response = client.post(
-        "/login", json={"username": "libowner", "password": "libownerpass1"}
+        "/login", json={"username": "libowner", "password": "example-libowner-password"}
     )
     assert response.status_code == 200, response.text
     if client_ip:

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -289,7 +289,8 @@ def shelf_env():
     try:
         owner = TestClient(server.api, raise_server_exceptions=True)
         r = owner.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 

--- a/tests/test_picture_mutation_scope.py
+++ b/tests/test_picture_mutation_scope.py
@@ -200,7 +200,8 @@ def _shared_env():
         try:
             client = TestClient(server.api, raise_server_exceptions=True)
             r = client.post(
-                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                f"{API}/login",
+                json={"username": "owner", "password": "example-owner-password"},
             )
             assert r.status_code == 200, r.text
 
@@ -303,7 +304,7 @@ def fresh_state(_shared_env):
     )
 
     r = shared.client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, (
         f"owner re-login failed — the shared environment is dirty: {r.text}"

--- a/tests/test_read_token_security.py
+++ b/tests/test_read_token_security.py
@@ -167,7 +167,7 @@ def _setup_server_with_pictures(temp_dir: str):
 
     # Set up credentials.
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
 
@@ -245,7 +245,7 @@ def _setup_two_picture_sets(tmp: str):
     client = TestClient(server.api, raise_server_exceptions=True)
 
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
 
@@ -382,9 +382,9 @@ def _reset_owner_credentials(server, owner_client) -> None:
     otherwise 429 the re-login below.
 
     The re-login is itself an assertion. It proves the owner password is still
-    ``ownerpass1``, which is precisely what the "READ token cannot change the
-    password" tests are protecting, and it fails loudly instead of letting a
-    dirty environment masquerade as a scope refusal.
+    ``example-owner-password``, which is precisely what the "READ token cannot
+    change the password" tests are protecting, and it fails loudly instead of
+    letting a dirty environment masquerade as a scope refusal.
     """
 
     def _wipe(session: Session):
@@ -399,7 +399,7 @@ def _reset_owner_credentials(server, owner_client) -> None:
     _clear_rate_limit_window(server)
 
     r = owner_client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, (
         f"owner re-login failed — the shared environment is dirty: {r.text}"
@@ -693,7 +693,8 @@ def _comfyui_stack_env():
         try:
             owner_client = TestClient(server.api, raise_server_exceptions=True)
             r = owner_client.post(
-                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                f"{API}/login",
+                json={"username": "owner", "password": "example-owner-password"},
             )
             assert r.status_code == 200, r.text
 
@@ -822,8 +823,8 @@ class TestReadTokenBlocksWrites(_SharedPictureLibrary):
         r = TestClient(library_env.server.api).post(
             f"{API}/users/me/auth",
             json={
-                "current_password": "ownerpass1",
-                "new_password": "hacked12345",
+                "current_password": "example-owner-password",
+                "new_password": "example-hacked-password",
             },
             headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
@@ -1994,7 +1995,8 @@ class TestComfyuiFilterCannotEscapeTokenScope:
             try:
                 owner_client = TestClient(server.api, raise_server_exceptions=True)
                 r = owner_client.post(
-                    f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                    f"{API}/login",
+                    json={"username": "owner", "password": "example-owner-password"},
                 )
                 assert r.status_code == 200, r.text
 
@@ -2247,7 +2249,7 @@ class TestLoginBruteForce:
                 # Establish a password.
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "correctpass123"},
+                    json={"username": "victim", "password": "example-correct-password"},
                 )
                 assert r.status_code == 200, r.text
 
@@ -2255,7 +2257,10 @@ class TestLoginBruteForce:
                 for i in range(5):
                     r = client.post(
                         f"{API}/login",
-                        json={"username": "victim", "password": f"wrongpass{i}"},
+                        json={
+                            "username": "victim",
+                            "password": f"example-wrong-password-{i}",
+                        },
                     )
                     assert r.status_code == 401, (
                         f"Expected 401 on attempt {i + 1}, got {r.status_code}"
@@ -2264,7 +2269,7 @@ class TestLoginBruteForce:
                 # The 6th attempt should be blocked.
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "wrongpass6"},
+                    json={"username": "victim", "password": "example-wrong-password-6"},
                 )
                 assert r.status_code == 429, (
                     f"Expected 429 lockout after 5 failures, got {r.status_code}: {r.text}"
@@ -2282,20 +2287,23 @@ class TestLoginBruteForce:
 
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "correctpass123"},
+                    json={"username": "victim", "password": "example-correct-password"},
                 )
                 assert r.status_code == 200, r.text
 
                 for i in range(5):
                     client.post(
                         f"{API}/login",
-                        json={"username": "victim", "password": f"wrongpass{i}"},
+                        json={
+                            "username": "victim",
+                            "password": f"example-wrong-password-{i}",
+                        },
                     )
 
                 # Correct password — should still be blocked during lockout.
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "correctpass123"},
+                    json={"username": "victim", "password": "example-correct-password"},
                 )
                 assert r.status_code == 429, (
                     f"Correct password during lockout should still return 429, "
@@ -2312,7 +2320,7 @@ class TestLoginBruteForce:
 
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "correctpass123"},
+                    json={"username": "victim", "password": "example-correct-password"},
                 )
                 assert r.status_code == 200, r.text
 
@@ -2320,13 +2328,16 @@ class TestLoginBruteForce:
                 for i in range(4):
                     client.post(
                         f"{API}/login",
-                        json={"username": "victim", "password": f"wrongpass{i}"},
+                        json={
+                            "username": "victim",
+                            "password": f"example-wrong-password-{i}",
+                        },
                     )
 
                 # 5th attempt with correct password should succeed (lockout hits at 5+).
                 r = client.post(
                     f"{API}/login",
-                    json={"username": "victim", "password": "correctpass123"},
+                    json={"username": "victim", "password": "example-correct-password"},
                 )
                 assert r.status_code == 200, (
                     f"4 failures should not yet trigger lockout; "
@@ -2357,13 +2368,16 @@ class TestRateLimiter:
                     for _ in range(5):
                         client.post(
                             f"{API}/login",
-                            json={"username": "u", "password": "initialpass"},
+                            json={
+                                "username": "u",
+                                "password": "example-initial-password",
+                            },
                         )
 
                     # This should now be rate limited.
                     r = client.post(
                         f"{API}/login",
-                        json={"username": "u", "password": "initialpass"},
+                        json={"username": "u", "password": "example-initial-password"},
                     )
                     assert r.status_code == 429, (
                         f"Expected 429 from rate limiter after {5} hits, "
@@ -2381,7 +2395,10 @@ class TestRateLimiter:
 
                     r = client.post(
                         f"{API}/login",
-                        json={"username": "owner", "password": "ownerpass99"},
+                        json={
+                            "username": "owner",
+                            "password": "example-owner-password-99",
+                        },
                     )
                     assert r.status_code == 200, r.text
 
@@ -2418,13 +2435,16 @@ class TestRateLimiter:
 
                     # Exhaust the limit.
                     assert client.post(
-                        f"{API}/login", json={"username": "u", "password": "password1"}
+                        f"{API}/login",
+                        json={"username": "u", "password": "example-password"},
                     ).status_code in {200, 401}
                     assert client.post(
-                        f"{API}/login", json={"username": "u", "password": "password1"}
+                        f"{API}/login",
+                        json={"username": "u", "password": "example-password"},
                     ).status_code in {200, 401}
                     r = client.post(
-                        f"{API}/login", json={"username": "u", "password": "password1"}
+                        f"{API}/login",
+                        json={"username": "u", "password": "example-password"},
                     )
                     assert r.status_code == 429
 
@@ -2432,7 +2452,8 @@ class TestRateLimiter:
                     time.sleep(window_seconds + 0.2)
 
                     r = client.post(
-                        f"{API}/login", json={"username": "u", "password": "password1"}
+                        f"{API}/login",
+                        json={"username": "u", "password": "example-password"},
                     )
                     assert r.status_code in {200, 401}, (
                         f"After window reset, login should no longer be rate-limited; "
@@ -2507,8 +2528,8 @@ class TestDataIntegrityUnderAttack(_SharedPictureLibrary):
         attack_client.post(
             f"{API}/users/me/auth",
             json={
-                "current_password": "ownerpass1",
-                "new_password": "hacked12345",
+                "current_password": "example-owner-password",
+                "new_password": "example-hacked-password",
             },
             headers=headers,
         )
@@ -2517,7 +2538,7 @@ class TestDataIntegrityUnderAttack(_SharedPictureLibrary):
         fresh_client = TestClient(library_env.server.api)
         r = fresh_client.post(
             f"{API}/login",
-            json={"username": "owner", "password": "ownerpass1"},
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, (
             f"Owner password must be unchanged after attack attempts, "
@@ -2534,7 +2555,7 @@ class TestDataIntegrityUnderAttack(_SharedPictureLibrary):
         for i in range(5):
             r = attack_client.post(
                 f"{API}/login",
-                json={"username": "owner", "password": f"wrongpass{i}"},
+                json={"username": "owner", "password": f"example-wrong-password-{i}"},
             )
             assert r.status_code == 401, (
                 f"attempt {i + 1} should have been a plain auth failure, "
@@ -2542,7 +2563,8 @@ class TestDataIntegrityUnderAttack(_SharedPictureLibrary):
                 "about was never reached"
             )
         r = attack_client.post(
-            f"{API}/login", json={"username": "owner", "password": "wrongpass5"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-wrong-password-5"},
         )
         assert r.status_code == 429, (
             f"the 6th failure should have hit the lockout, got {r.status_code}"

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -3465,7 +3465,8 @@ def _empty_scrapheap_via_http(server):
 
     client = TestClient(server.api, raise_server_exceptions=True)
     login = client.post(
-        "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+        "/api/v1/login",
+        json={"username": "owner", "password": "example-owner-password"},
     )
     assert login.status_code == 200, login.text
     # The destructive endpoint refuses without the single-use confirm_token the
@@ -4157,7 +4158,8 @@ def test_full_restore_closes_auth_before_swap_and_across_queue_gap(server, monke
 
     owner = TestClient(server.api, raise_server_exceptions=True)
     login = owner.post(
-        "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+        "/api/v1/login",
+        json={"username": "owner", "password": "example-owner-password"},
     )
     assert login.status_code == 200, login.text
     token_response = owner.post(
@@ -4246,7 +4248,8 @@ def test_share_link_is_unavailable_while_restore_admission_is_closed(server):
 
     owner = TestClient(server.api, raise_server_exceptions=True)
     login = owner.post(
-        "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+        "/api/v1/login",
+        json={"username": "owner", "password": "example-owner-password"},
     )
     assert login.status_code == 200, login.text
     _pic, created = _create_picture_share(owner, server, "share-gate.jpg")
@@ -4278,7 +4281,8 @@ def test_full_restore_drains_an_admitted_share_before_swap(server, monkeypatch):
 
     owner = TestClient(server.api, raise_server_exceptions=True)
     login = owner.post(
-        "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+        "/api/v1/login",
+        json={"username": "owner", "password": "example-owner-password"},
     )
     assert login.status_code == 200, login.text
     _pic, created = _create_picture_share(owner, server, "share-drain.jpg")
@@ -4399,7 +4403,8 @@ def test_full_restore_drains_an_admitted_http_request_before_swap(server, monkey
     blocked_client = TestClient(server.api, raise_server_exceptions=True)
     for client in (restore_client, blocked_client):
         login = client.post(
-            "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+            "/api/v1/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert login.status_code == 200, login.text
 
@@ -4524,7 +4529,8 @@ def test_full_restore_reset_failure_is_not_success_and_keeps_auth_closed(
 
     owner = TestClient(server.api, raise_server_exceptions=True)
     login = owner.post(
-        "/api/v1/login", json={"username": "owner", "password": "ownerpass1"}
+        "/api/v1/login",
+        json={"username": "owner", "password": "example-owner-password"},
     )
     assert login.status_code == 200, login.text
     _create_file(server, "restore-auth-reset-failure.jpg")

--- a/tests/test_snapshots_auth.py
+++ b/tests/test_snapshots_auth.py
@@ -45,7 +45,8 @@ def _setup_server_with_owner_session():
     try:
         client = TestClient(server.api, raise_server_exceptions=True)
         r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
     except BaseException:

--- a/tests/test_tag_suggestions_api.py
+++ b/tests/test_tag_suggestions_api.py
@@ -1465,7 +1465,8 @@ def _setup_scoped_token_env():
     # Versioned login so the auth middleware establishes the owner session.
     assert (
         client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         ).status_code
         == 200
     )

--- a/tests/test_telemetry_install_id_authz.py
+++ b/tests/test_telemetry_install_id_authz.py
@@ -41,7 +41,8 @@ def _owner_env():
     try:
         owner = TestClient(server.api, raise_server_exceptions=True)
         r = owner.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            f"{API}/login",
+            json={"username": "owner", "password": "example-owner-password"},
         )
         assert r.status_code == 200, r.text
 

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -88,7 +88,7 @@ def owner_client(server):
     """A TestClient logged in as the owner (carries the session cookie)."""
     client = TestClient(server.api, raise_server_exceptions=True)
     r = client.post(
-        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        f"{API}/login", json={"username": "owner", "password": "example-owner-password"}
     )
     assert r.status_code == 200, r.text
     return client


### PR DESCRIPTION
Closes #1108.

The fixture password `ownerpass1` does not follow the stand-in convention
CLAUDE.md documents, so an automated push scan reads it as real. It is not a
credential to anything — the first `POST /login` on a fresh vault *registers*
the owner with whatever it is sent, so the value is invented by the tests and
opens nothing outside a `tempfile.TemporaryDirectory()`.

## What changed

- `ownerpass1` → `example-owner-password`, 44 places across 27 files under `tests/`.
- The two file-local variants the blanket rename would have mangled, fixed by hand
  so the marker stays at the front of the value:
  `pinownerpass1` → `example-pinowner-password` (`test_authz_library_pin.py`),
  `libownerpass1` → `example-libowner-password` (`test_libraries_routes.py`).
- `ownerpass99` → `example-owner-password-99` — same `owner…` prefix, same scan
  trigger, one line in a file already in this diff.
- The other non-conforming fixture passwords **inside `test_read_token_security.py`**,
  because leaving them there would produce a half-converted file:
  `correctpass123`, `wrongpass{i}`, `initialpass`, `password1`, `hacked12345`
  → `example-correct-password`, `example-wrong-password-{i}`,
  `example-initial-password`, `example-password`, `example-hacked-password`.
- One docstring in `test_read_token_security.py` names the literal; it was updated
  with it.
- `ruff format` on the touched files — the longer literal pushes some login calls
  past the line limit. The reformatting is confined to those call sites; no
  unrelated churn.

Nothing under `pixlstash/` contains the string, so there is no production change.

## Verification

All 27 touched files run green locally (930 tests): the three shared-environment
suites with re-login assertions (`multi_project_authz`, `test_read_token_security`,
`test_picture_mutation_scope`) included, plus `ruff format --check` and
`ruff check` clean.

## What this deliberately does not do

An adversarial review pass raised these; they are answered here rather than acted on.

- **`tests/test_authentication.py` is untouched**, and still holds `ownerpassword`,
  `newownerpass`, `realownerpass`, `attackerpass`, `s3cretpass`, `testpassword`,
  `firstpass`/`secondpass`. That is the same class of value, but it is a different
  file and a different sweep; #1108 scoped the literal that has actually blocked
  branches. Folding a second suite in would make this stop reading as
  "rename a fixture constant", which is the property the issue asked for.
- **No CI guardrail enforcing the convention on fixture passwords was added.**
  A guardrail that pattern-matches "looks like a credential" across `tests/` is a
  design decision with a real false-positive budget, not a side effect of a rename.
  Worth its own issue.
