### PR TITLE
Explain a library from a newer PixlStash in plain words, with a way out

### DIFF
--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -721,13 +721,17 @@ def newer_library_message(unknown: list[str], *, library: str) -> str:
         this = f"This version ({package_version('pixlstash')})"
     except PackageNotFoundError:
         this = "This version"
-    latest = max(known_vault_revisions(), default="none")
+
+    def number(rev: str) -> str:
+        return rev.split("_", 1)[0]  # "0113_reset_..." -> "0113"
+
+    latest = number(max(known_vault_revisions(), default="none"))
     return (
         f"{library} was last opened by a newer PixlStash. {this} cannot "
         "read it; nothing has been changed.\n"
         f"  Update PixlStash and try again: {RELEASES_URL}\n"
-        f"  (Library revision {', '.join(unknown)}; this version knows up to "
-        f"{latest}.)"
+        f"  (Library revision {', '.join(map(number, unknown))}; this version "
+        f"knows up to {latest}.)"
     )
 
 

--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version as package_version
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Optional
@@ -693,6 +694,43 @@ def _opened_first(connection, sql: str, params: tuple = ()):
     return dict(row) if isinstance(row, sqlite3.Row) else row
 
 
+RELEASES_URL = "https://github.com/pikselkroken/pixlstash/releases/latest"
+_MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations" / "versions"
+
+
+def known_vault_revisions() -> set[str]:
+    """Return every Alembic revision id this build understands."""
+    pattern = re.compile(r'^revision(?:\s*:\s*[^=]+)?\s*=\s*["\']([^"\']+)', re.M)
+    revisions: set[str] = set()
+    for path in _MIGRATIONS_DIR.glob("*.py"):
+        if path.stem.startswith("__"):
+            continue
+        match = pattern.search(path.read_text(encoding="utf-8"))
+        if match:
+            revisions.add(match.group(1))
+    return revisions
+
+
+def newer_library_message(unknown: list[str], *, library: str) -> str:
+    """Explain a vault written by a later build than this one, in three lines.
+
+    *library* names the vault as the reader knows it. The revision ids stay
+    in, last, because a bug report needs them.
+    """
+    try:
+        this = f"This version ({package_version('pixlstash')})"
+    except PackageNotFoundError:
+        this = "This version"
+    latest = max(known_vault_revisions(), default="none")
+    return (
+        f"{library} was last opened by a newer PixlStash. {this} cannot "
+        "read it; nothing has been changed.\n"
+        f"  Update PixlStash and try again: {RELEASES_URL}\n"
+        f"  (Library revision {', '.join(unknown)}; this version knows up to "
+        f"{latest}.)"
+    )
+
+
 def _opened_revision_rows(connection) -> list[str]:
     try:
         exists = _opened_first(
@@ -765,21 +803,13 @@ def prevalidate_opened_library(connection, library: Library) -> None:
             f"contains {observed}, but this registration expects {library.uuid}."
         )
 
-    known = set()
-    revision_pattern = re.compile(
-        r'^revision(?:\s*:\s*[^=]+)?\s*=\s*["\']([^"\']+)', re.M
-    )
-    versions = Path(__file__).resolve().parent.parent / "migrations" / "versions"
-    for path in versions.glob("*.py"):
-        match = revision_pattern.search(path.read_text(encoding="utf-8"))
-        if match:
-            known.add(match.group(1))
+    known = known_vault_revisions()
     unknown = [rev for rev in _opened_revision_rows(connection) if rev not in known]
     if unknown:
         raise HubBootstrapError(
-            "This library was last opened by a newer version of PixlStash "
-            f"(database revision {', '.join(unknown)}). Update PixlStash before "
-            "opening it. Nothing has been changed."
+            newer_library_message(
+                unknown, library=f'The library "{library.name}" ({library.path})'
+            )
         )
 
 

--- a/pixlstash/services/library_backup_service.py
+++ b/pixlstash/services/library_backup_service.py
@@ -176,7 +176,8 @@ def _validate_vault_connection(
         required_tables={"picture", "alembic_version"},
     )
     rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
-    unknown = [row[0] for row in rows if row[0] not in known_vault_revisions()]
+    known = known_vault_revisions()
+    unknown = [row[0] for row in rows if row[0] and row[0] not in known]
     if unknown:
         raise BackupError(newer_library_message(unknown, library=label))
     if library.vault_uuid is not None:

--- a/pixlstash/services/library_backup_service.py
+++ b/pixlstash/services/library_backup_service.py
@@ -45,7 +45,7 @@ from tqdm import tqdm
 from pixlstash.hub.registry import VAULT_FILENAME, Library
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.system_utils import space_shortfall
-from pixlstash.services.library_switch_service import known_vault_revisions
+from pixlstash.hub.bootstrap import known_vault_revisions, newer_library_message
 from pixlstash.services.portable_identity import (
     PortableIdentityScrubError,
     sanitize_historical_snapshots,
@@ -178,9 +178,7 @@ def _validate_vault_connection(
     rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     unknown = [row[0] for row in rows if row[0] not in known_vault_revisions()]
     if unknown:
-        raise BackupError(
-            f"{label} has an unsupported schema revision: {', '.join(unknown)}."
-        )
+        raise BackupError(newer_library_message(unknown, library=label))
     if library.vault_uuid is not None:
         try:
             row = conn.execute(

--- a/pixlstash/services/library_switch_service.py
+++ b/pixlstash/services/library_switch_service.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-import re
 import shutil
 import threading
 from enum import Enum
@@ -40,6 +39,8 @@ from pixlstash.hub.registry import (
 )
 from pixlstash.pixl_logging import get_logger
 from pixlstash.hub.bootstrap import (
+    known_vault_revisions,
+    newer_library_message,
     registered_vault_path,
 )
 from pixlstash.routes.pictures import clear_stats_cache
@@ -99,19 +100,6 @@ def _bring_up(vault, label: str) -> None:
     vault.start()
 
 
-def known_vault_revisions() -> set[str]:
-    """Return every Alembic revision id this build understands."""
-    revisions: set[str] = set()
-    pattern = re.compile(r'^revision(?:\s*:\s*[^=]+)?\s*=\s*["\']([^"\']+)', re.M)
-    for path in _MIGRATIONS_DIR.glob("*.py"):
-        if path.stem.startswith("__"):
-            continue
-        match = pattern.search(path.read_text(encoding="utf-8"))
-        if match:
-            revisions.add(match.group(1))
-    return revisions
-
-
 def assert_vault_not_newer(vault_path: str) -> None:
     """Refuse a vault whose schema this build has never heard of.
 
@@ -144,9 +132,7 @@ def assert_vault_not_newer(vault_path: str) -> None:
     unknown = [row[0] for row in rows if row[0] and row[0] not in known]
     if unknown:
         raise LibrarySwitchError(
-            f"This library was last opened by a newer version of PixlStash "
-            f"(database revision {', '.join(unknown)}). Update PixlStash before "
-            "switching to it. Nothing has been changed."
+            newer_library_message(unknown, library=f"The library at {vault_path}")
         )
 
 

--- a/tests/test_library_switch.py
+++ b/tests/test_library_switch.py
@@ -294,7 +294,9 @@ class TestFailingToSwitch:
         with pytest.raises(LibrarySwitchError) as excinfo:
             server.library_switch.switch_to(library.uuid)
 
-        assert "newer version of PixlStash" in str(excinfo.value)
+        assert "newer PixlStash" in str(excinfo.value)
+        assert "releases/latest" in str(excinfo.value)
+        assert "9999_from_the_future" in str(excinfo.value)
         assert server.vault is before_vault
         assert server.library_switch.state is SwitchState.READY
 

--- a/tests/test_library_switch.py
+++ b/tests/test_library_switch.py
@@ -296,7 +296,7 @@ class TestFailingToSwitch:
 
         assert "newer PixlStash" in str(excinfo.value)
         assert "releases/latest" in str(excinfo.value)
-        assert "9999_from_the_future" in str(excinfo.value)
+        assert "revision 9999;" in str(excinfo.value)
         assert server.vault is before_vault
         assert server.library_switch.state is SwitchState.READY
 


### PR DESCRIPTION
## What

Seen on v1.11.0rc3 after a develop run had migrated the shared library to 0113:

```
PixlStash could not prepare its library:
- This library was last opened by a newer version of PixlStash (database revision 0113_reset_size_bin_without_likeness_parameters). Update PixlStash before opening it. Nothing has been changed.
```

The startup guard, the library switch and the snapshot restore each had their own variant of that line. They now share one builder in `hub.bootstrap` and print:

```
PixlStash could not prepare its library:
- The library "pixlstash-images" at /home/me/Pictures/pixlstash-images was last opened by a newer version of PixlStash, and this version (1.11.0rc3) cannot read it safely. Nothing has been changed.
  What to do:
  - Update PixlStash to the latest release, then open it again:
    https://github.com/pikselkroken/pixlstash/releases/latest
  - Or, if you went back to an older PixlStash on purpose, restore a backup of this library that was made with the version you are running now.
  For a bug report: the library is at database revision 0113_reset_size_bin_without_likeness_parameters; this version (1.11.0rc3) knows revisions up to 0112_add_image_embedding_probe_indexes.
```

The desktop shell already shows the backend's stderr tail in its failure dialog, so this is what the user sees there too.

## Also

- `known_vault_revisions` moved to `hub.bootstrap`, which had its own copy of the scanner; the service re-exports it so existing imports keep working.

## Tests

`test_library_switch`, `test_library_restore_cli`, `test_picture_is_video`, `test_library_backup*`, `test_hub_bootstrap*` pass locally. The switch test now also asserts the release link and the revision id are in the message.