### PR TITLE
Stop the GPU overlay shadowing the bundled env's dependencies

### DIFF
--- a/docs/desktop-backend-migration.md
+++ b/docs/desktop-backend-migration.md
@@ -59,6 +59,41 @@ proves fragile for torch/onnxruntime — to be validated during implementation.)
 installer pins to those same versions (just swapping the `+cpu` build for `+cu128`/
 `+rocm`), guaranteeing torch/torchvision ABI compatibility.
 
+**`--target` shadowing did prove fragile — but not for torch.** The fallback
+above anticipated the wrong package. `pip install --target` writes the *whole
+dependency closure* into the overlay, not just the wheels named on the command
+line: torch alone brings `typing_extensions`, `numpy`, `sympy`, `networkx`,
+`jinja2`, `filelock` and `fsspec`. Every one of those then precedes the bundled
+env on `PYTHONPATH` and shadows the bundle's own copy — for no benefit, since the
+constraints file pinned them to the bundle's versions in the first place.
+
+They only have to disagree once. Windows, 2026-09-03: an overlay carrying
+`typing_extensions` 4.15.0 over a bundle holding 4.16.0 made the *bundle's* anyio
+raise `ImportError: cannot import name 'sentinel'` (4.16 added it), killing the
+backend inside the `fastapi` import chain before the server existed. The
+overlay-fallback path caught it and ran on CPU, so the symptom was silent loss of
+GPU acceleration rather than a dead app.
+
+So the install **prunes** (`BackendManager.pruneOverlay`): after pip finishes,
+every distribution the bundled env also provides is deleted from the overlay,
+keeping only what the overlay exists for (`torch`, `torchvision`,
+`onnxruntime-gpu`, `nvidia-*`, `triton`) plus anything the bundle lacks. That is
+the state the overlay would have had if pip could install *only* the wheels we
+asked for. Deletion is driven by each distribution's own `RECORD`, and
+directories the deletions empty are removed too — an empty directory on
+`sys.path` is an implicit namespace package (PEP 420) and shadows just as
+effectively as a populated one.
+
+**Overlays are re-pruned after an app update.** An app update replaces the
+bundled `site-packages` wholesale, so an overlay pruned against the *previous*
+bundle can start shadowing again without anyone touching it. `OVERLAY.json`
+therefore records the `appVersion` it was pruned against, and
+`BackendManager.repairIfStale` re-prunes on a mismatch at launch. This is a
+repair, not a reinstall: the duplicates are exactly what breaks, and the bundle
+already holds a correct copy of every one of them, so nothing is re-downloaded.
+An overlay whose marker predates pruning has no `appVersion` at all, which reads
+as stale and gets the same repair — that is how already-installed overlays heal.
+
 ## Overlay install location (issue #472)
 
 The GPU overlay is a multi-GB download, so *where* it lands matters. Originally it

--- a/electron/src/backend/BackendManager.ts
+++ b/electron/src/backend/BackendManager.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { createWriteStream, mkdirSync } from 'node:fs';
-import { mkdir, rm, readFile, writeFile, access } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, readdir, rm, rmdir, readFile, writeFile, access } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
 import {
   Accel,
   ACCEL_LABELS,
@@ -66,6 +66,23 @@ export interface OverlayMeta {
   accel: Accel;
   torch: string;
   installedAt: string;
+  /**
+   * The app version whose bundled env this overlay was pruned against. The
+   * bundled site-packages only ever changes with an app update, so a mismatch
+   * means the prune below has not been re-run against the current bundle - see
+   * {@link BackendManager.repairIfStale}. Absent on overlays written before
+   * pruning existed, which is exactly the state that needs repairing.
+   */
+  appVersion?: string;
+}
+
+/** One distribution found in an overlay, read from its `<name>-<version>.dist-info`. */
+export interface DistInfo {
+  /** Distribution name as the directory spells it, e.g. "typing_extensions". */
+  name: string;
+  version: string;
+  /** The `.dist-info` directory name, relative to the overlay root. */
+  dirName: string;
 }
 
 /** GPU accelerators that can be layered on top of the bundled CPU/Metal env. */
@@ -164,6 +181,121 @@ export function filterConstraintsFreeze(frozen: string): string {
         l && !l.startsWith('-') && !l.startsWith('#') && !l.includes(' @ ') && !drop.test(l),
     );
   return kept.join('\n') + '\n';
+}
+
+/**
+ * The bundled env's installed versions, keyed by normalized distribution name,
+ * read from the same `pip freeze` that produces the install constraints. Used to
+ * decide which of the overlay's packages are duplicates of the bundle's - see
+ * {@link planOverlayPrune}. Direct references (`pkg @ url`) carry no comparable
+ * version and are skipped.
+ */
+export function parseFreezeVersions(frozen: string): Map<string, string> {
+  const versions = new Map<string, string>();
+  for (const raw of frozen.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('-') || line.startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z0-9._-]+)==(.+)$/);
+    if (match) versions.set(normalizeDistName(match[1]), match[2].trim());
+  }
+  return versions;
+}
+
+/** PEP 503 name normalization: case-folded, runs of -_. collapsed to "-". */
+export function normalizeDistName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/**
+ * The distributions an overlay exists to provide. Everything else pip puts in
+ * there is a dependency the bundled env already ships, and is deleted - see
+ * {@link planOverlayPrune} for why that matters.
+ *
+ * Prefix-matched rather than exact, because the CUDA stack is one wheel per
+ * library (`nvidia-cublas-cu12`, `nvidia-cudnn-cu12`, ...) and its membership
+ * changes with every torch release.
+ */
+export const OVERLAY_OWNED_PREFIXES = [
+  'torch',
+  'torchvision',
+  'onnxruntime-gpu',
+  'nvidia-',
+  'triton',
+  'pytorch-triton',
+];
+
+/** True when `name` is a distribution the overlay is *for*, not a duplicate. */
+export function overlayOwns(name: string): boolean {
+  const key = normalizeDistName(name);
+  return OVERLAY_OWNED_PREFIXES.some((p) => key === p || key.startsWith(p));
+}
+
+/**
+ * Decide which of an overlay's distributions must be deleted.
+ *
+ * `pip install --target` writes the *whole* dependency closure into the overlay,
+ * not just the GPU wheels: torch alone drags in typing_extensions, numpy, sympy,
+ * networkx, jinja2, filelock, fsspec and more. ServerProcess then prepends the
+ * overlay to PYTHONPATH, so every one of those copies shadows the bundled env's
+ * own - for no benefit, since the constraints file pinned them to the bundle's
+ * versions in the first place.
+ *
+ * The moment the two disagree, the bundle's own code imports the overlay's copy
+ * and dies before the server starts. Seen live on Windows 2026-09-03: an overlay
+ * carrying typing_extensions 4.15 over a bundle holding 4.16 made the bundle's
+ * anyio raise `ImportError: cannot import name 'sentinel'`, killing the backend
+ * in the fastapi import chain. `sentinel` exists only in 4.16+.
+ *
+ * So: keep what the overlay owns (torch and the GPU stack), keep anything the
+ * bundle does not have at all, delete the rest. That is the state the overlay
+ * would have if pip could install *only* the wheels we asked it for.
+ *
+ * Pure (no I/O) so the rule is unit-testable without a filesystem.
+ */
+export function planOverlayPrune(
+  overlayDists: readonly DistInfo[],
+  bundled: ReadonlyMap<string, string>,
+): { remove: DistInfo[]; keep: DistInfo[] } {
+  const remove: DistInfo[] = [];
+  const keep: DistInfo[] = [];
+  for (const dist of overlayDists) {
+    const key = normalizeDistName(dist.name);
+    if (overlayOwns(key) || !bundled.has(key)) keep.push(dist);
+    else remove.push(dist);
+  }
+  return { remove, keep };
+}
+
+/** Parse a "typing_extensions-4.15.0.dist-info" directory name, or null. */
+export function parseDistInfoDir(dirName: string): DistInfo | null {
+  if (!dirName.endsWith('.dist-info')) return null;
+  const stem = dirName.slice(0, -'.dist-info'.length);
+  const dash = stem.lastIndexOf('-');
+  if (dash < 1) return null;
+  return { name: stem.slice(0, dash), version: stem.slice(dash + 1), dirName };
+}
+
+/**
+ * The files a distribution's RECORD lists, resolved against `dir` and filtered
+ * to those that genuinely live inside it.
+ *
+ * RECORD paths are relative to the install root but may point outside it
+ * (`../../Scripts/foo.exe` for console entry points). An overlay is a plain
+ * `--target` directory with no siblings we own, so anything escaping it is not
+ * ours to delete - and following one would let a crafted RECORD reach the rest
+ * of the install. Pure so that containment is testable directly.
+ */
+export function recordedFilesWithin(dir: string, record: string): string[] {
+  const root = resolve(dir);
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  const files: string[] = [];
+  for (const line of record.split(/\r?\n/)) {
+    const rel = line.split(',')[0]?.trim();
+    if (!rel) continue;
+    const full = resolve(dir, rel);
+    if (full.startsWith(prefix)) files.push(full);
+  }
+  return files;
 }
 
 /** The message shown when a broken GPU overlay is bypassed at launch. */
@@ -283,6 +415,7 @@ export class BackendManager {
     accel: Accel,
     info: RuntimeInfo,
     onProgress: (p: InstallProgress) => void,
+    appVersion: string,
   ): Promise<OverlayMeta> {
     if (!OVERLAY_ACCELS.includes(accel)) {
       throw new Error(`${accel} is provided by the bundled runtime, not an overlay`);
@@ -299,7 +432,8 @@ export class BackendManager {
       bytesTotal: 0,
     });
     const constraints = join(dir, 'constraints.txt');
-    await writeFile(constraints, await this.bundledConstraints());
+    const bundled = await this.bundledFreeze();
+    await writeFile(constraints, bundled.constraints);
 
     const index = TORCH_INDEX[accel];
     const available = index ? await this.indexVersions('torch', index) : [];
@@ -323,7 +457,21 @@ export class BackendManager {
 
     await this.runPip(args, onProgress);
 
-    const meta: OverlayMeta = { accel, torch: info.torch, installedAt: new Date().toISOString() };
+    onProgress({
+      phase: 'install',
+      message: 'Removing duplicate packages…',
+      fraction: -1,
+      bytesDone: 0,
+      bytesTotal: 0,
+    });
+    await this.pruneOverlay(dir, bundled.versions);
+
+    const meta: OverlayMeta = {
+      accel,
+      torch: info.torch,
+      installedAt: new Date().toISOString(),
+      appVersion,
+    };
     await writeFile(overlayMarkerPath(accel), JSON.stringify(meta, null, 2));
     await this.setActiveAccel(accel);
     onProgress({
@@ -337,13 +485,130 @@ export class BackendManager {
   }
 
   /**
-   * `pip freeze` of the bundled env, minus the torch/onnx packages (those are
-   * overridden per accelerator). Used as install constraints so overlay deps
-   * resolve to the exact versions already in the bundled env.
+   * Delete every package in the overlay that duplicates one the bundled env
+   * already provides, keeping the GPU wheels the overlay exists for and anything
+   * the bundle lacks. See {@link planOverlayPrune} for why the duplicates are
+   * actively harmful rather than merely wasteful.
+   *
+   * Driven by each distribution's own RECORD, so a package's files go with its
+   * metadata and nothing is left half-deleted. Returns the names removed.
    */
-  private async bundledConstraints(): Promise<string> {
+  async pruneOverlay(dir: string, bundled: ReadonlyMap<string, string>): Promise<string[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch (e) {
+      console.warn(`[overlay] cannot read ${dir} to prune it: ${(e as Error).message}`);
+      return [];
+    }
+    const dists = entries
+      .map(parseDistInfoDir)
+      .filter((d): d is DistInfo => d !== null);
+    const { remove } = planOverlayPrune(dists, bundled);
+
+    const removed: string[] = [];
+    // Directories the deletions may have emptied, deepest first. They cannot be
+    // left behind: an empty directory on sys.path is an implicit namespace
+    // package (PEP 420), so an emptied `numpy/` still shadows the bundle's real
+    // numpy - the very failure this prune exists to remove, in a quieter form.
+    const emptied = new Set<string>();
+    for (const dist of remove) {
+      const distInfo = join(dir, dist.dirName);
+      try {
+        const record = await readFile(join(distInfo, 'RECORD'), 'utf8');
+        for (const file of recordedFilesWithin(dir, record)) {
+          await rm(file, { force: true });
+          for (let d = dirname(file); d.startsWith(dir) && d !== dir; d = dirname(d)) {
+            emptied.add(d);
+          }
+        }
+      } catch (e) {
+        // No RECORD (or an unreadable one) means we cannot know which files are
+        // this distribution's. Leaving the dist-info in place keeps the overlay
+        // describing itself honestly, so a later prune can retry.
+        console.warn(
+          `[overlay] skipping ${dist.name} ${dist.version}: RECORD unreadable (${(e as Error).message})`,
+        );
+        continue;
+      }
+      await rm(distInfo, { recursive: true, force: true });
+      removed.push(`${dist.name} ${dist.version}`);
+    }
+    // Deepest first, so a directory is retried only after its children are gone.
+    // rmdir refuses a non-empty one, which is exactly the wanted behaviour: a
+    // directory still holding a kept package's files must survive.
+    for (const d of [...emptied].sort((a, b) => b.length - a.length)) {
+      try {
+        await rmdir(d);
+      } catch {
+        // Non-empty (or already gone): another distribution still lives here.
+      }
+    }
+    if (removed.length) {
+      console.log(`[overlay] pruned ${removed.length} bundled duplicates: ${removed.join(', ')}`);
+    }
+    return removed;
+  }
+
+  /**
+   * Re-prune an overlay that was built against a different app version.
+   *
+   * The bundled site-packages is replaced wholesale by an app update, so an
+   * overlay's duplicates stop matching what the bundle now holds - which is the
+   * shadowing failure in {@link planOverlayPrune}, arriving without anyone
+   * touching the overlay. Pruning against the *current* bundle repairs it in
+   * place, with no re-download: the duplicates are what break, and the bundle
+   * already has correct copies of every one of them.
+   *
+   * An overlay whose marker predates pruning has no `appVersion` at all, which
+   * reads as stale and gets the same repair - that is how already-installed
+   * overlays are fixed.
+   *
+   * Never throws: a failed repair must not stop the app from launching, since a
+   * broken overlay still falls back to the bundled env.
+   */
+  async repairIfStale(accel: Accel, appVersion: string): Promise<boolean> {
+    let meta: OverlayMeta;
+    try {
+      meta = JSON.parse(await readFile(overlayMarkerPath(accel), 'utf8')) as OverlayMeta;
+    } catch {
+      return false; // not installed
+    }
+    if (meta.appVersion === appVersion) return false;
+    try {
+      const { versions } = await this.bundledFreeze();
+      const removed = await this.pruneOverlay(overlayDir(accel), versions);
+      await writeFile(
+        overlayMarkerPath(accel),
+        JSON.stringify({ ...meta, appVersion }, null, 2),
+      );
+      console.log(
+        `[overlay] ${accel} rebuilt for app ${appVersion} (was ${meta.appVersion ?? 'unpruned'}), ` +
+          `${removed.length} duplicates removed`,
+      );
+      return true;
+    } catch (e) {
+      console.warn(`[overlay] could not re-prune ${accel}: ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  /**
+   * `pip freeze` of the bundled env, as both the install constraints (minus the
+   * torch/onnx packages, which are overridden per accelerator) and the version
+   * map the post-install prune compares against. One capture serves both, so the
+   * pins and the prune can never disagree about what the bundle holds.
+   */
+  private async bundledFreeze(): Promise<{ constraints: string; versions: Map<string, string> }> {
     const frozen = await this.capture(bundledInterpreter(), ['-m', 'pip', 'freeze']);
-    return filterConstraintsFreeze(frozen);
+    const versions = parseFreezeVersions(frozen);
+    if (versions.size === 0) {
+      // Every bundled env has dependencies; an empty freeze means we did not read
+      // one. Installing on it would pin nothing and prune nothing, which is the
+      // silent-wrong-versions failure this whole path exists to prevent.
+      throw new Error('Could not read the bundled environment (pip freeze returned nothing)');
+    }
+    return { constraints: filterConstraintsFreeze(frozen), versions };
   }
 
   /** Public (local-tag-stripped) versions of `pkg` on `index`, newest first. */
@@ -370,15 +635,36 @@ export class BackendManager {
     }
   }
 
+  /**
+   * Run `cmd` and return its complete stdout.
+   *
+   * Resolves on 'close', NOT on 'exit'. 'exit' fires when the process ends,
+   * which can precede its stdout pipe being drained - so resolving there can
+   * return a *truncated* capture with no error of any kind. The one caller that
+   * matters is `pip freeze`, whose output feeds the install constraints file,
+   * and whose output is alphabetically sorted: a truncated capture silently
+   * drops the tail of the alphabet, leaving exactly those packages unpinned
+   * while every earlier one looks correctly constrained. 'close' fires only
+   * once all stdio streams are closed, so the capture is whole.
+   */
   private capture(cmd: string, args: string[]): Promise<string> {
     return new Promise((resolve, reject) => {
       const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
       let out = '';
+      let err = '';
+      let exitCode: number | null = null;
       child.stdout.on('data', (d) => (out += d.toString()));
+      child.stderr.on('data', (d) => (err += d.toString()));
       child.on('error', reject);
-      child.on('exit', (code) =>
-        code === 0 ? resolve(out) : reject(new Error(`${cmd} pip freeze exited ${code}`)),
-      );
+      child.on('exit', (code) => (exitCode = code));
+      child.on('close', () => {
+        if (exitCode === 0) {
+          resolve(out);
+          return;
+        }
+        const detail = err.trim() ? `: ${err.trim().slice(-500)}` : '';
+        reject(new Error(`${cmd} ${args.join(' ')} exited ${exitCode}${detail}`));
+      });
     });
   }
 

--- a/electron/src/backend/BackendManager.ts
+++ b/electron/src/backend/BackendManager.ts
@@ -498,8 +498,15 @@ export class BackendManager {
     try {
       entries = await readdir(dir);
     } catch (e) {
-      console.warn(`[overlay] cannot read ${dir} to prune it: ${(e as Error).message}`);
-      return [];
+      // No overlay directory means there is nothing to prune - that is the
+      // not-installed case repairIfStale asks about, not a failure.
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      // Anything else (unreadable, not a directory, permissions) means we cannot
+      // tell whether duplicates are present. Reporting success here would let
+      // installOverlay mark and activate an unpruned overlay, which is exactly
+      // the shadowing this method exists to prevent - so it fails the install.
+      // repairIfStale catches it separately so a launch is never blocked.
+      throw new Error(`Cannot prune the overlay at ${dir}: ${(e as Error).message}`);
     }
     const dists = entries
       .map(parseDistInfoDir)
@@ -652,18 +659,19 @@ export class BackendManager {
       const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
       let out = '';
       let err = '';
-      let exitCode: number | null = null;
       child.stdout.on('data', (d) => (out += d.toString()));
       child.stderr.on('data', (d) => (err += d.toString()));
       child.on('error', reject);
-      child.on('exit', (code) => (exitCode = code));
-      child.on('close', () => {
-        if (exitCode === 0) {
+      child.on('close', (code, signal) => {
+        if (code === 0) {
           resolve(out);
           return;
         }
+        // A signalled child reports code null, so name the signal instead of
+        // rejecting with "exited null".
+        const how = code === null ? `was killed by ${signal}` : `exited ${code}`;
         const detail = err.trim() ? `: ${err.trim().slice(-500)}` : '';
-        reject(new Error(`${cmd} ${args.join(' ')} exited ${exitCode}${detail}`));
+        reject(new Error(`${cmd} ${args.join(' ')} ${how}${detail}`));
       });
     });
   }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -861,15 +861,7 @@ async function startAndLoad(
 /** Which accelerator overlay (if any) should we launch with right now? */
 async function activeOverlayAccel(): Promise<Accel | null> {
   const active = await manager.getActiveAccel();
-  if (active && (await manager.isInstalled(active))) {
-    // An app update replaces the bundled site-packages wholesale, leaving the
-    // overlay's copies of shared dependencies shadowing versions they were never
-    // resolved against - which kills the backend on import, without anyone having
-    // touched the overlay. Re-pruning against the current bundle repairs that in
-    // place; it is a no-op once the marker matches this app version.
-    await manager.repairIfStale(active, app.getVersion());
-    return active;
-  }
+  if (active && (await manager.isInstalled(active))) return active;
   if (active) await manager.setActiveAccel(null); // stale (overlay removed/app moved)
   return null;
 }
@@ -890,6 +882,17 @@ async function startWithOverlayFallback(
   repairPermissions = false,
   navigate = true,
 ): Promise<void> {
+  // An app update replaces the bundled site-packages wholesale, leaving an
+  // overlay's copies of shared dependencies shadowing versions they were never
+  // resolved against - which kills the backend on import without anyone having
+  // touched the overlay. Re-prune against the current bundle first; it is a
+  // no-op once the marker matches this app version, and it never throws.
+  //
+  // Here rather than in activeOverlayAccel() because this is the chokepoint
+  // EVERY overlay launch passes through, including `accel:use` - which is the
+  // path a user takes to re-enable an accelerator the fallback just turned off,
+  // i.e. precisely the overlay most likely to need repairing.
+  if (accel) await manager.repairIfStale(accel, app.getVersion());
   await launchWithOverlayFallback(accel, {
     start: (candidate) => startAndLoad(candidate, repairPermissions, navigate),
     deactivateOverlay: () => manager.setActiveAccel(null),

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -861,7 +861,15 @@ async function startAndLoad(
 /** Which accelerator overlay (if any) should we launch with right now? */
 async function activeOverlayAccel(): Promise<Accel | null> {
   const active = await manager.getActiveAccel();
-  if (active && (await manager.isInstalled(active))) return active;
+  if (active && (await manager.isInstalled(active))) {
+    // An app update replaces the bundled site-packages wholesale, leaving the
+    // overlay's copies of shared dependencies shadowing versions they were never
+    // resolved against - which kills the backend on import, without anyone having
+    // touched the overlay. Re-pruning against the current bundle repairs that in
+    // place; it is a no-op once the marker matches this app version.
+    await manager.repairIfStale(active, app.getVersion());
+    return active;
+  }
   if (active) await manager.setActiveAccel(null); // stale (overlay removed/app moved)
   return null;
 }
@@ -1292,8 +1300,11 @@ function registerIpc(): void {
         activeOverlayAccel,
         startBackend: startFromSetup,
         installOverlay: (accel) =>
-          manager.installOverlay(accel, runtime as RuntimeInfo, (p) =>
-            mainWindow?.webContents.send('install:progress', p),
+          manager.installOverlay(
+            accel,
+            runtime as RuntimeInfo,
+            (p) => mainWindow?.webContents.send('install:progress', p),
+            app.getVersion(),
           ),
         readFolder: async (imageRoot) =>
           runningServer
@@ -1494,8 +1505,18 @@ function registerIpc(): void {
 
   ipcMain.handle('accel:install', async (_e, accel: Accel) => {
     if (!runtime) throw new Error('No bundled runtime available');
-    await manager.installOverlay(accel, runtime, (p) =>
-      mainWindow?.webContents.send('install:progress', p),
+    // installOverlay wipes the target directory first, and a backend running on
+    // this overlay holds its DLLs open - on Windows that wipe fails outright.
+    // Await teardown for the same reason changeBackendsLocation does.
+    if ((await manager.getActiveAccel()) === accel) {
+      await serverProcess?.stop();
+      serverProcess = null;
+    }
+    await manager.installOverlay(
+      accel,
+      runtime,
+      (p) => mainWindow?.webContents.send('install:progress', p),
+      app.getVersion(),
     );
     // If the freshly-installed overlay fails to start, fall back to CPU - the
     // just-downloaded dir is kept (only the active state is cleared), and the

--- a/electron/test/overlayPrune.test.ts
+++ b/electron/test/overlayPrune.test.ts
@@ -1,0 +1,343 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdtemp, mkdir, writeFile, readdir, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import {
+  BackendManager,
+  DistInfo,
+  normalizeDistName,
+  overlayOwns,
+  parseDistInfoDir,
+  parseFreezeVersions,
+  planOverlayPrune,
+  recordedFilesWithin,
+} from '../src/backend/BackendManager';
+
+/** Shorthand for a distribution as it appears in an overlay. */
+function dist(name: string, version: string): DistInfo {
+  return { name, version, dirName: `${name}-${version}.dist-info` };
+}
+
+/** True when `path` exists. */
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('planOverlayPrune', () => {
+  it('removes the duplicate that caused the 2026-09-03 Windows failure', () => {
+    // The overlay carried typing_extensions 4.15.0 over a bundle holding 4.16.0.
+    // PYTHONPATH puts the overlay first, so the bundle's own anyio imported 4.15
+    // and raised ImportError: cannot import name 'sentinel' - which exists only
+    // in 4.16+ - killing the backend during the fastapi import chain.
+    const overlay = [dist('typing_extensions', '4.15.0'), dist('torch', '2.13.0+cu128')];
+    const bundled = new Map([
+      ['typing-extensions', '4.16.0'],
+      ['torch', '2.13.0+cpu'],
+    ]);
+
+    const { remove, keep } = planOverlayPrune(overlay, bundled);
+
+    assert.deepEqual(
+      remove.map((d) => d.name),
+      ['typing_extensions'],
+      'the shadowing duplicate must go',
+    );
+    assert.deepEqual(
+      keep.map((d) => d.name),
+      ['torch'],
+      'torch is what the overlay exists for, even though the bundle also has one',
+    );
+  });
+
+  it('keeps every GPU wheel and drops every shared dependency', () => {
+    // The real closure of `pip install --target torch torchvision onnxruntime-gpu`:
+    // three wheels asked for, a dozen dependencies that duplicate the bundle.
+    const overlay = [
+      dist('torch', '2.13.0'),
+      dist('torchvision', '0.27.1'),
+      dist('onnxruntime_gpu', '1.26.0'),
+      dist('nvidia_cublas_cu12', '12.8.0'),
+      dist('nvidia_cudnn_cu12', '9.7.0'),
+      dist('triton', '3.5.0'),
+      dist('numpy', '2.5.2'),
+      dist('sympy', '1.14.0'),
+      dist('jinja2', '3.1.6'),
+      dist('filelock', '3.32.5'),
+      dist('fsspec', '2026.7.0'),
+      dist('networkx', '3.6.1'),
+      dist('typing_extensions', '4.16.0'),
+    ];
+    const bundled = new Map(
+      [
+        'torch',
+        'torchvision',
+        'numpy',
+        'sympy',
+        'jinja2',
+        'filelock',
+        'fsspec',
+        'networkx',
+        'typing-extensions',
+      ].map((n) => [n, '1.0.0'] as [string, string]),
+    );
+
+    const { remove, keep } = planOverlayPrune(overlay, bundled);
+
+    assert.deepEqual(
+      keep.map((d) => d.name).sort(),
+      [
+        'nvidia_cublas_cu12',
+        'nvidia_cudnn_cu12',
+        'onnxruntime_gpu',
+        'torch',
+        'torchvision',
+        'triton',
+      ],
+      'the GPU stack stays whole',
+    );
+    assert.equal(remove.length, 7, 'every shared dependency is removed');
+  });
+
+  it('keeps a package the bundle does not have at all', () => {
+    // Nothing shadows it, and deleting it would break the overlay's torch.
+    const { keep, remove } = planOverlayPrune([dist('mpmath', '1.3.0')], new Map());
+    assert.deepEqual(
+      keep.map((d) => d.name),
+      ['mpmath'],
+    );
+    assert.equal(remove.length, 0);
+  });
+
+  it('matches names across pip\'s spelling variants', () => {
+    // The overlay's dist-info says "typing_extensions"; pip freeze says
+    // "typing-extensions". PEP 503 normalization is what makes them one package -
+    // without it the duplicate is never spotted and the overlay stays broken.
+    const { remove } = planOverlayPrune(
+      [dist('Typing_Extensions', '4.15.0')],
+      new Map([['typing-extensions', '4.16.0']]),
+    );
+    assert.deepEqual(
+      remove.map((d) => d.name),
+      ['Typing_Extensions'],
+    );
+  });
+});
+
+describe('overlayOwns', () => {
+  it('claims the GPU stack, including per-library CUDA wheels', () => {
+    for (const name of [
+      'torch',
+      'torchvision',
+      'onnxruntime-gpu',
+      'onnxruntime_gpu',
+      'nvidia-cublas-cu12',
+      'nvidia_cudnn_cu12',
+      'triton',
+      'pytorch-triton',
+    ]) {
+      assert.ok(overlayOwns(name), `${name} must be treated as overlay-owned`);
+    }
+  });
+
+  it('claims nothing the bundle is responsible for', () => {
+    for (const name of ['numpy', 'typing_extensions', 'jinja2', 'onnxruntime', 'pillow']) {
+      assert.ok(!overlayOwns(name), `${name} must not be treated as overlay-owned`);
+    }
+  });
+});
+
+describe('parseDistInfoDir', () => {
+  it('splits a dist-info directory into name and version', () => {
+    assert.deepEqual(parseDistInfoDir('typing_extensions-4.15.0.dist-info'), {
+      name: 'typing_extensions',
+      version: '4.15.0',
+      dirName: 'typing_extensions-4.15.0.dist-info',
+    });
+  });
+
+  it('keeps a local version label with the version, not the name', () => {
+    assert.deepEqual(parseDistInfoDir('torch-2.13.0+cu128.dist-info')?.version, '2.13.0+cu128');
+  });
+
+  it('ignores anything that is not a dist-info directory', () => {
+    assert.equal(parseDistInfoDir('torch'), null);
+    assert.equal(parseDistInfoDir('constraints.txt'), null);
+    assert.equal(parseDistInfoDir('nodash.dist-info'), null);
+  });
+});
+
+describe('parseFreezeVersions', () => {
+  it('reads pinned versions under normalized names', () => {
+    const versions = parseFreezeVersions('numpy==2.5.2\nTyping_Extensions==4.16.0\n');
+    assert.equal(versions.get('numpy'), '2.5.2');
+    assert.equal(versions.get('typing-extensions'), '4.16.0');
+  });
+
+  it('skips direct references, options and comments', () => {
+    // A direct reference carries no comparable version, and the app's own wheel
+    // is installed that way - it must never look like something to prune against.
+    const versions = parseFreezeVersions(
+      ['# a comment', '-e .', 'pixlstash @ file:///build/pixlstash.whl', 'numpy==2.5.2'].join('\n'),
+    );
+    assert.deepEqual([...versions.keys()], ['numpy']);
+  });
+});
+
+describe('recordedFilesWithin', () => {
+  it('resolves RECORD entries against the overlay root', () => {
+    const files = recordedFilesWithin(
+      `${sep}ovl`,
+      ['typing_extensions.py,sha256=abc,123', 'numpy/__init__.py,sha256=def,456'].join('\n'),
+    );
+    assert.deepEqual(files, [
+      join(`${sep}ovl`, 'typing_extensions.py'),
+      join(`${sep}ovl`, 'numpy', '__init__.py'),
+    ]);
+  });
+
+  it('refuses entries that escape the overlay', () => {
+    // Console-script entry points are recorded as ../../Scripts/foo.exe. Those
+    // live outside the --target directory and are not ours to delete; following
+    // one would let a RECORD reach the rest of the installation.
+    const files = recordedFilesWithin(
+      `${sep}ovl`,
+      ['../../Scripts/f2py.exe,,', '../python.exe,,', 'numpy/__init__.py,,'].join('\n'),
+    );
+    assert.deepEqual(files, [join(`${sep}ovl`, 'numpy', '__init__.py')]);
+  });
+});
+
+describe('BackendManager.pruneOverlay', () => {
+  /** Write a fake `--target` overlay: a dist-info + RECORD per distribution. */
+  async function fakeOverlay(dists: Record<string, { version: string; files: string[] }>) {
+    const dir = await mkdtemp(join(tmpdir(), 'pixlstash-overlay-'));
+    for (const [name, { version, files }] of Object.entries(dists)) {
+      const info = join(dir, `${name}-${version}.dist-info`);
+      await mkdir(info, { recursive: true });
+      for (const rel of files) {
+        await mkdir(join(dir, rel, '..'), { recursive: true });
+        await writeFile(join(dir, rel), '# payload\n');
+      }
+      await writeFile(
+        join(info, 'RECORD'),
+        files.map((f) => `${f},sha256=x,1`).join('\n') + '\n',
+      );
+    }
+    return dir;
+  }
+
+  it('deletes a shadowing duplicate\'s files and metadata, and nothing else', async () => {
+    const dir = await fakeOverlay({
+      typing_extensions: { version: '4.15.0', files: ['typing_extensions.py'] },
+      torch: { version: '2.13.0', files: ['torch/__init__.py', 'torch/lib/c10.dll'] },
+      mpmath: { version: '1.3.0', files: ['mpmath/__init__.py'] },
+    });
+
+    const removed = await new BackendManager().pruneOverlay(
+      dir,
+      new Map([
+        ['typing-extensions', '4.16.0'],
+        ['torch', '2.13.0+cpu'],
+        // mpmath deliberately absent: the bundle does not ship it.
+      ]),
+    );
+
+    assert.deepEqual(removed, ['typing_extensions 4.15.0']);
+    assert.equal(
+      await exists(join(dir, 'typing_extensions.py')),
+      false,
+      'the shadowing module must be gone - this is the whole point',
+    );
+    assert.equal(await exists(join(dir, 'typing_extensions-4.15.0.dist-info')), false);
+    assert.equal(await exists(join(dir, 'torch', 'lib', 'c10.dll')), true, 'torch is untouched');
+    assert.equal(await exists(join(dir, 'mpmath', '__init__.py')), true, 'unshared deps stay');
+  });
+
+  it('is idempotent - a second prune finds nothing left to do', async () => {
+    const dir = await fakeOverlay({
+      numpy: { version: '2.5.2', files: ['numpy/__init__.py'] },
+    });
+    const bundled = new Map([['numpy', '2.5.2']]);
+    const manager = new BackendManager();
+
+    assert.deepEqual(await manager.pruneOverlay(dir, bundled), ['numpy 2.5.2']);
+    assert.deepEqual(await manager.pruneOverlay(dir, bundled), []);
+  });
+
+  it('leaves a distribution whose RECORD is unreadable, rather than half-deleting it', async () => {
+    // Without a RECORD we cannot know which files belong to it. Removing the
+    // dist-info alone would strand the files as an undeletable shadow.
+    const dir = await mkdtemp(join(tmpdir(), 'pixlstash-overlay-'));
+    await mkdir(join(dir, 'numpy-2.5.2.dist-info'), { recursive: true });
+    await writeFile(join(dir, 'numpy.py'), '# payload\n');
+
+    const removed = await new BackendManager().pruneOverlay(dir, new Map([['numpy', '2.5.2']]));
+
+    assert.deepEqual(removed, []);
+    assert.equal(await exists(join(dir, 'numpy-2.5.2.dist-info')), true);
+  });
+
+  it('reports nothing for a directory that does not exist', async () => {
+    const removed = await new BackendManager().pruneOverlay(
+      join(tmpdir(), 'pixlstash-overlay-does-not-exist'),
+      new Map([['numpy', '2.5.2']]),
+    );
+    assert.deepEqual(removed, []);
+  });
+
+  it('ignores non-distribution entries, and leaves no empty package directory', async () => {
+    // constraints.txt and OVERLAY.json live in the same directory and must stay.
+    // The emptied `numpy/` must NOT: an empty directory on sys.path is an
+    // implicit namespace package (PEP 420), so leaving it there keeps shadowing
+    // the bundle's real numpy - the same failure, only quieter.
+    const dir = await fakeOverlay({
+      numpy: { version: '2.5.2', files: ['numpy/__init__.py', 'numpy/lib/index.py'] },
+    });
+    await writeFile(join(dir, 'constraints.txt'), 'numpy==2.5.2\n');
+    await writeFile(join(dir, 'OVERLAY.json'), '{}');
+
+    await new BackendManager().pruneOverlay(dir, new Map([['numpy', '2.5.2']]));
+
+    const left = (await readdir(dir)).sort();
+    assert.deepEqual(left, ['OVERLAY.json', 'constraints.txt']);
+  });
+
+  it('keeps a directory a surviving distribution still shares', async () => {
+    // Both wheels install into nvidia/, and only one is pruned. Removing the
+    // shared parent would take the GPU library with it.
+    const dir = await fakeOverlay({
+      shared_dep: { version: '1.0.0', files: ['nvidia/dep.py'] },
+      nvidia_cublas_cu12: { version: '12.8.0', files: ['nvidia/cublas/lib.dll'] },
+    });
+
+    const removed = await new BackendManager().pruneOverlay(
+      dir,
+      new Map([
+        ['shared-dep', '1.0.0'],
+        ['nvidia-cublas-cu12', '12.8.0'],
+      ]),
+    );
+
+    assert.deepEqual(removed, ['shared_dep 1.0.0'], 'the nvidia wheel is overlay-owned');
+    assert.equal(await exists(join(dir, 'nvidia', 'dep.py')), false);
+    assert.equal(
+      await exists(join(dir, 'nvidia', 'cublas', 'lib.dll')),
+      true,
+      'the shared parent survives because it is not empty',
+    );
+  });
+});
+
+describe('normalizeDistName', () => {
+  it('collapses the separators PEP 503 treats as equivalent', () => {
+    assert.equal(normalizeDistName('Typing_Extensions'), 'typing-extensions');
+    assert.equal(normalizeDistName('onnxruntime.gpu'), 'onnxruntime-gpu');
+    assert.equal(normalizeDistName('nvidia--cublas__cu12'), 'nvidia-cublas-cu12');
+  });
+});

--- a/electron/test/overlayPrune.test.ts
+++ b/electron/test/overlayPrune.test.ts
@@ -284,11 +284,24 @@ describe('BackendManager.pruneOverlay', () => {
   });
 
   it('reports nothing for a directory that does not exist', async () => {
+    // The not-installed case repairIfStale asks about, not a failure.
     const removed = await new BackendManager().pruneOverlay(
       join(tmpdir(), 'pixlstash-overlay-does-not-exist'),
       new Map([['numpy', '2.5.2']]),
     );
     assert.deepEqual(removed, []);
+  });
+
+  it('throws when the overlay cannot be read at all', async () => {
+    // Returning [] here would let installOverlay mark and activate an overlay
+    // that was never pruned - the shadowing this whole path exists to prevent.
+    const notADir = join(await mkdtemp(join(tmpdir(), 'pixlstash-overlay-')), 'file');
+    await writeFile(notADir, 'not a directory\n');
+
+    await assert.rejects(
+      () => new BackendManager().pruneOverlay(notADir, new Map([['numpy', '2.5.2']])),
+      /Cannot prune the overlay/,
+    );
   });
 
   it('ignores non-distribution entries, and leaves no empty package directory', async () => {


### PR DESCRIPTION
## The bug

`pip install --target` writes torch's **whole dependency closure** into the GPU
overlay, not just the wheels we name: `typing_extensions`, `numpy`, `sympy`,
`networkx`, `jinja2`, `filelock`, `fsspec` and more. `ServerProcess` then
prepends the overlay to `PYTHONPATH`, so every one of those copies shadows the
bundled env's own — for no benefit, since the constraints file pinned them to the
bundle's versions in the first place.

They only have to disagree once. Reported on Windows 2026-09-03: an overlay
carrying `typing_extensions` 4.15.0 over a bundle holding 4.16.0 made the
*bundle's* `anyio` raise `ImportError: cannot import name 'sentinel'` — the name
exists only in 4.16+ — killing the backend inside the `fastapi` import chain
before the server existed. The overlay-fallback path caught it and ran on CPU, so
the symptom was silent loss of GPU acceleration rather than a dead app.

`docs/desktop-backend-migration.md` anticipated `--target` shadowing being
fragile, but named torch as the risk. The risk was everything around torch.

## The fix

**Prune after install** (`BackendManager.pruneOverlay`). Every distribution the
bundled env also provides is deleted from the overlay, keeping what the overlay
exists for (`torch`, `torchvision`, `onnxruntime-gpu`, `nvidia-*`, `triton`) plus
anything the bundle lacks — the state the overlay would have if pip could install
only the wheels we asked for. Deletion follows each distribution's own `RECORD`,
with entries that escape the overlay (`../../Scripts/*.exe`) refused. Directories
the deletions empty are removed too: an empty directory on `sys.path` is an
implicit namespace package (PEP 420) and shadows just as effectively as a
populated one.

**Re-prune after an app update** (`BackendManager.repairIfStale`). An app update
replaces the bundled `site-packages` wholesale, so an overlay pruned against the
previous bundle can start shadowing again untouched. `OVERLAY.json` records the
`appVersion` it was pruned against and a mismatch re-prunes at launch. This is a
repair, not a reinstall — the duplicates are what break, and the bundle already
holds a correct copy of each, so nothing is re-downloaded. A marker predating
pruning has no `appVersion`, reads as stale, and gets the same repair; that is how
already-installed overlays heal.

It runs in `startWithOverlayFallback`, the chokepoint every overlay launch passes
through — including `accel:use`, which is the path a user takes to re-enable the
accelerator the CPU fallback just turned off.

**Two related defects found while tracing it:**

- `capture()` resolved on the child's `'exit'` event, which can fire before
  stdout has drained — returning a *truncated* capture with no error. Its one
  significant caller is the `pip freeze` that becomes the install constraints,
  and `pip freeze` output is alphabetically sorted, so a truncated capture
  silently unpins the tail of the alphabet (`sympy`, `torch…`,
  `typing_extensions`, `uvicorn`) while every earlier package looks correctly
  constrained. Now resolves on `'close'`, reports stderr on failure, and an empty
  freeze throws rather than installing with no pins at all.
- `accel:install` wipes the overlay directory without stopping the backend, which
  holds those DLLs open on Windows. Now tears down first, as
  `changeBackendsLocation` already did for the same reason.

## Tests

`electron/test/overlayPrune.test.ts` — 20 cases over the prune rule (the reported
version pair as a named regression, the full `--target` closure, PEP 503 name
matching across pip's spellings), `RECORD` containment, and the filesystem
behaviour against real temp directories: idempotence, an unreadable `RECORD`
leaving the distribution intact rather than half-deleted, a shared parent
directory surviving because a kept distribution still lives in it, and no empty
package directory left behind.

Suite is green (183 pass) and `tsc --noEmit` is clean. PRs touching `electron/**`
already run that job.

## Not in this change

There is still no **Reinstall** control in Settings — once an overlay is
installed the row offers only Use and Remove, so recovering from a broken one
means Remove then Install. The auto-repair above should make that rare, but it is
a real gap and a flow change worth routing past `ui-ux-expert` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xbGodfbBH5z3RkwfWtfME
