### PR TITLE
List the backup command in the Libraries CLI dialog

### DIFF
--- a/frontend/src/components/settings/LibrariesSection.test.js
+++ b/frontend/src/components/settings/LibrariesSection.test.js
@@ -655,6 +655,7 @@ describe("teaching the CLI", () => {
     // the poorer of the two, which it is not.
     expect(wrapper.text()).toContain("rename <name> <new name>");
     expect(wrapper.text()).toContain("No files are removed");
+    expect(wrapper.text()).toContain("backup <name> <destination>");
   });
 
   it("keeps the commands behind a button so the pane stays short", async () => {

--- a/frontend/src/components/settings/LibrariesSection.vue
+++ b/frontend/src/components/settings/LibrariesSection.vue
@@ -120,6 +120,12 @@ const cliCommands = computed(() => {
       description:
         "Forget one. No files are removed and nothing inside the folder changes.",
     },
+    {
+      verb: "backup",
+      syntax: "backup <name> <destination>",
+      description:
+        "Write the library and the hub to one archive, even while it is open. Read it back with restore.",
+    },
   ].map((item) => ({ ...item, command: `${base} ${item.syntax}` }));
 });
 

--- a/frontend/src/components/settings/LibraryLayoutDialog.test.js
+++ b/frontend/src/components/settings/LibraryLayoutDialog.test.js
@@ -511,6 +511,37 @@ describe("LibraryLayoutDialog", () => {
     );
   });
 
+  it("says undoing, with an indeterminate bar, while the undo runs", async () => {
+    // Undo is one request. Rendering it through the per-pass "Moving X of Y"
+    // template read the finished run's count against a post-run preview of 0.
+    runLayoutMigrationPass.mockResolvedValue(PASS_DONE);
+    let finishUndo;
+    undoBatchById.mockReturnValue(
+      new Promise((resolve) => {
+        finishUndo = resolve;
+      }),
+    );
+
+    const wrapper = mountDialog();
+    await flushPromises();
+    await buttonWith(wrapper, "Move them now").trigger("click");
+    await flushPromises();
+    await buttonWith(wrapper, "Undo").trigger("click");
+    await flushPromises();
+
+    const text = wrapper.find(".layout-consequence__num").text();
+    expect(text).toContain("Undoing…");
+    expect(text).not.toContain("of 0");
+    expect(wrapper.find("progress").attributes("value")).toBeUndefined();
+    expect(buttonWith(wrapper, "Stop after this pass")).toBeFalsy();
+
+    finishUndo({ operations: [] });
+    await flushPromises();
+    expect(wrapper.find(".layout-consequence__num").text()).not.toContain(
+      "Undoing",
+    );
+  });
+
   it("will not move on a stale count, and says counting instead of a number", async () => {
     // The bar carries the number beside the verb, so a modal confirm would be a
     // second yes for one gesture. The button being inert while the number does

--- a/frontend/src/components/settings/LibraryLayoutDialog.vue
+++ b/frontend/src/components/settings/LibraryLayoutDialog.vue
@@ -306,6 +306,8 @@ const previewing = ref(false);
 /** The count on the bar no longer describes the layout on screen. */
 const countStale = ref(true);
 const migrating = ref(false);
+/** Undo is one request with no per-pass progress, so its bar is indeterminate. */
+const undoing = ref(false);
 const migrationError = ref("");
 /** `{movedCount, batchId}` once a run finishes, so Undo has something to undo. */
 const lastRun = ref(null);
@@ -527,6 +529,7 @@ async function undoMigration() {
   const batchId = lastRun.value?.batchId;
   if (!batchId) return;
   migrating.value = true;
+  undoing.value = true;
   try {
     // `undoBatchById` answers `null` rather than throwing when it refuses - a
     // read-only session, another operation already in flight, or a failure it
@@ -543,6 +546,7 @@ async function undoMigration() {
     }
   } finally {
     migrating.value = false;
+    undoing.value = false;
     countStale.value = true;
     await refreshPreview();
   }
@@ -768,17 +772,26 @@ function netDelta(row) {
             role="status"
             aria-live="polite"
           >
-            <div class="layout-consequence__num">
-              Moving… {{ movedSoFar.toLocaleString() }} of
-              {{ wouldMove.toLocaleString() }}
-            </div>
-            <progress
-              class="layout-consequence__bar"
-              :max="wouldMove || 1"
-              :value="movedSoFar"
-            />
+            <template v-if="undoing">
+              <div class="layout-consequence__num">
+                Undoing… {{ lastRun.movedCount.toLocaleString() }}
+                {{ lastRun.movedCount === 1 ? "picture" : "pictures" }}
+              </div>
+              <progress class="layout-consequence__bar" />
+            </template>
+            <template v-else>
+              <div class="layout-consequence__num">
+                Moving… {{ movedSoFar.toLocaleString() }} of
+                {{ wouldMove.toLocaleString() }}
+              </div>
+              <progress
+                class="layout-consequence__bar"
+                :max="wouldMove || 1"
+                :value="movedSoFar"
+              />
+            </template>
           </div>
-          <div class="layout-consequence__buttons">
+          <div v-if="!undoing" class="layout-consequence__buttons">
             <AppButton
               variant="danger"
               size="sm"

--- a/frontend/src/components/settings/LibraryLayoutDialog.vue
+++ b/frontend/src/components/settings/LibraryLayoutDialog.vue
@@ -652,7 +652,7 @@ function netDelta(row) {
       <div class="layout-unfiled">
         <v-checkbox
           v-model="sweepUnfiled"
-          label="Also move pictures nothing files into"
+          label="Move unassigned pictures into"
           density="compact"
           hide-details
           :disabled="migrating"
@@ -663,7 +663,7 @@ function netDelta(row) {
           variant="outlined"
           hide-details
           class="layout-unfiled__name"
-          aria-label="Folder for pictures nothing files"
+          aria-label="Folder for unassigned pictures"
           title="Where a picture with no project, person, set or tag is written"
           :disabled="migrating"
           @update:model-value="setUnfiled"


### PR DESCRIPTION
The "Show the commands" dialog in Settings > Libraries listed list, create, attach, rename and detach but not backup. Adds the backup verb with its syntax and a one-line description pointing at restore.