### PR TITLE
Keep the likeness sort on the stack_id index, restore the likeness pill

### DIFF
--- a/pixlstash/migrations/versions/0113_reset_size_bin_without_likeness_parameters.py
+++ b/pixlstash/migrations/versions/0113_reset_size_bin_without_likeness_parameters.py
@@ -1,0 +1,43 @@
+"""Re-queue pictures whose likeness parameters are missing but look done.
+
+Data-only reset, no schema change. ``LikenessParametersTask`` writes
+``likeness_parameters`` and ``size_bin_index`` in one statement, and the
+parameters finder treats ``size_bin_index IS NULL`` as the sole pending-work
+marker (``LikenessParameterUtils.find_next_work``). A row with the index set
+and the blob NULL is therefore invisible to that finder, while the pairs
+batch (``LikenessUtils.get_next_work_batch``) requires the blob, so such a
+picture sits in the likeness queue forever and the Likeness Pairs progress
+stops short of its total. Restored snapshots have produced exactly that row
+shape. Nulling ``size_bin_index`` on those rows hands them back to the
+finder, which rewrites both columns and the pairs task drains them.
+
+Revision ID: 0113_reset_size_bin_without_likeness_parameters
+Revises: 0112_add_image_embedding_probe_indexes
+Create Date: 2026-09-04
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0113_reset_size_bin_without_likeness_parameters"
+down_revision: Union[str, None] = "0112_add_image_embedding_probe_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    if "picture" in sa.inspect(op.get_bind()).get_table_names():
+        op.execute(
+            "UPDATE picture SET size_bin_index = NULL "
+            "WHERE likeness_parameters IS NULL AND size_bin_index IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    # The reset only asks for a recompute; there is nothing to restore.
+    pass

--- a/pixlstash/routes/pictures/_listing.py
+++ b/pixlstash/routes/pictures/_listing.py
@@ -187,7 +187,7 @@ class GridPicture(BaseModel):
         description=(
             "`sort=CHARACTER_LIKENESS` only. Softmax-weighted cosine similarity "
             "of the picture's best face to `reference_character_id`'s reference "
-            "faces, 0.0-1.0, the value the rows are ordered by. Absent for "
+            "faces, 0.0-1.0, the value the rows are ordered by. `null` for "
             "every other sort."
         ),
         examples=[0.83],

--- a/pixlstash/routes/pictures/_listing.py
+++ b/pixlstash/routes/pictures/_listing.py
@@ -182,6 +182,16 @@ class GridPicture(BaseModel):
         ),
         examples=["locked"],
     )
+    character_likeness: float | None = Field(
+        None,
+        description=(
+            "`sort=CHARACTER_LIKENESS` only. Softmax-weighted cosine similarity "
+            "of the picture's best face to `reference_character_id`'s reference "
+            "faces, 0.0-1.0, the value the rows are ordered by. Absent for "
+            "every other sort."
+        ),
+        examples=[0.83],
+    )
 
 
 class StreamPicturesResponse(BaseModel):

--- a/pixlstash/scoring/character_likeness.py
+++ b/pixlstash/scoring/character_likeness.py
@@ -494,9 +494,19 @@ def _scoped_stack_leader_clause(character_id, candidate_ids: list[int] | None):
             select(sib_face.id).where(sib_face.picture_id == sibling.id)
         )
 
+    # ``deleted IS NOT 1`` rather than ``deleted IS 0`` on purpose. As an
+    # equality term ``deleted`` lets the planner serve the sibling lookup from
+    # ``ix_picture_deleted``, which ties on cost with ``ix_picture_stack_id``
+    # (no ``sqlite_stat1``, see ``Picture.__table_args__``) and wins or loses
+    # on index-creation order. When it won, every face row walked every live
+    # picture: 6.5 s for one page on a 12k-picture library, 0.13 s the other
+    # way. ``IS NOT`` is not an indexable term, so only the stack_id indexes
+    # can answer the correlated lookup, whichever order the indexes were built
+    # in. (``~sibling.deleted`` does not do this: SQLAlchemy compiles it to
+    # ``deleted = 0`` for SQLite, which is indexable again.)
     conditions = [
         sibling.stack_id == Picture.stack_id,
-        sibling.deleted.is_(False),
+        sibling.deleted.is_not(True),
         sibling_in_scope,
     ]
     if candidate_ids is not None:

--- a/tests/test_finder_query_cost.py
+++ b/tests/test_finder_query_cost.py
@@ -253,6 +253,58 @@ def test_character_features_rollup_is_served_by_its_partial_index(tmp_path):
         )
 
 
+def test_likeness_stack_leader_sibling_lookup_uses_the_stack_index(tmp_path):
+    """The scoped-leader clause's correlated sibling lookup is keyed on stack_id.
+
+    The sibling row is narrowed by ``stack_id`` and by ``deleted``. Written as
+    two equality terms, ``ix_picture_stack_id`` and ``ix_picture_deleted`` tie
+    (no ``sqlite_stat1``) and creation order decides. When ``ix_picture_deleted``
+    won, each face row walked every live picture: one CHARACTER_LIKENESS page
+    cost 6.5 s on a 12k-picture library against 0.13 s. The clause now writes
+    the deleted test as ``deleted IS NOT 1``, which no index can serve, so the
+    only candidates left are the stack_id indexes and the plan cannot flip.
+
+    ``metadata.create_all()`` builds the indexes in set order, so a single
+    fresh database is a coin flip and would pass half the time without the
+    fix. The two competing indexes are therefore rebuilt in BOTH orders and
+    the plan asserted after each.
+    """
+    from sqlmodel import select
+
+    from pixlstash.scoring.character_likeness import _scoped_stack_leader_clause
+
+    def rebuild(session: Session, *ddl: str):
+        for statement in ddl:
+            session.connection().exec_driver_sql(statement)
+        session.commit()
+
+    deleted_last = (
+        "DROP INDEX ix_picture_deleted",
+        "CREATE INDEX ix_picture_deleted ON picture (deleted)",
+    )
+    stack_last = (
+        "DROP INDEX ix_picture_stack_id",
+        "CREATE INDEX ix_picture_stack_id ON picture (stack_id)",
+    )
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        _seed(vault, tmp_path, count=4, with_faces=True)
+        statement = (
+            select(Picture.id)
+            .where(Picture.deleted.is_(False))
+            .where(_scoped_stack_leader_clause("ALL", None))
+            .compile(vault.db._engine, compile_kwargs={"literal_binds": True})
+        )
+        for order in (deleted_last, stack_last):
+            vault.db.run_task(rebuild, *order)
+            plan = _explain(vault, str(statement), ())
+            sibling_lines = [line for line in plan if "picture_1" in line]
+            assert sibling_lines, f"no sibling lookup in plan {plan}"
+            assert all("ix_picture_stack_id" in line for line in sibling_lines), (
+                f"sibling lookup is not keyed on stack_id; plan was {plan}"
+            )
+
+
 # ── column width ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_likeness_and_face_search.py
+++ b/tests/test_likeness_and_face_search.py
@@ -312,7 +312,12 @@ def test_character_likeness_stack_scoped_leader_listing_and_count():
                 },
             )
             assert resp.status_code == 200, resp.text
-            listed_ids = [row["id"] for row in resp.json()]
+            rows = resp.json()
+            listed_ids = [row["id"] for row in rows]
+            # The grid's likeness pill reads this field. ``GridPicture`` is the
+            # enforced response model and drops any key it does not declare,
+            # which is how the pill went missing.
+            assert all(isinstance(row.get("character_likeness"), float) for row in rows)
 
             # Stack 1 is represented by exactly its in-scope member b (the
             # stack must not be dropped), stack 2 by its actual leader d, and
@@ -367,6 +372,10 @@ def test_pictures_count_character_likeness_matches_stream():
             stream = resp.json()
             assert stream["done"] is True
             assert len(stream["pictures"]) == likeness_count == 3
+            assert all(
+                isinstance(row.get("character_likeness"), float)
+                for row in stream["pictures"]
+            )
 
             # The normal (sort-less) count the frontend grid uses must agree
             # with the likeness count for the same character view.


### PR DESCRIPTION
Sorting by similarity to a person took 6.5 s per page on a 12k-picture library after upgrading to 1.11.0rc1, and the grid's likeness pill had been missing since v1.10.0.

- The scoped stack-leader clause's correlated sibling lookup filtered on `deleted` as an equality term. With no `sqlite_stat1` the planner ties `ix_picture_deleted` against `ix_picture_stack_id` and breaks the tie on index-creation order; the v1.11 migrations flipped it and every face row walked every live picture. The deleted test is now `deleted IS NOT 1`, which no index can serve, so only the stack_id indexes remain candidates. Measured on a 12k-picture library: 6.46 s to 0.16 s for a 200-row page, 6.52 s to 0.31 s for 5000 rows. The new plan test rebuilds the two indexes in both orders and fails without the fix.
- `GridPicture` is the enforced response model and never declared `character_likeness`, so the listing and stream routes dropped it. One field added; both likeness tests now assert it.
- Migration 0113 nulls `size_bin_index` where `likeness_parameters` is NULL. That row shape came out of a restored snapshot, is invisible to the parameters finder and rejected by the pairs batch, and left Likeness Pairs stuck two short of its total.

Not in this PR: with a filter active the candidate id list lands inside the same correlated subquery and costs about 1.9 s. Separate change.

https://claude.ai/code/session_01H7BtzHGungFesWpqn5Ns2g