### PR TITLE
Drop a stale stack refresh instead of re-expanding collapsed stacks

### DIFF
--- a/frontend/src/composables/useStackOrdering.js
+++ b/frontend/src/composables/useStackOrdering.js
@@ -18,7 +18,11 @@ import {
   shiftRangesForDelta,
 } from "../utils/utils.js";
 import { getPictureId } from "../utils/media.js";
-import { isLockedRefusal, lockedSetsSentence, lockedSets } from "../utils/dedup.js";
+import {
+  isLockedRefusal,
+  lockedSetsSentence,
+  lockedSets,
+} from "../utils/dedup.js";
 import {
   getStack,
   listStackPictures,
@@ -637,7 +641,10 @@ export function useStackOrdering(
   }
 
   async function refreshExpandedStacksAfterFetch() {
-    const expanded = Array.from(expandedStackIds.value || []);
+    // Every mutation of expandedStackIds assigns a fresh Set, so identity is
+    // enough to tell whether an expand/collapse landed during the await below.
+    const startIds = expandedStackIds.value;
+    const expanded = Array.from(startIds || []);
     if (!expanded.length) return;
     const fetchStart = visibleStart.value;
     const fetchEnd = visibleEnd.value;
@@ -673,6 +680,13 @@ export function useStackOrdering(
         })),
       ),
     );
+
+    if (expandedStackIds.value !== startIds) {
+      // A collapse (or another expand) superseded this refresh while the
+      // members were loading; writing nextExpanded back would re-expand
+      // stacks the user just collapsed.
+      return;
+    }
 
     for (const { stackId, fallbackCount, loaded } of fetchResults) {
       if (loaded !== false) {


### PR DESCRIPTION
## What

The e2e job on #1157 failed twice in `stacks.spec.js`: after **Expand all** then **Collapse all**, four cards still carried `.image-card-stack-expanded` and the snapshot showed **Expand all** disabled, i.e. the expanded-id set had been written back after the collapse.

`refreshExpandedStacksAfterFetch` snapshots `expandedStackIds` into `nextExpanded`, awaits the member fetches, then assigns `nextExpanded` back if the sizes differ. A collapse landing during the await is therefore overwritten. It only shows when the member fetch is slow, which is why the same base passed on #1156.

## Fix

Capture the Set at the start and, after the await, return if `expandedStackIds.value` is no longer that same object. Every mutation in the composable assigns a fresh Set, so identity is sufficient. Same pattern `toggleStackExpand` already uses with its `has(stackId)` re-check after its await.

## Tests

`stacks.spec.js` passes locally 3/3 with `--repeat-each 3`. No unit test: the composable has no harness and needs ~20 injected refs and callbacks; the e2e spec is the check that caught it.