### PR TITLE
Theme the Tag Confidence dropdown list in the stats sidebar

### DIFF
--- a/frontend/src/components/panels/StatsSidebar.vue
+++ b/frontend/src/components/panels/StatsSidebar.vue
@@ -2384,6 +2384,13 @@ defineExpose({ focusTasksTab });
   outline: none;
   appearance: none;
 }
+/* The popup list is native chrome: without an explicit fill it paints the
+   OS default (white) under the select's on-surface text in dark mode. */
+.conf-tag-select option,
+.conf-tag-select optgroup {
+  background-color: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+}
 .conf-tag-select:hover {
   border-color: rgba(var(--v-theme-on-surface), 0.3);
 }


### PR DESCRIPTION
In dark mode the Tag Confidence tag picker in the stats sidebar opened a white popup with light text. The native option list has no fill of its own and falls back to the OS default; the select's own background is a translucent wash that never reaches the popup.

Fix: give `option` and `optgroup` under `.conf-tag-select` the theme surface and on-surface colours, the same approach `TagHealthBoard` and `NewReviewDialog` use for their native selects.

CSS-only change; prettier and eslint pass.