### PR TITLE
Fix two gaps in the add-a-library flow: no AI workers after a switch, and snapshots/ offered for mapping

### DIFF
--- a/pixlstash/routes/folder_structure.py
+++ b/pixlstash/routes/folder_structure.py
@@ -264,6 +264,9 @@ def create_router(server) -> APIRouter:
             task_id = str(uuid.uuid4())
             read = FolderStructureRead(
                 root,
+                exclude={
+                    os.path.join(server.vault.image_root, "snapshots"),
+                },
                 detect_faces=detect,
                 existing_entities=entities,
                 progress=lambda stage, processed, total: _on_progress(

--- a/pixlstash/services/folder_structure_service.py
+++ b/pixlstash/services/folder_structure_service.py
@@ -226,6 +226,9 @@ class FolderStructureRead:
         progress: Called as ``(stage, processed, total)`` whenever either moves.
         deadline_s: Wall-clock budget for the whole read. Past it the read stops
             where it is and returns what it has, exactly as a cancel does.
+        exclude: Absolute paths the walk must not descend into, matched on
+            realpath. Used for the library's own ``snapshots/`` tree, which is
+            not the owner's pictures.
     """
 
     def __init__(
@@ -236,8 +239,10 @@ class FolderStructureRead:
         existing_entities: Optional[list[tuple[str, Optional[int], str]]] = None,
         progress: Optional[Callable[[str, int, int], None]] = None,
         deadline_s: float = DEFAULT_DEADLINE_S,
+        exclude: Optional[set[str]] = None,
     ) -> None:
         self._root = root
+        self._exclude = {os.path.realpath(p) for p in (exclude or ())}
         self._detect_faces = detect_faces
         self._progress = progress or (lambda stage, processed, total: None)
         self._cancel = threading.Event()
@@ -352,6 +357,13 @@ class FolderStructureRead:
                     self._skipped_hidden += 1
                     continue
                 child = os.path.join(dirpath, name)
+                if os.path.realpath(child) in self._exclude:
+                    # The library's own snapshots/ tree. Not the owner's
+                    # pictures, so it is not theirs to map — and creating it
+                    # later instead would only move the problem: a GFS or
+                    # safety snapshot can land at any time, including before a
+                    # second run of the wizard on the same root.
+                    continue
                 if validate_reference_folder_path(os.path.realpath(child)):
                     # The route validates the ROOT. That is not containment for a
                     # recursive walk: `POST {"path": "/"}` names no restricted

--- a/pixlstash/services/library_switch_service.py
+++ b/pixlstash/services/library_switch_service.py
@@ -73,6 +73,32 @@ class LibrarySwitchError(LibraryError):
     """A switch was refused or failed, with the session left on its old library."""
 
 
+def _bring_up(vault, label: str) -> None:
+    """Build the inference engine, then start the vault's background workers.
+
+    ``Vault.start()`` alone gets the WorkPlanner running, but every
+    engine-gated finder — tags, descriptions, face extraction, embeddings,
+    likeness — returns ``None`` for as long as ``Vault._engine`` is ``None``,
+    so a switched-to library would sit there with the planner sweeping and no
+    AI work ever queued, until the next restart. ``app.main`` does this for the
+    boot vault; a switch has to do it for its own.
+
+    A failed engine build costs the AI workers, not the switch: the library is
+    perfectly usable without them, and raising here would roll the user back to
+    the library they just left.
+    """
+    try:
+        vault.ensure_ready()
+    except Exception:
+        logger.exception(
+            "Could not build the inference engine for the %s library; it will "
+            "serve without tagging, descriptions, face extraction or embeddings "
+            "until the next restart",
+            label,
+        )
+    vault.start()
+
+
 def known_vault_revisions() -> set[str]:
     """Return every Alembic revision id this build understands."""
     revisions: set[str] = set()
@@ -304,7 +330,7 @@ class LibrarySwitchService:
             # Treat any exception from this point as a retired old handle.
             old_retirement_started = True
             previous.close()
-            incoming.start()
+            _bring_up(incoming, "incoming")
 
             # The candidate is now fully started and admission is still closed.
             # Remove every old-generation capability/artifact before publishing
@@ -366,7 +392,7 @@ class LibrarySwitchService:
                     recovered.auth_service = self._server.auth
                     self._server.apply_user_settings_to_vault(recovered)
                     self._server.reconcile_library_settings(recovered, previous_library)
-                    recovered.start()
+                    _bring_up(recovered, "recovered previous")
                     self._server.library_registry.set_active(previous_library.id)
                     self._server.vault = recovered
                     self._server.auth.vault_db = recovered.db

--- a/tests/test_folder_structure_read.py
+++ b/tests/test_folder_structure_read.py
@@ -1240,3 +1240,23 @@ def test_a_read_rooted_at_a_filesystem_root_still_has_a_name(monkeypatch):
         assert FolderStructureRead(root + os.sep).run()["root"]["name"] == (
             "Generations"
         )
+
+
+def test_the_librarys_own_snapshots_tree_is_never_offered_for_mapping():
+    """A snapshot can land at any time, so excluding beats creating it later."""
+    with _tree(
+        {
+            "": [],
+            "Holiday": ["a.jpg"],
+            "snapshots": [],
+            "snapshots/2026/08/26": [],
+        }
+    ) as root:
+        result = FolderStructureRead(
+            root, exclude={os.path.join(root, "snapshots")}
+        ).run()
+
+    names = {row["name"] for level in result["levels"] for row in level["folders"]}
+    assert "Holiday" in names
+    assert "snapshots" not in names
+    assert "26" not in names, "the whole subtree, not just its top"

--- a/tests/test_library_switch.py
+++ b/tests/test_library_switch.py
@@ -102,6 +102,47 @@ class TestSwitching:
         finally:
             server.library_switch.switch_to(original.uuid)
 
+    def test_the_switched_to_vault_gets_its_inference_engine(
+        self, server, second_library, monkeypatch
+    ):
+        """Without this the planner sweeps a library nothing ever queues work for:
+        every engine-gated finder (tags, descriptions, faces, embeddings) short-
+        circuits on a None engine."""
+        from pixlstash.vault import Vault
+
+        calls = []
+        monkeypatch.setattr(
+            Vault, "ensure_ready", lambda self: calls.append(self.image_root)
+        )
+
+        original = server.library_registry.active_library()
+        try:
+            server.library_switch.switch_to(second_library.uuid)
+            assert second_library.path in calls, (
+                "the incoming vault was started without an inference engine"
+            )
+        finally:
+            server.library_switch.switch_to(original.uuid)
+
+    def test_an_engine_that_cannot_be_built_does_not_fail_the_switch(
+        self, server, second_library, monkeypatch
+    ):
+        """A library is usable without AI workers; rolling the user back is worse."""
+        from pixlstash.vault import Vault
+
+        def _boom(self):
+            raise RuntimeError("no models on this machine")
+
+        monkeypatch.setattr(Vault, "ensure_ready", _boom)
+
+        original = server.library_registry.active_library()
+        try:
+            active = server.library_switch.switch_to(second_library.uuid)
+            assert active.uuid == second_library.uuid
+            assert server.vault.image_root == second_library.path
+        finally:
+            server.library_switch.switch_to(original.uuid)
+
     def test_switching_to_the_active_library_is_a_no_op(self, server):
         active = server.library_registry.active_library()
         before = server.vault


### PR DESCRIPTION
Two bugs found while working through the "Add a library" flow.

## A switched-to library gets no AI work at all

`Vault.ensure_ready()`, which builds the `InferenceEngine`, is called from
exactly one place: `app.main`, at boot. `LibrarySwitchService._swap` called
`incoming.start()` and nothing else, so a vault reached by switching came up
with `_engine is None`.

The WorkPlanner ran and swept normally, but every engine-gated finder opens
with:

```python
engine = self._engine_getter()
if engine is None:
    return None
```

That is tagging, descriptions, face extraction, text and image embeddings,
likeness and tag prediction. All of them returned `None` on every cycle, so
nothing was ever queued and the task manager stayed empty — until a restart,
or until a manual worker trigger took the lazy path through
`get_worker_future()`. Thumbnails still appeared, because the local import
writes those inline, so the import itself looked healthy.

`_bring_up(vault, label)` now does ensure_ready-then-start at both sites: the
incoming vault, and the recovered previous one in the failure path. A failed
engine build is logged and the switch still completes — a library is usable
without AI workers, and raising there would roll the user back to the library
they just left.

## `snapshots/` was offered as a top-level folder to map

The folder-structure walk skipped only dot-prefixed directories, so the vault's
own `snapshots/` tree showed up in the mapping wizard as a folder to assign to
a project, person or set.

Creating it after the assignment instead would only move the problem: a GFS
daily or a safety-snapshot-before-restore can land at any moment, and a second
run of the wizard on the same root would show it again. `FolderStructureRead`
now takes an `exclude` set matched on realpath and the route passes the active
library's snapshots directory, so a user's own folder named "snapshots"
elsewhere in the tree still maps normally.

## Tests

Three added; each fails against the code it fixes.

- `test_the_switched_to_vault_gets_its_inference_engine`
- `test_an_engine_that_cannot_be_built_does_not_fail_the_switch`
- `test_the_librarys_own_snapshots_tree_is_never_offered_for_mapping`

191 pass across `test_library_switch.py`, `test_folder_structure_read.py`,
`test_folder_structure_commit.py` and `test_libraries_routes.py`.
