### PR TITLE
Skip locked-set pictures in the folder-mapping commit

### DIFF
--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -68,6 +68,7 @@ from pixlstash.services.project_membership_service import (
     set_character_projects,
     set_picture_set_projects,
 )
+from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.library_layout import Facet
@@ -555,6 +556,19 @@ def _link_pictures(
     place the two callers' pictures actually differ.
     """
     by_path = {a.relative_path: a for a in assignments}
+
+    # `apply_local_mapping` is handed pictures that may already have been
+    # indexed before the wizard ran, so some can sit in a locked set. Skip
+    # those rather than failing the whole commit — the rest of the library
+    # still gets filed. (`apply_mapping`'s pictures are new, so it is a no-op
+    # there.)
+    frozen = locked_picture_ids(session, [p.id for p in pictures if p.id is not None])
+    if frozen:
+        logger.info(
+            "Folder-mapping commit skipping %d picture(s) frozen by a locked set",
+            len(frozen),
+        )
+        pictures = [p for p in pictures if p.id not in frozen]
 
     # Group by containing folder first: every picture in the same folder
     # resolves to the same (project, person, set, tags), so the ancestor

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -453,11 +453,6 @@ _LABEL_SINK_EXEMPT = {
     ("pixlstash/tasks/reference_folder_scan_task.py", "_build_picture"): (
         "builds NEW picture rows during a reference-folder scan"
     ),
-    ("pixlstash/services/folder_structure_commit_service.py", "commit"): (
-        "v1.11 Phase 3: tags pictures the reference-folder scan just created "
-        "in this same commit (new pics) — a not-yet-imported picture cannot "
-        "be in a locked set"
-    ),
     ("pixlstash/vault.py", "import_default_data"): (
         "logo / default-data import (new pictures)"
     ),

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -487,3 +487,54 @@ def test_local_import_mode_refuses_a_root_outside_image_root(owner_env):
     body = _drain_commit(owner, commit_started.json()["task_id"], timeout_s=30.0)
     assert body["status"] == "failed", body
     assert "library's own folder" in body["error"], body
+
+
+def test_a_picture_frozen_by_a_locked_set_is_skipped_not_filed(owner_env):
+    """`local_import` may be handed pictures indexed before the wizard ran, so
+    some can already sit in a locked set. Those are skipped; the rest of the
+    folder is still filed."""
+    from pixlstash.db_models.picture import Picture
+    from pixlstash.db_models.picture_set import PictureSet, PictureSetMember
+    from pixlstash.db_models.tag import Tag
+    from pixlstash.services.folder_structure_commit_service import (
+        Assignment,
+        CommitResult,
+        _link_pictures,
+    )
+    from sqlmodel import select
+
+    server = owner_env["server"]
+    image_root = server.vault.image_root
+
+    def scenario(session):
+        frozen = Picture(file_path="locked-set-skip/gallery/frozen.jpg")
+        free = Picture(file_path="locked-set-skip/gallery/free.jpg")
+        session.add(frozen)
+        session.add(free)
+        session.flush()
+        locked_set = PictureSet(name="frozen-by-a-lock", locked=True)
+        session.add(locked_set)
+        session.flush()
+        session.add(PictureSetMember(set_id=locked_set.id, picture_id=frozen.id))
+        session.flush()
+
+        _link_pictures(
+            session,
+            [frozen, free],
+            [Assignment(relative_path="gallery", kind="tag")],
+            os.path.join(image_root, "locked-set-skip"),
+            image_root,
+            CommitResult(),
+        )
+        session.commit()
+
+        tagged = set(
+            session.exec(
+                select(Tag.picture_id).where(Tag.picture_id.in_([frozen.id, free.id]))
+            ).all()
+        )
+        return frozen.id, free.id, tagged
+
+    frozen_id, free_id, tagged = server.vault.db.run_task(scenario)
+    assert free_id in tagged, "an unlocked picture must still be filed"
+    assert frozen_id not in tagged, "a picture frozen by a locked set must be skipped"


### PR DESCRIPTION
`develop` is red on `test_label_mutation_sinks_are_lock_guarded` (backend shard 2 and backend-windows shard 1, run 32946603076).

241e4a46 extracted the tag/set/project linking into a shared `_link_pictures`, moving the `Tag(picture_id=…)` sink out of `apply_mapping.commit` — the function the `_LABEL_SINK_EXEMPT` entry named. The exemption's justification ("a not-yet-imported picture cannot be in a locked set") also stopped being true: the new `apply_local_mapping` caller is handed pictures that may already have been indexed before the wizard ran, so one can sit in a locked set.

Fixed at the sink rather than by re-pointing the exemption: `_link_pictures` filters ids returned by `locked_picture_ids` and logs how many it skipped, so the rest of the library is still filed. No-op for the `apply_mapping` path, whose pictures are new. The stale exemption entry is removed.

Covered by a new test in `tests/test_folder_structure_commit.py` (already gated); mutation-checked by removing the filter and confirming it goes red.