### PR TITLE
Let tagger plugins produce tag predictions

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1377,6 +1377,18 @@ Every plugin declares:
 - **Lifecycle**: `needs_download()`, `download()`, `init(parameters)`, `unload()`, `is_loaded()`.
 - **Inference**: `tag_images(...)` (when `supports_tags`) returns `{path: list[TagResult]}`; `generate_descriptions(...)` (when `supports_descriptions`) returns `{path: caption_str}`. `TagResult` carries `tag` and `confidence` (may be `None` for LLM-based plugins).
 - **VRAM hints**: `estimated_vram_mb()`, `effective_batch_size()`.
+- **`model_version()`** — a string identifying the weights *and how they are run*, defaulting to `""`. See the fence below for why it matters; it must change whenever the numbers do, quantisation and inference runtime included.
+
+### Prediction provenance and the anomaly fence
+
+A tagger plugin whose `TagResult`s carry confidences now gets `TagPrediction` rows like the built-in tagger does — `TaggingWorkflow.tag_images(out_raw_scores=...)` collects them for whichever plugin is active, and `_tag_images_single_plugin` no longer reduces the results to bare tag strings.
+
+Two rules keep that from moving anything it should not, both in `pixlstash/db_models/tag_prediction.py`:
+
+- **Rows are stamped `<plugin>@<version>`** (`qualify_plugin_model_version`), with `unknown` when the plugin declares none. `model_version` is the *sole* staleness key — `TagTask._write_predictions_from_tags` deletes rows whose version differs and rewrites them — so a plugin that cannot version itself keeps its confidences forever. The built-in tagger keeps its bare `v<n>`, so its existing rows are not orphaned and no migration is needed.
+- **Only unqualified rows feed the anomaly penalty** (`feeds_anomaly_score`, enforced in `smart_score.fetch_anomaly_confidences` and `recompute_anomaly_tag_uncertainty`). Raw confidences are not comparable across models and the apply thresholds are calibrated against the built-in tagger, so a plugin's 0.4 reaching the penalty would move every affected picture's smart score with no user action. A **human** verdict is exempt in both directions: `label_source == HUMAN` is tested before the fence, so a person's POS/NEG counts whichever row carries it.
+
+The same built-in/plugin split guards the stale-row delete and the overwrite path (`is_plugin_model_version`): a picture holds one prediction row per tag, so without it a plugin run would clear the built-in tagger's confidences and take the picture's `anomaly_tag_uncertainty` with them. The consequence is that whichever population owns a tag keeps it — a plugin cannot record a prediction for a tag the built-in tagger already has a row for. Widening the unique key to `(picture_id, tag, model_version)` is the upgrade path if per-source predictions are ever needed. Covered by `tests/test_smart_score_invalidation.py::test_plugin_sourced_model_prediction_is_not_scored`, `::test_human_decision_on_a_plugin_row_still_counts` and `::test_plugin_write_leaves_the_built_in_taggers_predictions_alone`.
 
 ### `tagger_settings` JSON column
 

--- a/pixlstash/db_models/tag_prediction.py
+++ b/pixlstash/db_models/tag_prediction.py
@@ -9,6 +9,71 @@ if TYPE_CHECKING:
     from .picture import Picture
 
 
+# ``model_version`` recorded when the producing model cannot say what it is.
+# It never compares unequal to itself, so such rows never go stale - which is
+# why a plugin should return a real version from ``TaggerPlugin.model_version``.
+UNKNOWN_MODEL_VERSION = "unknown"
+
+# Separates the plugin name from its version in a stored ``model_version``.
+# Rows written by a tagger plugin are qualified (``joycaption@2024-11``); rows
+# from the built-in PixlStash tagger are not (``v43``), and neither is the
+# ``manual`` sentinel the human-label ledger writes.  That is what
+# :func:`feeds_anomaly_score` tests, and it is why the separator must never
+# appear in a bare version string.
+PLUGIN_VERSION_SEPARATOR = "@"
+
+
+def qualify_plugin_model_version(plugin_name: str, version: str | None) -> str:
+    """Return the ``model_version`` to store for a tagger plugin's predictions.
+
+    Qualifying with the plugin name keeps two plugins that happen to share a
+    version string ("v3") from looking like the same model, which would make
+    each one's run delete the other's rows as stale.
+
+    Args:
+        plugin_name: Registered plugin name, e.g. ``'joycaption'``.
+        version: What the plugin reported, or ``None``/``""`` when it said
+            nothing.
+
+    Returns:
+        ``'<plugin_name>@<version>'``, with ``unknown`` for an absent version.
+    """
+    return (
+        f"{plugin_name}{PLUGIN_VERSION_SEPARATOR}"
+        f"{(version or '').strip() or UNKNOWN_MODEL_VERSION}"
+    )
+
+
+def is_plugin_model_version(model_version: str | None) -> bool:
+    """Whether a stored ``model_version`` was written by a tagger plugin.
+
+    Splits prediction rows into two populations that must not overwrite or
+    delete each other: the built-in PixlStash tagger's (plus the ledger's
+    ``manual`` sentinel), and the tagger plugins'.  A picture holds at most one
+    row per tag, so without this split, switching to a plugin would delete the
+    built-in tagger's confidences as stale and take the picture's
+    ``anomaly_tag_uncertainty`` down with them.
+    """
+    return PLUGIN_VERSION_SEPARATOR in (model_version or "")
+
+
+def feeds_anomaly_score(model_version: str | None) -> bool:
+    """Whether a prediction row's confidence may feed ``anomaly_tag_uncertainty``.
+
+    Only the built-in PixlStash tagger's confidences may. The anomaly score
+    compares a stored confidence against the human's current tag, and raw
+    confidences are not comparable across models: another tagger's 0.4 does not
+    mean what the PixlStash tagger's 0.4 means, so letting one in would shift
+    every affected picture's smart score with no user action and no way to see
+    why.
+
+    Unqualified rows pass: the built-in tagger's (``v43``, ``unknown``) and the
+    ledger's ``manual`` sentinel, which is every row written before plugins
+    could produce predictions at all.
+    """
+    return not is_plugin_model_version(model_version)
+
+
 class TagPrediction(SQLModel, table=True):
     """Model confidence score for a single tag on a picture.
 

--- a/pixlstash/inference/workflows/tagging.py
+++ b/pixlstash/inference/workflows/tagging.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from pixlstash.db_models.tag_prediction import (
+    qualify_plugin_model_version,
+    UNKNOWN_MODEL_VERSION,
+)
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.service.caption_utils import merge_video_frame_tags
@@ -74,6 +78,67 @@ class TaggingWorkflow:
             return engine_override
         return self._tagger_settings.get("active_tag_plugin") or "pixlstash_tagger"
 
+    def active_model_version(self, engine_override: str | None = None) -> str:
+        """The ``model_version`` to stamp on predictions from the active plugin.
+
+        This is the sole staleness key for stored predictions - rows whose
+        version differs from the current one are deleted and rewritten - so it
+        has to change whenever the numbers do.  Plugin versions are qualified
+        with the plugin name; the built-in PixlStash tagger keeps its bare
+        ``v<n>`` so its existing rows are not orphaned.
+
+        Args:
+            engine_override: Same meaning as in :meth:`active_plugin_name`.
+
+        Returns:
+            The version string, ``'unknown'`` when nothing can say.
+        """
+        active = self.active_plugin_name(engine_override)
+        if not active:
+            return UNKNOWN_MODEL_VERSION
+
+        if active == "pixlstash_tagger":
+            try:
+                version_fn = getattr(self._engine, "pixlstash_tagger_version", None)
+                if callable(version_fn):
+                    return f"v{version_fn()}"
+                logger.warning(
+                    "[TaggingWorkflow] engine has no pixlstash_tagger_version(); "
+                    "predictions will be stamped %r and never go stale.",
+                    UNKNOWN_MODEL_VERSION,
+                )
+            except Exception:
+                logger.warning(
+                    "pixlstash_tagger_version() failed, using %r model version",
+                    UNKNOWN_MODEL_VERSION,
+                    exc_info=True,
+                )
+            return UNKNOWN_MODEL_VERSION
+
+        from pixlstash.tagger_plugins.registry import get_tagger_plugin_manager
+
+        version = ""
+        plugin = get_tagger_plugin_manager().get_plugin(active)
+        if plugin is None:
+            logger.warning(
+                "[TaggingWorkflow] active_tag_plugin %r not found while resolving "
+                "its model version; predictions will be stamped %r.",
+                active,
+                UNKNOWN_MODEL_VERSION,
+            )
+        else:
+            try:
+                version = plugin.model_version() or ""
+            except Exception:
+                logger.warning(
+                    "[TaggingWorkflow] %r.model_version() failed; predictions will "
+                    "be stamped %r and never go stale.",
+                    active,
+                    UNKNOWN_MODEL_VERSION,
+                    exc_info=True,
+                )
+        return qualify_plugin_model_version(active, version)
+
     # ------------------------------------------------------------------
     # Public inference methods
     # ------------------------------------------------------------------
@@ -83,7 +148,7 @@ class TaggingWorkflow:
         image_paths,
         stop_event=None,
         preloaded_images=None,
-        out_raw_pixlstash_scores: dict | None = None,
+        out_raw_scores: dict | None = None,
         engine_override: str | None = None,
     ) -> dict[str, list[str]]:
         """Tag a batch of images using the active tag plugin.
@@ -98,10 +163,12 @@ class TaggingWorkflow:
             stop_event: Optional :class:`threading.Event` to interrupt inference.
             preloaded_images: Optional ``{path: PIL.Image}`` map to skip
                 re-loading images from disk.
-            out_raw_pixlstash_scores: When provided, per-label confidence scores
-                from the PixlStash tagger's full-image pass are written here
-                (``{path: {label: float}}``).  Only populated when the active
-                plugin is ``'pixlstash_tagger'``.
+            out_raw_scores: When provided, per-label confidence scores from
+                the full-image pass are written here (``{path: {label: float}}``).
+                Populated for the PixlStash tagger and for any third-party
+                plugin whose :class:`~pixlstash.tagger_plugins.base.TagResult`
+                objects carry a confidence; left empty for a plugin that
+                reports none (WD14 thresholds internally and reports none).
             engine_override: If given, run this specific plugin instead of the
                 configured ``active_tag_plugin``.
 
@@ -145,11 +212,14 @@ class TaggingWorkflow:
                 image_paths,
                 stop_event=stop_event,
                 preloaded_images=preloaded_map,
-                out_raw_scores=out_raw_pixlstash_scores,
+                out_raw_scores=out_raw_scores,
             )
 
         return self._tag_images_single_plugin(
-            active, image_paths, stop_event=stop_event
+            active,
+            image_paths,
+            stop_event=stop_event,
+            out_raw_scores=out_raw_scores,
         )
 
     def tag_quality_crops(
@@ -333,6 +403,7 @@ class TaggingWorkflow:
         plugin_name: str,
         image_paths,
         stop_event=None,
+        out_raw_scores: dict | None = None,
     ) -> dict[str, list[str]]:
         """Dispatch tagging to a single named third-party plugin.
 
@@ -340,6 +411,10 @@ class TaggingWorkflow:
             plugin_name: The registered plugin name (e.g. ``'joycaption'``).
             image_paths: Sequence of absolute image/video file paths.
             stop_event: Optional :class:`threading.Event` to interrupt.
+            out_raw_scores: When provided, the confidences the plugin reported
+                are written here as ``{path: {tag: float}}``.  A plugin that
+                returns ``TagResult.confidence=None`` contributes nothing, so
+                the caller cannot tell "no confidence" from "scored zero".
 
         Returns:
             ``{path: [tag, ...]}`` or an empty dict on failure.
@@ -396,6 +471,14 @@ class TaggingWorkflow:
         for path, tag_results in raw.items():
             path_str = str(path)
             combined[path_str] = sorted(tr.tag for tr in tag_results)
+            if out_raw_scores is not None:
+                scores = {
+                    tr.tag: float(tr.confidence)
+                    for tr in tag_results
+                    if tr.confidence is not None
+                }
+                if scores:
+                    out_raw_scores[path_str] = scores
         return combined
 
     # ------------------------------------------------------------------

--- a/pixlstash/inference/workflows/tagging.py
+++ b/pixlstash/inference/workflows/tagging.py
@@ -5,10 +5,6 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from pixlstash.db_models.tag_prediction import (
-    qualify_plugin_model_version,
-    UNKNOWN_MODEL_VERSION,
-)
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.service.caption_utils import merge_video_frame_tags
@@ -93,6 +89,14 @@ class TaggingWorkflow:
         Returns:
             The version string, ``'unknown'`` when nothing can say.
         """
+        # Imported here, not at module scope: this is an inference module and
+        # pulling a db_models table in at import time is the only such edge in
+        # the package. It also reorders native library loading on Windows.
+        from pixlstash.db_models.tag_prediction import (
+            qualify_plugin_model_version,
+            UNKNOWN_MODEL_VERSION,
+        )
+
         active = self.active_plugin_name(engine_override)
         if not active:
             return UNKNOWN_MODEL_VERSION

--- a/pixlstash/scoring/smart_score.py
+++ b/pixlstash/scoring/smart_score.py
@@ -26,6 +26,7 @@ from pixlstash.db_models import (
     TagPrediction,
     User,
 )
+from pixlstash.db_models.tag_prediction import feeds_anomaly_score
 from pixlstash.services.tagger_run_service import get_latest_tag_precisions
 from pixlstash.utils.quality.anomaly_penalty import ANOMALY_PENALTY_TAGS
 from pixlstash.utils.quality.smart_score_utils import (
@@ -203,6 +204,7 @@ def fetch_anomaly_confidences(
             TagPrediction.confidence,
             TagPrediction.label_state,
             TagPrediction.label_source,
+            TagPrediction.model_version,
         ).where(
             TagPrediction.picture_id.in_(picture_ids),
             func.lower(TagPrediction.tag).in_(ANOMALY_PENALTY_TAGS),
@@ -211,7 +213,8 @@ def fetch_anomaly_confidences(
 
     below_threshold = 0
     not_applied = 0
-    for picture_id, tag, confidence, label_state, label_source in rows:
+    plugin_sourced = 0
+    for picture_id, tag, confidence, label_state, label_source, model_version in rows:
         if not tag:
             continue
         key = tag.strip().lower()
@@ -221,6 +224,16 @@ def fetch_anomaly_confidences(
         elif label_source == HUMAN and label_state == NEG:
             probs_map[picture_id][key] = 0.0
         else:
+            if not feeds_anomaly_score(model_version):
+                # A tagger plugin's confidence. Raw confidences are not comparable
+                # between models - a plugin's 0.4 is not the built-in tagger's 0.4,
+                # and the penalty thresholds are calibrated against the latter - so
+                # this would move the score with no user action and nothing on
+                # screen to explain it. The human branches above are deliberately
+                # ahead of this one: a person's verdict counts whichever model's
+                # row happens to be carrying it.
+                plugin_sourced += 1
+                continue
             if key not in applied_tags.get(picture_id, ()):
                 not_applied += 1
                 continue
@@ -232,12 +245,14 @@ def fetch_anomaly_confidences(
                     continue
             probs_map[picture_id][key] = value
 
-    if below_threshold or not_applied:
+    if below_threshold or not_applied or plugin_sourced:
         logger.debug(
-            "Anomaly penalty inputs: dropped %d sub-threshold and %d not-applied model "
-            "prediction(s) across %d picture(s); neither is visible in the tag list.",
+            "Anomaly penalty inputs: dropped %d sub-threshold, %d not-applied and %d "
+            "plugin-sourced model prediction(s) across %d picture(s); none of them is "
+            "usable as a penalty input.",
             below_threshold,
             not_applied,
+            plugin_sourced,
             len(picture_ids),
         )
 

--- a/pixlstash/tagger_plugins/base.py
+++ b/pixlstash/tagger_plugins/base.py
@@ -122,6 +122,31 @@ class TaggerPlugin(ABC):
         """Return a dict of ``{name: default}`` from ``parameter_schema``."""
         return {field["name"]: field["default"] for field in self.parameter_schema()}
 
+    def model_version(self) -> str:
+        """Return a version string identifying the weights this plugin runs.
+
+        Stored on every :class:`~pixlstash.db_models.tag_prediction.TagPrediction`
+        row this plugin produces, qualified with the plugin name, and it is the
+        **only** thing that marks a stored prediction stale: when the version
+        changes, the host deletes the previous generation's rows and rewrites
+        them. A plugin that always returns the same string therefore keeps its
+        confidences forever, even after its weights change.
+
+        It is also the value the human-label ledger freezes at review time
+        (``TagPrediction.label_model_version``), so that a human accept/reject
+        stays meaningful as training data once the model has moved on.
+
+        Return whatever identifies the weights *and how they are being run* -
+        a repo revision, a file hash, a release tag - and include anything that
+        changes the numbers, such as quantisation or the inference runtime: two
+        builds of the same weights that score differently are two versions.
+
+        Returns:
+            Version string, or ``""`` when the plugin cannot say (the host then
+            records ``unknown``, which never goes stale).
+        """
+        return ""
+
     def plugin_schema(self) -> dict[str, Any]:
         """Return the JSON-serialisable metadata dict for this plugin.
 

--- a/pixlstash/tagger_plugins/plugin_template.py
+++ b/pixlstash/tagger_plugins/plugin_template.py
@@ -111,6 +111,18 @@ class MyCaptioner(TaggerPlugin):
         self._model = None
         self._device = "cpu"
 
+    def model_version(self) -> str:
+        """Identify the weights, and how they are being run.
+
+        Only matters when the plugin sets ``supports_tags`` and returns
+        confidences: it is stamped on every prediction row and is the only
+        thing that marks one stale, so returning a constant means your
+        confidences are never refreshed after the model changes.  Include
+        anything that moves the numbers - a quantisation, a different runtime -
+        because two builds that score differently are two versions.
+        """
+        return "2026-01"
+
     # ------------------------------------------------------------------
     # Schema - this JSON *is* the settings UI
     # ------------------------------------------------------------------

--- a/pixlstash/tasks/tag_prediction_backfill_task.py
+++ b/pixlstash/tasks/tag_prediction_backfill_task.py
@@ -95,14 +95,20 @@ class TagPredictionBackfillTask(BaseTask):
         if not image_paths:
             return {"backfilled": 0, "pictures": 0}
 
-        # Make sure the tagger model is loaded before inference.
-        workflow.ensure_active_plugin_ready()
+        # Make sure the tagger model is loaded before inference. The override
+        # is explicit so the backfill stays PixlStash-tagger-only even if the
+        # enabled flag and active_tag_plugin ever drift apart.
+        workflow.ensure_active_plugin_ready(engine_override="pixlstash_tagger")
 
         # Single inference pass: we only want the raw scores, not the tags the
         # model would apply (the picture already has its tags).
         full_scores_by_path: dict = {}
         inference_start = time.perf_counter()
-        workflow.tag_images(image_paths, out_raw_scores=full_scores_by_path)
+        workflow.tag_images(
+            image_paths,
+            out_raw_scores=full_scores_by_path,
+            engine_override="pixlstash_tagger",
+        )
         inference_s = time.perf_counter() - inference_start
 
         label_scores_by_pic_id: dict[int, dict] = {}
@@ -127,7 +133,9 @@ class TagPredictionBackfillTask(BaseTask):
                 unscored,
             )
 
-        model_version = workflow.active_model_version()
+        model_version = workflow.active_model_version(
+            engine_override="pixlstash_tagger"
+        )
         written = self._db.run_task(
             self._backfill_predictions,
             label_scores_by_pic_id,

--- a/pixlstash/tasks/tag_prediction_backfill_task.py
+++ b/pixlstash/tasks/tag_prediction_backfill_task.py
@@ -102,7 +102,7 @@ class TagPredictionBackfillTask(BaseTask):
         # model would apply (the picture already has its tags).
         full_scores_by_path: dict = {}
         inference_start = time.perf_counter()
-        workflow.tag_images(image_paths, out_raw_pixlstash_scores=full_scores_by_path)
+        workflow.tag_images(image_paths, out_raw_scores=full_scores_by_path)
         inference_s = time.perf_counter() - inference_start
 
         label_scores_by_pic_id: dict[int, dict] = {}
@@ -127,7 +127,7 @@ class TagPredictionBackfillTask(BaseTask):
                 unscored,
             )
 
-        model_version = self._resolve_model_version(workflow)
+        model_version = workflow.active_model_version()
         written = self._db.run_task(
             self._backfill_predictions,
             label_scores_by_pic_id,
@@ -149,20 +149,6 @@ class TagPredictionBackfillTask(BaseTask):
             "backfilled": int(written or 0),
             "pictures": len(attempted_pic_ids),
         }
-
-    @staticmethod
-    def _resolve_model_version(workflow: TaggingWorkflow) -> str:
-        """Resolve the PixlStash tagger version string (mirrors TagTask)."""
-        try:
-            version_fn = getattr(workflow._engine, "pixlstash_tagger_version", None)
-            if callable(version_fn):
-                return f"v{version_fn()}"
-        except Exception:
-            logger.warning(
-                "pixlstash_tagger_version() failed, using 'unknown' model version",
-                exc_info=True,
-            )
-        return "unknown"
 
     @staticmethod
     def _backfill_predictions(

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -1073,20 +1073,23 @@ class TagTask(BaseTask):
         # row per tag, so a plugin run would otherwise clear the built-in tagger's
         # confidences and silently zero the picture's anomaly_tag_uncertainty.
         writing_as_plugin = is_plugin_model_version(model_version)
-        stale_ids = [
-            row.id
+        stale_rows = [
+            row
             for row in existing_rows
             if row.model_version != model_version
             and row.model_version != "manual"
             and row.label_source != "human"
             and is_plugin_model_version(row.model_version) == writing_as_plugin
         ]
-        if stale_ids:
-            session.exec(delete(TagPrediction).where(TagPrediction.id.in_(stale_ids)))
+        if stale_rows:
+            session.exec(
+                delete(TagPrediction).where(
+                    TagPrediction.id.in_([row.id for row in stale_rows])
+                )
+            )
             # Remove from map so they are not treated as existing below.
-            for row in existing_rows:
-                if row.id in set(stale_ids):
-                    existing_map.pop((row.picture_id, row.tag), None)
+            for row in stale_rows:
+                existing_map.pop((row.picture_id, row.tag), None)
 
         # --- Bulk fetch applied tags for anomaly uncertainty computation ---
         tag_rows = session.exec(

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -18,7 +18,11 @@ from pixlstash.db_models import (
     TAG_SENTINEL_LIKE_PATTERN,
     TAG_SENTINEL_ESCAPE_CHAR,
 )
-from pixlstash.db_models.tag_prediction import TagPrediction
+from pixlstash.db_models.tag_prediction import (
+    feeds_anomaly_score,
+    is_plugin_model_version,
+    TagPrediction,
+)
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.image_processing.face_utils import expand_bbox_to_square
@@ -745,15 +749,17 @@ class TagTask(BaseTask):
                 logger.debug("Tagging %s images", len(image_paths))
                 logger.debug("Tagging image paths: %s", image_paths)
                 # Collect raw confidence scores in the same GPU pass as tagging.
+                # Whatever the active tagger is: a plugin that reports
+                # confidences gets prediction rows too, fenced out of the
+                # anomaly score by ``feeds_anomaly_score`` because raw
+                # confidences are not comparable between models.
                 full_scores_by_path: dict = {}
                 use_pixlstash_tagger = active_workflow.is_pixlstash_tagger_enabled
                 inference_start = time.perf_counter()
                 tag_results = active_workflow.tag_images(
                     image_paths,
                     preloaded_images=preloaded_images,
-                    out_raw_pixlstash_scores=full_scores_by_path
-                    if use_pixlstash_tagger
-                    else None,
+                    out_raw_scores=full_scores_by_path,
                     engine_override=self._engine_override,
                 )
                 inference_s = time.perf_counter() - inference_start
@@ -923,20 +929,9 @@ class TagTask(BaseTask):
                                 u["pic_id"]: set(u.get("tags") or [])
                                 for u in update_payloads
                             }
-                            model_version = "unknown"
-                            try:
-                                version_fn = getattr(
-                                    active_workflow._engine,
-                                    "pixlstash_tagger_version",
-                                    None,
-                                )
-                                if callable(version_fn):
-                                    model_version = f"v{version_fn()}"
-                            except Exception:
-                                logger.warning(
-                                    "pixlstash_tagger_version() failed, using 'unknown' model version",
-                                    exc_info=True,
-                                )
+                            model_version = active_workflow.active_model_version(
+                                self._engine_override
+                            )
                             db_pred_start = time.perf_counter()
                             self._db.run_task(
                                 self._write_predictions_from_tags,
@@ -1074,12 +1069,17 @@ class TagTask(BaseTask):
         # --- Bulk delete stale model-version rows ---
         # Never delete a human-labeled row: its label_state/label_source is durable
         # supervision the tagger must not clobber (mirrors not_human_labeled()).
+        # Never delete across the built-in/plugin split either: a picture holds one
+        # row per tag, so a plugin run would otherwise clear the built-in tagger's
+        # confidences and silently zero the picture's anomaly_tag_uncertainty.
+        writing_as_plugin = is_plugin_model_version(model_version)
         stale_ids = [
             row.id
             for row in existing_rows
             if row.model_version != model_version
             and row.model_version != "manual"
             and row.label_source != "human"
+            and is_plugin_model_version(row.model_version) == writing_as_plugin
         ]
         if stale_ids:
             session.exec(delete(TagPrediction).where(TagPrediction.id.in_(stale_ids)))
@@ -1111,6 +1111,20 @@ class TagTask(BaseTask):
             for tag, confidence in label_scores.items():
                 status = "CONFIRMED" if tag in applied_tags else "REJECTED"
                 existing = existing_map.get((picture_id, tag))
+                if (
+                    existing is not None
+                    and existing.model_version != "manual"
+                    and is_plugin_model_version(existing.model_version)
+                    != writing_as_plugin
+                ):
+                    # A row from the other population (built-in vs plugin) owns
+                    # this tag, and the unique key allows only one.  Leave it:
+                    # overwriting would swap a confidence the anomaly score is
+                    # calibrated against for one that is not comparable to it.
+                    # ponytail: whoever got there first wins; widen the unique
+                    # key to (picture_id, tag, model_version) if predictions
+                    # from several taggers ever need to coexist per tag.
+                    continue
                 if existing is None:
                     session.add(
                         TagPrediction(
@@ -1177,6 +1191,12 @@ class TagTask(BaseTask):
 
             # Compute anomaly_tag_uncertainty using the already-fetched applied tags
             # (avoids a redundant SELECT per picture inside recompute_anomaly_tag_uncertainty).
+            # Only the built-in tagger's confidences may: they are what the anomaly
+            # score is calibrated against, and a plugin's 0.4 does not mean the same
+            # thing.  Leave the stored value alone rather than zeroing it, so a run
+            # under a plugin does not discard the built-in tagger's assessment.
+            if not feeds_anomaly_score(model_version):
+                continue
             pic_applied = applied_tags_by_pic.get(picture_id, set())
             anomaly_scores: list[float] = []
             for tag, confidence in label_scores.items():

--- a/pixlstash/utils/service/tag_prediction_utils.py
+++ b/pixlstash/utils/service/tag_prediction_utils.py
@@ -7,7 +7,10 @@ from pixlstash.db_models.tag import (
     TAG_SENTINEL_ESCAPE_CHAR,
     Tag,
 )
-from pixlstash.db_models.tag_prediction import TagPrediction
+from pixlstash.db_models.tag_prediction import (
+    PLUGIN_VERSION_SEPARATOR,
+    TagPrediction,
+)
 
 PENALISED_TAG_SET = {t.strip().lower() for t in DEFAULT_SMART_SCORE_PENALIZED_TAGS}
 
@@ -33,9 +36,14 @@ def recompute_anomaly_tag_uncertainty(session: Session, picture_id: int) -> None
     Call this **after** any ``session.flush()`` that modifies ``Tag`` rows, and
     **before** ``session.commit()``, so the read sees the latest state.
     """
+    # Built-in tagger rows only (see
+    # :func:`~pixlstash.db_models.tag_prediction.feeds_anomaly_score`): raw
+    # confidences are not comparable across models, so letting a tagger
+    # plugin's rows in here would move the smart score with no user action.
     predictions = session.exec(
         select(TagPrediction.tag, TagPrediction.confidence).where(
-            TagPrediction.picture_id == picture_id
+            TagPrediction.picture_id == picture_id,
+            ~TagPrediction.model_version.contains(PLUGIN_VERSION_SEPARATOR),
         )
     ).all()
 

--- a/tests/test_smart_score_invalidation.py
+++ b/tests/test_smart_score_invalidation.py
@@ -24,7 +24,11 @@ from sqlmodel import select
 from pixlstash.database import DBPriority
 from pixlstash.db_models import Picture, Tag
 from pixlstash.db_models.tag import DEFAULT_SMART_SCORE_PENALIZED_TAGS
-from pixlstash.db_models.tag_prediction import TagPrediction
+from pixlstash.db_models.tag_prediction import (
+    feeds_anomaly_score,
+    qualify_plugin_model_version,
+    TagPrediction,
+)
 from pixlstash.event_types import EventType
 from pixlstash.scoring import (
     fetch_anomaly_confidences,
@@ -135,6 +139,36 @@ def _seed_tag(server, pic_id, tag):
         session.commit()
 
     server.vault.db.run_task(insert)
+
+
+def _set_model_version(server, pic_id, tag, model_version):
+    """Restamp a seeded prediction so the test can vary only its source."""
+
+    def update(session):
+        row = session.exec(
+            select(TagPrediction).where(
+                TagPrediction.picture_id == pic_id, TagPrediction.tag == tag
+            )
+        ).one()
+        row.model_version = model_version
+        session.commit()
+
+    server.vault.db.run_task(update)
+
+
+def _set_label_state(server, pic_id, tag, label_state):
+    """Flip an existing ledger row's human verdict in place."""
+
+    def update(session):
+        row = session.exec(
+            select(TagPrediction).where(
+                TagPrediction.picture_id == pic_id, TagPrediction.tag == tag
+            )
+        ).one()
+        row.label_state = label_state
+        session.commit()
+
+    server.vault.db.run_task(update)
 
 
 def _wait_for(predicate, timeout=10.0):
@@ -1707,3 +1741,133 @@ def test_penalised_tag_change_invalidates_atomically_no_second_task():
     finally:
         server.close()
         temp_dir.cleanup()
+
+
+# --- Tagger-plugin predictions are fenced out of the anomaly penalty --------------
+# ``TagPrediction`` rows can now come from a third-party tagger plugin, stamped with a
+# qualified ``model_version`` (``<plugin>@<version>``). Raw confidences are not
+# comparable between models - the apply thresholds above are calibrated against the
+# built-in tagger - so a plugin's score must never reach the penalty, or switching
+# tagger would move every affected picture's smart score with nothing on screen to
+# explain it. A *human* verdict still counts whichever row carries it.
+
+
+def test_plugin_sourced_model_prediction_is_not_scored():
+    """A plugin's confidence is dropped even when tagged and above the threshold."""
+    temp_dir, client, server = _setup()
+    try:
+        pic_id = _upload_picture(client)
+        _seed_tag(server, pic_id, "watermark")
+        _seed_prediction(server, pic_id, "watermark", confidence=0.8)  # > 0.6
+        _set_model_version(server, pic_id, "watermark", "joycaption@2026-01")
+
+        probs, human = _probs(server, pic_id)
+        assert "watermark" not in probs.get(pic_id, {})
+        assert (
+            anomaly_penalty(
+                probs.get(pic_id, {}),
+                tag_thresholds=_THRESHOLDS,
+                human_tags=human.get(pic_id),
+            )
+            == 0.0
+        )
+
+        # The ungated read drops it too: this is a source fence, not a threshold.
+        raw, _ = server.vault.db.run_task(
+            lambda s: fetch_anomaly_confidences(s, [pic_id])
+        )
+        assert "watermark" not in raw.get(pic_id, {})
+
+        # Control: the identical row unqualified *is* scored, proving the
+        # model_version is what removed it and not the seeding.
+        _set_model_version(server, pic_id, "watermark", "v43")
+        probs, _ = _probs(server, pic_id)
+        assert probs[pic_id]["watermark"] == pytest.approx(0.8)
+    finally:
+        server.close()
+        temp_dir.cleanup()
+
+
+def test_human_decision_on_a_plugin_row_still_counts():
+    """The fence drops model confidences, never a person's verdict."""
+    temp_dir, client, server = _setup()
+    try:
+        pic_id = _upload_picture(client)
+        _seed_human_prediction(server, pic_id, "watermark", POS, confidence=0.1)
+        _set_model_version(server, pic_id, "watermark", "joycaption@2026-01")
+
+        probs, human = _probs(server, pic_id)
+        assert probs[pic_id]["watermark"] == pytest.approx(1.0)
+        assert "watermark" in human[pic_id]
+
+        # And the negative direction, on the same plugin-stamped row.
+        _set_label_state(server, pic_id, "watermark", NEG)
+        probs, _ = _probs(server, pic_id)
+        assert probs[pic_id]["watermark"] == pytest.approx(0.0)
+    finally:
+        server.close()
+        temp_dir.cleanup()
+
+
+def test_plugin_write_leaves_the_built_in_taggers_predictions_alone():
+    """A plugin run must not delete or overwrite built-in rows as stale.
+
+    One row per ``(picture, tag)`` is all the unique key allows, so without the
+    built-in/plugin split in the stale-row delete, running a plugin would clear the
+    built-in tagger's confidences and take the picture's anomaly penalty with them.
+    """
+    temp_dir, client, server = _setup()
+    try:
+        pic_id = _upload_picture(client)
+        _seed_tag(server, pic_id, "watermark")
+        _seed_prediction(server, pic_id, "watermark", confidence=0.8)
+
+        written = server.vault.db.run_task(
+            TagTask._write_predictions_from_tags,
+            {pic_id: {"watermark": 0.05, "bad anatomy": 0.9}},
+            {pic_id: {"watermark"}},
+            "joycaption@2026-01",
+        )
+
+        rows = server.vault.db.run_task(
+            lambda s: {
+                r.tag: (r.model_version, r.confidence)
+                for r in s.exec(
+                    select(TagPrediction).where(TagPrediction.picture_id == pic_id)
+                ).all()
+            }
+        )
+        # The built-in row survives untouched, version and confidence.
+        assert rows["watermark"] == ("test-v1", pytest.approx(0.8))
+        # The plugin's own prediction for a tag nobody owned is still recorded.
+        assert rows["bad anatomy"][0] == "joycaption@2026-01"
+        assert written >= 1
+
+        # And the surviving built-in confidence still drives the penalty.
+        probs, human = _probs(server, pic_id)
+        assert probs[pic_id]["watermark"] == pytest.approx(0.8)
+        assert (
+            anomaly_penalty(
+                probs[pic_id],
+                tag_thresholds=_THRESHOLDS,
+                human_tags=human.get(pic_id),
+            )
+            > 0.0
+        )
+    finally:
+        server.close()
+        temp_dir.cleanup()
+
+
+def test_model_version_helpers_split_built_in_from_plugin_rows():
+    """The predicate the fence is built on, including the legacy shapes."""
+    assert qualify_plugin_model_version("joycaption", "2026-01") == "joycaption@2026-01"
+    assert qualify_plugin_model_version("joycaption", None) == "joycaption@unknown"
+    assert qualify_plugin_model_version("joycaption", "  ") == "joycaption@unknown"
+
+    # Every row written before plugins could predict at all must keep scoring.
+    assert feeds_anomaly_score("v43")
+    assert feeds_anomaly_score("unknown")
+    assert feeds_anomaly_score("manual")
+    assert not feeds_anomaly_score("joycaption@2026-01")
+    assert not feeds_anomaly_score("joycaption@unknown")

--- a/tests/test_tag_prediction_backfill.py
+++ b/tests/test_tag_prediction_backfill.py
@@ -131,3 +131,60 @@ def test_backfill_marks_unscored_pictures_so_they_drop_out(tmp_path):
         found = MissingTagPredictionFinder._fetch_missing_predictions(session, 100)
         assert pic_id not in [p.id for p in found]
         assert Vault._count_missing_tag_predictions(session) == 0
+
+
+class _RecordingWorkflow:
+    """Minimal TaggingWorkflow stand-in that records the engine overrides it got.
+
+    Mirrors the real contract: ``active_model_version`` qualifies the version
+    with the plugin name for anything but the built-in tagger, so a backfill
+    that failed to pin the override would stamp ``<plugin>@<version>`` here.
+    """
+
+    def __init__(self, configured_plugin):
+        self._configured = configured_plugin
+        self.overrides = []
+        self.is_pixlstash_tagger_enabled = True
+
+    def _resolve(self, engine_override):
+        self.overrides.append(engine_override)
+        return engine_override if engine_override is not None else self._configured
+
+    def ensure_active_plugin_ready(self, engine_override=None):
+        self._resolve(engine_override)
+
+    def tag_images(self, image_paths, out_raw_scores=None, engine_override=None):
+        self._resolve(engine_override)
+        return {}
+
+    def active_model_version(self, engine_override=None):
+        active = self._resolve(engine_override)
+        return "v7" if active == "pixlstash_tagger" else f"{active}@1.0"
+
+
+class _FakeDB:
+    image_root = "/images"
+
+    def run_task(self, func, *args, priority=None, **kwargs):
+        return 0
+
+
+def test_backfill_pins_to_the_pixlstash_tagger_even_when_a_plugin_is_active(tmp_path):
+    """The backfill exists to recover *PixlStash tagger* confidences.
+
+    It must not silently run whatever third-party plugin the UI has configured:
+    that would stamp plugin-qualified rows, which are fenced out of anomaly
+    scoring, defeating the point of the backfill.
+    """
+    engine = _make_engine(tmp_path)
+    with Session(engine) as session:
+        pic_id = _add_picture(session, "a.jpg", tags=["dog"])
+        pic = session.get(Picture, pic_id)
+
+        workflow = _RecordingWorkflow(configured_plugin="thirdparty_tagger")
+        task = TagPredictionBackfillTask(_FakeDB(), workflow, [pic])
+        task._run_task()
+
+        # Every call pinned the built-in tagger, never the configured plugin.
+        assert workflow.overrides == ["pixlstash_tagger"] * 3
+        assert workflow.active_model_version("pixlstash_tagger") == "v7"

--- a/tests/test_tagger_plugin_registry.py
+++ b/tests/test_tagger_plugin_registry.py
@@ -1,7 +1,12 @@
 """Tests for TaggerPluginManager and first-party plugin schemas."""
 
+from types import SimpleNamespace
+
 import pytest
 
+from pixlstash.db_models.tag_prediction import feeds_anomaly_score
+from pixlstash.inference.workflows.tagging import TaggingWorkflow
+from pixlstash.tagger_plugins.base import TaggerPlugin, TagResult
 from pixlstash.tagger_plugins.registry import TaggerPluginManager
 
 
@@ -200,3 +205,107 @@ def test_joycaption_schema_has_required_parameters(manager):
 def test_joycaption_is_not_loaded_before_init(manager):
     plugin = manager.get_plugin("joycaption")
     assert plugin.is_loaded() is False
+
+
+# --- Plugin-sourced tag predictions ----------------------------------------------
+# No shipped plugin exercises this path: wd14 and pixlstash_tagger both take
+# built-in routes through TaggingWorkflow, and the description plugins produce no
+# tags.  A stub stands in for the third-party plugin the path exists for.
+
+
+class _StubTagger(TaggerPlugin):
+    """Minimal third-party tag plugin: two scored tags and one unscored."""
+
+    name = "stub_tagger"
+    supports_tags = True
+    requires_download = False
+
+    def __init__(self, version: str = "2026-01") -> None:
+        self._version = version
+
+    def model_version(self) -> str:
+        return self._version
+
+    def parameter_schema(self):
+        return []
+
+    def needs_download(self, parameters=None) -> bool:
+        return False
+
+    def init(self, parameters) -> None:
+        pass
+
+    def unload(self) -> None:
+        pass
+
+    def is_loaded(self) -> bool:
+        return True
+
+    def tag_images(self, image_paths, parameters, preloaded=None, stop_event=None):
+        return {
+            path: [
+                TagResult("watermark", 0.8),
+                TagResult("sunset", 0.25),
+                TagResult("unscored", None),
+            ]
+            for path in image_paths
+        }
+
+
+def _workflow(monkeypatch, plugin, active="stub_tagger", tagger_version=43):
+    """A TaggingWorkflow whose registry resolves *plugin* by name."""
+    manager = SimpleNamespace(get_plugin=lambda n: plugin if n == plugin.name else None)
+    monkeypatch.setattr(
+        "pixlstash.tagger_plugins.registry.get_tagger_plugin_manager",
+        lambda: manager,
+    )
+    engine = SimpleNamespace(
+        device="cpu", pixlstash_tagger_version=lambda: tagger_version
+    )
+    return TaggingWorkflow(
+        engine=engine,
+        use_wd14=False,
+        use_pixlstash_tagger=(active == "pixlstash_tagger"),
+        tagger_settings={"active_tag_plugin": active},
+    )
+
+
+def test_plugin_confidences_reach_the_caller(monkeypatch):
+    """The workflow used to reduce results to bare tags and drop every score."""
+    workflow = _workflow(monkeypatch, _StubTagger())
+    scores = {}
+
+    tags = workflow.tag_images(["/tmp/a.png"], out_raw_scores=scores)
+
+    assert tags["/tmp/a.png"] == ["sunset", "unscored", "watermark"]
+    # A tag the plugin declined to score contributes nothing, rather than a 0.0
+    # the caller would be unable to tell from a real zero.
+    assert scores["/tmp/a.png"] == {"watermark": 0.8, "sunset": 0.25}
+
+
+def test_plugin_predictions_are_stamped_with_the_plugin_and_version(monkeypatch):
+    workflow = _workflow(monkeypatch, _StubTagger("2026-01"))
+    assert workflow.active_model_version() == "stub_tagger@2026-01"
+
+
+def test_a_plugin_that_declares_no_version_is_stamped_unknown(monkeypatch):
+    """The default from the ABC. Such rows never go stale - documented, not silent."""
+    workflow = _workflow(monkeypatch, _StubTagger(""))
+    assert workflow.active_model_version() == "stub_tagger@unknown"
+
+
+def test_a_plugin_whose_version_raises_does_not_break_tagging(monkeypatch):
+    plugin = _StubTagger()
+    monkeypatch.setattr(plugin, "model_version", lambda: 1 / 0, raising=False)
+    workflow = _workflow(monkeypatch, plugin)
+    assert workflow.active_model_version() == "stub_tagger@unknown"
+
+
+def test_the_built_in_tagger_keeps_its_bare_version(monkeypatch):
+    """Unqualified on purpose: it is what feeds_anomaly_score() lets through, and
+    changing it would orphan every prediction row already in a vault."""
+    workflow = _workflow(
+        monkeypatch, _StubTagger(), active="pixlstash_tagger", tagger_version=43
+    )
+    assert workflow.active_model_version() == "v43"
+    assert feeds_anomaly_score(workflow.active_model_version())


### PR DESCRIPTION
Fix the limitations that only PixlStash tagger can produce tag predictions