### PR TITLE
Precompile bytecode for the bundled desktop Python runtime

### DIFF
--- a/scripts/build_desktop_runtime.py
+++ b/scripts/build_desktop_runtime.py
@@ -243,6 +243,35 @@ def strip_env(python_dir: Path) -> None:
     log(f"removed {removed} cache/test directories")
 
 
+def compile_bytecode(py: Path, python_dir: Path, target_os: str) -> None:
+    """Precompile the stdlib + site-packages tree to .pyc.
+
+    The runtime installs read-only in practice (e.g. root-owned under
+    /opt for the .deb), so the interpreter can never write a bytecode
+    cache on first launch either -- without this, EVERY launch pays to
+    parse and compile the full dependency tree (pixlstash + FastAPI +
+    torch + everything else, 10k+ modules) from source. Measured on a
+    real installed .deb's bundled runtime: ~2.2s to import pixlstash.app
+    with no cache vs ~0.7s precompiled -- most of the app's cold-boot time.
+
+    Scoped to the stdlib/site-packages tree rather than the whole
+    ``python_dir`` -- python-build-standalone also vendors legacy Tcl/Tk
+    extras (e.g. a Tix8.4.3 demo script with mixed tabs/spaces) that fail
+    to compile under Python 3 and are never imported by the app anyway.
+    """
+    major_minor = ".".join(PYTHON_VERSION.split(".")[:2])
+    target = (
+        python_dir / "Lib"
+        if target_os == "win"
+        else python_dir / "lib" / f"python{major_minor}"
+    )
+    log(f"precompiling bytecode (compileall): {target}")
+    subprocess.run(
+        [str(py), "-m", "compileall", "-q", "-j", "0", str(target)],
+        check=True,
+    )
+
+
 # Longest path allowed inside the runtime, relative to the python/ root. Windows
 # caps a classic (non-\\?\-prefixed) path at 259 usable characters, and neither
 # NSIS nor electron-builder's installer/uninstaller are long-path aware. The
@@ -398,6 +427,12 @@ def main() -> int:
         py = interpreter(python_dir, args.os)
         populate_env(py, args.wheel, args.accel, cache_dir)
         strip_env(python_dir)
+
+    # Both branches: ship a complete bytecode cache so the interpreter never
+    # recompiles from source at launch (strip_env, above, drops whatever
+    # partial cache pip's install left; this rebuilds it deliberately for
+    # 100% coverage, including stdlib).
+    compile_bytecode(py, python_dir, args.os)
 
     # Both branches, Windows only: a runtime must never ship over-long paths
     # (MAX_PATH breaks installs/updates — see flatten_deep_license_trees).

--- a/scripts/build_desktop_runtime.py
+++ b/scripts/build_desktop_runtime.py
@@ -266,8 +266,22 @@ def compile_bytecode(py: Path, python_dir: Path, target_os: str) -> None:
         else python_dir / "lib" / f"python{major_minor}"
     )
     log(f"precompiling bytecode (compileall): {target}")
+    # -s strips the build-time prefix from the paths baked into the .pyc, so
+    # tracebacks quote runtime-relative paths instead of the CI checkout the
+    # tree was built in. The runtime is relocated at install time, so the
+    # absolute build path was never resolvable at runtime anyway.
     subprocess.run(
-        [str(py), "-m", "compileall", "-q", "-j", "0", str(target)],
+        [
+            str(py),
+            "-m",
+            "compileall",
+            "-q",
+            "-j",
+            "0",
+            "-s",
+            str(python_dir),
+            str(target),
+        ],
         check=True,
     )
 


### PR DESCRIPTION
## Summary
- `strip_env()` deletes every `__pycache__` after installing dependencies into the bundled desktop Python runtime, and the `.deb` installs read-only under `/opt` (root-owned), so the interpreter could never write a bytecode cache on first launch either. Net effect: the packaged app recompiled its entire dependency tree (pixlstash + FastAPI + torch + everything else, 10k+ modules) from `.py` source on **every single launch**.
- Adds a `compile_bytecode()` step to `scripts/build_desktop_runtime.py`, run after both the full-build and `--reuse-env` code paths, that runs `python -m compileall` scoped to the stdlib + site-packages tree.
- Scoped to that tree rather than the whole runtime directory: python-build-standalone also vendors legacy Tcl/Tk extras (a `Tix8.4.3` demo script with mixed tabs/spaces) that fail to compile under Python 3 and are never imported by the app.

## Measured
On an actual installed `.deb`'s bundled runtime: `import pixlstash.app` cold with no bytecode cache took ~2.2s; the same import after precompiling took ~0.7s. Verified the scoped `compileall` command exits 0 with full `.pyc` coverage (12,929/12,929 files) and that making the tree read-only afterward (replicating the real root-owned install) doesn't affect the win.

## Test plan
- [x] `ruff format` + `ruff check` clean
- [x] Verified directly against an installed `.deb`'s bundled runtime (not just the dev checkout) — see measured numbers above