### PR TITLE
Offer to start over when a library database will not open

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3187,6 +3187,19 @@ ambiguity here resolves towards *not* moving a file.
     - Instantiates `Vault` (opens `VaultDatabase` and runs Alembic), then stamps/validates `library_settings.library_uuid` and completes crash-safe legacy blanking before authentication starts.
     - Applies user-configured model/runtime settings (`keep_models_in_memory`, VRAM cap, tagger toggles/thresholds) to `Vault`.
    - Builds the FastAPI app, attaches middleware (CORS, rate limiter, auth), mounts routers and the SPA.
+**Every interactive start-up question holds the log while it is on screen**
+(`pixl_logging.hold_log_output`). Three of the four are asked from inside
+`Server.__init__` and the fourth (`_prompt_bootstrap_credentials`) after it
+returns, so by then the boot log is running and the background workers have
+started: the first-run credentials prompt was written between two INFO lines,
+and a snapshot task logged its progress onto the same line while the prompt
+waited for an answer. The context manager swaps the root handlers for a
+buffering one and replays every held record, in order, once the question has
+been answered - held, never dropped. It only covers the logging path, so a bare
+`print` from another thread can still reach the terminal; that narrows the
+window rather than sealing it. The credentials prompt also prints its own
+heading, so it reads as a question rather than as one more line of start-up.
+
 4. A retained `uvicorn.Server` listener enters the **lifespan** (Electron retains both listeners):
    - Optional `_cleanup_missing_pictures()`.
    - Optional `_generate_missing_thumbnails()`.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2764,6 +2764,34 @@ interactive terminal: an unmounted external drive looks exactly like an empty
 folder, and a fresh vault inside the mount point would lock the real library
 out once the drive came back.
 
+**A vault that is present but will not open is a question, not a crash.** It is
+the third case beside "gone" and "fine", and it used to be neither: `attach`
+raised `NotAVaultError` out of `Server.__init__`, `app.main` had no clause for
+it, and the desktop shell showed a Python traceback over the first-run setup
+window. Two things fix it.
+
+*What counts as a vault.* `validate_vault_folder` accepts a pre-Alembic vault —
+`_LEGACY_VAULT_MARKER_TABLES`, the `0001_baseline` table set — as well as one
+carrying `alembic_version`. `VaultDatabase` has always known how to open that
+file (it stamps the baseline and upgrades to head), so refusing it in the
+registry made that branch unreachable for every library the hub owns, and a
+December-2025 folder read as "not a PixlStash vault". The legacy set is
+deliberately wide: one stray table named `picture` is still not a library.
+
+*What happens when it genuinely will not open.* `_register_first_library` and
+`_offer_a_usable_library` raise `UnusableVaultError` (a `HubBootstrapError`)
+carrying the folder, the file and the reason. `app.main` catches it, explains
+what starting over costs, and asks — inline on a TTY, and for Electron by
+printing the single-line `PIXLSTASH_VAULT_UNUSABLE=` record the shell parses
+(`electron/src/backend/VaultRecovery.ts`), exactly as the permission repair
+does. A yes relaunches with `PIXLSTASH_RECREATE_VAULT=1`, the only value
+`set_aside_unusable_vault` acts on; it **renames** `vault.db` and its sidecars
+to `vault.db.unusable-<timestamp>` and never deletes them. A vault we cannot
+read is not a vault that holds nothing, and somebody who is shown a traceback
+instead of an offer deletes the file by hand to get the app started. A
+*fingerprint conflict* is not this case — that vault loads fine, and the answer
+is to put the right one back.
+
 Hub loss therefore does not re-import the blank legacy identity or deadlock
 registration. A recreated hub mints a fresh immutable registry UUID, records
 the vault fingerprint only as advisory evidence, creates an unclaimed hub

--- a/docs/desktop-backend-migration.md
+++ b/docs/desktop-backend-migration.md
@@ -246,6 +246,22 @@ change an answer and Try again to re-run the commit. It must never drop the user
 at the first question: the message lives on the install step, so a screen change
 is also a message that vanishes.
 
+**The second recoverable failure is a library database that will not open.**
+Same shape as the permission repair, and for the same reason: Electron has no
+usable stdin, so the backend prints a one-line record
+(`PIXLSTASH_VAULT_UNUSABLE=`), exits, and the shell turns it into a typed
+`VaultUnusableError` rather than a startup message
+(`backend/VaultRecovery.ts`). The offer is a native box — one file, one
+sentence of consequence, one decision — and it names what starting over costs
+*and* that the old file is renamed rather than deleted, which is the line that
+stops somebody deleting it themselves. Accepting relaunches with
+`PIXLSTASH_RECREATE_VAULT=1`; the backend does the renaming, so a dismissed
+dialog changes nothing on disk. The decline button differs by where it happens:
+from setup it is **Choose Another Folder** and returns to the picker, from
+`boot()` there is no picker to return to, so it is **Quit**. Neither path falls
+back to the CPU overlay first — the database has nothing to do with the
+accelerator, and retrying there would throw the typed error away.
+
 Subsequent launches see the config exists → no steps to run → straight into the
 library.
 

--- a/electron/src/backend/ServerProcess.ts
+++ b/electron/src/backend/ServerProcess.ts
@@ -11,6 +11,19 @@ import {
   parsePermissionRepairRequest,
   PermissionRepairRequiredError,
 } from './StartupPermissions';
+import { parseUnusableVaultReport, VaultUnusableError } from './VaultRecovery';
+
+/**
+ * One-shot authorisations carried into a relaunch, each standing for a native
+ * dialog the user has already answered "yes" to. Never defaulted on: a launch
+ * that sets neither is the ordinary one.
+ */
+export interface StartupRecovery {
+  /** Tighten the file modes the backend refused to start with. */
+  repairPermissions?: boolean;
+  /** Set the unopenable library database aside and start with a new one. */
+  recreateVault?: boolean;
+}
 
 export interface RunningServer {
   url: string;
@@ -152,16 +165,17 @@ function startupFailureMessage(
   );
 }
 
-/** Preserve repairable permission failures as a typed desktop-shell event. */
+/** Preserve recoverable startup failures as typed desktop-shell events. */
 export function startupFailureError(
   code: number | null,
   signal: NodeJS.Signals | null,
   tail: string,
 ): Error {
   const request = parsePermissionRepairRequest(tail);
-  return request
-    ? new PermissionRepairRequiredError(request)
-    : new Error(startupFailureMessage(code, signal, tail));
+  if (request) return new PermissionRepairRequiredError(request);
+  const unusableVault = parseUnusableVaultReport(tail);
+  if (unusableVault) return new VaultUnusableError(unusableVault);
+  return new Error(startupFailureMessage(code, signal, tail));
 }
 
 /**
@@ -261,7 +275,7 @@ export class ServerProcess {
   async start(
     overlayDir: string | null,
     device?: string,
-    repairPermissions = false,
+    recovery: StartupRecovery = {},
   ): Promise<RunningServer> {
     const python = isDevBackend() ? devInterpreter() : bundledInterpreter();
     if (!existsSync(python)) {
@@ -300,7 +314,11 @@ export class ServerProcess {
       PIXLSTASH_DESKTOP_SESSION: sessionToken,
       // Set only after the user accepts the native repair dialog. An explicit
       // value prevents a parent-shell variable from authorising it accidentally.
-      PIXLSTASH_REPAIR_PERMISSIONS: repairPermissions ? '1' : '0',
+      PIXLSTASH_REPAIR_PERMISSIONS: recovery.repairPermissions ? '1' : '0',
+      // Likewise: only after the user has been shown what starting over costs
+      // and has agreed. The backend renames the old database rather than
+      // deleting it, but this is still the one flag that abandons a library.
+      PIXLSTASH_RECREATE_VAULT: recovery.recreateVault ? '1' : '0',
       // Force the inference device to match this runtime (the bundled env is
       // CPU-only); overrides default_device in the shared on-disk config.
       ...(device ? { PIXLSTASH_DEFAULT_DEVICE: device } : {}),

--- a/electron/src/backend/VaultRecovery.ts
+++ b/electron/src/backend/VaultRecovery.ts
@@ -1,0 +1,80 @@
+/** Structured startup protocol for a library database that will not open. */
+
+export const VAULT_UNUSABLE_PREFIX = 'PIXLSTASH_VAULT_UNUSABLE=';
+
+/** What the backend found, and where. */
+export interface UnusableVaultReport {
+  version: 1;
+  /** The library folder the app is configured to open. */
+  folder: string;
+  /** The `vault.db` inside it that could not be opened. */
+  vault_path: string;
+  /** The backend's own one-line reason, shown verbatim. */
+  reason: string;
+}
+
+/**
+ * A backend startup failure the desktop shell can offer a way out of.
+ *
+ * Distinct from a bare startup crash because there is exactly one thing a
+ * person can do about it, and the app knows what it is: start over with an
+ * empty database, keeping the old file. Without this the backend exited 1 and
+ * the shell showed a Python traceback over the setup window, which is how a
+ * December-2025 library folder read as "the app is broken" - and how the file
+ * that would have opened after an upgrade got deleted by hand.
+ */
+export class VaultUnusableError extends Error {
+  constructor(public readonly report: UnusableVaultReport) {
+    super('PixlStash could not open the library database.');
+    this.name = 'VaultUnusableError';
+  }
+}
+
+function isReport(value: unknown): value is UnusableVaultReport {
+  if (!value || typeof value !== 'object') return false;
+  const report = value as Record<string, unknown>;
+  return (
+    report.version === 1 &&
+    typeof report.folder === 'string' &&
+    report.folder.length > 0 &&
+    report.folder.length <= 4096 &&
+    typeof report.vault_path === 'string' &&
+    report.vault_path.length > 0 &&
+    report.vault_path.length <= 4096 &&
+    typeof report.reason === 'string' &&
+    report.reason.length <= 4096
+  );
+}
+
+/** Parse the last valid record from the backend's bounded output tail. */
+export function parseUnusableVaultReport(output: string): UnusableVaultReport | null {
+  const records = output.split(/\r?\n/).filter((line) => line.startsWith(VAULT_UNUSABLE_PREFIX));
+  for (const line of records.reverse()) {
+    try {
+      const value = JSON.parse(line.slice(VAULT_UNUSABLE_PREFIX.length)) as unknown;
+      if (isReport(value)) return value;
+    } catch {
+      // Malformed diagnostic output never authorises touching a database.
+    }
+  }
+  return null;
+}
+
+/**
+ * Native-dialog detail: what failed, what the offer costs, and that the old
+ * file survives. The last line is the one that matters - somebody who believes
+ * the app is about to delete their library will go and delete it themselves.
+ */
+export function vaultRecoveryDialogDetail(report: UnusableVaultReport): string {
+  return (
+    `${report.vault_path}\n${report.reason}\n\n` +
+    'PixlStash can start over with a new, empty library database in that folder. ' +
+    'Your pictures are untouched and will be offered for import again, but the tags, ' +
+    'scores, characters and history recorded in the old database are not carried over.\n\n' +
+    'The old file is renamed, never deleted, so it can still be recovered.'
+  );
+}
+
+export function isVaultUnusable(error: unknown): error is VaultUnusableError {
+  return error instanceof VaultUnusableError;
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -24,13 +24,18 @@ import { BackendManager, OVERLAY_ACCELS, launchWithOverlayFallback } from './bac
 import { uniqueDownloadPath } from './downloads';
 import { ipcBytes, pngClipboardPayload, safeMediaFilename } from './mediaIpc';
 import { isAllowedNavigation, redactUrl } from './urlPolicy';
-import { ServerProcess, devInterpreter } from './backend/ServerProcess';
+import { ServerProcess, StartupRecovery, devInterpreter } from './backend/ServerProcess';
 import {
   isPermissionRepairRequired,
   mkdirPrivateIfMissing,
   permissionRepairDialogDetail,
   PermissionRepairRequiredError,
 } from './backend/StartupPermissions';
+import {
+  isVaultUnusable,
+  vaultRecoveryDialogDetail,
+  VaultUnusableError,
+} from './backend/VaultRecovery';
 import {
   Accel,
   ACCEL_LABELS,
@@ -817,7 +822,7 @@ function deviceFor(accel: Accel | null): string | undefined {
  */
 async function startAndLoad(
   accel: Accel | null,
-  repairPermissions = false,
+  recovery: StartupRecovery = {},
   navigate = true,
 ): Promise<void> {
   sendPhase({ phase: 'starting' });
@@ -832,11 +837,7 @@ async function startAndLoad(
       );
     }
   });
-  const running = await serverProcess.start(
-    overlayFor(accel),
-    deviceFor(accel),
-    repairPermissions,
-  );
+  const running = await serverProcess.start(overlayFor(accel), deviceFor(accel), recovery);
   // Setup talks to this server while the GPU runtime downloads, so where it is
   // and how to authenticate to it outlive this function.
   runningServer = { url: running.url, sessionToken: running.sessionToken };
@@ -879,16 +880,18 @@ async function activeOverlayAccel(): Promise<Accel | null> {
  */
 async function startWithOverlayFallback(
   accel: Accel | null,
-  repairPermissions = false,
+  recovery: StartupRecovery = {},
   navigate = true,
 ): Promise<void> {
   await launchWithOverlayFallback(accel, {
-    start: (candidate) => startAndLoad(candidate, repairPermissions, navigate),
+    start: (candidate) => startAndLoad(candidate, recovery, navigate),
     deactivateOverlay: () => manager.setActiveAccel(null),
     notify: (message) => dialog.showErrorBox('GPU acceleration unavailable', message),
-    // Permission failures are unrelated to an accelerator. Preserve the active
-    // overlay and let boot() offer the dedicated recovery dialog.
-    shouldFallback: (error) => !isPermissionRepairRequired(error),
+    // Permission failures and an unopenable library database are unrelated to
+    // an accelerator: retrying on the CPU env fails identically and throws the
+    // typed error away. Preserve the active overlay and let the caller offer
+    // the dedicated recovery dialog.
+    shouldFallback: (error) => !isPermissionRepairRequired(error) && !isVaultUnusable(error),
   });
 }
 
@@ -905,8 +908,21 @@ async function startWithOverlayFallback(
  */
 async function startFromSetup(accel: Accel | null, navigate: boolean): Promise<void> {
   try {
-    await startWithOverlayFallback(accel, false, navigate);
+    await startWithOverlayFallback(accel, {}, navigate);
   } catch (caught) {
+    // A folder holding a database we cannot open is a folder choice, so the
+    // refusal returns to the picker rather than quitting: "choose another
+    // folder" is the answer, and here it is one click away.
+    if (isVaultUnusable(caught)) {
+      if (!(await offerVaultRecreation(caught, 'Choose Another Folder'))) {
+        await mainWindow?.loadFile(join(__dirname, 'renderer', 'setup.html'));
+        throw new Error(
+          'PixlStash could not open the library database in that folder. Choose another folder, or let PixlStash start a new one there.',
+        );
+      }
+      await startWithOverlayFallback(accel, { recreateVault: true }, navigate);
+      return;
+    }
     if (!isPermissionRepairRequired(caught)) throw caught;
     if (!(await offerPermissionRepair(caught))) {
       await mainWindow?.loadFile(join(__dirname, 'renderer', 'setup.html'));
@@ -916,8 +932,34 @@ async function startFromSetup(accel: Accel | null, navigate: boolean): Promise<v
     }
     // Exactly one user-authorised retry, as boot() does. Python rechecks
     // ownership, type and inode before changing any recorded path.
-    await startWithOverlayFallback(accel, true, navigate);
+    await startWithOverlayFallback(accel, { repairPermissions: true }, navigate);
   }
+}
+
+/**
+ * Ask whether the library database that will not open may be set aside.
+ *
+ * A native box rather than a styled screen: unlike the permission repair this
+ * is one file, one sentence of consequence and one decision, and it can appear
+ * over the setup window the user is already looking at. The backend does the
+ * renaming - and only when the relaunch carries the flag this returning true
+ * sets - so a dismissed dialog changes nothing on disk.
+ */
+async function offerVaultRecreation(
+  error: VaultUnusableError,
+  declineLabel: string,
+): Promise<boolean> {
+  const result = await dialog.showMessageBox({
+    type: 'warning',
+    title: 'PixlStash',
+    message: 'PixlStash could not open the library database',
+    detail: vaultRecoveryDialogDetail(error.report),
+    buttons: ['Start a New Library Database', declineLabel],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  });
+  return result.response === 0;
 }
 
 /**
@@ -1020,11 +1062,7 @@ async function boot(): Promise<void> {
       try {
         // Exactly one user-authorised retry. Python rechecks ownership, type,
         // and inode before changing any recorded path.
-        if (isDevBackend()) {
-          await startAndLoad(null, true);
-        } else {
-          await startWithOverlayFallback(await activeOverlayAccel(), true);
-        }
+        await retryLaunch({ repairPermissions: true });
         return;
       } catch (retryError) {
         error = retryError;
@@ -1033,9 +1071,32 @@ async function boot(): Promise<void> {
         // failed repair leaves the offer on screen with nothing happening.
         await mainWindow?.loadFile(join(__dirname, 'renderer', 'index.html'));
       }
+    } else if (isVaultUnusable(error)) {
+      // Not first-run: there is no folder picker to send them back to, so the
+      // choice is starting over or quitting. Either way it is a question, not
+      // a traceback on the splash screen.
+      if (!(await offerVaultRecreation(error, 'Quit'))) {
+        app.quit();
+        return;
+      }
+      try {
+        await retryLaunch({ recreateVault: true });
+        return;
+      } catch (retryError) {
+        error = retryError;
+      }
     }
     sendPhase({ phase: 'error', message: (error as Error).message });
   }
+}
+
+/** The one authorised relaunch a recovery dialog buys, dev passthrough included. */
+async function retryLaunch(recovery: StartupRecovery): Promise<void> {
+  if (isDevBackend()) {
+    await startAndLoad(null, recovery);
+    return;
+  }
+  await startWithOverlayFallback(await activeOverlayAccel(), recovery);
 }
 
 /**

--- a/electron/test/vaultRecovery.test.ts
+++ b/electron/test/vaultRecovery.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  parseUnusableVaultReport,
+  vaultRecoveryDialogDetail,
+  VaultUnusableError,
+  VAULT_UNUSABLE_PREFIX,
+} from '../src/backend/VaultRecovery';
+import { startupFailureError } from '../src/backend/ServerProcess';
+import { PermissionRepairRequiredError, PERMISSION_REPAIR_PREFIX } from '../src/backend/StartupPermissions';
+
+const report = {
+  version: 1 as const,
+  folder: '/home/me/images',
+  vault_path: '/home/me/images/vault.db',
+  reason: '/home/me/images/vault.db does not look like a PixlStash vault (missing alembic_version).',
+};
+
+describe('the unopenable-library startup protocol', () => {
+  it('parses the backend record out of ordinary diagnostic output', () => {
+    const output = [
+      'CUDA is unavailable; forcing CPU inference.',
+      'PixlStash could not open the library database in /home/me/images:',
+      `${VAULT_UNUSABLE_PREFIX}${JSON.stringify(report)}`,
+    ].join('\n');
+
+    assert.deepEqual(parseUnusableVaultReport(output), report);
+  });
+
+  it('turns the record into a typed error instead of a raw exit message', () => {
+    const output = `${VAULT_UNUSABLE_PREFIX}${JSON.stringify(report)}`;
+    const error = startupFailureError(1, null, output);
+
+    assert.ok(error instanceof VaultUnusableError, 'the shell can only offer what it can recognise');
+    assert.deepEqual(error.report, report);
+  });
+
+  it('leaves a permission repair as a permission repair', () => {
+    // Both records can be in one tail (a repaired launch that then found a bad
+    // vault). The permission repair has to run first: without it the backend
+    // never gets far enough to say anything about the database.
+    const output = [
+      `${PERMISSION_REPAIR_PREFIX}${JSON.stringify({
+        version: 1,
+        issues: [
+          { area: 'Library', path: '/home/me/images', current_mode: '775', repaired_mode: '700' },
+        ],
+      })}`,
+      `${VAULT_UNUSABLE_PREFIX}${JSON.stringify(report)}`,
+    ].join('\n');
+
+    assert.ok(startupFailureError(1, null, output) instanceof PermissionRepairRequiredError);
+  });
+
+  it('refuses malformed records rather than offering to touch a database', () => {
+    assert.equal(parseUnusableVaultReport(`${VAULT_UNUSABLE_PREFIX}{oops`), null);
+    assert.equal(
+      parseUnusableVaultReport(`${VAULT_UNUSABLE_PREFIX}${JSON.stringify({ ...report, version: 2 })}`),
+      null,
+    );
+    assert.equal(
+      parseUnusableVaultReport(`${VAULT_UNUSABLE_PREFIX}${JSON.stringify({ ...report, vault_path: '' })}`),
+      null,
+    );
+    assert.equal(parseUnusableVaultReport('nothing structured here at all'), null);
+  });
+
+  it('takes the last record, so a retry describes the retry', () => {
+    const older = { ...report, vault_path: '/home/me/old/vault.db' };
+    const output = [
+      `${VAULT_UNUSABLE_PREFIX}${JSON.stringify(older)}`,
+      `${VAULT_UNUSABLE_PREFIX}${JSON.stringify(report)}`,
+    ].join('\n');
+
+    assert.equal(parseUnusableVaultReport(output)?.vault_path, report.vault_path);
+  });
+});
+
+describe('what the recovery dialog says', () => {
+  it('names the file, the reason, and what starting over costs', () => {
+    const detail = vaultRecoveryDialogDetail(report);
+
+    assert.match(detail, /vault\.db/);
+    assert.match(detail, /alembic_version/, 'the backend reason is shown, not paraphrased away');
+    assert.match(detail, /pictures are untouched/i);
+    assert.match(detail, /tags, scores, characters and history/i);
+  });
+
+  it('promises the old file survives, because that is the line that stops a manual delete', () => {
+    assert.match(vaultRecoveryDialogDetail(report), /renamed, never deleted/i);
+  });
+});

--- a/pixlstash/app.py
+++ b/pixlstash/app.py
@@ -11,7 +11,7 @@ from platformdirs import user_config_dir
 from passlib.hash import bcrypt
 
 
-from pixlstash.pixl_logging import setup_logging, get_logger
+from pixlstash.pixl_logging import setup_logging, get_logger, hold_log_output
 from pixlstash.server import Server
 from pixlstash.startup_checks import StartupCheckError
 from pixlstash.hub.bootstrap import (
@@ -195,23 +195,23 @@ def _offer_vault_recreation(exc: UnusableVaultError) -> bool:
     as it does for a permission repair, because Electron has no usable stdin.
     """
 
-    message = _format_unusable_vault(exc)
-    print(message, file=sys.stderr)
+    with hold_log_output():
+        print(_format_unusable_vault(exc), file=sys.stderr)
 
-    if os.environ.get("PIXLSTASH_INSTALL_TYPE", "").lower() == "electron":
-        # Human text stays in the log; the JSON line is the stable protocol.
-        print(_vault_unusable_signal(exc), file=sys.stderr)
-        return False
+        if os.environ.get("PIXLSTASH_INSTALL_TYPE", "").lower() == "electron":
+            # Human text stays in the log; the JSON line is the stable protocol.
+            print(_vault_unusable_signal(exc), file=sys.stderr)
+            return False
 
-    if getattr(sys.stdin, "isatty", lambda: False)():
-        try:
-            answer = input("\nStart over with an empty library database? [y/N] ")
-        except EOFError:
-            answer = "n"
-        if answer.strip().lower() in {"y", "yes"}:
-            return True
-        print("The library database was left alone.", file=sys.stderr)
-        return False
+        if getattr(sys.stdin, "isatty", lambda: False)():
+            try:
+                answer = input("\nStart over with an empty library database? [y/N] ")
+            except EOFError:
+                answer = "n"
+            if answer.strip().lower() in {"y", "yes"}:
+                return True
+            print("The library database was left alone.", file=sys.stderr)
+            return False
 
     print(
         "\nStart PixlStash again with "
@@ -252,21 +252,23 @@ def _prompt_legacy_identity_migration(library) -> bool:
         )
         return False
 
-    print(
-        f"\n{library.path} still holds an owner account and API tokens from "
-        "before PixlStash introduced its hub. PixlStash can move them into "
-        "the hub now, after which this library will no longer be readable "
-        "as an owner/token store by versions of PixlStash older than the hub.",
-        file=sys.stderr,
-    )
-    try:
-        answer = (
-            input("Migrate this library's identity into the hub now? [y/N] ")
-            .strip()
-            .lower()
+    # Asked from inside `Server.__init__`, between two boot log lines.
+    with hold_log_output():
+        print(
+            f"\n{library.path} still holds an owner account and API tokens from "
+            "before PixlStash introduced its hub. PixlStash can move them into "
+            "the hub now, after which this library will no longer be readable "
+            "as an owner/token store by versions of PixlStash older than the hub.",
+            file=sys.stderr,
         )
-    except EOFError:
-        answer = "n"
+        try:
+            answer = (
+                input("Migrate this library's identity into the hub now? [y/N] ")
+                .strip()
+                .lower()
+            )
+        except EOFError:
+            answer = "n"
     return answer in {"y", "yes"}
 
 
@@ -287,17 +289,20 @@ def _prompt_library_switch(library, reason: str, alternatives: list):
     if is_electron or not getattr(sys.stdin, "isatty", lambda: False)():
         return None
 
-    print(
-        f"\nPixlStash cannot open its library {library.name} ({library.path}):"
-        f"\n  {reason}\n\nThese attached libraries do open:",
-        file=sys.stderr,
-    )
-    for index, candidate in enumerate(alternatives, start=1):
-        print(f"  {index}. {candidate.name} ({candidate.path})", file=sys.stderr)
-    try:
-        answer = input("Open which one instead? [number, or Enter to stop] ").strip()
-    except EOFError:
-        return None
+    with hold_log_output():
+        print(
+            f"\nPixlStash cannot open its library {library.name} ({library.path}):"
+            f"\n  {reason}\n\nThese attached libraries do open:",
+            file=sys.stderr,
+        )
+        for index, candidate in enumerate(alternatives, start=1):
+            print(f"  {index}. {candidate.name} ({candidate.path})", file=sys.stderr)
+        try:
+            answer = input(
+                "Open which one instead? [number, or Enter to stop] "
+            ).strip()
+        except EOFError:
+            return None
     if not answer.isdigit() or not 1 <= int(answer) <= len(alternatives):
         return None
     return alternatives[int(answer) - 1]
@@ -375,55 +380,65 @@ def _bootstrap_server_config(server_config_path: str, force: bool = False) -> bo
 
 
 def _prompt_bootstrap_credentials(server) -> None:
+    """Ask for the owner's credentials, on a screen the boot log is not writing to.
+
+    This runs after ``Server.__init__``, so the whole boot log and the first
+    background tasks are already going past. Held output and a heading of its
+    own are what make it a question rather than another line of start-up.
+    """
     if not sys.stdin.isatty():
         return
 
     user = server.auth.user or server.auth.ensure_user()
     has_existing_credentials = bool(user and user.username and user.password_hash)
 
-    if has_existing_credentials:
-        keep_input = input("Keep existing username/password? [Y/n]: ").strip()
-        keep_existing = _parse_yes_no(keep_input, True)
-        if keep_existing:
-            return
-    else:
-        setup_input = input("Set username/password now before launch? [Y/n]: ").strip()
-        should_setup = _parse_yes_no(setup_input, True)
-        if not should_setup:
-            return
+    with hold_log_output():
+        print("\nPixlStash first-run credentials")
+        if has_existing_credentials:
+            keep_input = input("Keep existing username/password? [Y/n]: ").strip()
+            keep_existing = _parse_yes_no(keep_input, True)
+            if keep_existing:
+                return
+        else:
+            setup_input = input(
+                "Set username/password now before launch? [Y/n]: "
+            ).strip()
+            should_setup = _parse_yes_no(setup_input, True)
+            if not should_setup:
+                return
 
-    existing_username = str(user.username).strip() if user and user.username else ""
-    username = existing_username
-    while True:
-        prompt_suffix = f" [{existing_username}]" if existing_username else ""
-        username_input = input(f"Username{prompt_suffix}: ").strip()
-        if username_input:
-            username = username_input
-        if username:
+        existing_username = str(user.username).strip() if user and user.username else ""
+        username = existing_username
+        while True:
+            prompt_suffix = f" [{existing_username}]" if existing_username else ""
+            username_input = input(f"Username{prompt_suffix}: ").strip()
+            if username_input:
+                username = username_input
+            if username:
+                break
+            print("Username cannot be empty.")
+
+        while True:
+            password = getpass.getpass("Password (min 8 chars): ")
+            if len(password) < 8:
+                print("Password must be at least 8 characters.")
+                continue
+            try:
+                password_bytes = len(password.encode("utf-8"))
+            except Exception:
+                password_bytes = len(password)
+            if password_bytes > 72:
+                print("Password cannot exceed 72 bytes.")
+                continue
+            password_confirm = getpass.getpass("Confirm password: ")
+            if password != password_confirm:
+                print("Passwords do not match.")
+                continue
             break
-        print("Username cannot be empty.")
 
-    while True:
-        password = getpass.getpass("Password (min 8 chars): ")
-        if len(password) < 8:
-            print("Password must be at least 8 characters.")
-            continue
-        try:
-            password_bytes = len(password.encode("utf-8"))
-        except Exception:
-            password_bytes = len(password)
-        if password_bytes > 72:
-            print("Password cannot exceed 72 bytes.")
-            continue
-        password_confirm = getpass.getpass("Confirm password: ")
-        if password != password_confirm:
-            print("Passwords do not match.")
-            continue
-        break
-
-    server.auth.set_username(username)
-    server.auth.set_password_hash(bcrypt.hash(password))
-    print("Bootstrap credentials saved.\n")
+        server.auth.set_username(username)
+        server.auth.set_password_hash(bcrypt.hash(password))
+        print("Bootstrap credentials saved.\n")
 
 
 def _force_utf8_streams():

--- a/pixlstash/app.py
+++ b/pixlstash/app.py
@@ -14,7 +14,11 @@ from passlib.hash import bcrypt
 from pixlstash.pixl_logging import setup_logging, get_logger
 from pixlstash.server import Server
 from pixlstash.startup_checks import StartupCheckError
-from pixlstash.hub.bootstrap import HubBootstrapError
+from pixlstash.hub.bootstrap import (
+    HubBootstrapError,
+    UnusableVaultError,
+    VAULT_RECREATE_ENV,
+)
 from pixlstash.hub.db import HubPermissionError
 from pixlstash.startup_permissions import (
     PERMISSION_REPAIR_ENV,
@@ -147,6 +151,72 @@ def _prepare_startup_permissions(
 
     print(
         "PixlStash still found unsafe permissions after attempting the repair.",
+        file=sys.stderr,
+    )
+    return False
+
+
+VAULT_UNUSABLE_PREFIX = "PIXLSTASH_VAULT_UNUSABLE="
+
+
+def _vault_unusable_signal(exc: UnusableVaultError) -> str:
+    """The single-line record the desktop shell parses out of our output."""
+
+    return VAULT_UNUSABLE_PREFIX + json.dumps(
+        {
+            "version": 1,
+            "folder": exc.folder,
+            "vault_path": exc.vault_path,
+            "reason": exc.reason,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _format_unusable_vault(exc: UnusableVaultError) -> str:
+    """Say what is wrong, what the offer is, and what it costs - in that order."""
+
+    return (
+        f"PixlStash could not open the library database in {exc.folder}:\n"
+        f"- {exc.reason}\n\n"
+        "PixlStash can start over with a new, empty library database in that "
+        "folder. The pictures are untouched and are offered for import again, "
+        f"but the tags, scores, characters and history recorded in "
+        f"{os.path.basename(exc.vault_path)} are not carried over.\n"
+        "The old file is renamed, never deleted, so it can still be recovered."
+    )
+
+
+def _offer_vault_recreation(exc: UnusableVaultError) -> bool:
+    """Ask whether the unopenable vault may be set aside, as this launch can ask.
+
+    Returns True only when a human said yes to this process; the desktop shell
+    answers by relaunching with ``PIXLSTASH_RECREATE_VAULT=1`` instead, exactly
+    as it does for a permission repair, because Electron has no usable stdin.
+    """
+
+    message = _format_unusable_vault(exc)
+    print(message, file=sys.stderr)
+
+    if os.environ.get("PIXLSTASH_INSTALL_TYPE", "").lower() == "electron":
+        # Human text stays in the log; the JSON line is the stable protocol.
+        print(_vault_unusable_signal(exc), file=sys.stderr)
+        return False
+
+    if getattr(sys.stdin, "isatty", lambda: False)():
+        try:
+            answer = input("\nStart over with an empty library database? [y/N] ")
+        except EOFError:
+            answer = "n"
+        if answer.strip().lower() in {"y", "yes"}:
+            return True
+        print("The library database was left alone.", file=sys.stderr)
+        return False
+
+    print(
+        "\nStart PixlStash again with "
+        f"{VAULT_RECREATE_ENV}=1 to accept that, or point image_root at "
+        "another folder.",
         file=sys.stderr,
     )
     return False
@@ -494,13 +564,25 @@ def main():
     else:
         setup_logging(log_level=log_level)
 
-    try:
-        server = Server(
+    def build_server() -> Server:
+        return Server(
             server_config_path=args.server_config,
             path_map=path_map,
             legacy_identity_prompt=_prompt_legacy_identity_migration,
             library_switch_prompt=_prompt_library_switch,
         )
+
+    try:
+        try:
+            server = build_server()
+        except UnusableVaultError as exc:
+            # Exactly one authorised retry, as the permission repair does. A
+            # second UnusableVaultError falls through to the HubBootstrapError
+            # clause below and is reported rather than looping.
+            if not _offer_vault_recreation(exc):
+                return 1
+            os.environ[VAULT_RECREATE_ENV] = "1"
+            server = build_server()
     except StartupCheckError as exc:
         print("Startup checks failed. Please resolve the following issues:")
         for failure in exc.failures:

--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -25,6 +26,7 @@ from pixlstash.hub.registry import (
     Library,
     LibraryError,
     LibraryRegistry,
+    NotAVaultError,
     VAULT_FILENAME,
     validate_vault_folder,
 )
@@ -37,6 +39,122 @@ logger = get_logger(__name__)
 
 class HubBootstrapError(RuntimeError):
     """Startup cannot safely establish a consistent hub/vault pair."""
+
+
+# Set to "1" by the caller that has already asked a human whether the
+# unopenable vault may be moved aside. An explicit value, checked here and
+# nowhere else, so an inherited shell variable cannot authorise it by accident.
+VAULT_RECREATE_ENV = "PIXLSTASH_RECREATE_VAULT"
+
+# SQLite keeps these beside the database. A vault moved aside without them
+# would leave a stale journal for the replacement to be opened against.
+_VAULT_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
+
+class UnusableVaultError(HubBootstrapError):
+    """The configured folder holds a ``vault.db`` this build cannot open.
+
+    Carries the folder, the file and the reason so a caller can offer the one
+    recovery that exists - start over with an empty database, keeping the old
+    file - instead of printing a traceback at somebody who has just installed
+    the app. See :func:`set_aside_unusable_vault`.
+    """
+
+    def __init__(self, folder: str, vault_path: str, reason: str):
+        super().__init__(
+            f"{vault_path} cannot be opened as a PixlStash library ({reason})"
+        )
+        self.folder = folder
+        self.vault_path = vault_path
+        self.reason = reason
+
+
+# Failures that are about the machine rather than the database. Offering to
+# start a library over because the disk filled up would be a catastrophe
+# dressed as a recovery, so these keep their own traceback and are never turned
+# into the question.
+_ENVIRONMENTAL_SQLITE_FAILURES = (
+    "database is locked",
+    "disk i/o error",
+    "unable to open database file",
+    "no space left",
+    "readonly database",
+    "permission denied",
+    "database disk image is malformed",
+)
+
+
+def unusable_vault_from_open_failure(
+    library: Library, exc: BaseException
+) -> "UnusableVaultError | None":
+    """Classify a failure to open or migrate a registered vault.
+
+    Validation only reads ``sqlite_master``, so a vault can pass it and still
+    be one no migration path reaches: the December-2025 schema is stamped at
+    the baseline it predates, and the chain dies on a table it never had. That
+    is the same dead end as a file that will not open at all, and it deserves
+    the same question rather than a traceback on the splash screen.
+
+    Nothing is masked: the caller logs the original exception in full, the
+    reason quotes it, and the recovery renames rather than deletes. Returns
+    None for a failure that is about the machine - those must keep failing.
+    """
+    lowered = str(exc).lower()
+    if any(marker in lowered for marker in _ENVIRONMENTAL_SQLITE_FAILURES):
+        return None
+    # SQLAlchemy's own message is often a bare identifier - `NoSuchTableError:
+    # user` reads as "user" on its own - so the reason says what the failure
+    # means before it quotes what raised it.
+    reason = (
+        "The library database could not be upgraded to this version of "
+        f"PixlStash ({type(exc).__name__}: {exc})"
+    )
+    return UnusableVaultError(library.path, library.vault_path, reason)
+
+
+def set_aside_unusable_vault(vault_path: str) -> str:
+    """Rename an unopenable vault and its sidecars out of the way.
+
+    Renamed, never deleted, and never by this function's own decision: the
+    caller has to have been told "yes" by a human first. A vault we cannot read
+    is not a vault that holds nothing, and the file is the only copy of
+    whatever catalogue it does hold - somebody who deletes it to get the app
+    started has thrown away work they could still have recovered.
+
+    Returns:
+        The path the vault was renamed to.
+    """
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    target = f"{vault_path}.unusable-{stamp}"
+    attempt = 0
+    while os.path.exists(target):
+        attempt += 1
+        target = f"{vault_path}.unusable-{stamp}-{attempt}"
+
+    os.rename(vault_path, target)
+    logger.warning(
+        "Moved the unopenable vault %s to %s and will start with a new, empty "
+        "library database. The old file is kept; nothing was deleted.",
+        vault_path,
+        target,
+    )
+    for suffix in _VAULT_SIDECAR_SUFFIXES:
+        sidecar = f"{vault_path}{suffix}"
+        if not os.path.exists(sidecar):
+            continue
+        try:
+            os.rename(sidecar, f"{target}{suffix}")
+        except OSError as exc:
+            # Not fatal: SQLite recreates its own sidecars. Worth recording,
+            # because a leftover -wal beside a new vault is confusing enough on
+            # its own that the next reader should know where it came from.
+            logger.warning(
+                "Could not move the sidecar %s beside the vault it belongs to "
+                "(%s); it is stale and can be removed.",
+                sidecar,
+                exc,
+            )
+    return target
 
 
 class RegisteredVaultPath(str):
@@ -244,7 +362,23 @@ def _register_first_library(
             "only an explicit durable preparation operation can authorize import",
             image_root,
         )
-        return registry.attach(image_root, "Library 1")
+        try:
+            return registry.attach(image_root, "Library 1")
+        except NotAVaultError as exc:
+            # The file is there and is not something we can open. That is a
+            # decision for a human - the only way forward loses whatever the
+            # file holds - so raise a typed error the caller can put a question
+            # behind, rather than letting an exception out of a constructor and
+            # ending first-run setup on a traceback.
+            if os.environ.get(VAULT_RECREATE_ENV) != "1":
+                raise UnusableVaultError(image_root, vault_path, str(exc)) from exc
+            logger.warning(
+                "Recreating the library database at %s was authorised: %s",
+                image_root,
+                exc,
+            )
+            set_aside_unusable_vault(vault_path)
+            return registry.register_pending(image_root, "Library 1")
 
     # This process is creating the SQLite namespace, so establish the trust
     # boundary now instead of inheriting a permissive umask-created directory.
@@ -418,6 +552,20 @@ def prevalidate_library_fingerprint(library: Library) -> None:
         )
 
 
+def _vault_is_loadable(library: Library) -> bool:
+    """True when the file at ``vault_path`` is one this build could open.
+
+    Read-only, and about the file rather than the registration: a vault that
+    passes here but still fails to open is a different problem with a different
+    answer, and must not be offered the recreate-it recovery.
+    """
+    try:
+        validate_vault_folder(library.path)
+    except NotAVaultError:
+        return False
+    return True
+
+
 def _library_opens(library: Library) -> bool:
     """True when this library's vault is present and still the one recorded."""
     if not library.is_reachable:
@@ -503,6 +651,17 @@ def _offer_a_usable_library(
     ]
     chosen = prompt(library, reason, alternatives) if prompt and alternatives else None
     if chosen is None:
+        # A file that is there and will not open is the one failure with a
+        # recovery: start over with an empty database and keep the old file.
+        # Offered here as well as on the first run, because a library that
+        # opened yesterday is exactly where an unreadable vault shows up.
+        # A fingerprint conflict is not this case - that vault loads fine, and
+        # the answer is to put the right one back, not to start over.
+        if os.path.isfile(library.vault_path) and not _vault_is_loadable(library):
+            if os.environ.get(VAULT_RECREATE_ENV) == "1":
+                set_aside_unusable_vault(library.vault_path)
+                return registry.forget_vault_fingerprint(library)
+            raise UnusableVaultError(library.path, library.vault_path, reason)
         raise HubBootstrapError(f"{reason}{_alternatives_note(alternatives)}")
     logger.warning(
         "%s could not be opened (%s); the active library is now %s at %s, as "

--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -74,14 +74,18 @@ class UnusableVaultError(HubBootstrapError):
 # dressed as a recovery, so these keep their own traceback and are never turned
 # into the question.
 _ENVIRONMENTAL_SQLITE_FAILURES = (
-    "database is locked",
-    "disk i/o error",
-    "unable to open database file",
-    "no space left",
-    "readonly database",
-    "permission denied",
-    "database disk image is malformed",
+    "database is locked",  # SQLITE_BUSY
+    "disk i/o error",  # SQLITE_IOERR
+    "unable to open database file",  # SQLITE_CANTOPEN
+    "database or disk is full",  # SQLITE_FULL - SQLite's own wording
+    "no space left",  # ...and the OS's, for a write that never reached SQLite
+    "readonly database",  # SQLITE_READONLY
+    "permission denied",  # SQLITE_PERM
+    "database disk image is malformed",  # SQLITE_CORRUPT
+    "out of memory",  # SQLITE_NOMEM
 )
+# Deliberately absent: SQLITE_NOTADB ("file is not a database"). That one is a
+# statement about the file, which is exactly what the offer is for.
 
 
 def unusable_vault_from_open_failure(

--- a/pixlstash/hub/registry.py
+++ b/pixlstash/hub/registry.py
@@ -44,6 +44,26 @@ _LIBRARY_COLUMNS = (
 # PixlStash-managed SQLite file. Checked read-only, without importing the ORM.
 _VAULT_MARKER_TABLES = ("alembic_version", "picture")
 
+# A vault written before PixlStash adopted Alembic has no ``alembic_version``,
+# so the lineage has to be recognised from the schema itself. This is the
+# ``0001_baseline`` table set minus the tables a later migration added, and
+# ``VaultDatabase`` already knows what to do with such a file: it stamps the
+# baseline and upgrades it to head (see ``database.py``'s "Existing database
+# without Alembic version table" branch). Refusing it here would make that
+# branch unreachable for every library the hub owns, which is what turned an
+# upgradable December-2025 vault into a backend that exited during first-run
+# setup. The set is deliberately wide: one stray table named ``picture`` must
+# still not be mistaken for a library.
+_LEGACY_VAULT_MARKER_TABLES = (
+    "picture",
+    "character",
+    "face",
+    "tag",
+    "quality",
+    "metadata",
+    "pictureset",
+)
+
 
 class LibraryError(RuntimeError):
     """Base class for registry errors that carry a user-facing message."""
@@ -125,6 +145,10 @@ def validate_vault_folder(folder: str) -> str:
     migrate, write to, or otherwise touch a foreign vault, and it must not read
     its identity tables.
 
+    "Usable" means a vault ``VaultDatabase`` can open, which includes a
+    pre-Alembic one it will stamp and upgrade - see
+    :data:`_LEGACY_VAULT_MARKER_TABLES`.
+
     Raises:
         NotAVaultError: No folder, no ``vault.db``, unreadable, or missing the
             marker tables.
@@ -160,9 +184,18 @@ def validate_vault_folder(folder: str) -> str:
     tables = {row[0] for row in rows}
     missing = [table for table in _VAULT_MARKER_TABLES if table not in tables]
     if missing:
-        raise NotAVaultError(
-            f"{vault_path} does not look like a PixlStash vault (missing "
-            f"{', '.join(missing)})."
+        legacy_missing = [
+            table for table in _LEGACY_VAULT_MARKER_TABLES if table not in tables
+        ]
+        if legacy_missing:
+            raise NotAVaultError(
+                f"{vault_path} does not look like a PixlStash vault (missing "
+                f"{', '.join(missing)})."
+            )
+        logger.info(
+            "%s is a PixlStash vault from before Alembic (no alembic_version); "
+            "it will be stamped at the baseline and upgraded when it is opened.",
+            vault_path,
         )
 
     return vault_path

--- a/pixlstash/hub/registry.py
+++ b/pixlstash/hub/registry.py
@@ -188,9 +188,16 @@ def validate_vault_folder(folder: str) -> str:
             table for table in _LEGACY_VAULT_MARKER_TABLES if table not in tables
         ]
         if legacy_missing:
+            # Both sets, not just the modern one. A database holding nothing
+            # but a `picture` table is missing only `alembic_version` by the
+            # modern reckoning, and saying so alone reads as "an old vault we
+            # could upgrade" - the opposite of the truth. The reason is
+            # surfaced verbatim by the recovery dialog, so it has to carry
+            # which of the two it failed to be.
             raise NotAVaultError(
                 f"{vault_path} does not look like a PixlStash vault (missing "
-                f"{', '.join(missing)})."
+                f"{', '.join(missing)}), and not a pre-Alembic one either "
+                f"(missing {', '.join(legacy_missing)})."
             )
         logger.info(
             "%s is a PixlStash vault from before Alembic (no alembic_version); "

--- a/pixlstash/pixl_logging.py
+++ b/pixlstash/pixl_logging.py
@@ -1,4 +1,7 @@
 import logging as logging_
+import threading
+from contextlib import contextmanager
+
 from uvicorn.logging import ColourizedFormatter as ColourisedFormatter
 
 LOG_FORMAT = "%(asctime)s %(levelprefix)s %(name)s: %(message)s"
@@ -56,6 +59,56 @@ def setup_logging(log_file=None, log_level=LOG_LEVEL):
     logging_.getLogger("alembic.runtime.migration").setLevel(logging_.WARNING)
     # Suppress repetitive uvicorn lifecycle/connection messages
     logging_.getLogger("uvicorn.error").addFilter(_SuppressFilter())
+
+
+class _HoldingHandler(logging_.Handler):
+    """Collect records instead of emitting them, so a prompt owns the screen."""
+
+    def __init__(self):
+        super().__init__()
+        self._records = []
+        self._records_lock = threading.Lock()
+
+    def emit(self, record: logging_.LogRecord) -> None:
+        with self._records_lock:
+            self._records.append(record)
+
+    def take(self) -> list:
+        with self._records_lock:
+            held, self._records = self._records, []
+        return held
+
+
+@contextmanager
+def hold_log_output():
+    """Buffer log output while an interactive question is on screen.
+
+    Start-up asks its questions after the server has been built and its
+    background workers are already running, so the answer to "did anyone see
+    the question?" used to be no: a first-run credentials prompt was written
+    between two INFO lines, and a snapshot task logged its progress onto the
+    same line as the prompt while it waited for an answer. Nothing is dropped -
+    every held record is emitted, in order, once the question has been
+    answered.
+
+    Only the logging path is held. A bare ``print`` from another thread still
+    reaches the terminal, so this narrows the window rather than sealing it.
+    """
+    root = logging_.getLogger()
+    held = _HoldingHandler()
+    previous = list(root.handlers)
+    # Assigning a new list rather than mutating: a logging call on another
+    # thread sees either the old handlers or the holder, never a half-empty
+    # list it would silently drop a record into.
+    root.handlers = [held]
+    try:
+        yield
+    finally:
+        root.handlers = previous
+        for record in held.take():
+            for handler in previous:
+                if record.levelno >= handler.level:
+                    handler.handle(record)
 
 
 def get_logger(name=None):

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -10,7 +10,9 @@ import threading
 import time
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version as package_version
+from alembic.util.exc import CommandError as AlembicCommandError
 from platformdirs import user_config_dir
+from sqlalchemy.exc import SQLAlchemyError
 
 
 from contextlib import asynccontextmanager
@@ -51,8 +53,11 @@ from pixlstash.db_models.tag import DEFAULT_SMART_SCORE_PENALIZED_TAGS
 from pixlstash.startup_checks import StartupChecks
 from pixlstash.startup_permissions import mkdir_private
 from pixlstash.hub.bootstrap import (
+    VAULT_RECREATE_ENV,
     bootstrap_hub,
     registered_vault_path,
+    set_aside_unusable_vault,
+    unusable_vault_from_open_failure,
 )
 from pixlstash.hub.registry import LibraryRegistry
 from pixlstash.services.library_switch_service import LibrarySwitchService
@@ -573,13 +578,7 @@ class Server(
                 self.hub.path,
             )
 
-        self.vault = self.build_vault(
-            registered_vault_path(
-                self.hub,
-                self._hub_bootstrap.library,
-                self._hub_bootstrap,
-            )
-        )
+        self.vault = self._open_registered_vault()
         self._hub_bootstrap.library = (
             self.library_registry.by_uuid(self._hub_bootstrap.library.uuid)
             or self._hub_bootstrap.library
@@ -907,6 +906,44 @@ class Server(
                 "Could not reconcile the settings fingerprint for library %s",
                 library.name,
             )
+
+    def _open_registered_vault(self) -> Vault:
+        """Open the active library, turning a dead end into an answerable question.
+
+        ``validate_vault_folder`` reads ``sqlite_master`` and nothing else, so a
+        vault can pass registration and still be one no migration path reaches -
+        a schema stamped at a baseline it predates dies here, on a table it
+        never had. Before this, that was a SQLAlchemy traceback on the desktop
+        splash screen with no way forward. Now it is the same offer an
+        unreadable file gets: start over with an empty database, keeping the old
+        one. Environmental failures (locked, full, unreadable) are re-raised
+        untouched - see :func:`unusable_vault_from_open_failure` - and the
+        original exception is logged in full either way.
+        """
+        library = self._hub_bootstrap.library
+        try:
+            return self.build_vault(
+                registered_vault_path(self.hub, library, self._hub_bootstrap)
+            )
+        except (SQLAlchemyError, AlembicCommandError) as exc:
+            unusable = unusable_vault_from_open_failure(library, exc)
+            if unusable is None:
+                raise
+            logger.exception(
+                "Could not open the library database at %s", library.vault_path
+            )
+            if os.environ.get(VAULT_RECREATE_ENV) != "1":
+                raise unusable from exc
+
+        # Authorised by a human on the launch that failed. The half-built vault
+        # above is unreachable and its engine is collected with it; nothing here
+        # can reuse a connection that was mid-migration when it raised.
+        set_aside_unusable_vault(library.vault_path)
+        library = self.library_registry.forget_vault_fingerprint(library)
+        self._hub_bootstrap.library = library
+        return self.build_vault(
+            registered_vault_path(self.hub, library, self._hub_bootstrap)
+        )
 
     def build_vault(self, image_root: str) -> Vault:
         """Construct (but do not start) a Vault over *image_root*.

--- a/tests/test_app_permission_repair.py
+++ b/tests/test_app_permission_repair.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import stat
+from types import SimpleNamespace
 
 import pytest
 
 from pixlstash import app
+from pixlstash.pixl_logging import hold_log_output
 import pixlstash.startup_permissions as startup_permissions
 from pixlstash.startup_permissions import PERMISSION_REPAIR_PREFIX
 
@@ -96,3 +99,116 @@ def test_noninteractive_launch_prints_copyable_commands(tmp_path, monkeypatch, c
     stderr = capsys.readouterr().err
     assert f"chmod 700 {config_path.parent}" in stderr
     assert f"chmod 700 {library}" in stderr
+
+
+class RecordingHandler(logging.Handler):
+    """A console stand-in that records what actually reached the screen."""
+
+    def __init__(self):
+        super().__init__()
+        self.lines: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(record.getMessage())
+
+
+@pytest.fixture
+def console():
+    """Give the root logger one recording handler, and put it back afterwards."""
+    root = logging.getLogger()
+    previous_handlers, previous_level = list(root.handlers), root.level
+    handler = RecordingHandler()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+    try:
+        yield handler
+    finally:
+        root.handlers = previous_handlers
+        root.setLevel(previous_level)
+
+
+class TestAQuestionOwnsTheScreen:
+    """Start-up asks after the workers are running, so it has to hold the log.
+
+    The first-run credentials prompt was written between two INFO lines and a
+    snapshot task logged onto the same line while it waited for an answer.
+    """
+
+    def test_a_record_logged_during_a_question_waits_for_the_answer(self, console):
+        logger = logging.getLogger("pixlstash.test.holding")
+
+        with hold_log_output():
+            logger.info("a worker logging while the question is on screen")
+            assert console.lines == [], "the question would be buried under this"
+
+        assert console.lines == ["a worker logging while the question is on screen"]
+
+    def test_nothing_is_dropped_and_the_order_survives(self, console):
+        logger = logging.getLogger("pixlstash.test.holding")
+
+        logger.info("before")
+        with hold_log_output():
+            logger.info("held first")
+            logger.warning("held second")
+        logger.info("after")
+
+        assert console.lines == ["before", "held first", "held second", "after"]
+
+    def test_the_console_works_again_even_if_the_question_raises(self, console):
+        logger = logging.getLogger("pixlstash.test.holding")
+
+        with pytest.raises(KeyboardInterrupt):
+            with hold_log_output():
+                logger.info("held")
+                raise KeyboardInterrupt
+        logger.info("after")
+
+        assert console.lines == ["held", "after"]
+
+
+class TestTheFirstRunCredentialsPrompt:
+    def _server(self):
+        auth = SimpleNamespace(
+            user=SimpleNamespace(username="", password_hash=""),
+            ensure_user=lambda: SimpleNamespace(username="", password_hash=""),
+            set_username=lambda value: recorded.setdefault("username", value),
+            set_password_hash=lambda value: recorded.setdefault("hash", value),
+        )
+        recorded: dict = {}
+        return SimpleNamespace(auth=auth), recorded
+
+    def test_it_announces_itself_and_holds_the_log_until_it_is_answered(
+        self, monkeypatch, capsys, console
+    ):
+        server, recorded = self._server()
+        monkeypatch.setattr("sys.stdin", TerminalInput("y\nme\n"))
+
+        # A background worker logging exactly where it used to land: while the
+        # prompt sits waiting for a password.
+        def answer_password(_prompt):
+            logging.getLogger("pixlstash.test.worker").info("snapshot 1 created")
+            return "a-long-enough-password"
+
+        monkeypatch.setattr(app.getpass, "getpass", answer_password)
+
+        app._prompt_bootstrap_credentials(server)
+
+        out = capsys.readouterr().out
+        assert "PixlStash first-run credentials" in out, "the question needs a heading"
+        assert "Bootstrap credentials saved." in out
+        assert recorded["username"] == "me"
+        # Held, not lost: both records (password and confirmation) reach the
+        # console once the answer is in.
+        assert console.lines == ["snapshot 1 created", "snapshot 1 created"]
+
+    def test_declining_still_releases_the_held_output(
+        self, monkeypatch, capsys, console
+    ):
+        server, recorded = self._server()
+        monkeypatch.setattr("sys.stdin", TerminalInput("n\n"))
+        logging.getLogger("pixlstash.test.worker").info("before the question")
+
+        app._prompt_bootstrap_credentials(server)
+
+        assert recorded == {}, "declining sets nothing"
+        assert console.lines == ["before the question"]

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -10,18 +10,24 @@ import sqlite3
 import stat
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
+from sqlalchemy.exc import NoSuchTableError, OperationalError
+
 from pixlstash.hub.bootstrap import (
     HubBootstrapError,
+    UnusableVaultError,
     bootstrap_hub,
     finalize_opened_library,
     prepare_legacy_identity,
     prevalidate_library_fingerprint,
     registered_vault_path,
+    unusable_vault_from_open_failure,
 )
 from pixlstash.hub.db import HubDatabase, HubPermissionError
+from pixlstash.server import Server
 from pixlstash.hub.registry import LibraryRegistry, read_vault_uuid
 from pixlstash.trusted_sqlite import TrustedSQLiteLocation, TrustedSQLiteLocationError
 from pixlstash.vault import Vault
@@ -1788,3 +1794,232 @@ class TestPortableIdentityScrub:
         ) == [(1,)]
         result.engine.close()
         result.hub.close()
+
+
+def make_unopenable_vault(folder):
+    """A ``vault.db`` that is present and is not a database we can open.
+
+    The shape that ended a first run on a traceback: the file exists, so
+    ``register_pending`` is not used, and it does not validate, so ``attach``
+    refuses. Bytes rather than SQLite, because "unopenable" has to cover a
+    truncated or foreign file and not only an old schema.
+    """
+    os.makedirs(folder, exist_ok=True)
+    vault = os.path.join(folder, "vault.db")
+    with open(vault, "wb") as handle:
+        handle.write(b"not a database, not even close")
+    return vault
+
+
+def make_pre_alembic_vault(folder):
+    """A real vault from before Alembic: openable, upgradable, no version table."""
+    os.makedirs(folder, exist_ok=True)
+    conn = sqlite3.connect(os.path.join(folder, "vault.db"))
+    for table in (
+        "picture",
+        "character",
+        "face",
+        "tag",
+        "quality",
+        "metadata",
+        "pictureset",
+    ):
+        conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    return os.path.join(folder, "vault.db")
+
+
+class TestAVaultThatWillNotOpen:
+    """Start-up asks a question about it rather than dying on it."""
+
+    def test_bootstrap_raises_a_typed_error_and_touches_nothing(self, tmp_path):
+        folder = str(tmp_path / "library")
+        vault = make_unopenable_vault(folder)
+        before = open(vault, "rb").read()
+
+        with pytest.raises(UnusableVaultError) as caught:
+            bootstrap_hub(folder, str(tmp_path / "hub.db"))
+
+        assert caught.value.folder == os.path.realpath(folder)
+        assert caught.value.vault_path == vault
+        assert "vault.db" in caught.value.reason
+        assert open(vault, "rb").read() == before, "refusing must not edit the file"
+
+    def test_it_is_a_hub_bootstrap_error_so_existing_callers_report_it(self, tmp_path):
+        """`app.main` already prints HubBootstrapError concisely; inherit that."""
+        folder = str(tmp_path / "library")
+        make_unopenable_vault(folder)
+
+        with pytest.raises(HubBootstrapError):
+            bootstrap_hub(folder, str(tmp_path / "hub.db"))
+
+    def test_recreation_moves_the_old_file_aside_rather_than_deleting_it(
+        self, tmp_path, monkeypatch
+    ):
+        folder = str(tmp_path / "library")
+        vault = make_unopenable_vault(folder)
+        before = open(vault, "rb").read()
+        # Sidecars travel with the database; a stale -wal beside a new vault is
+        # its own bug report.
+        for suffix in ("-wal", "-shm"):
+            with open(f"{vault}{suffix}", "wb") as handle:
+                handle.write(b"stale")
+        monkeypatch.setenv("PIXLSTASH_RECREATE_VAULT", "1")
+
+        result = bootstrap_hub(folder, str(tmp_path / "hub.db"))
+        try:
+            assert result.library.path == os.path.realpath(folder)
+            assert not os.path.exists(vault), "the new vault is created on open"
+
+            moved = [
+                name
+                for name in os.listdir(folder)
+                if name.startswith("vault.db.unusable-")
+            ]
+            assert len(moved) == 3, f"database and both sidecars, got {sorted(moved)}"
+            kept = next(name for name in moved if not name.endswith(("-wal", "-shm")))
+            assert open(os.path.join(folder, kept), "rb").read() == before
+        finally:
+            result.engine.close()
+            result.hub.close()
+
+    def test_nothing_is_moved_without_the_explicit_authorisation(self, tmp_path):
+        """An inherited '0' - or no variable at all - is not a yes."""
+        folder = str(tmp_path / "library")
+        make_unopenable_vault(folder)
+
+        with pytest.raises(UnusableVaultError):
+            bootstrap_hub(folder, str(tmp_path / "hub.db"))
+
+        assert os.listdir(folder) == ["vault.db"]
+
+    def test_a_pre_alembic_vault_is_opened_rather_than_recreated(self, tmp_path):
+        """The regression itself: this vault upgrades, so it must never be offered
+        the recovery that abandons it."""
+        folder = str(tmp_path / "library")
+        vault = make_pre_alembic_vault(folder)
+        before = open(vault, "rb").read()
+
+        result = bootstrap_hub(folder, str(tmp_path / "hub.db"))
+        try:
+            assert result.library.path == os.path.realpath(folder)
+            assert open(vault, "rb").read() == before, "registration must not migrate"
+            assert not any(
+                name.startswith("vault.db.unusable-") for name in os.listdir(folder)
+            )
+        finally:
+            result.engine.close()
+            result.hub.close()
+
+
+def sqlalchemy_operational_error(message):
+    """An OperationalError shaped the way SQLAlchemy actually raises one."""
+    return OperationalError("SELECT 1", {}, sqlite3.OperationalError(message))
+
+
+class TestAVaultThatRegistersButWillNotMigrate:
+    """Validation reads `sqlite_master`; the migration chain reads much more."""
+
+    def _library(self, tmp_path):
+        folder = str(tmp_path / "library")
+        make_pre_alembic_vault(folder)
+        registry = LibraryRegistry(HubDatabase(str(tmp_path / "hub.db")))
+        return registry.attach(folder, "Library 1")
+
+    def test_a_schema_failure_becomes_the_same_offer(self, tmp_path):
+        library = self._library(tmp_path)
+
+        unusable = unusable_vault_from_open_failure(library, NoSuchTableError("user"))
+
+        assert unusable is not None
+        assert unusable.vault_path == library.vault_path
+        # "NoSuchTableError: user" alone reads as the word "user".
+        assert "could not be upgraded" in unusable.reason
+        assert "NoSuchTableError" in unusable.reason
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "database is locked",
+            "unable to open database file",
+            "attempt to write a readonly database",
+            "disk I/O error",
+            "database disk image is malformed",
+        ],
+    )
+    def test_a_failure_about_the_machine_is_never_offered_a_recreate(
+        self, tmp_path, message
+    ):
+        """A full disk must not be answered by abandoning a good library."""
+        library = self._library(tmp_path)
+
+        assert (
+            unusable_vault_from_open_failure(
+                library, sqlalchemy_operational_error(message)
+            )
+            is None
+        )
+
+
+class TestOpeningTheRegisteredVault:
+    """`Server._open_registered_vault`'s branches, without standing up a Server."""
+
+    def _server_double(self, tmp_path, failure, *, opened=None):
+        folder = str(tmp_path / "library")
+        make_pre_alembic_vault(folder)
+        hub = HubDatabase(str(tmp_path / "hub.db"))
+        registry = LibraryRegistry(hub)
+        library = registry.attach(folder, "Library 1")
+        attempts = []
+
+        def build_vault(image_root):
+            attempts.append(image_root)
+            if len(attempts) == 1:
+                raise failure
+            return opened
+
+        return SimpleNamespace(
+            hub=hub,
+            library_registry=registry,
+            _hub_bootstrap=SimpleNamespace(library=library),
+            build_vault=build_vault,
+        ), attempts
+
+    def test_a_schema_failure_raises_the_typed_error(self, tmp_path):
+        double, attempts = self._server_double(tmp_path, NoSuchTableError("user"))
+
+        with pytest.raises(UnusableVaultError):
+            Server._open_registered_vault(double)
+
+        assert len(attempts) == 1, "nothing is retried without authorisation"
+
+    def test_an_environmental_failure_is_re_raised_untouched(self, tmp_path):
+        double, _ = self._server_double(
+            tmp_path, sqlalchemy_operational_error("database is locked")
+        )
+
+        with pytest.raises(OperationalError):
+            Server._open_registered_vault(double)
+
+    def test_an_authorised_retry_sets_the_old_file_aside_and_reopens(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("PIXLSTASH_RECREATE_VAULT", "1")
+        sentinel = object()
+        double, attempts = self._server_double(
+            tmp_path, NoSuchTableError("user"), opened=sentinel
+        )
+        vault_path = double._hub_bootstrap.library.vault_path
+        before = open(vault_path, "rb").read()
+
+        assert Server._open_registered_vault(double) is sentinel
+        assert len(attempts) == 2
+
+        folder = os.path.dirname(vault_path)
+        moved = [n for n in os.listdir(folder) if n.startswith("vault.db.unusable-")]
+        assert len(moved) == 1
+        assert open(os.path.join(folder, moved[0]), "rb").read() == before
+        assert not os.path.exists(vault_path), "the replacement is made by the open"
+        # Without this the new vault would be refused for carrying no fingerprint.
+        assert double._hub_bootstrap.library.vault_uuid is None

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -1946,6 +1946,12 @@ class TestAVaultThatRegistersButWillNotMigrate:
             "attempt to write a readonly database",
             "disk I/O error",
             "database disk image is malformed",
+            # SQLITE_FULL says it in SQLite's words, ENOSPC in the OS's. A
+            # full disk answered by abandoning the library is the worst
+            # outcome this classification exists to prevent.
+            "database or disk is full",
+            "no space left on device",
+            "out of memory",
         ],
     )
     def test_a_failure_about_the_machine_is_never_offered_a_recreate(
@@ -1960,6 +1966,18 @@ class TestAVaultThatRegistersButWillNotMigrate:
             )
             is None
         )
+
+    def test_a_file_that_is_not_a_database_is_still_offered_the_recovery(
+        self, tmp_path
+    ):
+        """SQLITE_NOTADB is a statement about the file, not about the machine."""
+        library = self._library(tmp_path)
+
+        unusable = unusable_vault_from_open_failure(
+            library, sqlalchemy_operational_error("file is not a database")
+        )
+
+        assert unusable is not None
 
 
 class TestOpeningTheRegisteredVault:

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -57,6 +57,35 @@ def make_vault_folder(root, name="library", *, with_credentials=False):
     return folder
 
 
+def make_legacy_vault_folder(root, name="legacy"):
+    """A vault from before PixlStash adopted Alembic: no ``alembic_version``.
+
+    This is the ``0001_baseline`` table set as a December-2025 install left it.
+    ``VaultDatabase`` opens exactly this by stamping the baseline and upgrading,
+    so the registry has to let it through - refusing it is what exited the
+    backend during first-run setup instead.
+    """
+    folder = os.path.join(str(root), name)
+    os.makedirs(folder, exist_ok=True)
+    conn = sqlite3.connect(os.path.join(folder, "vault.db"))
+    for table in (
+        "picture",
+        "character",
+        "face",
+        "tag",
+        "quality",
+        "metadata",
+        "pictureset",
+        "picturesetmember",
+        "conversation",
+        "message",
+    ):
+        conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    return folder
+
+
 def set_vault_uuid(folder, value):
     """Give a test vault the ``library_settings`` fingerprint row."""
     conn = sqlite3.connect(os.path.join(folder, "vault.db"))
@@ -194,6 +223,24 @@ class TestVaultValidation:
         folder.mkdir()
         conn = sqlite3.connect(str(folder / "vault.db"))
         conn.execute("CREATE TABLE something_else (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(NotAVaultError):
+            validate_vault_folder(str(folder))
+
+    def test_accepts_a_vault_from_before_alembic(self, tmp_path):
+        """The opener stamps and upgrades these; the registry must not refuse them."""
+        folder = make_legacy_vault_folder(tmp_path)
+
+        assert validate_vault_folder(folder).endswith("vault.db")
+
+    def test_a_lone_picture_table_is_still_not_a_vault(self, tmp_path):
+        """The pre-Alembic allowance is a whole schema, not one familiar name."""
+        folder = tmp_path / "impostor-with-pictures"
+        folder.mkdir()
+        conn = sqlite3.connect(str(folder / "vault.db"))
+        conn.execute("CREATE TABLE picture (id INTEGER PRIMARY KEY)")
         conn.commit()
         conn.close()
 

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -244,8 +244,13 @@ class TestVaultValidation:
         conn.commit()
         conn.close()
 
-        with pytest.raises(NotAVaultError):
+        with pytest.raises(NotAVaultError) as caught:
             validate_vault_folder(str(folder))
+
+        # "missing alembic_version" on its own reads as an old vault we could
+        # upgrade, and the recovery dialog shows this text verbatim.
+        assert "not a pre-Alembic one either" in str(caught.value)
+        assert "character" in str(caught.value)
 
     def test_rejects_a_missing_folder(self, tmp_path):
         with pytest.raises(NotAVaultError):


### PR DESCRIPTION
A vault that is present on disk and cannot be opened used to end startup on a
traceback. `LibraryRegistry.attach` raised `NotAVaultError` out of
`Server.__init__`, and `app.main()` had clauses for `StartupCheckError`,
`HubPermissionError` and `HubBootstrapError` but none for this, so the desktop
shell could only report that the backend had exited with code 1. There was
nothing on screen to act on, and the only obvious move — deleting the file to
get the app started — throws away whatever catalogue it holds.

## What changed

**A pre-Alembic vault is a vault.** `validate_vault_folder` now also accepts the
`0001_baseline` table set (`_LEGACY_VAULT_MARKER_TABLES`). `VaultDatabase` has
always known how to open such a file — it stamps the baseline and upgrades to
head — so refusing it in the registry made that branch unreachable for every
library the hub owns. Verified: a baseline-shaped vault with no
`alembic_version` now upgrades in place with its rows intact. The legacy set is
deliberately wide, so one stray table named `picture` is still not a library.

**A vault that genuinely will not open is a question, not a crash.**
`_register_first_library` and `_offer_a_usable_library` raise
`UnusableVaultError` (a `HubBootstrapError`) carrying the folder, the file and
the reason. `app.main()` explains what starting over costs and asks — inline on
a TTY, and for Electron by printing a single-line `PIXLSTASH_VAULT_UNUSABLE=`
record, the same protocol shape the permission repair already uses. A yes
relaunches with `PIXLSTASH_RECREATE_VAULT=1`, the only value
`set_aside_unusable_vault` acts on; it **renames** `vault.db` and its sidecars
to `vault.db.unusable-<timestamp>` and never deletes them.

**Registration is not the last place this can fail.** Validation reads
`sqlite_master` and nothing else, so a vault can register and still be one no
migration path reaches — a schema stamped at a baseline it predates dies during
the upgrade on a table it never had. `Server._open_registered_vault` routes that
into the same offer. Failures about the machine rather than the database
(locked, full, unreadable, malformed) are excluded by
`unusable_vault_from_open_failure` and keep raising: offering to abandon a
library because a disk filled up would be a catastrophe dressed as a recovery.
Nothing is masked either way — the original exception is logged in full and
quoted in the reason.

**Desktop.** `backend/VaultRecovery.ts` parses the record into a typed
`VaultUnusableError`; `startupFailureError` prefers the permission repair when a
tail carries both. The offer is a native box that names the file, the cost, and
that the old file is renamed rather than deleted. Declining reads
**Choose Another Folder** from setup (and returns to the picker) and **Quit**
from `boot()`. Neither path falls back to the CPU overlay first — the database
has nothing to do with the accelerator, and retrying there would discard the
typed error.

## Tests

- `tests/test_hub_registry.py`: a pre-Alembic vault is accepted; a lone
  `picture` table still is not.
- `tests/test_hub_bootstrap.py`: the typed error and its `HubBootstrapError`
  base; the old file and both sidecars are renamed, byte-identical, and nothing
  moves without the explicit authorisation; the environmental classification in
  both directions; `Server._open_registered_vault`'s three branches.
- `electron/test/vaultRecovery.test.ts`: the parse (including malformed records
  and the permission-repair precedence) and what the dialog promises.

Mutation-checked: emptying `_ENVIRONMENTAL_SQLITE_FAILURES` turns six tests red.

Docs: `docs/backend_architecture.md` (Hub and library identity) and
`docs/desktop-backend-migration.md` (the startup framework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvWc4tnJTd61MAYubcYXdL
