### PR TITLE
Warn instead of refuse on loose file modes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,7 @@ if [ ! -f "$CONFIG_PATH" ]; then
     # os.path.join(config_dir, "images")
     DEFAULT_IMAGE_ROOT="$(dirname "$CONFIG_PATH")/images"
     IMAGE_ROOT="${PIXLSTASH_IMAGE_ROOT:-$DEFAULT_IMAGE_ROOT}"
-    mkdir -p "$IMAGE_ROOT"
+    mkdir -p -m 700 "$IMAGE_ROOT"
     cat > "$CONFIG_PATH" <<EOF
 {
   "host": "$HOST",

--- a/pixlstash/app.py
+++ b/pixlstash/app.py
@@ -24,7 +24,6 @@ from pixlstash.startup_permissions import (
     PERMISSION_REPAIR_ENV,
     find_startup_permission_issues,
     format_permission_problem,
-    permission_repair_signal,
     repair_permission_issues,
 )
 from pixlstash.trusted_sqlite import TrustedSQLiteLocationError
@@ -84,17 +83,15 @@ def _permission_fix_commands(issues) -> list[str]:
 def _prepare_startup_permissions(
     server_config_path: str,
     server_config: dict,
-) -> bool:
-    """Offer or perform the bounded permission repair needed before startup.
+) -> None:
+    """Warn about loose permissions and offer to tighten them; never block.
 
-    Electron has no usable stdin, so the first backend launch emits a structured
-    line for the shell and exits. After the user accepts the native dialog, the
-    shell retries once with ``PIXLSTASH_REPAIR_PERMISSIONS=1``. A terminal gets
-    the same decision inline; services get actionable commands and a clean exit.
+    A terminal is asked inline. Anything else (a service, Docker, Electron)
+    is told what to run and started anyway, unless
+    ``PIXLSTASH_REPAIR_PERMISSIONS=1`` asks for the repair up front.
     """
 
     repair_requested = os.environ.get(PERMISSION_REPAIR_ENV) == "1"
-    is_electron = os.environ.get("PIXLSTASH_INSTALL_TYPE", "").lower() == "electron"
 
     # Usually one pass is enough. A second pass can discover an active library
     # stored in the hub only after the hub directory itself has been repaired.
@@ -104,56 +101,35 @@ def _prepare_startup_permissions(
             str(server_config.get("image_root") or "") or None,
         )
         if not issues:
-            return True
+            return
 
-        message = format_permission_problem(issues)
-        if repair_requested:
-            print(message, file=sys.stderr)
-            try:
-                repair_permission_issues(issues)
-            except OSError as exc:
-                print(
-                    f"\nPixlStash could not fix the permissions: {exc}", file=sys.stderr
-                )
-                return False
-            continue
-
-        if is_electron:
-            # Human text remains in the log; the single-line JSON record is the
-            # stable protocol consumed by the desktop shell.
-            print(message, file=sys.stderr)
-            print(permission_repair_signal(issues), file=sys.stderr)
-            return False
-
-        print(message, file=sys.stderr)
-        if getattr(sys.stdin, "isatty", lambda: False)():
+        print(format_permission_problem(issues), file=sys.stderr)
+        if not repair_requested and getattr(sys.stdin, "isatty", lambda: False)():
             try:
                 answer = input("\nFix permissions now? [Y/n] ").strip().lower()
             except EOFError:
                 answer = "n"
-            if answer not in {"", "y", "yes"}:
+            repair_requested = answer in {"", "y", "yes"}
+            if not repair_requested:
                 print("Permissions were not changed.", file=sys.stderr)
-                return False
-            try:
-                repair_permission_issues(issues)
-            except OSError as exc:
-                print(
-                    f"\nPixlStash could not fix the permissions: {exc}", file=sys.stderr
-                )
-                return False
-            print("Permissions fixed. Starting PixlStash…", file=sys.stderr)
-            continue
 
-        print("\nFix them and start PixlStash again:", file=sys.stderr)
-        for command in _permission_fix_commands(issues):
-            print(f"  {command}", file=sys.stderr)
-        return False
+        if not repair_requested:
+            print("\nFix them with:", file=sys.stderr)
+            for command in _permission_fix_commands(issues):
+                print(f"  {command}", file=sys.stderr)
+            return
+
+        try:
+            repair_permission_issues(issues)
+        except OSError as exc:
+            print(f"\nPixlStash could not fix the permissions: {exc}", file=sys.stderr)
+            return
+        print("Permissions fixed.", file=sys.stderr)
 
     print(
         "PixlStash still found unsafe permissions after attempting the repair.",
         file=sys.stderr,
     )
-    return False
 
 
 VAULT_UNUSABLE_PREFIX = "PIXLSTASH_VAULT_UNUSABLE="
@@ -566,8 +542,7 @@ def main():
         path_map[parts[0]] = parts[1]
 
     server_config = Server.init_server_config(args.server_config)
-    if not _prepare_startup_permissions(args.server_config, server_config):
-        return 1
+    _prepare_startup_permissions(args.server_config, server_config)
 
     log_level = _resolve_log_level(server_config.get("log_level"))
     log_file = server_config.get("log_file")

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -21,6 +21,7 @@ The file also holds the password hash and every token hash, so it is created
 from __future__ import annotations
 
 import os
+import shlex
 import sqlite3
 import stat
 import threading
@@ -224,12 +225,12 @@ def check_file_mode(path: str, *, repair: bool) -> None:
 
     logger.warning(
         "Hub file %s has mode %o; it holds the password hash and every token "
-        "hash and should be %o. Fix it with `chmod %o %s`.",
+        "hash and should be %o. Fix it with chmod %o %s",
         path,
         mode,
         HUB_FILE_MODE,
         HUB_FILE_MODE,
-        path,
+        shlex.quote(path),
     )
 
 

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -185,13 +185,10 @@ def check_file_mode(path: str, *, repair: bool) -> None:
         path: The hub file. A missing file is not an error (it is about to be
             created 0600).
         repair: When True, tighten the mode in place and log it, which is what
-            the CLI does. When False, raise instead, which is what the server
-            does: a hub whose permissions were loosened by something else is a
-            credential-exposure event the operator must see, and silently
-            fixing it hides that it happened.
-
-    Raises:
-        HubPermissionError: ``repair`` is False and the mode is too permissive.
+            the CLI does. When False, warn and carry on, which is what the
+            server does: a hub whose permissions were loosened by something
+            else is worth telling the operator about, but not worth refusing
+            to start over.
     """
     if os.name == "nt":
         # Windows has no mode bits to check: `st_mode` is synthesised from the
@@ -225,10 +222,14 @@ def check_file_mode(path: str, *, repair: bool) -> None:
         os.chmod(path, HUB_FILE_MODE)
         return
 
-    raise HubPermissionError(
-        f"Hub file {path} has mode {mode:o}; it holds the password hash and "
-        f"every token hash and must be {HUB_FILE_MODE:o}. Fix it with "
-        f"`chmod {HUB_FILE_MODE:o} {path}` and restart."
+    logger.warning(
+        "Hub file %s has mode %o; it holds the password hash and every token "
+        "hash and should be %o. Fix it with `chmod %o %s`.",
+        path,
+        mode,
+        HUB_FILE_MODE,
+        HUB_FILE_MODE,
+        path,
     )
 
 

--- a/pixlstash/startup_permissions.py
+++ b/pixlstash/startup_permissions.py
@@ -1,15 +1,14 @@
-"""Detect and safely repair POSIX permissions that block startup.
+"""Detect and safely repair loose POSIX permissions at startup.
 
-PixlStash's SQLite guards deliberately refuse namespaces another local account
-can modify.  Older releases created the app config and default library under
-the process umask, which is commonly ``0002`` on Linux and therefore produced
-``0775`` directories.  This module turns that upgrade failure into a bounded,
-explicit recovery operation shared by the terminal and Electron launchers.
+PixlStash's SQLite guards warn about namespaces another local account can
+modify.  Older releases created the app config and default library under the
+process umask, which is commonly ``0002`` on Linux and therefore produced
+``0775`` directories.  This module finds those and offers a bounded, explicit
+chmod; startup goes ahead either way.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import stat
@@ -23,7 +22,6 @@ from pixlstash.trusted_sqlite import TrustedSQLiteLocation, TrustedSQLiteLocatio
 
 
 PERMISSION_REPAIR_ENV = "PIXLSTASH_REPAIR_PERMISSIONS"
-PERMISSION_REPAIR_PREFIX = "PIXLSTASH_PERMISSION_REPAIR="
 
 _SQLITE_SIDECARS = ("-wal", "-shm", "-journal")
 
@@ -68,14 +66,6 @@ class PermissionIssue:
     is_directory: bool
     device: int
     inode: int
-
-    def record(self) -> dict[str, object]:
-        return {
-            "area": self.area,
-            "path": self.path,
-            "current_mode": f"{self.current_mode:03o}",
-            "repaired_mode": f"{self.repaired_mode:03o}",
-        }
 
 
 def _repairable_issue(
@@ -252,36 +242,27 @@ def find_startup_permission_issues(
         if active:
             roots.append(active)
 
+    # The vault guard opens every library with private=False and refuses only
+    # group/world-writable modes, wherever the library lives. Holding the
+    # default library under the config root to 0700 here refused a 0755
+    # directory the guard would have accepted (the Docker image did exactly
+    # that on first run), so this scan asks for no more than the guard does.
     seen: set[str] = set()
     for root in roots:
         resolved = os.path.realpath(os.path.abspath(os.path.expanduser(str(root))))
         if resolved in seen:
             continue
         seen.add(resolved)
-        try:
-            library_is_app_owned = (
-                private_config_dir
-                and os.path.commonpath((resolved, canonical_config_dir))
-                == canonical_config_dir
-            )
-        except ValueError:
-            library_is_app_owned = False
         directory_issue = _repairable_issue(
             resolved,
             area="Library",
-            private=library_is_app_owned,
+            private=False,
             is_directory=True,
         )
         if directory_issue is not None:
             issues.append(directory_issue)
         vault_path = os.path.join(resolved, "vault.db")
-        issues.extend(
-            _database_issues(
-                vault_path,
-                area="Library",
-                private=library_is_app_owned,
-            )
-        )
+        issues.extend(_database_issues(vault_path, area="Library", private=False))
         issues.extend(_ancestor_issues(vault_path, area="Folder holding your library"))
     return _deduplicated(issues)
 
@@ -332,14 +313,7 @@ def format_permission_problem(issues: Iterable[PermissionIssue]) -> str:
     lines.extend(
         [
             "",
-            "PixlStash will not run with these permissions.",
+            "PixlStash will start anyway.",
         ]
     )
     return "\n".join(lines)
-
-
-def permission_repair_signal(issues: Iterable[PermissionIssue]) -> str:
-    """Return the machine-readable line consumed by the Electron shell."""
-
-    payload = {"version": 1, "issues": [issue.record() for issue in issues]}
-    return PERMISSION_REPAIR_PREFIX + json.dumps(payload, separators=(",", ":"))

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -6,6 +6,14 @@ Instead, require a namespace in which another OS principal cannot replace the
 main file or pre-position a sidecar, hold a no-follow guard, open SQLite by the
 canonical path, and compare identities before doing decisive work.
 
+**Mode bits warn; everything else refuses.** Ownership, symlinks, junctions and
+non-regular files are refused outright. A loose mode (group/world-writable
+directory or file, a credential file wider than 0600) is logged as a WARNING
+with the ``chmod`` that fixes it, and the open goes ahead. Refusing on mode
+alone took the app down twice for nobody's benefit (a 0775 directory under a
+stock Ubuntu umask, then a 0755 library made by the Docker entrypoint), and a
+loose mode on the owner's own files has never been an observed attack.
+
 **What these checks actually cover: the moment of open, not "the database".**
 ``TrustedSQLiteLocation.open`` validates the main file and any pre-existing
 sidecar before SQLite touches the path, and ``verify_after_open`` re-checks the
@@ -51,12 +59,12 @@ account a group of its own and default to umask 002, so a directory this app
 created before it started passing 0700 is 0775 with a one-member group - no
 other principal at all, and the blanket test refused it and exited 1 with no way
 back except a manual ``chmod``. ``_is_private_group`` names the actor instead of
-the bit: group-write is tolerated only when the group is the owner's own,
-same-named, and has no other member, on a directory this user owns. World-write
-is refused as before, root-owned ancestors are refused as before, and the two
-limits of the group answer - supplementary members only, and NSS resolved in
-this process - are recorded as accepted risk beside W17 in
-``docs/backend_architecture.md`` §13.
+the bit: group-write is not even warned about when the group is the owner's
+own, same-named, and has no other member, on a directory this user owns.
+World-write and root-owned group-writable ancestors warn, and the two limits of
+the group answer - supplementary members only, and NSS resolved in this process
+- are recorded as accepted risk beside W17 in ``docs/backend_architecture.md``
+§13.
 
 **Windows, and what this cannot check.** Python exposes neither owner SID nor
 directory DACL portably, so the "another principal cannot write this directory"
@@ -197,11 +205,17 @@ def _require_owned_directory(path: str, *, immediate: bool) -> os.stat_result:
             f"chmod g-w {shlex.quote(path)}",
         )
         exposed = 0
+    # Mode bits warn rather than refuse: a loose mode on the owner's own
+    # directory has never been an observed attack, and refusing it took the
+    # app down on stock umasks and in Docker for nobody's benefit. Ownership,
+    # symlink and type checks above still refuse.
     if exposed and (immediate or not (info.st_mode & stat.S_ISVTX)):
-        raise TrustedSQLiteLocationError(
-            f"SQLite directory {path} is group/world-writable; another account "
+        logger.warning(
+            "SQLite directory %s is group/world-writable; another account "
             "could replace the database or its WAL/SHM files. Tighten it with "
-            f"chmod g-w,o-w {shlex.quote(path)}"
+            "chmod g-w,o-w %s",
+            path,
+            shlex.quote(path),
         )
     return info
 
@@ -378,13 +392,20 @@ def _validate_file(path: str, *, private: bool) -> os.stat_result:
         raise TrustedSQLiteLocationError(
             f"SQLite file {path} is owned by uid {info.st_uid}, not this user."
         )
+    # Mode bits warn rather than refuse (see _require_owned_directory).
     if private and stat.S_IMODE(info.st_mode) & 0o077:
-        raise TrustedSQLiteLocationError(
-            f"SQLite credential file {path} must be mode 600."
+        logger.warning(
+            "SQLite credential file %s should be mode 600; other accounts can "
+            "read it. Tighten it with chmod 600 %s",
+            path,
+            shlex.quote(path),
         )
-    if stat.S_IMODE(info.st_mode) & 0o022:
-        raise TrustedSQLiteLocationError(
-            f"SQLite file {path} is group/world-writable; refusing to open it."
+    elif stat.S_IMODE(info.st_mode) & 0o022:
+        logger.warning(
+            "SQLite file %s is group/world-writable; another account could "
+            "modify it. Tighten it with chmod g-w,o-w %s",
+            path,
+            shlex.quote(path),
         )
     return info
 

--- a/tests/test_app_permission_repair.py
+++ b/tests/test_app_permission_repair.py
@@ -11,7 +11,6 @@ import pytest
 from pixlstash import app
 from pixlstash.pixl_logging import hold_log_output
 import pixlstash.startup_permissions as startup_permissions
-from pixlstash.startup_permissions import PERMISSION_REPAIR_PREFIX
 
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
@@ -52,11 +51,9 @@ def test_terminal_default_yes_repairs_and_continues(tmp_path, monkeypatch, capsy
     monkeypatch.setattr(app.sys, "stdin", TerminalInput())
     monkeypatch.setattr("builtins.input", lambda _prompt: "")
 
-    assert app._prepare_startup_permissions(
-        str(config_path), {"image_root": str(library)}
-    )
+    app._prepare_startup_permissions(str(config_path), {"image_root": str(library)})
     assert mode(config_path.parent) == 0o700
-    assert mode(library) == 0o700
+    assert mode(library) == 0o755
     assert "Permissions fixed" in capsys.readouterr().err
 
 
@@ -67,24 +64,9 @@ def test_terminal_no_leaves_permissions_unchanged(tmp_path, monkeypatch, capsys)
     monkeypatch.setattr(app.sys, "stdin", TerminalInput())
     monkeypatch.setattr("builtins.input", lambda _prompt: "n")
 
-    assert not app._prepare_startup_permissions(
-        str(config_path), {"image_root": str(library)}
-    )
+    app._prepare_startup_permissions(str(config_path), {"image_root": str(library)})
     assert mode(config_path.parent) == 0o775
     assert "Permissions were not changed" in capsys.readouterr().err
-
-
-def test_electron_emits_signal_without_changing_anything(tmp_path, monkeypatch, capsys):
-    config_path, library = loose_config(tmp_path)
-    monkeypatch.setenv("PIXLSTASH_INSTALL_TYPE", "electron")
-    monkeypatch.delenv("PIXLSTASH_REPAIR_PERMISSIONS", raising=False)
-
-    assert not app._prepare_startup_permissions(
-        str(config_path), {"image_root": str(library)}
-    )
-    stderr = capsys.readouterr().err
-    assert PERMISSION_REPAIR_PREFIX in stderr
-    assert mode(config_path.parent) == 0o775
 
 
 def test_noninteractive_launch_prints_copyable_commands(tmp_path, monkeypatch, capsys):
@@ -93,12 +75,12 @@ def test_noninteractive_launch_prints_copyable_commands(tmp_path, monkeypatch, c
     monkeypatch.delenv("PIXLSTASH_REPAIR_PERMISSIONS", raising=False)
     monkeypatch.setattr(app.sys, "stdin", io.StringIO())
 
-    assert not app._prepare_startup_permissions(
-        str(config_path), {"image_root": str(library)}
-    )
+    app._prepare_startup_permissions(str(config_path), {"image_root": str(library)})
     stderr = capsys.readouterr().err
+    assert "PixlStash will start anyway" in stderr
     assert f"chmod 700 {config_path.parent}" in stderr
-    assert f"chmod 700 {library}" in stderr
+    assert f"chmod 755 {library}" in stderr
+    assert mode(config_path.parent) == 0o775
 
 
 class RecordingHandler(logging.Handler):

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -26,10 +26,10 @@ from pixlstash.hub.bootstrap import (
     registered_vault_path,
     unusable_vault_from_open_failure,
 )
-from pixlstash.hub.db import HubDatabase, HubPermissionError
+from pixlstash.hub.db import HubDatabase
 from pixlstash.server import Server
 from pixlstash.hub.registry import LibraryRegistry, read_vault_uuid
-from pixlstash.trusted_sqlite import TrustedSQLiteLocation, TrustedSQLiteLocationError
+from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 from pixlstash.vault import Vault
 
 
@@ -328,13 +328,14 @@ class TestFreshInstall:
         TrustedSQLiteLocation.open(str(image_root / "vault.db")).close()
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_a_loose_existing_ancestor_is_kept_and_still_refused(self, tmp_path):
+    def test_a_loose_existing_ancestor_is_kept_and_still_reported(
+        self, tmp_path, caplog
+    ):
         """Creation only: the fix never chmods a directory the owner already had.
 
         The loose ancestor keeps its mode (owner's folder, owner's business),
-        and the guarded open goes on refusing the namespace - that refusal is
-        pre-existing behaviour, asserted here so the fix cannot drift into
-        repairing directories it did not create.
+        and the guarded open goes on warning about the namespace, asserted here
+        so the fix cannot drift into repairing directories it did not create.
 
         World-writable, not the 0775 this asserted originally: group-write alone
         is no longer an exposure when the group is the owner's own one-member
@@ -357,16 +358,19 @@ class TestFreshInstall:
 
         assert stat.S_IMODE(os.lstat(loose).st_mode) == 0o777
         assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o700
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(image_root / "vault.db"))
+        TrustedSQLiteLocation.open(str(image_root / "vault.db")).close()
+        assert any(
+            "group/world-writable" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
 
     def test_existing_loose_hub_directory_is_reported_not_silently_repaired(
-        self, tmp_path
+        self, tmp_path, caplog
     ):
         """A permission someone else loosened is an event the operator must see.
 
         Same rule ``check_file_mode`` follows for the hub file: the server
-        raises rather than tightening in place, because silently fixing it hides
+        warns rather than tightening in place, because silently fixing it hides
         that it ever happened.
         """
         os.chmod(tmp_path, 0o700)
@@ -384,9 +388,12 @@ class TestFreshInstall:
         # would make this pass there and fail nothing.
         os.chmod(parent, 0o777)
 
-        with pytest.raises(HubPermissionError, match="group/world-writable"):
-            HubDatabase(str(parent / "hub.db"))
+        HubDatabase(str(parent / "hub.db")).close()
 
+        assert any(
+            "group/world-writable" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
         assert stat.S_IMODE(parent.stat().st_mode) == 0o777
 
     def test_existing_foreign_vault_is_not_an_implicit_identity_source(self, tmp_path):

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -7,7 +7,6 @@ the claim the hub schema's shape exists to support.
 """
 
 import os
-import re
 import sqlite3
 import stat
 import threading
@@ -34,6 +33,14 @@ from pixlstash.trusted_sqlite import (
     _reject_symlinked_path,
     _validate_file,
 )
+
+
+def _warned(caplog, text: str) -> bool:
+    """A WARNING record mentioning *text* was logged; mode bits warn, not refuse."""
+    return any(
+        text in record.message and record.levelname == "WARNING"
+        for record in caplog.records
+    )
 
 
 @pytest.fixture
@@ -272,22 +279,22 @@ class TestHubFileSecurity:
         )
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_a_hostile_file_that_wins_the_creation_race_is_still_refused(
-        self, tmp_path, monkeypatch
+    def test_a_hostile_file_that_wins_the_creation_race_is_still_reported(
+        self, tmp_path, monkeypatch, caplog
     ):
         """The logged race branch must fall through to validation, not accept.
 
         A loose-mode file that won the race is exactly what the old silent
-        ``pass`` could have hidden; ``_validate_file`` must still refuse it.
+        ``pass`` could have hidden; ``_validate_file`` must still see it.
         """
         path = tmp_path / "hub.db"
         os.close(os.open(path, os.O_RDWR | os.O_CREAT, 0o644))
         monkeypatch.setattr(os.path, "lexists", lambda _p: False)
 
-        with pytest.raises(TrustedSQLiteLocationError, match="mode 600"):
-            TrustedSQLiteLocation.open(
-                str(path), private=True, create=True, trusted_root=str(tmp_path)
-            )
+        TrustedSQLiteLocation.open(
+            str(path), private=True, create=True, trusted_root=str(tmp_path)
+        ).close()
+        assert _warned(caplog, "mode 600")
 
     def test_path_replacement_during_sqlite_open_is_refused_before_schema_writes(
         self, tmp_path, monkeypatch
@@ -367,7 +374,9 @@ class TestHubFileSecurity:
         # assert nothing at all while still looking green.
         assert swapped, "the swap never fired; this test proved nothing"
 
-    def test_a_directory_that_turns_writable_after_open_is_refused(self, tmp_path):
+    def test_a_directory_that_turns_writable_after_open_is_reported(
+        self, tmp_path, caplog
+    ):
         """The property that replaced the timestamp snapshot, asserted directly.
 
         verify_after_open now re-runs the ownership/permission check instead of
@@ -384,10 +393,11 @@ class TestHubFileSecurity:
         )
         try:
             guard.verify_after_open()  # clean while the directory is private
+            assert not _warned(caplog, "world-writable")
 
             os.chmod(directory, 0o777)
-            with pytest.raises(TrustedSQLiteLocationError, match="world-writable"):
-                guard.verify_after_open()
+            guard.verify_after_open()
+            assert _warned(caplog, "world-writable")
         finally:
             os.chmod(directory, 0o700)
             guard.close()
@@ -620,7 +630,9 @@ class TestGroupWritableDirectories:
         )
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_a_private_group_makes_group_write_harmless(self, tmp_path, monkeypatch):
+    def test_a_private_group_makes_group_write_harmless(
+        self, tmp_path, monkeypatch, caplog
+    ):
         directory = tmp_path / "images"
         directory.mkdir()
         os.chmod(tmp_path, 0o755)
@@ -628,20 +640,23 @@ class TestGroupWritableDirectories:
         self._patch_groups(monkeypatch, group_name="me", members=["me"])
 
         TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert not _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_a_shared_group_still_refuses_group_write(self, tmp_path, monkeypatch):
+    def test_a_shared_group_still_warns_about_group_write(
+        self, tmp_path, monkeypatch, caplog
+    ):
         directory = tmp_path / "images"
         directory.mkdir()
         os.chmod(directory, 0o775)
         self._patch_groups(monkeypatch, group_name="staff", members=["me", "someone"])
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
     def test_a_same_named_group_with_another_member_is_not_private(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, caplog
     ):
         """The name alone is not the property; a group of one is."""
         directory = tmp_path / "images"
@@ -649,22 +664,24 @@ class TestGroupWritableDirectories:
         os.chmod(directory, 0o775)
         self._patch_groups(monkeypatch, group_name="me", members=["me", "someone"])
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_world_write_is_refused_whatever_the_group_is(self, tmp_path, monkeypatch):
+    def test_world_write_warns_whatever_the_group_is(
+        self, tmp_path, monkeypatch, caplog
+    ):
         directory = tmp_path / "images"
         directory.mkdir()
         os.chmod(directory, 0o777)
         self._patch_groups(monkeypatch, group_name="me", members=["me"])
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
     def test_a_differently_named_group_of_one_is_not_private(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, caplog
     ):
         """The member count alone is not the property; the name carries half of it.
 
@@ -679,16 +696,16 @@ class TestGroupWritableDirectories:
         os.chmod(directory, 0o775)
         self._patch_groups(monkeypatch, group_name="staff", members=[])
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
     @pytest.mark.skipif(
         hasattr(os, "geteuid") and os.geteuid() == 0,
         reason="running as root makes root-owned the owner's own directory",
     )
-    def test_a_root_owned_group_writable_ancestor_is_still_refused(
-        self, tmp_path, monkeypatch
+    def test_a_root_owned_group_writable_ancestor_still_warns(
+        self, tmp_path, monkeypatch, caplog
     ):
         """gid 0 is the administrators' group, not one owner's own.
 
@@ -723,8 +740,8 @@ class TestGroupWritableDirectories:
         monkeypatch.setattr(os, "lstat", as_root)
         self._patch_groups(monkeypatch, group_name="me", members=["me"])
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
     @pytest.mark.skipif(
@@ -762,7 +779,7 @@ class TestGroupWritableDirectories:
         assert _is_private_group(os.geteuid(), -2) is False
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
-    def test_an_unresolvable_group_fails_closed(self, tmp_path, monkeypatch):
+    def test_an_unresolvable_group_fails_closed(self, tmp_path, monkeypatch, caplog):
         """A lookup that did not work must not be read as "nobody else"."""
         directory = tmp_path / "images"
         directory.mkdir()
@@ -782,8 +799,8 @@ class TestGroupWritableDirectories:
             trusted_sqlite, "grp", types.SimpleNamespace(getgrgid=explode)
         )
 
-        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
-            TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True).close()
+        assert _warned(caplog, "group/world-writable")
 
 
 class TestWindowsHasNoModeBits:
@@ -809,13 +826,13 @@ class TestWindowsHasNoModeBits:
 
         _validate_file(str(path), private=True)
 
-    def test_validate_file_still_refuses_that_mode_on_posix(self, tmp_path):
+    def test_validate_file_still_reports_that_mode_on_posix(self, tmp_path, caplog):
         path = tmp_path / "hub.db"
         path.touch()
         os.chmod(path, 0o666)
 
-        with pytest.raises(TrustedSQLiteLocationError, match="mode 600"):
-            _validate_file(str(path), private=True)
+        _validate_file(str(path), private=True)
+        assert _warned(caplog, "mode 600")
 
     def test_check_file_mode_is_a_no_op_on_windows(self, tmp_path, monkeypatch):
         path = tmp_path / "hub.db"
@@ -825,13 +842,14 @@ class TestWindowsHasNoModeBits:
 
         check_file_mode(str(path), repair=False)
 
-    def test_check_file_mode_still_reports_a_loose_hub_on_posix(self, tmp_path):
+    def test_check_file_mode_still_reports_a_loose_hub_on_posix(self, tmp_path, caplog):
         path = tmp_path / "hub.db"
         path.touch()
         os.chmod(path, 0o666)
 
-        with pytest.raises(HubPermissionError):
-            check_file_mode(str(path), repair=False)
+        check_file_mode(str(path), repair=False)
+        assert _warned(caplog, "should be 600")
+        assert stat.S_IMODE(os.lstat(path).st_mode) == 0o666
 
 
 class TestHostileSidecarRefusal:
@@ -895,44 +913,20 @@ class TestHostileSidecarRefusal:
         return path, sidecar
 
     @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
-    def test_a_loose_mode_sidecar_is_refused_by_the_guard(self, tmp_path, suffix):
-        """Mode 0o666 on the sidecar alone must refuse the open.
+    def test_a_loose_mode_sidecar_is_reported_by_the_guard(
+        self, tmp_path, suffix, caplog
+    ):
+        """Mode 0o666 on the sidecar alone is warned about, naming the sidecar.
 
-        The error must name the sidecar: a refusal naming the directory or the
-        main file would mean a different control fired and this attack is
-        still uncovered.
+        The warning must name the sidecar: one naming the directory or the
+        main file would mean a different check fired and this one is silent.
         """
         path, sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o666)
 
-        with pytest.raises(TrustedSQLiteLocationError, match=re.escape(sidecar)):
-            TrustedSQLiteLocation.open(
-                path, private=True, trusted_root=os.path.dirname(path)
-            )
-
-    @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
-    def test_the_refusal_happens_before_sqlite_connects(
-        self, tmp_path, monkeypatch, suffix
-    ):
-        """SQLite must never see the path: replay happens inside connect().
-
-        Asserting that ``verify_after_open`` raises would be theatre; by then
-        the hostile WAL is already in the database. Zero connect calls is the
-        property that matters.
-        """
-        path, _sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o666)
-        real_connect = sqlite3.connect
-        connects = []
-
-        def spying_connect(database, *args, **kwargs):
-            connects.append(str(database))
-            return real_connect(database, *args, **kwargs)
-
-        monkeypatch.setattr(sqlite3, "connect", spying_connect)
-
-        with pytest.raises(HubPermissionError):
-            HubDatabase(path)
-
-        assert connects == []
+        TrustedSQLiteLocation.open(
+            path, private=True, trusted_root=os.path.dirname(path)
+        ).close()
+        assert _warned(caplog, sidecar)
 
     @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
     def test_a_foreign_owned_sidecar_is_refused(self, tmp_path, monkeypatch, suffix):
@@ -1380,24 +1374,25 @@ class TestHubUnderASymlinkedAncestor:
         assert target.read_bytes() == b"do not open"
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX only")
-    def test_a_symlink_to_an_exposed_directory_is_still_refused(self, tmp_path):
+    def test_a_symlink_to_an_exposed_directory_is_still_reported(
+        self, tmp_path, caplog
+    ):
         """Resolving the ancestor must not smuggle past the namespace walk.
 
-        This is what carries the security load now that the redirect itself is
-        followed: the link is resolved, and then the directory it lands on is
-        judged on its own ownership and mode.
+        The link is resolved, and then the directory it lands on is judged on
+        its own ownership and mode.
         """
         exposed = tmp_path / "exposed"
         exposed.mkdir()
         # chmod, not mkdir(mode=...): the process umask is commonly 0o022, which
         # would silently make this 0o755 and leave nothing for the guard to
-        # refuse - the assertion would then pass for the wrong reason.
+        # report - the assertion would then pass for the wrong reason.
         os.chmod(exposed, 0o777)
         link = tmp_path / "config"
         link.symlink_to(exposed, target_is_directory=True)
 
-        with pytest.raises(HubPermissionError, match="writable"):
-            HubDatabase(str(link / "hub.db"))
+        HubDatabase(str(link / "hub.db")).close()
+        assert _warned(caplog, str(exposed))
 
 
 class TestCanonicalHubPath:

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -14,7 +14,7 @@ import uuid
 
 import pytest
 
-from pixlstash.hub.db import HUB_FILE_MODE, HubDatabase, HubPermissionError
+from pixlstash.hub.db import HUB_FILE_MODE, HubDatabase
 from pixlstash.hub.registry import (
     ActiveLibraryError,
     LibraryError,
@@ -142,13 +142,17 @@ class TestHubDatabase:
         HubDatabase(path).close()
         assert stat.S_IMODE(os.stat(path).st_mode) == HUB_FILE_MODE
 
-    def test_server_refuses_a_group_readable_hub(self, tmp_path):
+    def test_server_warns_about_a_group_readable_hub(self, tmp_path, caplog):
         path = str(tmp_path / "hub.db")
         HubDatabase(path).close()
         os.chmod(path, 0o640)
 
-        with pytest.raises(HubPermissionError):
-            HubDatabase(path)
+        HubDatabase(path).close()
+        assert any(
+            "should be 600" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o640
 
     def test_cli_repairs_a_group_readable_hub(self, tmp_path):
         path = str(tmp_path / "hub.db")

--- a/tests/test_library_backup.py
+++ b/tests/test_library_backup.py
@@ -102,18 +102,21 @@ class TestWhatIsInTheArchive:
         assert manifest["vault_revision"] == "0100_add_pending_score_invalidation"
         assert manifest["contains_hub"] is True
 
-    def test_a_prepositioned_writable_wal_sidecar_is_refused(
-        self, registry, library, tmp_path
+    def test_a_prepositioned_writable_wal_sidecar_is_reported(
+        self, registry, library, tmp_path, caplog
     ):
-        """Another account must not be able to choose SQLite's WAL contents."""
+        """A loose-mode sidecar is warned about; the backup still runs."""
         open(os.path.join(library.path, "vault.db-wal"), "wb").write(b"junk")
         os.chmod(os.path.join(library.path, "vault.db-wal"), 0o666)
         destination = tmp_path / "out.tar.zst"
 
-        with pytest.raises(BackupError, match="group/world-writable"):
-            create_backup(library, str(destination), registry.hub_path)
+        create_backup(library, str(destination), registry.hub_path)
 
-        assert not destination.exists()
+        assert any(
+            "group/world-writable" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+        assert destination.exists()
 
     def test_a_real_live_wal_is_captured_but_not_archived_raw(
         self, registry, library, tmp_path

--- a/tests/test_startup_permissions.py
+++ b/tests/test_startup_permissions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import stat
@@ -9,16 +8,13 @@ import pytest
 
 import pixlstash.startup_permissions as startup_permissions
 from pixlstash.startup_permissions import (
-    PERMISSION_REPAIR_PREFIX,
     find_startup_permission_issues,
     format_permission_problem,
     mkdir_private,
-    permission_repair_signal,
     repair_permission_issues,
 )
 from pixlstash.trusted_sqlite import (
     TrustedSQLiteLocation,
-    TrustedSQLiteLocationError,
 )
 
 
@@ -77,15 +73,16 @@ def test_find_and_repair_hub_and_configured_library_permissions(
 
     assert by_path[str(config_dir)].repaired_mode == 0o700
     assert by_path[str(hub)].repaired_mode == 0o600
-    # The default library sits inside PixlStash's private config root.
-    assert by_path[str(library)].repaired_mode == 0o700
-    assert by_path[str(vault)].repaired_mode == 0o600
+    # The library is held to what the vault guard checks: not writable by
+    # others. Living inside the config root does not make it a credential store.
+    assert by_path[str(library)].repaired_mode == 0o755
+    assert by_path[str(vault)].repaired_mode == 0o644
 
     repair_permission_issues(issues)
     assert mode(config_dir) == 0o700
     assert mode(hub) == 0o600
-    assert mode(library) == 0o700
-    assert mode(vault) == 0o600
+    assert mode(library) == 0o755
+    assert mode(vault) == 0o644
     assert not find_startup_permission_issues(
         str(config_dir / "server-config.json"), str(library)
     )
@@ -158,7 +155,7 @@ def test_external_library_preserves_read_access(tmp_path):
     assert issues[0].repaired_mode == 0o755
 
 
-def test_human_and_electron_messages_name_paths_and_modes(tmp_path, app_owned_config):
+def test_message_names_paths_and_modes(tmp_path, app_owned_config):
     config_dir = tmp_path / "config with spaces"
     config_dir.mkdir(mode=0o700)
     app_owned_config.add(os.path.realpath(config_dir))
@@ -168,25 +165,21 @@ def test_human_and_electron_messages_name_paths_and_modes(tmp_path, app_owned_co
     )
 
     message = format_permission_problem(issues)
-    assert "PixlStash will not run" in message
+    assert "PixlStash will start anyway" in message
     assert str(config_dir) in message
     assert "mode 775; needs 700" in message
 
-    signal = permission_repair_signal(issues)
-    assert signal.startswith(PERMISSION_REPAIR_PREFIX)
-    payload = json.loads(signal.removeprefix(PERMISSION_REPAIR_PREFIX))
-    assert payload["version"] == 1
-    assert payload["issues"][0]["path"] == str(config_dir)
 
-
-def test_offers_the_writable_ancestor_the_guard_refuses(tmp_path, app_owned_config):
+def test_offers_the_writable_ancestor_the_guard_warns_about(
+    tmp_path, app_owned_config, caplog
+):
     """The repair offer must cover every directory ``TrustedSQLiteLocation`` walks.
 
     The desktop shape that exposed the gap: the Electron config dir and the
     library root are both private, but the library sits inside a shared folder
-    left at 0777 by an older release. The guard refuses on that ancestor, so an
+    left at 0777 by an older release. The guard warns on that ancestor, so an
     offer that only inspects leaf paths reports "nothing to fix" for a startup
-    that cannot succeed.
+    that will keep warning.
     """
 
     desktop_config = tmp_path / "pixlstash-desktop"
@@ -207,8 +200,11 @@ def test_offers_the_writable_ancestor_the_guard_refuses(tmp_path, app_owned_conf
     # and must never be offered for a chmod.
     os.chmod(tmp_path, 0o1777)
 
-    with pytest.raises(TrustedSQLiteLocationError):
-        TrustedSQLiteLocation.open(str(vault)).close()
+    TrustedSQLiteLocation.open(str(vault)).close()
+    assert any(
+        str(shared) in record.message and record.levelname == "WARNING"
+        for record in caplog.records
+    )
 
     issues = find_startup_permission_issues(server_config, str(library))
     assert [issue.path for issue in issues] == [str(shared)]


### PR DESCRIPTION
The 1.11.0rc2 Docker image refused to start: the entrypoint's `mkdir -p` made the default library 0755 and the startup pre-check held a library inside the config dir to 0700, a rule the SQLite guard itself never had.

- Group/world bits on the hub, vault, library and their ancestors now log a warning with the chmod that fixes them, and the open goes ahead. Ownership, symlink, junction and file-type checks still refuse.
- The startup pre-check offers the repair in a terminal and never exits. The Electron exit-and-retry signal is gone; `electron/src/backend/StartupPermissions.ts` is now dead code and will be removed separately.
- The library is no longer held to 0700 for living inside the config dir.
- The Docker entrypoint creates the default library 0700, like `mkdir_private` does everywhere else, so a fresh container produces no permission warning at all.

https://claude.ai/code/session_01H7BtzHGungFesWpqn5Ns2g