### PR TITLE
Fix task-manager caption count, grid blanking and Windows VRAM readout (#1162)

### DIFF
--- a/docs/authz-coverage-matrix.md
+++ b/docs/authz-coverage-matrix.md
@@ -312,6 +312,8 @@ Rationale column is empty where it equals the policy-meaning table above (e.g. `
 |---|---|---|---|---|
 | POST | `/api/v1/pictures/{id}/reset_description` | picture_scoped | id=id |  |
 | POST | `/api/v1/pictures/{id}/reset_tags` | picture_scoped | id=id |  |
+| POST | `/api/v1/pictures/reset_description` | picture_scoped | body=picture_ids |  |
+| POST | `/api/v1/pictures/reset_tags` | picture_scoped | body=picture_ids |  |
 | GET | `/api/v1/pictures/{id}/tag_predictions` | picture_scoped | id=id |  |
 | POST | `/api/v1/pictures/{id}/tag_predictions/delete` | picture_scoped | id=id |  |
 | POST | `/api/v1/pictures/{id}/tag_predictions/{tag}/confirm` | picture_scoped | id=id |  |

--- a/frontend/src/api/pictures.js
+++ b/frontend/src/api/pictures.js
@@ -553,6 +553,33 @@ export async function resetPictureDescription(
 }
 
 /**
+ * Re-run tagging on many pictures in one request. The backend marks them and
+ * the background tagger batches them; nothing is queued per picture.
+ * @param {Array<number|string>} pictureIds
+ * @param {Object} [body] - `{ model }` to pick a tagger.
+ * @returns {Promise<Object>} the response body: `count` marked.
+ */
+export async function resetPicturesTags(pictureIds, body = {}) {
+  return unwrap(apiClient.post(
+    "/pictures/reset_tags",
+    { ...body, picture_ids: pictureIds },
+  ));
+}
+
+/**
+ * Re-run captioning on many pictures in one request; see `resetPicturesTags`.
+ * @param {Array<number|string>} pictureIds
+ * @param {Object} [body] - `{ model }` to pick a captioner.
+ * @returns {Promise<Object>} the response body: `count` marked.
+ */
+export async function resetPicturesDescriptions(pictureIds, body = {}) {
+  return unwrap(apiClient.post(
+    "/pictures/reset_description",
+    { ...body, picture_ids: pictureIds },
+  ));
+}
+
+/**
  * Remove tags the model could not possibly be right about.
  * @param {Array<number|string>} pictureIds
  * @param {Object} filters - the scope the caller is viewing.

--- a/frontend/src/components/panels/TagGestureBatch.test.js
+++ b/frontend/src/components/panels/TagGestureBatch.test.js
@@ -29,7 +29,7 @@ const tagsApi = vi.hoisted(() => ({
 
 vi.mock("../../api/tags", () => tagsApi);
 vi.mock("../../api/pictures", () => ({
-  resetPictureTags: vi.fn(async () => ({})),
+  resetPicturesTags: vi.fn(async () => ({})),
 }));
 vi.mock("../../api/taggers", () => ({
   listTaggers: vi.fn(async () => ({ plugins: [] })),

--- a/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
+++ b/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
@@ -27,7 +27,7 @@ const tagsApi = vi.hoisted(() => ({
 
 vi.mock("../../api/tags", () => tagsApi);
 vi.mock("../../api/pictures", () => ({
-  resetPictureTags: vi.fn(async () => ({})),
+  resetPicturesTags: vi.fn(async () => ({})),
 }));
 vi.mock("../../api/taggers", () => ({
   listTaggers: vi.fn(async () => ({ plugins: [] })),

--- a/frontend/src/components/panels/TbTagPanel.vue
+++ b/frontend/src/components/panels/TbTagPanel.vue
@@ -339,7 +339,7 @@ import {
   confirmTagPrediction,
   rejectTagPrediction,
 } from "../../api/tags";
-import { resetPictureTags } from "../../api/pictures";
+import { resetPicturesTags } from "../../api/pictures";
 import { listTaggers } from "../../api/taggers";
 import { getUserConfig } from "../../api/config";
 import { isSentinelTag, formatSentinelTag } from "../../utils/tags.js";
@@ -762,12 +762,7 @@ async function generateTagsForAll(model = null) {
   generateTagsError.value = "";
   generateTagsSuccess.value = "";
   try {
-    const body = model ? { model } : {};
-    await Promise.all(
-      ids.map((id) =>
-        resetPictureTags(id, body),
-      ),
-    );
+    await resetPicturesTags(ids, model ? { model } : {});
     const suffix = model ? ` with ${model}` : "";
     generateTagsSuccess.value = `Queued ${ids.length} image${ids.length !== 1 ? "s" : ""} for re-tagging${suffix}`;
     emit("tags-applied", { pictureIds: ids, action: "reset" });

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1142,7 +1142,7 @@
           @create-stacks-from-groups="createStacksFromSelectedGroups"
           @run-plugin="handlePluginRunRequest"
           @comfyui-run="handleComfyuiRun"
-          @tags-applied="debouncedFetchAllGridImages({ force: true })"
+          @tags-applied="handleTagsApplied"
           @auto-tag="handleAutoTag"
           @generate-description="handleGenerateDescription"
           @reverse-image-search="handleReverseImageSearch"
@@ -1267,8 +1267,8 @@ import {
   detectPictures,
   listPicturePlugins,
   runPicturePlugin,
-  resetPictureTags,
-  resetPictureDescription,
+  resetPicturesTags,
+  resetPicturesDescriptions,
   clearImpossibleTags,
   restoreImpossibleTags,
   startExport,
@@ -1782,19 +1782,25 @@ async function fetchTaggerPlugins() {
   }
 }
 
+function handleTagsApplied(payload) {
+  // A reset only marks pictures for the background tagger; the grid shows
+  // nothing of that until the tagger's own tags_changed event lands, so the
+  // reload that blanked the grid buys nothing here (#1162).
+  if (payload?.action === "reset") return;
+  debouncedFetchAllGridImages({ force: true });
+}
+
 async function handleAutoTag({ model } = {}) {
   const ids = selectedImageIds.value
     .map((id) => Number(id))
     .filter((id) => Number.isFinite(id) && id > 0);
   if (!ids.length || !props.backendUrl) return;
   try {
-    const body = model ? { model } : {};
-    await Promise.all(
-      ids.map((id) =>
-        resetPictureTags(id, body),
-      ),
-    );
-    debouncedFetchAllGridImages({ force: true });
+    // One request marks the whole selection. No grid reload: the backend's
+    // origin-stamped tags_changed event already refreshes a tag-filtered grid,
+    // and reloading every card for a change that touches none of their
+    // thumbnails is what blanked the grid (#1162).
+    await resetPicturesTags(ids, model ? { model } : {});
   } catch (err) {
     console.error("Auto-tag failed:", err);
   }
@@ -1806,13 +1812,10 @@ async function handleGenerateDescription({ model } = {}) {
     .filter((id) => Number.isFinite(id) && id > 0);
   if (!ids.length || !props.backendUrl) return;
   try {
-    const body = model ? { model } : {};
-    await Promise.all(
-      ids.map((id) =>
-        resetPictureDescription(id, body),
-      ),
-    );
-    debouncedFetchAllGridImages({ force: true });
+    // One request marks the whole selection; each finished caption arrives
+    // over descriptions_changed and refreshes its own card. No grid reload:
+    // that is what blanked the grid (#1162).
+    await resetPicturesDescriptions(ids, model ? { model } : {});
   } catch (err) {
     console.error("Generate description failed:", err);
   }

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -969,6 +969,10 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
     ("POST", "/api/v1/pictures/{id}/reset_description"): RoutePolicy(
         _PIC, id_param="id"
     ),
+    ("POST", "/api/v1/pictures/reset_tags"): RoutePolicy(_PIC, body_ids="picture_ids"),
+    ("POST", "/api/v1/pictures/reset_description"): RoutePolicy(
+        _PIC, body_ids="picture_ids"
+    ),
     ("GET", "/api/v1/tagger/label-thresholds"): RoutePolicy(_ANY),
     # ── stacks.py ───────────────────────────────────────────────────────────
     (

--- a/pixlstash/routes/tag_predictions.py
+++ b/pixlstash/routes/tag_predictions.py
@@ -21,6 +21,20 @@ class ResetTagsRequest(BaseModel):
     model: str | None = None
 
 
+class BulkResetRequest(BaseModel):
+    """Request body for the multi-picture reset_tags / reset_description endpoints."""
+
+    picture_ids: list[int]
+    model: str | None = None
+
+
+class BulkResetResponse(BaseModel):
+    """How many pictures a bulk reset queued."""
+
+    status: str
+    count: int
+
+
 class TagPredictionItemResponse(BaseModel):
     """A single stored tag prediction."""
 
@@ -346,6 +360,58 @@ def create_router(server) -> APIRouter:
         if not found:
             raise HTTPException(status_code=404, detail="Picture not found")
         return {"status": "reset"}
+
+    @router.post(
+        "/pictures/reset_tags",
+        summary="Reset tags for many pictures",
+        description=(
+            "The multi-picture form of /pictures/{id}/reset_tags: one transaction "
+            "drops every listed picture's non-manual predictions and tags and "
+            "restores the pending-retag sentinel. The background tagger then "
+            "processes them in batches; no per-picture task is queued."
+        ),
+        response_model=BulkResetResponse,
+    )
+    def reset_pictures_tags(request: Request, payload: BulkResetRequest):
+        origin_client_id = getattr(request.state, "origin_client_id", None)
+        ids = sorted({int(pid) for pid in payload.picture_ids if int(pid) > 0})
+        if not ids:
+            return {"status": "reset", "count": 0}
+        reset_ids = tag_prediction_service.reset_pictures_tags(
+            server.vault,
+            ids,
+            engine_name=payload.model,
+            origin_client_id=origin_client_id,
+        )
+        if reset_ids:
+            server.vault.notify(
+                EventType.CHANGED_TAGS,
+                {
+                    "picture_ids": reset_ids,
+                    "origin_client_id": origin_client_id,
+                    "change_kind": "updated",
+                },
+            )
+        return {"status": "reset", "count": len(reset_ids)}
+
+    @router.post(
+        "/pictures/reset_description",
+        summary="Reset descriptions for many pictures",
+        description=(
+            "The multi-picture form of /pictures/{id}/reset_description: one "
+            "transaction marks every listed picture for re-captioning, and the "
+            "background captioner processes them in batches. Pass 'model' to "
+            "pick the description plugin."
+        ),
+        response_model=BulkResetResponse,
+    )
+    def reset_pictures_descriptions(request: Request, payload: BulkResetRequest):
+        origin_client_id = getattr(request.state, "origin_client_id", None)
+        ids = [int(pid) for pid in payload.picture_ids if int(pid) > 0]
+        count = server.vault.reset_descriptions(
+            ids, engine_name=payload.model, origin_client_id=origin_client_id
+        )
+        return {"status": "reset", "count": count}
 
     @router.get(
         "/tagger/label-thresholds",

--- a/pixlstash/services/config_service.py
+++ b/pixlstash/services/config_service.py
@@ -351,6 +351,8 @@ class HardwareMonitor:
                 pid = os.getpid()
                 used_bytes = 0
                 total_bytes = 0
+                process_listed = False
+                figure_seen = False
                 device_count = pynvml.nvmlDeviceGetCount()
                 for index in range(device_count):
                     handle = pynvml.nvmlDeviceGetHandleByIndex(index)
@@ -381,13 +383,20 @@ class HardwareMonitor:
                     for entry in processes:
                         if entry.pid != pid:
                             continue
+                        process_listed = True
                         used_gpu = getattr(entry, "usedGpuMemory", None)
                         if used_gpu is None:
                             continue
                         if used_gpu == getattr(pynvml, "NVML_VALUE_NOT_AVAILABLE", -1):
                             continue
+                        figure_seen = True
                         used_bytes += used_gpu
-                vram_collected = _set_vram_payload(payload, used_bytes, total_bytes)
+                # Windows (WDDM) lists the process but reports its memory as not
+                # available, which read as "0 / 31.8 GB" during CUDA inference
+                # (#1162). Leave that case to torch's allocator below; a process
+                # NVML does not list at all genuinely holds nothing.
+                if figure_seen or not process_listed:
+                    vram_collected = _set_vram_payload(payload, used_bytes, total_bytes)
             except Exception as exc:
                 logger.debug("Failed to read VRAM usage: %s", exc)
             finally:

--- a/pixlstash/services/tag_prediction_service.py
+++ b/pixlstash/services/tag_prediction_service.py
@@ -9,11 +9,12 @@ from typing import TYPE_CHECKING
 from sqlalchemy import delete
 from sqlmodel import Session, select
 
-from pixlstash.db_models import Tag
+from pixlstash.db_models import Picture, Tag
 from pixlstash.db_models.tag import make_tag_sentinel
 from pixlstash.db_models.tag_prediction import TagPrediction
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.set_lock_service import enforce_pictures_not_locked
+from pixlstash.utils.sql_chunking import chunked
 from pixlstash.utils.service.label_ledger import (
     NEG,
     POS,
@@ -289,11 +290,28 @@ def reset_picture_tags(
     engine_name: str | None = None,
     origin_client_id: str | None = None,
 ) -> None:
+    """Single-picture form of :func:`reset_pictures_tags`."""
+    reset_pictures_tags(
+        vault, [pic_id], engine_name=engine_name, origin_client_id=origin_client_id
+    )
+
+
+def reset_pictures_tags(
+    vault: "Vault",
+    pic_ids: list[int],
+    engine_name: str | None = None,
+    origin_client_id: str | None = None,
+) -> list[int]:
     """Atomically delete all non-manual predictions and all tags, then restore the sentinel.
+
+    One transaction for the whole list: a bulk retag used to be one request
+    and one urgent single-picture task per picture (#1162). Ids that name no
+    picture are skipped rather than failing the batch on the sentinel's
+    foreign key.
 
     Args:
         vault: Application vault, used for DB task dispatch.
-        pic_id: Picture ID to reset.
+        pic_ids: Picture IDs to reset.
         engine_name: Optional engine/plugin name to embed in the sentinel so the
             background tagger uses that specific engine for this picture.  Pass
             ``None`` to use the default ``active_tag_plugin`` setting.
@@ -304,26 +322,46 @@ def reset_picture_tags(
             that card instead of the deferred bulk-drain path.
     """
 
-    def _reset(session: Session) -> None:
-        # Reset deletes ALL confirmed Tag rows and drops a retag sentinel - a
-        # destructive rewrite of frozen label data. Refuse on a locked picture.
-        enforce_pictures_not_locked(session, [pic_id], "reset tags on a locked picture")
-        # Dropping the model's prediction rows removes their anomaly probabilities
-        # from the scorer's inputs, so the cached smart score goes stale.
-        with invalidate_on_anomaly_change(
-            session,
-            [pic_id],
-            context="reset picture tags",
-            registry=vault.interactive_rescore_registry,
-            origin_client_id=origin_client_id,
-        ):
-            session.exec(
-                delete(TagPrediction)
-                .where(TagPrediction.picture_id == pic_id)
-                .where(not_human_labeled())
-            )
-            session.exec(delete(Tag).where(Tag.picture_id == pic_id))
-            session.add(Tag(tag=make_tag_sentinel(engine_name), picture_id=pic_id))
-        session.commit()
+    ids = sorted({int(pid) for pid in pic_ids})
+    if not ids:
+        return []
+    sentinel = make_tag_sentinel(engine_name)
 
-    vault.db.run_task(_reset)
+    def _reset(session: Session) -> list[int]:
+        reset_ids: list[int] = []
+        # Chunked: a whole-library selection can exceed SQLite's parameter cap.
+        for chunk in chunked(ids):
+            # Reset deletes ALL confirmed Tag rows and drops a retag sentinel -
+            # a destructive rewrite of frozen label data. Refuse on a locked
+            # picture.
+            enforce_pictures_not_locked(
+                session, chunk, "reset tags on a locked picture"
+            )
+            present = list(
+                session.exec(select(Picture.id).where(Picture.id.in_(chunk))).all()
+            )
+            if not present:
+                continue
+            # Dropping the model's prediction rows removes their anomaly
+            # probabilities from the scorer's inputs, so the cached smart score
+            # goes stale.
+            with invalidate_on_anomaly_change(
+                session,
+                present,
+                context="reset picture tags",
+                registry=vault.interactive_rescore_registry,
+                origin_client_id=origin_client_id,
+            ):
+                session.exec(
+                    delete(TagPrediction)
+                    .where(TagPrediction.picture_id.in_(present))
+                    .where(not_human_labeled())
+                )
+                session.exec(delete(Tag).where(Tag.picture_id.in_(present)))
+                for pic_id in present:
+                    session.add(Tag(tag=sentinel, picture_id=pic_id))
+            reset_ids.extend(present)
+        session.commit()
+        return reset_ids
+
+    return vault.db.run_task(_reset)

--- a/pixlstash/task_runner.py
+++ b/pixlstash/task_runner.py
@@ -541,6 +541,13 @@ class TaskRunner:
         with self._active_task_lock:
             return [t for t in self._active_tasks.values() if t.type == task_type]
 
+    def has_active_gpu_tasks(self) -> bool:
+        """True while the GPU worker is executing a task."""
+        with self._active_task_lock:
+            return any(
+                t.queue_type == QueueType.GPU for t in self._active_tasks.values()
+            )
+
     def start(self):
         with self._lock:
             self._threads = [t for t in self._threads if t.is_alive()]

--- a/pixlstash/tasks/missing_description_finder.py
+++ b/pixlstash/tasks/missing_description_finder.py
@@ -60,23 +60,23 @@ class MissingDescriptionFinder(BaseTaskFinder):
         if not pictures:
             return None
 
-        # Group pictures by the engine embedded in their sentinel (None = use
-        # active_description_plugin).  Process only the first group per cycle so
-        # that interactive requests with a specific engine are not starved by a
-        # large backlog of NULL-description pictures.
-        groups: dict[str | None, list] = {}
-        for pic in pictures:
-            engine_name = (
-                parse_engine_from_description_sentinel(pic.description)
-                if is_description_sentinel(pic.description)
-                else None
-            )
-            groups.setdefault(engine_name, []).append(pic)
-
-        # Prefer explicit-engine (sentinel) requests first to avoid starvation
-        # by the NULL-description backlog.
-        first_engine = next((k for k in groups if k is not None), None)
-        first_pics = groups[first_engine] if first_engine is not None else groups[None]
+        # A sentinel is a user's reset (#1162): those pictures come first, as
+        # an urgent task, ahead of the NULL backlog the import left behind.
+        # Group them by the engine embedded in the sentinel (None = use
+        # active_description_plugin) and process one group per cycle.
+        requested = [
+            pic for pic in pictures if is_description_sentinel(pic.description)
+        ]
+        if requested:
+            groups: dict[str | None, list] = {}
+            for pic in requested:
+                engine_name = parse_engine_from_description_sentinel(pic.description)
+                groups.setdefault(engine_name, []).append(pic)
+            first_engine = next((k for k in groups if k is not None), None)
+            first_pics = groups[first_engine]
+        else:
+            first_engine = None
+            first_pics = pictures
         selected = self._filter_and_claim(first_pics, batch_limit)
         if not selected:
             return None
@@ -86,6 +86,7 @@ class MissingDescriptionFinder(BaseTaskFinder):
             workflow=engine.description_workflow,
             pictures=selected,
             engine_override=first_engine,
+            interactive=bool(requested),
         )
 
     @staticmethod
@@ -114,6 +115,8 @@ class MissingDescriptionFinder(BaseTaskFinder):
                 ),
                 not_locked,
             )
-            .order_by(Picture.id)
+            # Sentinels (a reset) ahead of NULLs (never captioned), then by id,
+            # so a request never waits behind the backlog.
+            .order_by(Picture.description.is_(None), Picture.id)
             .limit(limit)
         ).all()

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -13,7 +13,7 @@ from typing import Optional
 from concurrent.futures import Future
 
 from sqlmodel import Session, select
-from sqlalchemy import func, and_
+from sqlalchemy import func, and_, or_, update
 
 
 from .database import DBPriority, VaultDatabase
@@ -27,6 +27,9 @@ from .db_models import (
     Tag,
     TAG_SENTINEL_LIKE_PATTERN,
     TAG_SENTINEL_ESCAPE_CHAR,
+    DESCRIPTION_SENTINEL_LIKE_PATTERN,
+    DESCRIPTION_SENTINEL_ESCAPE_CHAR,
+    make_description_sentinel,
 )
 from .pixl_logging import get_logger
 from pixlstash.startup_permissions import mkdir_private
@@ -51,7 +54,11 @@ from pixlstash.tagger_plugins.registry import (
     get_tagger_plugin_manager,
     unload_loaded_tagger_plugins,
 )
-from pixlstash.services.set_lock_service import enforce_pictures_not_locked
+from pixlstash.services.set_lock_service import (
+    enforce_pictures_not_locked,
+    locked_picture_id_subquery,
+)
+from pixlstash.utils.sql_chunking import chunked
 from pixlstash.services.scrapheap_service import DEFAULT_RETENTION_DAYS
 from pixlstash.services.snapshot_service import SnapshotService
 from pixlstash.services.restore import RestoreService
@@ -866,8 +873,6 @@ class Vault:
         Returns:
             ``True`` if the picture was found and updated, ``False`` otherwise.
         """
-        from pixlstash.db_models import make_description_sentinel
-
         sentinel = make_description_sentinel(engine_name)
 
         def _set_sentinel(session: Session) -> bool:
@@ -896,6 +901,69 @@ class Vault:
         )
         self.redescribe_picture_interactive(picture_id, engine_name=engine_name)
         return True
+
+    def reset_descriptions(
+        self,
+        picture_ids: list[int],
+        engine_name: str | None = None,
+        origin_client_id: str | None = None,
+    ) -> int:
+        """Queue a fresh description pass for many pictures in one write.
+
+        Writes the ``__description::<engine>`` sentinel on every picture in one
+        transaction and wakes the planner; ``MissingDescriptionFinder`` then
+        captions them in properly sized batches. Unlike
+        :meth:`reset_description_interactive` no per-picture task is submitted:
+        one urgent single-image task per picture ran the captioner N times at
+        batch size 1 while the finder, which cannot tell those sentinels from
+        its own, captioned the same pictures a second time (#1162).
+
+        Args:
+            picture_ids: Primary keys of the pictures to reset.
+            engine_name: Optional plugin name to embed in the sentinel.
+            origin_client_id: Opaque ``X-Client-Id`` of the originating tab.
+
+        Returns:
+            How many pictures were found and reset.
+        """
+        ids = sorted({int(pid) for pid in picture_ids})
+        if not ids:
+            return 0
+        sentinel = make_description_sentinel(engine_name)
+
+        def _set_sentinels(session: Session) -> list[int]:
+            found: list[int] = []
+            # Chunked: "all pictures" can exceed SQLite's bound-parameter cap.
+            for chunk in chunked(ids):
+                enforce_pictures_not_locked(
+                    session, chunk, "reset the description of a locked picture"
+                )
+                present = list(
+                    session.exec(select(Picture.id).where(Picture.id.in_(chunk))).all()
+                )
+                if not present:
+                    continue
+                session.exec(
+                    update(Picture)
+                    .where(Picture.id.in_(present))
+                    .values(description=sentinel)
+                )
+                found.extend(present)
+            session.commit()
+            return found
+
+        reset_ids = self.db.run_task(_set_sentinels)
+        if not reset_ids:
+            return 0
+        self.notify(
+            EventType.CHANGED_PICTURES,
+            {
+                "picture_ids": reset_ids,
+                "origin_client_id": origin_client_id,
+                "change_kind": "updated",
+            },
+        )
+        return len(reset_ids)
 
     def generate_text_embedding(self, query: str) -> Optional[np.ndarray]:
         """
@@ -1692,10 +1760,23 @@ class Vault:
 
     @staticmethod
     def _count_missing_descriptions(session: Session) -> int:
+        # The same predicate MissingDescriptionFinder selects on: NULL or a
+        # ``__description::`` sentinel, and never a picture frozen by a locked
+        # set. A reset writes the sentinel, not NULL, so counting NULL alone
+        # read "N / N" through an entire regeneration (#1162).
         result = session.exec(
             select(func.count())
             .select_from(Picture)
-            .where(Picture.description.is_(None))
+            .where(
+                or_(
+                    Picture.description.is_(None),
+                    Picture.description.like(
+                        DESCRIPTION_SENTINEL_LIKE_PATTERN,
+                        escape=DESCRIPTION_SENTINEL_ESCAPE_CHAR,
+                    ),
+                ),
+                ~Picture.id.in_(locked_picture_id_subquery()),
+            )
         ).one()
         if isinstance(result, (tuple, list)):
             return result[0]
@@ -1846,6 +1927,13 @@ class Vault:
                 any_busy = True
                 break
         if any_busy:
+            return
+        # The snapshot only sees planner in-flight counts. A task submitted
+        # straight to the runner (an interactive retag or redescribe) is
+        # invisible to it, and unloading the model under a running caption
+        # batch makes the captioner return nothing for every picture in it.
+        # GPU-queue tasks only: a dedup scan or an import holds no model.
+        if self._task_runner is not None and self._task_runner.has_active_gpu_tasks():
             return
 
         logger.warning("All workers idle; aggressively unloading models.")

--- a/tests/test_picture_set_locking.py
+++ b/tests/test_picture_set_locking.py
@@ -789,6 +789,9 @@ def test_reset_tags_and_description_blocked_on_locked_pic():
 
         assert client.post(f"/pictures/{pic}/reset_tags").status_code == 423
         assert client.post(f"/pictures/{pic}/reset_description").status_code == 423
+        bulk = {"picture_ids": [pic]}
+        assert client.post("/pictures/reset_tags", json=bulk).status_code == 423
+        assert client.post("/pictures/reset_description", json=bulk).status_code == 423
 
         # The confirmed tag survived the refused reset.
         tags = client.get(f"/pictures/{pic}/tags").json()["tags"]

--- a/tests/test_plugin_lifecycle_gaps.py
+++ b/tests/test_plugin_lifecycle_gaps.py
@@ -330,12 +330,21 @@ def test_the_vault_idle_sweep_is_the_caller(install_plugins):
         _last_aggressive_unload_at=0.0,
         AGGRESSIVE_UNLOAD_INTERVAL=Vault.AGGRESSIVE_UNLOAD_INTERVAL,
         _disable_background_workers=True,
+        _task_runner=types.SimpleNamespace(has_active_gpu_tasks=lambda: False),
     )
     busy = {"tagging": {"running": True, "status": "running", "remaining": 5}}
 
     Vault._maybe_aggressive_unload(fake_vault, busy)
     assert captioner.unload_calls == 0, "a busy worker must not lose its model"
 
+    # An interactive task runs outside the planner's in-flight counts, so the
+    # snapshot reads idle while a caption batch is executing; the runner's own
+    # active set is what keeps the model under it (#1162).
+    fake_vault._task_runner = types.SimpleNamespace(has_active_gpu_tasks=lambda: True)
+    Vault._maybe_aggressive_unload(fake_vault, {})
+    assert captioner.unload_calls == 0, "a running task must not lose its model"
+
+    fake_vault._task_runner = types.SimpleNamespace(has_active_gpu_tasks=lambda: False)
     Vault._maybe_aggressive_unload(fake_vault, {})
     assert captioner.unload_calls == 1
 

--- a/tests/test_tag_prediction_scope.py
+++ b/tests/test_tag_prediction_scope.py
@@ -35,8 +35,10 @@ from datetime import datetime
 import pytest
 from fastapi.testclient import TestClient
 
+from pixlstash.db_models import Picture, Tag, is_description_sentinel, is_tag_sentinel
 from pixlstash.db_models.tag_prediction import TagPrediction
 from pixlstash.server import Server
+from pixlstash.tasks.task_type import TaskType
 from tests.authz_guard import no_spa_fallback  # noqa: F401
 from tests.utils import upload_pictures_and_wait
 
@@ -212,6 +214,99 @@ def test_reset_description_scope(env):
     assert r.status_code == 403, r.text
     r = client.post(f"/pictures/{target}/reset_description")
     assert r.status_code == 200, r.text
+
+
+def _descriptions(server, picture_ids):
+    def query(session):
+        from sqlmodel import select
+
+        rows = session.exec(select(Picture).where(Picture.id.in_(picture_ids))).all()
+        return {row.id: row.description for row in rows}
+
+    return server.vault.db.run_immediate_read_task(query)
+
+
+def _write_descriptions(server, by_id):
+    def op(session):
+        for pic_id, description in by_id.items():
+            pic = session.get(Picture, pic_id)
+            pic.description = description
+            session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(op)
+
+
+def _detach_finders(server, task_types):
+    for task_type in task_types:
+        server.vault._planner_work_finders.pop(task_type, None)
+    server.vault._work_planner.detach_finders(task_types)
+
+
+def test_bulk_reset_description_scope_and_count(env):
+    """The multi-picture reset (#1162): a scoped token is refused, the owner's
+    one call marks every picture with the sentinel, and the task manager counts
+    those sentinels as remaining work - it used to count NULL only, so a
+    regeneration read "N / N" from start to finish."""
+    server, client, anon, picture_ids, scoped = env
+    # The finder would caption the sentinels straight away; the assertion is
+    # about the write and the count, not the captioner.
+    _detach_finders(server, [TaskType.DESCRIPTION])
+    # Both pictures start captioned: one real caption, one blanked by an
+    # earlier failed pass (the permanent exclusion). Under the old NULL-only
+    # count both are "done", and the reset must move both to "remaining".
+    _write_descriptions(server, {picture_ids[0]: "a caption", picture_ids[1]: ""})
+    remaining_key = TaskType.DESCRIPTION.value
+    workers = client.get("/workers/progress").json()["workers"]
+    assert workers[remaining_key]["remaining"] == 0
+    # A stale id must be skipped, not fail the batch.
+    body = {"picture_ids": [*picture_ids, 999_999]}
+
+    r = anon.post("/pictures/reset_description", json=body, headers=_bearer(scoped))
+    assert r.status_code == 403, r.text
+    assert not any(
+        is_description_sentinel(d) for d in _descriptions(server, picture_ids).values()
+    ), "a scoped token's blocked reset must not mark anything"
+
+    r = client.post("/pictures/reset_description", json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["count"] == len(picture_ids)
+    descriptions = _descriptions(server, picture_ids)
+    assert all(is_description_sentinel(d) for d in descriptions.values()), descriptions
+
+    progress = client.get("/workers/progress").json()["workers"]
+    assert progress[remaining_key]["remaining"] == len(picture_ids)
+
+
+def test_bulk_reset_tags_scope(env):
+    server, client, anon, picture_ids, scoped = env
+    _detach_finders(server, [TaskType.TAGGER])
+    target = picture_ids[1]
+    _seed_prediction(server, target, "gale")
+    body = {"picture_ids": picture_ids}
+
+    r = anon.post("/pictures/reset_tags", json=body, headers=_bearer(scoped))
+    assert r.status_code == 403, r.text
+    assert _prediction_exists(server, target, "gale"), (
+        "a scoped token's blocked reset_tags must not destroy tag-prediction data"
+    )
+
+    # A stale id is skipped: it must not sink the batch on the sentinel's FK.
+    body = {"picture_ids": [*picture_ids, 999_999]}
+    r = client.post("/pictures/reset_tags", json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["count"] == len(picture_ids)
+    assert not _prediction_exists(server, target, "gale")
+
+    def sentinel_owners(session):
+        from sqlmodel import select
+
+        rows = session.exec(select(Tag).where(Tag.picture_id.in_(picture_ids))).all()
+        return sorted({row.picture_id for row in rows if is_tag_sentinel(row.tag)})
+
+    assert server.vault.db.run_immediate_read_task(sentinel_owners) == sorted(
+        picture_ids
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workers_api.py
+++ b/tests/test_workers_api.py
@@ -4,10 +4,12 @@ import gc
 import json
 import os
 import tempfile
+import types
 
 from fastapi.testclient import TestClient
 
 from pixlstash.server import Server
+from pixlstash.services import config_service
 from pixlstash.tasks.dedup_scan_task import DedupScanTask
 from pixlstash.tasks.task_type import TaskType
 
@@ -123,3 +125,41 @@ def test_version_endpoint_returns_200():
         server.close()
         temp_dir.cleanup()
         gc.collect()
+
+
+def test_vram_falls_back_to_torch_when_nvml_reports_no_process_figure(monkeypatch):
+    """Windows (WDDM) NVML lists the process but its ``usedGpuMemory`` is not
+    available, which rendered "0 / 31.8 GB" during CUDA inference (#1162). With
+    no per-process figure the monitor must leave the reading to torch."""
+    entry = types.SimpleNamespace(pid=os.getpid(), usedGpuMemory=None)
+    handle = object()
+    fake_nvml = types.SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetCount=lambda: 1,
+        nvmlDeviceGetHandleByIndex=lambda index: handle,
+        nvmlDeviceGetMemoryInfo=lambda h: types.SimpleNamespace(total=32 * 1024**3),
+        nvmlDeviceGetComputeRunningProcesses=lambda h: [entry],
+        nvmlDeviceGetGraphicsRunningProcesses=lambda h: [],
+        NVML_VALUE_NOT_AVAILABLE=-1,
+    )
+    monkeypatch.setattr(config_service, "pynvml", fake_nvml)
+
+    def torch_reading(payload):
+        payload["vram_used_gb"] = 4.5
+        payload["vram_total_gb"] = 32.0
+        payload["vram_percent"] = 14.1
+        return True
+
+    monkeypatch.setattr(config_service, "collect_vram_from_torch", torch_reading)
+    monitor = config_service.HardwareMonitor()
+    usage = monitor.get_usage()
+    assert usage["vram_used_gb"] == 4.5
+
+    # With a real per-process figure NVML still wins.
+    entry.usedGpuMemory = 2 * 1024**3
+    assert config_service.HardwareMonitor().get_usage()["vram_used_gb"] == 2.0
+
+    # A process NVML does not list holds nothing: that zero stands, no torch.
+    fake_nvml.nvmlDeviceGetComputeRunningProcesses = lambda h: []
+    assert config_service.HardwareMonitor().get_usage()["vram_used_gb"] == 0.0

--- a/website/index.html
+++ b/website/index.html
@@ -495,7 +495,7 @@
           <span class="badge">Simple install</span>
           <span class="badge">Runs locally</span>
           <span class="badge">Headless server option</span>
-          <span class="badge">Supports NVIDIA GPUs</span>
+          <span class="badge">Supports NVIDIA and AMD GPUs</span>
           <span class="badge">ComfyUI nodes</span>
         </div>
 


### PR DESCRIPTION
Closes #1162.

## What changed

**Task manager stuck at N / N during a description regeneration.** `Vault._count_missing_descriptions` counted only `NULL` descriptions, while a reset writes a `__description::<engine>` sentinel. The count now uses the same predicate as `MissingDescriptionFinder` (NULL or sentinel, locked pictures excluded), so the row drops as captions land, the way the tagger row already did.

**Bulk regeneration ran the captioner twice per picture, one image at a time.** The grid's "generate descriptions" / "auto-tag" and the tag panel's reset fired one `POST /pictures/{id}/reset_*` per selected picture. Each call wrote the sentinel *and* queued an urgent single-picture task, and the finder, which cannot tell those sentinels from its own, then picked the same pictures up again. New `POST /pictures/reset_tags` and `POST /pictures/reset_description` take `{picture_ids, model}`, write the sentinels in one chunked transaction (SQLite parameter cap respected, ids that name no picture skipped) and leave the batching to the finders. The single-picture routes are unchanged; the overlay panels still use them.

To keep a user's request from waiting behind the never-captioned backlog, `MissingDescriptionFinder` now selects sentinel pictures ahead of NULL ones and builds an urgent task for them. Tag sentinels also mark fresh imports, so the tag finder keeps its normal priority; a bulk retag waits only for the handful of GPU tasks already in flight.

**Grid flashed and went blank when a regeneration started.** Both grid handlers followed the requests with a forced full grid reload. The reload replaces every row with a placeholder and reseeds the visible window at the top, and if the viewport was scrolled the rendered rows sit off-screen until a scroll event recomputes them. Nothing about a reset changes what the cards show, and each finished caption already refreshes its own card over `descriptions_changed`, so the reload is gone; a `tags-applied` with `action: "reset"` no longer reloads either.

**VRAM 0 / 31.8 GB on Windows during CUDA inference.** Under WDDM, NVML lists the process but reports its memory as not available. The monitor took that as zero; it now leaves that case to torch's allocator. A process NVML does not list at all still reads zero from NVML.

**Model unload under a running caption batch.** With "keep models in memory" off, the idle sweep only looked at planner in-flight counts, so an interactive task submitted straight to the runner could have its model unloaded mid-batch, which makes the captioner return nothing and blank every picture in the batch. The sweep now also waits for the GPU worker to be idle.

## Reviewer objections not taken

- *Bulk retag lost its urgent priority.* Accepted as a trade: the tag sentinel cannot distinguish a reset from an import, and the GPU queue depth is bounded by per-finder in-flight limits, so the wait is a few tasks, not a backlog. Descriptions keep urgency via the finder.
- *Torch only counts its own allocator.* True; an ONNX tagger's memory still reads low on Windows. The previous reading was zero, and nvidia-smi has the same WDDM limit.

## Not verified here

The Windows/WDDM NVML behaviour and the Electron grid blanking were reasoned from code and NVIDIA's documentation, not reproduced on Windows. Pictures already blanked by an earlier failed pass stay excluded until reset; selecting them and regenerating now covers them in one request.

## Tests

Bulk routes: scoped token refused with data intact, owner accepted, sentinels written, stale id skipped, locked picture refused (423), task-manager count moves from 0 to N after the reset. NVML fallback and idle-sweep guard unit-tested. Authz registry and coverage matrix updated; guardrails green.