### PR TITLE
Keep thumbnails in .pixlstash-thumbnails, not beside the pictures (#1164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,7 @@ jobs:
           tests/test_tag_worker.py
           tests/test_tagger_user_plugins.py
           tests/test_thumbnail_cache_headers.py
+          tests/test_thumbnail_location.py
           tests/test_token_identity.py
           tests/test_telemetry_install_id.py
           tests/test_telemetry_install_id_authz.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.11.1]
+
+- Thumbnails no longer sit next to your pictures. They live in one hidden
+  `.pixlstash-thumbnails` folder at the top of the library, so your own folders
+  hold only your own files and nothing PixlStash writes is ever mistaken for a
+  picture. Existing thumbnails move there on their own, the first time each is
+  needed; nothing is re-generated.
+
 # [1.11.0] [Security:High]
 
 - Several dependabot updates: transformers, xmldom, humanfs, fast-uri

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4049,11 +4049,22 @@ and updates `file_path` on the existing row instead.
 - **Confirmation stops at the size.** Import de-dup follows a candidate match
   with a full-byte hash of *both* sides; here one side is a file that no longer
   exists, so the stored columns are all there is to compare.
+- **Every thumbnail lives in `image_root/.pixlstash-thumbnails/` (#1164).**
+  `ImageUtils.get_thumbnail_path` names it `<stem>_<sha256(stored file_path)[:16]>_thumb.webp`
+  for managed and reference pictures alike; the hash is of the STORED path
+  (relative for a library picture, absolute for a reference one), so callers hand
+  it that form and never the resolved one. Before 1.11.1 a managed picture's
+  bitmap sat beside it as `<stem>_thumb.webp` and a reference picture's under
+  `.ref_thumbs/`. Nothing migrates them in one go: `find_thumbnail` moves a
+  legacy bitmap home the first time it is looked for, the startup pass in
+  `maintenance.py` looks for every one, and `remove_thumbnail` deletes at every
+  location a picture's bitmap could be. `is_pixlstash_thumbnail` keeps excluding
+  the old siblings from every walk until they have all moved.
 - **A followed move carries its thumbnail bitmap.** Thumbnails are keyed
   `sha256(file_path)` (`ImageUtils.get_thumbnail_path`), so the file is renamed
-  alongside the picture rather than abandoned: nothing sweeps `.ref_thumbs` by
-  anything but a row's *current* `file_path`, so a bitmap left at the old name
-  would never be reachable and never be collected. Only when there is nothing to
+  alongside the picture rather than abandoned: nothing sweeps
+  `.pixlstash-thumbnails` by anything but a row's *current* `file_path`, so a
+  bitmap left at the old name would never be reachable and never be collected. Only when there is nothing to
   carry, or the rename fails, are `thumbnail_width` / `thumbnail_height` blanked
   so `MissingThumbnailFinder` renders a fresh one.
 - **`original_file_name` follows too**, matching the explicit move route
@@ -4536,8 +4547,7 @@ worth knowing:
   the same validity rule as the watermark cache — the cached file must be at
   least as new as the source, so the next rotate invalidates it by rewriting the
   original. Reference-folder pictures are rendered per request instead: this
-  library does not write beside the user's own files, the same rule that puts
-  their thumbnails under `.ref_thumbs`.
+  library does not write beside the user's own files.
 - **Re-encoding drops PNG text chunks, so they are carried across explicitly.**
   This response is what "Save image as" hands the user, and a saved copy of a
   rotated picture that had quietly lost its `workflow` / `prompt` would be a
@@ -6320,7 +6330,8 @@ layout and for a file that is not going into the library's own root at all (a
 ComfyUI edit or a plugin output written beside its original in a reference
 folder is already where the owner's tree put it). `ImageUtils.create_picture_from_bytes`
 takes the answer as `subfolder` and keeps the stored path **relative**, so the
-picture is still a library picture and its thumbnail is still a sibling file;
+picture is still a library picture and its thumbnail is still keyed by that
+relative path;
 only `output_dir` makes a path absolute, and that means a reference folder.
 
 Wired at every site that writes into the library root: the staged import, the

--- a/pixlstash/maintenance.py
+++ b/pixlstash/maintenance.py
@@ -36,8 +36,10 @@ class MaintenanceMixin:
             pic_id, file_path = row
             if not file_path:
                 continue
-            thumb_path = ImageUtils.get_thumbnail_path(self.vault.image_root, file_path)
-            if thumb_path and os.path.exists(thumb_path):
+            # find_thumbnail moves a pre-#1164 bitmap into .pixlstash-thumbnails
+            # as a side effect, so this pass is also the library's migration:
+            # nothing is re-rendered for having lived beside its picture.
+            if ImageUtils.find_thumbnail(self.vault.image_root, file_path):
                 continue
             missing.append((pic_id, file_path))
 
@@ -146,16 +148,9 @@ class MaintenanceMixin:
 
         thumbnails_removed = 0
         for rel_path in thumbnail_candidates:
-            thumb_path = ImageUtils.get_thumbnail_path(self.vault.image_root, rel_path)
-            if not thumb_path or not os.path.isfile(thumb_path):
-                continue
-            try:
-                os.remove(thumb_path)
-                thumbnails_removed += 1
-            except Exception as exc:
-                logger.warning(
-                    "Failed to delete orphan thumbnail %s: %s", thumb_path, exc
-                )
+            thumbnails_removed += ImageUtils.remove_thumbnail(
+                self.vault.image_root, rel_path
+            )
 
         logger.info(
             "Startup missing-file cleanup completed: %s records removed, %s orphan thumbnails removed.",

--- a/pixlstash/routes/pictures/_serving.py
+++ b/pixlstash/routes/pictures/_serving.py
@@ -139,8 +139,8 @@ def register_routes(router, server):
         )
 
         # Reference-folder pictures are the user's own files in the user's own
-        # folders; this library does not write beside them (the same rule that
-        # puts their thumbnails under `.ref_thumbs`). They render per request.
+        # folders; this library does not write beside them. They render per
+        # request.
         cacheable = not (pic.file_path and os.path.isabs(pic.file_path))
         if not is_heic and cacheable and (apply_wm or needs_transpose):
             file_stem, file_ext = os.path.splitext(file_path)

--- a/pixlstash/routes/pictures/_thumbnails.py
+++ b/pixlstash/routes/pictures/_thumbnails.py
@@ -169,8 +169,8 @@ def register_routes(router, server):
         if not pic or not getattr(pic, "file_path", None):
             raise HTTPException(status_code=404, detail="Picture not found")
 
-        thumb_path = ImageUtils.get_thumbnail_path(vault.image_root, pic.file_path)
-        if thumb_path and os.path.exists(thumb_path):
+        thumb_path = ImageUtils.find_thumbnail(vault.image_root, pic.file_path)
+        if thumb_path:
             if not discard_stale_thumbnail(id, pic.file_path, thumb_path):
                 elapsed_ms = (datetime.now() - started_at).total_seconds() * 1000.0
                 logger.debug(

--- a/pixlstash/routes/pictures/_thumbnails.py
+++ b/pixlstash/routes/pictures/_thumbnails.py
@@ -169,18 +169,24 @@ def register_routes(router, server):
         if not pic or not getattr(pic, "file_path", None):
             raise HTTPException(status_code=404, detail="Picture not found")
 
-        thumb_path = ImageUtils.find_thumbnail(vault.image_root, pic.file_path)
-        if thumb_path:
-            if not discard_stale_thumbnail(id, pic.file_path, thumb_path):
+        # Where the bitmap belongs, kept for the in-lock re-check below: a
+        # concurrent request that generated it while this one waited writes
+        # exactly here. `find_thumbnail` is the read that also brings a
+        # pre-#1164 bitmap home, and may answer a legacy path if that move
+        # failed, so the two are deliberately separate variables.
+        thumb_path = ImageUtils.get_thumbnail_path(vault.image_root, pic.file_path)
+        existing = ImageUtils.find_thumbnail(vault.image_root, pic.file_path)
+        if existing:
+            if not discard_stale_thumbnail(id, pic.file_path, existing):
                 elapsed_ms = (datetime.now() - started_at).total_seconds() * 1000.0
                 logger.debug(
                     "Thumbnail GET cache-hit: id=%s path=%s elapsed_ms=%.1f",
                     id,
-                    thumb_path,
+                    existing,
                     elapsed_ms,
                 )
                 return FileResponse(
-                    thumb_path,
+                    existing,
                     media_type="image/webp",
                     headers=_THUMBNAIL_CACHE_HEADERS,
                 )

--- a/pixlstash/routes/reference_folders.py
+++ b/pixlstash/routes/reference_folders.py
@@ -1646,15 +1646,7 @@ def create_router(server) -> APIRouter:
         if image_root:
             removed_thumbs = 0
             for rel_path in file_paths:
-                thumb_path = ImageUtils.get_thumbnail_path(image_root, rel_path)
-                if thumb_path and os.path.isfile(thumb_path):
-                    try:
-                        os.remove(thumb_path)
-                        removed_thumbs += 1
-                    except Exception as exc:
-                        logger.warning(
-                            "Failed to delete orphan thumbnail %s: %s", thumb_path, exc
-                        )
+                removed_thumbs += ImageUtils.remove_thumbnail(image_root, rel_path)
             if removed_thumbs:
                 logger.info(
                     "Removed %d orphan thumbnails for reference folder: %s",

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -447,8 +447,9 @@ def register_reference_folder(
 #: Top-level folders under a library's own root that hold PixlStash's files,
 #: not the owner's pictures: the snapshot tree, and the ``tmp/`` cache the
 #: set and character thumbnail routes write into. Every walk of a library's
-#: root skips these; the dot-folder rule covers the rest (``.ref_thumbs``,
-#: ``.pixlstash``, ``.staging``). Found the hard way: an import of a library's
+#: root skips these; the dot-folder rule covers the rest
+#: (``.pixlstash-thumbnails``, the older ``.ref_thumbs``, ``.staging``). Found
+#: the hard way: an import of a library's
 #: own root indexed 24 set and face thumbnails as pictures.
 LIBRARY_OWN_FOLDERS = ("snapshots", "tmp")
 
@@ -601,11 +602,11 @@ def local_import_pictures(
     image_root = os.path.normpath(server.vault.image_root)
 
     # Prune dot-folders exactly as the Phase 2 read does (`folder_structure_
-    # service.py`): a vault's own caches - `.ref_thumbs/`, `.pixlstash`
-    # sidecars - sit *inside* image_root, and root_path is commonly
-    # image_root itself. Without this prune, local_import would re-import
-    # every reference-folder thumbnail already sitting in `.ref_thumbs/` as
-    # if it were a picture of its own (`.webp` is a supported extension).
+    # service.py`): a vault's own caches - `.pixlstash-thumbnails/`, the
+    # older `.ref_thumbs/` - sit *inside* image_root, and root_path is
+    # commonly image_root itself. Without this prune, local_import would
+    # re-import every thumbnail in there as if it were a picture of its own
+    # (`.webp` is a supported extension).
     own = library_own_folders(image_root)
     file_paths: list[str] = []
     for dirpath, dirnames, filenames in os.walk(root_path):

--- a/pixlstash/services/folder_structure_service.py
+++ b/pixlstash/services/folder_structure_service.py
@@ -503,8 +503,8 @@ class FolderStructureRead:
             )
             lowered = {f.lower() for f in filenames}
             # `is_supported_media_file` drops our own `_thumb.webp` files, which
-            # a library that has been indexed before is full of, sitting beside
-            # every original. Counting them made the total grow on every re-read
+            # a library indexed before #1164 is full of, sitting beside every
+            # original. Counting them made the total grow on every re-read
             # of the same folder - the "different number each time" - and
             # sampling them spent the face pass on 96px thumbnails.
             folder.direct_media = sum(

--- a/pixlstash/services/layout_move_service.py
+++ b/pixlstash/services/layout_move_service.py
@@ -809,23 +809,21 @@ def _carry_thumbnail(
     """Move a moved picture's thumbnail to its new path-derived name.
 
     **Both arguments are the STORED form of the path, never the absolute one**,
-    because that is the form ``get_thumbnail_path`` branches on: an absolute
-    path means a reference-folder picture and routes the bitmap to a hashed name
-    under ``.ref_thumbs``, and a relative one means a library picture whose
-    thumbnail is a sibling file. Handing it the absolute path of a library
-    picture would look for the sibling under ``.ref_thumbs``, find nothing, and
-    strand a bitmap at the old name that nothing ever collects - the sweep only
-    ever looks where a row's *current* path says.
+    because the thumbnail's name is a hash of exactly that string
+    (``get_thumbnail_path``): a library picture is keyed by its root-relative
+    path and a reference-folder picture by its absolute one, and handing over
+    the other form looks for a name nobody wrote, finds nothing, and strands a
+    bitmap at the old name that nothing ever collects - the sweep only ever
+    looks where a row's *current* path says. ``find_thumbnail`` also brings a
+    pre-#1164 sibling bitmap home before the rename.
     """
-    old_thumb = ImageUtils.get_thumbnail_path(image_root, old_stored)
+    old_thumb = ImageUtils.find_thumbnail(image_root, old_stored)
     new_thumb = ImageUtils.get_thumbnail_path(image_root, new_stored)
     if not old_thumb or not new_thumb:
         return False
     if old_thumb == new_thumb:
         return os.path.exists(new_thumb)
     try:
-        if not os.path.exists(old_thumb):
-            return False
         os.makedirs(os.path.dirname(new_thumb), exist_ok=True)
         os.replace(old_thumb, new_thumb)
         return True

--- a/pixlstash/services/scrapheap_service.py
+++ b/pixlstash/services/scrapheap_service.py
@@ -1429,18 +1429,7 @@ def remove_picture_files(
                 file_path,
                 was_reference_protected,
             )
-        thumb_path = ImageUtils.get_thumbnail_path(image_root, rel_path)
-        if thumb_path and os.path.isfile(thumb_path):
-            try:
-                os.remove(thumb_path)
-            except Exception as e:
-                logger.warning(
-                    "Delete-forever: failed to delete thumbnail %s for "
-                    "picture id=%s: %s",
-                    thumb_path,
-                    pic_id,
-                    e,
-                )
+        ImageUtils.remove_thumbnail(image_root, rel_path)
     return unconfirmed
 
 

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -719,11 +719,12 @@ class ReferenceFolderScanTask(BaseTask):
     def _carry_thumbnail(self, old_path: str, new_path: str) -> bool:
         """Move a followed picture's thumbnail bitmap to its new path-derived name.
 
-        Thumbnails live at ``sha256(file_path)`` under ``image_root/.ref_thumbs``
-        (``ImageUtils.get_thumbnail_path``), so a followed move renames the
-        bitmap rather than re-rendering it.  Nothing sweeps that directory by
-        anything but a row's current ``file_path``, so a bitmap left at the old
-        name would never be reachable and never be collected.
+        Thumbnails live at ``sha256(file_path)`` under
+        ``image_root/.pixlstash-thumbnails`` (``ImageUtils.get_thumbnail_path``),
+        so a followed move renames the bitmap rather than re-rendering it.
+        Nothing sweeps that directory by anything but a row's current
+        ``file_path``, so a bitmap left at the old name would never be reachable
+        and never be collected.
 
         Returns:
             ``True`` when the new path now has the bitmap, so the caller can keep
@@ -732,13 +733,11 @@ class ReferenceFolderScanTask(BaseTask):
             ``MissingThumbnailFinder`` renders a fresh one.
         """
         image_root = self._db.image_root
-        old_thumb = ImageUtils.get_thumbnail_path(image_root, old_path)
+        old_thumb = ImageUtils.find_thumbnail(image_root, old_path)
         new_thumb = ImageUtils.get_thumbnail_path(image_root, new_path)
         if not old_thumb or not new_thumb or old_thumb == new_thumb:
             return bool(old_thumb and old_thumb == new_thumb)
         try:
-            if not os.path.exists(old_thumb):
-                return False
             os.makedirs(os.path.dirname(new_thumb), exist_ok=True)
             os.replace(old_thumb, new_thumb)
             return True
@@ -1025,8 +1024,8 @@ class ReferenceFolderScanTask(BaseTask):
                     exc,
                 )
 
-        # Write thumbnail into image_root/.ref_thumbs/ so it doesn't land
-        # inside the reference folder and get re-indexed on the next scan.
+        # The thumbnail goes to image_root/.pixlstash-thumbnails/, never
+        # inside the reference folder where the next scan would index it.
         if thumbnail_bytes:
             ImageUtils.write_thumbnail_bytes(
                 self._db.image_root, file_path, thumbnail_bytes

--- a/pixlstash/utils/image_processing/image_utils.py
+++ b/pixlstash/utils/image_processing/image_utils.py
@@ -33,6 +33,12 @@ logger = get_logger(__name__)
 
 THUMBNAIL_FORMAT = "WEBP"
 THUMBNAIL_EXTENSION = ".webp"
+#: Where every thumbnail lives, under the library root. One hidden folder for
+#: managed and reference pictures alike, so the owner's own folders hold only
+#: the owner's files and a walk of the library never meets a thumbnail (#1164).
+THUMBNAIL_DIR_NAME = ".pixlstash-thumbnails"
+#: The folder reference-folder thumbnails lived in before THUMBNAIL_DIR_NAME.
+_LEGACY_REF_THUMB_DIR = ".ref_thumbs"
 THUMBNAIL_QUALITY = 80
 THUMBNAIL_WEBP_METHOD = 2
 # A thumbnail is ONE aspect-ratio-preserving bitmap of the whole frame. It is
@@ -152,30 +158,123 @@ class ImageUtils:
         return os.path.join(image_root, file_path)
 
     @staticmethod
+    def _hashed_thumbnail_name(file_path: str) -> str:
+        path_hash = hashlib.sha256(file_path.encode()).hexdigest()[:16]
+        stem = os.path.splitext(os.path.basename(file_path))[0]
+        return f"{stem}_{path_hash}_thumb{THUMBNAIL_EXTENSION}"
+
+    @staticmethod
     def get_thumbnail_path(
         image_root: Optional[str], file_path: Optional[str]
     ) -> Optional[str]:
-        """Return the expected thumbnail file path for a given picture path.
+        """Return where the thumbnail for *file_path* belongs.
 
-        For reference-folder pictures (absolute ``file_path``), thumbnails are
-        stored under ``image_root/.ref_thumbs/`` so they don't pollute the
-        source directory and get re-indexed on the next scan.
+        ``image_root/.pixlstash-thumbnails/<stem>_<sha256(file_path)[:16]>_thumb.webp``
+        for every picture. *file_path* is ``Picture.file_path`` in its STORED
+        form - relative for a library picture, absolute for a reference-folder
+        one - because the hash is of that string; the two forms of one file
+        would hash to two names. The key is the path, so a followed move has to
+        carry the bitmap (``_carry_thumbnail`` in the scan task and the move
+        engine), which it did before this folder existed too.
+
+        A bitmap written before 1.11.1 may still sit at one of
+        :meth:`legacy_thumbnail_paths`; :meth:`find_thumbnail` looks there and
+        brings it home. Callers that only READ should use that.
         """
         if not file_path:
             return None
-        if os.path.isabs(file_path) and image_root:
-            # Reference-folder picture - redirect thumbnail into image_root.
-            path_hash = hashlib.sha256(file_path.encode()).hexdigest()[:16]
-            stem = os.path.splitext(os.path.basename(file_path))[0]
-            thumb_dir = os.path.join(image_root, ".ref_thumbs")
-            return os.path.join(
-                thumb_dir, f"{stem}_{path_hash}_thumb{THUMBNAIL_EXTENSION}"
-            )
+        if not image_root:
+            # No root to put the folder under (tests, some tools): the old
+            # sibling rule is the only answer that names a real place.
+            base, _ = os.path.splitext(file_path)
+            return f"{base}_thumb{THUMBNAIL_EXTENSION}"
+        return os.path.join(
+            image_root, THUMBNAIL_DIR_NAME, ImageUtils._hashed_thumbnail_name(file_path)
+        )
+
+    @staticmethod
+    def legacy_thumbnail_paths(
+        image_root: Optional[str], file_path: Optional[str]
+    ) -> list[str]:
+        """Where the thumbnail for *file_path* was written before #1164.
+
+        A managed picture's sat beside it as ``<stem>_thumb.webp``; a
+        reference-folder picture's sat under ``image_root/.ref_thumbs/`` with the
+        same hashed name the new folder uses. Order matters to nobody: at most
+        one of them ever existed for a given picture.
+        """
+        if not file_path or not image_root:
+            return []
+        if os.path.isabs(file_path):
+            return [
+                os.path.join(
+                    image_root,
+                    _LEGACY_REF_THUMB_DIR,
+                    ImageUtils._hashed_thumbnail_name(file_path),
+                )
+            ]
         resolved = ImageUtils.resolve_picture_path(image_root, file_path)
-        if not resolved:
-            return None
         base, _ = os.path.splitext(resolved)
-        return f"{base}_thumb{THUMBNAIL_EXTENSION}"
+        return [f"{base}_thumb{THUMBNAIL_EXTENSION}"]
+
+    @staticmethod
+    def find_thumbnail(
+        image_root: Optional[str], file_path: Optional[str]
+    ) -> Optional[str]:
+        """Return the path of the existing thumbnail for *file_path*, or ``None``.
+
+        Looks at :meth:`get_thumbnail_path` first. A bitmap still at a legacy
+        location is MOVED home and the new path returned, so the library
+        migrates itself one picture at a time - the startup pass in
+        ``maintenance.py`` visits every row, the thumbnail route catches the
+        rest - and no thumbnail is ever re-rendered for having moved house. A
+        move that fails is logged and the legacy path is served from where it
+        is; the next read tries again.
+        """
+        thumb_path = ImageUtils.get_thumbnail_path(image_root, file_path)
+        if not thumb_path:
+            return None
+        if os.path.isfile(thumb_path):
+            return thumb_path
+        for legacy in ImageUtils.legacy_thumbnail_paths(image_root, file_path):
+            if legacy == thumb_path or not os.path.isfile(legacy):
+                continue
+            try:
+                os.makedirs(os.path.dirname(thumb_path), exist_ok=True)
+                os.replace(legacy, thumb_path)
+                return thumb_path
+            except OSError as exc:
+                logger.warning(
+                    "Could not move thumbnail %s into %s (%s); serving it from "
+                    "where it is.",
+                    legacy,
+                    THUMBNAIL_DIR_NAME,
+                    exc,
+                )
+                return legacy
+        return None
+
+    @staticmethod
+    def remove_thumbnail(image_root: Optional[str], file_path: Optional[str]) -> int:
+        """Delete the thumbnail for *file_path* wherever it is; count removed.
+
+        Both the current home and every legacy location, so deleting a picture
+        indexed before #1164 does not leave its bitmap behind in the owner's
+        folder. Failures are logged, not raised: the picture is already gone
+        and a stray bitmap is the lesser problem.
+        """
+        removed = 0
+        candidates = [ImageUtils.get_thumbnail_path(image_root, file_path)]
+        candidates += ImageUtils.legacy_thumbnail_paths(image_root, file_path)
+        for path in dict.fromkeys(p for p in candidates if p):
+            if not os.path.isfile(path):
+                continue
+            try:
+                os.remove(path)
+                removed += 1
+            except OSError as exc:
+                logger.warning("Failed to delete thumbnail %s: %s", path, exc)
+        return removed
 
     @staticmethod
     def write_thumbnail_bytes(
@@ -780,8 +879,8 @@ class ImageUtils:
             original_file_name: Original filename to store on the Picture record.
             output_dir: When set, save the image file into this directory instead
                 of ``image_root_path``.  The Picture's ``file_path`` is stored as
-                the full absolute path so that reference-folder thumbnails are
-                correctly routed to ``image_root/.ref_thumbs/``.
+                the full absolute path, which is what marks a reference-folder
+                picture everywhere else.
             reference_folder_id: When set, assigned to the Picture so that the
                 reference-folder scan recognises the record as already indexed.
             subfolder: A ``/``-separated relative folder under
@@ -893,8 +992,8 @@ class ImageUtils:
         file_name = os.path.basename(picture_uuid)
         if output_dir:
             # Save into the caller-specified directory (e.g. a reference folder).
-            # Store the absolute path so thumbnail routing treats this as a
-            # reference-folder picture and writes the thumb to .ref_thumbs/.
+            # Store the absolute path: that is what marks a reference-folder
+            # picture for every reader.
             full_path = os.path.join(output_dir, file_name)
             picture_file_path: str = full_path
         elif subfolder:

--- a/pixlstash/utils/media_files.py
+++ b/pixlstash/utils/media_files.py
@@ -33,19 +33,21 @@ SUPPORTED_IMAGE_EXTS: frozenset[str] = frozenset(
 DEFAULT_ENTRY_CAP = 200_000
 
 
-#: What ``ImageUtils.get_thumbnail_path`` writes beside a managed picture.
+#: The suffix every thumbnail PixlStash writes carries.
 THUMBNAIL_SUFFIX = f"_thumb{THUMBNAIL_EXTENSION}"
 
 
 def is_pixlstash_thumbnail(name_or_path: str) -> bool:
     """True when this file is a thumbnail PixlStash itself wrote.
 
-    Managed pictures keep their thumbnail *beside* the original as
+    Until #1164 a managed picture kept its thumbnail *beside* the original as
     ``<name>_thumb.webp``, so a walk of a library's own folder finds them, and
     ``.webp`` is a supported extension. Indexing one makes it a picture, which
     earns it a thumbnail of its own - ``<name>_thumb_thumb.webp`` - which the
     next walk indexes in turn. That is not a slow leak: it is a generation per
-    pass, and it was found four deep in a real library.
+    pass, and it was found four deep in a real library. New thumbnails live in
+    ``.pixlstash-thumbnails/``, a dot-folder every walk prunes, but a library
+    is migrated one picture at a time, so the old siblings stay excluded.
     """
     return name_or_path.lower().endswith(THUMBNAIL_SUFFIX)
 

--- a/scripts/find_orphaned_files.py
+++ b/scripts/find_orphaned_files.py
@@ -12,11 +12,11 @@ accumulate from:
 
 What counts as "not orphaned" (kept):
   * every managed picture file (``Picture.file_path`` joined to image_root);
-  * its thumbnail ``{stem}_thumb.webp``;
+  * its pre-#1164 sibling thumbnail ``{stem}_thumb.webp``;
   * its sidecar caption ``{stem}.txt`` / ``{stem}.caption``;
   * system content under image_root: ``vault.db`` (+ ``-wal``/``-shm``/
-    ``-journal``), and the ``snapshots/``, ``.ref_thumbs/``, ``tmp/`` and
-    ``.orphan_trash/`` directories.
+    ``-journal``), and the ``snapshots/``, ``.pixlstash-thumbnails/``,
+    ``.ref_thumbs/``, ``tmp/`` and ``.orphan_trash/`` directories.
 
 Reference-folder pictures have absolute ``file_path`` (outside image_root), so
 they are never scanned.
@@ -45,7 +45,13 @@ _SIDECAR_EXTENSIONS = (".txt", ".caption")
 
 # Top-level directories under image_root that hold system / derived content
 # and must never be treated as orphans. Pruned from the walk entirely.
-_EXCLUDED_DIRS = {"snapshots", ".ref_thumbs", "tmp", ".orphan_trash"}
+_EXCLUDED_DIRS = {
+    "snapshots",
+    ".pixlstash-thumbnails",
+    ".ref_thumbs",
+    "tmp",
+    ".orphan_trash",
+}
 
 # System files that legitimately live at the image_root top level.
 _EXCLUDED_FILES = {

--- a/tests/test_find_orphaned_files.py
+++ b/tests/test_find_orphaned_files.py
@@ -70,6 +70,7 @@ def vault(tmp_path):
     _touch(os.path.join(root, "vault.db-wal"))
     _touch(os.path.join(root, "snapshots/2026/05/31/abc.sqlite"))
     _touch(os.path.join(root, ".ref_thumbs/ref_thumb.webp"))
+    _touch(os.path.join(root, ".pixlstash-thumbnails/keep_0123456789abcdef_thumb.webp"))
     _touch(os.path.join(root, "tmp/set_thumbnails/cache.webp"))
     return root
 
@@ -108,7 +109,8 @@ def test_ignores_system_dirs_and_db_files(vault):
     orphan_rel = {os.path.relpath(p, vault) for p in mod._iter_orphans(vault, known)}
 
     assert not any(
-        r.startswith(("snapshots", ".ref_thumbs", "tmp")) or r.startswith("vault.db")
+        r.startswith(("snapshots", ".ref_thumbs", ".pixlstash-thumbnails", "tmp"))
+        or r.startswith("vault.db")
         for r in orphan_rel
     ), f"system content must be excluded; got {orphan_rel}"
 

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -481,18 +481,18 @@ def test_local_import_mode_imports_as_managed_pictures_and_assigns(owner_env):
     characters = owner.get(f"{API}/characters").json()
     assert any(c["name"] == "nova" for c in characters)
 
-    # The originals are untouched - no move, rename or copy - but a sibling
-    # `_thumb.webp` per image is expected: for a MANAGED picture (unlike a
-    # reference-folder one) the thumbnail lands next to the source file, same
-    # as any other ordinary import. `_snapshot` doesn't distinguish; filter
-    # it back out before comparing.
-    after = _snapshot(root)
-    after_originals = {k: v for k, v in after.items() if not k.endswith("_thumb.webp")}
-    assert after_originals == before, (
-        "local_import must move, rename or copy zero files"
+    # The originals are untouched - no move, rename or copy, and since #1164
+    # not even a thumbnail beside them: those land in the library's own
+    # `.pixlstash-thumbnails/`, one per imported image.
+    assert _snapshot(root) == before, (
+        "local_import must move, rename, copy or write zero files in the folder"
     )
-    new_thumbs = [k for k in after if k.endswith("_thumb.webp")]
-    assert len(new_thumbs) == 3, "each imported image should get its own thumbnail"
+    from pixlstash.utils.image_processing.image_utils import ImageUtils
+
+    for relative in ("2027/nova/a.jpg", "2027/nova/b.jpg", "2027/raw/c.jpg"):
+        stored = f"local-import-library/{relative}"
+        thumb = ImageUtils.get_thumbnail_path(server.vault.image_root, stored)
+        assert os.path.isfile(thumb), f"{relative} should have a thumbnail at {thumb}"
 
 
 def test_local_import_wakes_the_planner_as_each_chunk_lands(

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -729,16 +729,17 @@ def test_swapping_the_project_moves_the_file_and_keeps_the_owners_subfolder(libr
 
 
 def test_the_thumbnail_follows_the_file(library):
-    """A library picture's thumbnail is a SIBLING file, not a ``.ref_thumbs``
-    entry, and the difference is which path form the mover hands to
-    ``get_thumbnail_path``: it branches on absolute-vs-relative. Handing it the
-    absolute path would look under ``.ref_thumbs``, find nothing, blank the
-    stored dimensions and strand a bitmap nothing ever collects."""
+    """A library picture's thumbnail is keyed by its RELATIVE stored path, and
+    the mover has to hand ``get_thumbnail_path`` exactly that form: the name is
+    a hash of the string. Handing it the absolute path would look for a name
+    nobody wrote, find nothing, blank the stored dimensions and strand a bitmap
+    nothing ever collects."""
     from pixlstash.utils.image_processing.image_utils import ImageUtils
 
     session, root = library["session"], library["root"]
     picture = session.get(Picture, library["picture_id"])
     old_thumb = ImageUtils.get_thumbnail_path(root, picture.file_path)
+    os.makedirs(os.path.dirname(old_thumb), exist_ok=True)
     with open(old_thumb, "wb") as handle:
         handle.write(b"thumbnail")
     picture.thumbnail_width = 320
@@ -1204,6 +1205,7 @@ def test_the_rollback_brings_the_thumbnail_back_too(library):
     session, root = library["session"], library["root"]
     picture = session.get(Picture, library["picture_id"])
     old_thumb = ImageUtils.get_thumbnail_path(root, picture.file_path)
+    os.makedirs(os.path.dirname(old_thumb), exist_ok=True)
     with open(old_thumb, "wb") as handle:
         handle.write(b"thumbnail")
 

--- a/tests/test_thumbnail_location.py
+++ b/tests/test_thumbnail_location.py
@@ -1,0 +1,91 @@
+"""Thumbnails live in ``image_root/.pixlstash-thumbnails/`` (#1164).
+
+Before this a managed picture's thumbnail sat beside it as ``<stem>_thumb.webp``
+and a reference-folder picture's under ``.ref_thumbs/``. Both are still found,
+moved home on first read, and deleted with their picture.
+"""
+
+import os
+
+from pixlstash.utils.image_processing.image_utils import (
+    THUMBNAIL_DIR_NAME,
+    ImageUtils,
+)
+
+
+def _touch(path: str, payload: bytes = b"webp") -> str:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(payload)
+    return path
+
+
+def test_every_thumbnail_is_under_the_hidden_folder(tmp_path):
+    root = str(tmp_path)
+    managed = ImageUtils.get_thumbnail_path(root, "Mira/shoot_01.png")
+    reference = ImageUtils.get_thumbnail_path(root, "/elsewhere/refs/shoot_01.png")
+
+    for thumb in (managed, reference):
+        assert os.path.dirname(thumb) == os.path.join(root, THUMBNAIL_DIR_NAME)
+        assert os.path.basename(thumb).startswith("shoot_01_")
+        assert thumb.endswith("_thumb.webp")
+    # Same stem, different path: different bitmap. The name is a hash of the
+    # STORED path, so two pictures cannot share one thumbnail by accident.
+    assert managed != reference
+    assert managed != ImageUtils.get_thumbnail_path(root, "Jonas/shoot_01.png")
+
+
+def test_a_sibling_thumbnail_is_moved_home_on_first_read(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "Mira", "a.png"))
+    legacy = _touch(os.path.join(root, "Mira", "a_thumb.webp"), b"legacy")
+    home = ImageUtils.get_thumbnail_path(root, "Mira/a.png")
+    assert not os.path.exists(home)
+
+    found = ImageUtils.find_thumbnail(root, "Mira/a.png")
+
+    assert found == home
+    assert not os.path.exists(legacy), "the owner's folder must be left clean"
+    with open(home, "rb") as fh:
+        assert fh.read() == b"legacy", "moved, not re-rendered"
+    # Second read: nothing left to move, same answer.
+    assert ImageUtils.find_thumbnail(root, "Mira/a.png") == home
+
+
+def test_a_ref_thumbs_thumbnail_is_moved_home_on_first_read(tmp_path):
+    root = str(tmp_path)
+    stored = os.path.join(str(tmp_path / "refs"), "b.png")
+    home = ImageUtils.get_thumbnail_path(root, stored)
+    legacy = _touch(
+        os.path.join(root, ".ref_thumbs", os.path.basename(home)), b"legacy"
+    )
+
+    assert ImageUtils.find_thumbnail(root, stored) == home
+    assert not os.path.exists(legacy)
+    assert os.path.isfile(home)
+
+
+def test_nothing_anywhere_is_none(tmp_path):
+    assert ImageUtils.find_thumbnail(str(tmp_path), "Mira/none.png") is None
+    assert ImageUtils.find_thumbnail(str(tmp_path), None) is None
+
+
+def test_remove_thumbnail_clears_the_legacy_home_too(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "Mira", "c.png"))
+    legacy = _touch(os.path.join(root, "Mira", "c_thumb.webp"))
+    home = _touch(ImageUtils.get_thumbnail_path(root, "Mira/c.png"))
+
+    assert ImageUtils.remove_thumbnail(root, "Mira/c.png") == 2
+    assert not os.path.exists(legacy)
+    assert not os.path.exists(home)
+    assert ImageUtils.remove_thumbnail(root, "Mira/c.png") == 0
+
+
+def test_write_lands_in_the_hidden_folder(tmp_path):
+    root = str(tmp_path)
+    written = ImageUtils.write_thumbnail_bytes(root, "Mira/d.png", b"bytes")
+
+    assert written == ImageUtils.get_thumbnail_path(root, "Mira/d.png")
+    assert os.path.isfile(written)
+    assert not os.path.exists(os.path.join(root, "Mira", "d_thumb.webp"))


### PR DESCRIPTION
Closes #1164.

## What changed

- `ImageUtils.get_thumbnail_path` puts every thumbnail in `image_root/.pixlstash-thumbnails/<stem>_<sha256(stored path)[:16]>_thumb.webp`, for managed and reference pictures alike. The hash is of the stored `file_path` (relative for a library picture, absolute for a reference one), which is what the move engine and the reference-folder scan already hand it.
- `ImageUtils.find_thumbnail` is what readers use now (thumbnail route, startup pass, both thumbnail carries). It looks in the new home first and moves a legacy bitmap there on first read, from either `<stem>_thumb.webp` beside a managed picture or `.ref_thumbs/`. Nothing is re-rendered for having moved.
- `ImageUtils.remove_thumbnail` deletes at the new home and every legacy location. Scrapheap delete-forever, reference-folder removal and startup cleanup use it, so a picture indexed before this change does not leave its bitmap behind in the owner's folder.
- The startup `_generate_missing_thumbnails` pass goes through `find_thumbnail`, so a library migrates on the first boot after upgrade, one `os.replace` per picture. With that pass disabled the thumbnail route migrates each picture the first time it is viewed.
- `is_pixlstash_thumbnail` stays: pre-migration siblings still exist and must stay excluded from imports and counts. Its docstring, the folder-structure comments, `scripts/find_orphaned_files.py` and the architecture doc say where thumbnails live now.

## Why

A laid-out library is a folder tree the owner reorganises by hand, and a `_thumb.webp` beside every picture is both pollution and a trap for every walk of the tree. This also removes the "owner renamed the picture but not its thumbnail" case from the upcoming library-root scan, which follows renames the owner makes in their file manager.

## Tests

- New `tests/test_thumbnail_location.py`: both path forms land in the hidden folder, sibling and `.ref_thumbs` bitmaps are moved home on first read, removal clears legacy homes, writes land in the hidden folder.
- `test_folder_structure_commit` now asserts that a local import writes nothing at all into the imported folder.
- Ran `test_folder_structure_commit`, `test_library_layout`, `test_reference_folder_moves`, `test_reference_folder_sidecars`, `test_import_scrapheap_match`, `test_scrapheap_retention`, `test_inline_rotate`, `test_find_orphaned_files`, `test_folder_structure_read` and `test_libraries_routes` locally, all green.

## Not in this PR

The `_watermarked` and `_oriented` cache files the serving route writes beside managed pictures are the same kind of pollution and should follow the thumbnails into a hidden folder. Separate change.
