### PR TITLE
Add boot-time stage instrumentation; defer scipy.ndimage import

### DIFF
--- a/pixlstash/app.py
+++ b/pixlstash/app.py
@@ -5,6 +5,7 @@ import sys
 import json
 import getpass
 import shlex
+import time
 
 from platformdirs import user_config_dir
 from passlib.hash import bcrypt
@@ -431,6 +432,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main():
+    _boot_t0 = time.perf_counter()
     _force_utf8_streams()
     args = build_parser().parse_args()
 
@@ -510,7 +512,16 @@ def main():
         vault.db.run_task(clear_embeddings, priority=1)
         return None
 
+    _t_engine = time.perf_counter()
     server.vault.ensure_ready()
+    logger.info(
+        "[boot] inference engine ready (models loaded): %.3fs",
+        time.perf_counter() - _t_engine,
+    )
+    logger.info(
+        "[boot] total before serving (config + Server() + engine warm-up): %.3fs",
+        time.perf_counter() - _boot_t0,
+    )
     server.run()
     return 0
 

--- a/pixlstash/db_models/quality.py
+++ b/pixlstash/db_models/quality.py
@@ -5,8 +5,6 @@ import time
 from sqlmodel import Column, ForeignKey, Integer, SQLModel, Field, Relationship
 from typing import List, Optional, TYPE_CHECKING
 
-from scipy.ndimage import median_filter
-
 from pixlstash.pixl_logging import get_logger
 
 if TYPE_CHECKING:
@@ -343,6 +341,15 @@ class Quality(SQLModel, table=True):
     @staticmethod
     def _calculate_noise_level(image: np.ndarray) -> float:
         # Optimised: grayscale and quarter resolution
+
+        # Local import: scipy.ndimage costs ~120ms to import (it pulls in its
+        # numpy array-API compat layer) and this static method is the only
+        # user of it in the whole codebase. Importing it here instead of at
+        # module scope keeps that cost off every server boot (this module is
+        # reached from pixlstash.db_models at startup) and off every test
+        # that merely imports the model, paying it only when a quality score
+        # is actually calculated (a background task).
+        from scipy.ndimage import median_filter
 
         # Convert to grayscale
         if image.ndim == 3:

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -403,14 +403,12 @@ class Server(
                 unprepared legacy vault instead of requiring
                 ``pixlstash-cli libraries prepare-legacy-identity`` first.
         """
-        # Ensure garbage collection before starting server to free up memory.
-        # This is mainly to ensure repeated runs within the testing framework do not accumulate memory usage.
-        gc.collect()
-
         # Boot-time instrumentation (issue: v1.11.0 startup latency). Local,
         # operator-visible stage timings only — no telemetry, nothing leaves
         # the process. Same perf_counter-and-log shape TaskRunner already uses
-        # for per-task timing (pixlstash/task_runner.py).
+        # for per-task timing (pixlstash/task_runner.py). Started before the
+        # gc.collect() below so GC time is counted as its own stage rather
+        # than silently excluded from "Server.__init__ total".
         _boot_t0 = time.perf_counter()
         _stage_t = _boot_t0
 
@@ -419,6 +417,11 @@ class Server(
             now = time.perf_counter()
             logger.info("[boot] %s: %.3fs", name, now - _stage_t)
             _stage_t = now
+
+        # Ensure garbage collection before starting server to free up memory.
+        # This is mainly to ensure repeated runs within the testing framework do not accumulate memory usage.
+        gc.collect()
+        _log_stage("gc.collect()")
 
         self._server_config_path = server_config_path
         self.path_mapper = PathMapper(path_map)

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -7,6 +7,7 @@ import re
 import socket
 import asyncio
 import threading
+import time
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version as package_version
 from platformdirs import user_config_dir
@@ -406,6 +407,19 @@ class Server(
         # This is mainly to ensure repeated runs within the testing framework do not accumulate memory usage.
         gc.collect()
 
+        # Boot-time instrumentation (issue: v1.11.0 startup latency). Local,
+        # operator-visible stage timings only — no telemetry, nothing leaves
+        # the process. Same perf_counter-and-log shape TaskRunner already uses
+        # for per-task timing (pixlstash/task_runner.py).
+        _boot_t0 = time.perf_counter()
+        _stage_t = _boot_t0
+
+        def _log_stage(name: str) -> None:
+            nonlocal _stage_t
+            now = time.perf_counter()
+            logger.info("[boot] %s: %.3fs", name, now - _stage_t)
+            _stage_t = now
+
         self._server_config_path = server_config_path
         self.path_mapper = PathMapper(path_map)
 
@@ -422,6 +436,7 @@ class Server(
             server_config_path=self._server_config_path,
             logger=logger,
         ).run()
+        _log_stage("startup checks (disk/VRAM/CUDA/SSL)")
         write_json_atomic(server_config_path, self._server_config)
 
         # Internal loopback transport (Electron desktop shell).
@@ -486,6 +501,7 @@ class Server(
         # services/managed_model_store.py for why it is `managed` rather than a
         # seeded `user` folder nobody is allowed to remove.
         ensure_managed_folder(self.hub, os.path.dirname(self._server_config_path))
+        _log_stage("hub bootstrap (open/migrate hub.db)")
         # The three roots PixlStash's models live in, declared rather than
         # scanned. Off in the test suite: they are machine-global, so a Server
         # on a temp config dir would otherwise describe whichever engines the
@@ -532,6 +548,7 @@ class Server(
                         label,
                         exc,
                     )
+        _log_stage("model shelf declarations (builtin/insightface/huggingface)")
         if self._hub_bootstrap.migrated:
             logger.info(
                 "First run after the hub/vault split: identity now lives in %s",
@@ -549,6 +566,7 @@ class Server(
             self.library_registry.by_uuid(self._hub_bootstrap.library.uuid)
             or self._hub_bootstrap.library
         )
+        _log_stage("vault opened (VaultDatabase open/migrate + task-runner wiring)")
 
         self._ws_clients = []
         self._ws_clients_lock = threading.Lock()
@@ -596,6 +614,7 @@ class Server(
         self.apply_user_settings_to_vault(self.vault)
         self.reconcile_library_settings(self.vault)
         self.vault.start()
+        _log_stage("auth wired + background workers started")
 
         # Owns replacing the vault when the active library changes, and the
         # state requests are refused in while that is happening.
@@ -658,6 +677,7 @@ class Server(
         # Added last so Starlette makes it outermost: its lease begins before
         # authentication and ends only after the final ASGI body frame.
         self.api.add_middleware(LibraryAdmissionMiddleware, server=self)
+        _log_stage("FastAPI app built (middleware + routes + authz gate)")
 
         # Temporary storage for export tasks
         self.export_tasks = {}
@@ -682,6 +702,9 @@ class Server(
         self.staging_sessions = {}
         self._shutdown_on_lifespan = False
         self._telemetry_thread = None
+        logger.info(
+            "[boot] Server.__init__ total: %.3fs", time.perf_counter() - _boot_t0
+        )
 
     def _maybe_send_telemetry_ping(self) -> None:
         """Send the daily install ping, if the owner has turned it on.


### PR DESCRIPTION
## Summary
- Logs per-stage `perf_counter` timings through `Server.__init__` and around `InferenceEngine` warm-up in `app.main()`, same perf_counter-and-log shape `task_runner.py` already uses, so a slow boot is diagnosable from the server log without extra tooling.
- Moves the `scipy.ndimage` import in `db_models/quality.py` from module scope into the one method that uses it (`_calculate_noise_level`). That import cost ~110-120ms and was paid on every boot (and every test importing the model) for a function only ever called from a background quality-scoring task.

## Measured
Warm boot on the measuring machine: ~2.7-3.0s total. `import pixlstash.app` dropped from 743ms to 630ms cumulative after the scipy fix. Full stage breakdown is in the new boot log lines this PR adds.

## Test plan
- [x] `ruff format` + `ruff check` clean
- [x] `tests/test_quality_task_shutdown.py`, `tests/test_dedup_tier_service.py` pass, confirming `_calculate_noise_level` output is unchanged