### PR TITLE
Never persist the runtime's device override into server-config.json

### DIFF
--- a/pixlstash/auth.py
+++ b/pixlstash/auth.py
@@ -22,7 +22,7 @@ from sqlmodel import Session, select
 
 from pixlstash.database import DBPriority, VaultDatabase
 from pixlstash.db_models import Character, PictureSet, Project, User, UserToken
-from pixlstash.utils.atomic_write import write_json_atomic
+from pixlstash.server_config_io import persist_server_config
 from pixlstash.utils.system_utils import default_max_vram_gb
 
 
@@ -1254,7 +1254,7 @@ class AuthService:
         # nested under the USERNAME branch, so removing only PASSWORD_HASH left
         # the stale hash on disk.
         if removed_any:
-            write_json_atomic(self._server_config_path, self._server_config)
+            persist_server_config(self._server_config_path, self._server_config)
         return user
 
     def token_from_value(self, token_value: str) -> Optional[UserToken]:

--- a/pixlstash/routes/config.py
+++ b/pixlstash/routes/config.py
@@ -25,7 +25,7 @@ from pixlstash.services import (
     views_service,
 )
 from pixlstash.telemetry import mark_install_established
-from pixlstash.utils.atomic_write import write_json_atomic
+from pixlstash.server_config_io import persist_server_config
 from pixlstash.utils.quality.smart_score_utils import smart_score_penalised_tags
 from pixlstash.utils.service.smart_score_invalidation import (
     changed_penalised_tags,
@@ -986,7 +986,7 @@ def create_router(server) -> APIRouter:
         server.vault.set_daily_snapshots_enabled(body.daily_snapshots)
         config_path = getattr(server, "_server_config_path", None)
         if config_path:
-            write_json_atomic(config_path, server._server_config)
+            persist_server_config(config_path, server._server_config)
         return {"status": "success", "daily_snapshots": body.daily_snapshots}
 
     def _scrapheap_retention_payload() -> dict:
@@ -1089,7 +1089,7 @@ def create_router(server) -> APIRouter:
         server.vault.set_scrapheap_retention(effective_days, reduced_at)
         config_path = getattr(server, "_server_config_path", None)
         if config_path:
-            write_json_atomic(config_path, server._server_config)
+            persist_server_config(config_path, server._server_config)
         return _scrapheap_retention_payload()
 
     @router.get(

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -132,6 +132,7 @@ from pixlstash.routes.taggers import create_router as create_taggers_router
 from pixlstash.routes.snapshots import create_router as create_snapshots_router
 from pixlstash.routes.telemetry import create_router as create_telemetry_router
 from pixlstash.routes.test_hooks import create_router as create_test_hooks_router
+from pixlstash.server_config_io import DEVICE_ON_DISK_KEY, persist_server_config
 from pixlstash.utils.atomic_write import write_json_atomic
 from pixlstash.utils.path_mapper import PathMapper
 from pixlstash.utils.rate_limiter import RateLimitMiddleware
@@ -459,7 +460,7 @@ class Server(
             logger=logger,
         ).run()
         _log_stage("startup checks (disk/VRAM/CUDA/SSL)")
-        write_json_atomic(server_config_path, self._server_config)
+        persist_server_config(server_config_path, self._server_config)
 
         # Internal loopback transport (Electron desktop shell).
         #
@@ -1260,6 +1261,9 @@ class Server(
             # falling back to CPU with no explanation.
             _valid_devices = {"cpu", "cuda", "gpu", "auto"}
             if _device_override in _valid_devices:
+                # Remember what the owner configured: persist_server_config
+                # writes that back, never the runtime's answer.
+                server_config[DEVICE_ON_DISK_KEY] = server_config.get("default_device")
                 server_config["default_device"] = _device_override
             else:
                 logger.warning(

--- a/pixlstash/server_config_io.py
+++ b/pixlstash/server_config_io.py
@@ -9,8 +9,8 @@ without the variable (a developer's own env, a Docker deploy) read it as the
 owner's choice and ran CPU inference on a CUDA machine.
 
 So the decided value lives under a ``_``-prefixed key that this writer never
-persists, and ``default_device`` goes back to the file as the owner had it.
-Every writer of the file goes through :func:`persist_server_config`.
+persists, and ``default_device`` goes back to disk as the owner had it.
+Writers that rewrite an existing config file should use :func:`persist_server_config`.
 """
 
 from pixlstash.utils.atomic_write import write_json_atomic

--- a/pixlstash/server_config_io.py
+++ b/pixlstash/server_config_io.py
@@ -1,0 +1,34 @@
+"""Writing ``server-config.json`` back without the running process's overrides.
+
+The config dict a ``Server`` holds is both what the owner wrote and what this
+process decided at boot: ``PIXLSTASH_DEFAULT_DEVICE`` (the desktop shell naming
+the device its active runtime supports) replaces ``default_device`` in memory.
+Writing that dict straight back made the runtime's answer permanent - one boot
+under the CPU-only runtime left ``"cpu"`` in the file, and every later launch
+without the variable (a developer's own env, a Docker deploy) read it as the
+owner's choice and ran CPU inference on a CUDA machine.
+
+So the decided value lives under a ``_``-prefixed key that this writer never
+persists, and ``default_device`` goes back to the file as the owner had it.
+Every writer of the file goes through :func:`persist_server_config`.
+"""
+
+from pixlstash.utils.atomic_write import write_json_atomic
+
+#: The ``default_device`` the file held before an environment override replaced
+#: it in memory. Present only while an override is active.
+DEVICE_ON_DISK_KEY = "_default_device_on_disk"
+
+
+def persist_server_config(path: str, config: dict) -> None:
+    """Write *config* to *path*, minus what only this process decided.
+
+    Restores ``default_device`` to the on-disk value when an override is
+    active and drops every ``_``-prefixed key.
+    """
+    on_disk = dict(config)
+    if DEVICE_ON_DISK_KEY in on_disk:
+        on_disk["default_device"] = on_disk[DEVICE_ON_DISK_KEY]
+    for key in [k for k in on_disk if k.startswith("_")]:
+        del on_disk[key]
+    write_json_atomic(path, on_disk)

--- a/tests/test_default_device_override.py
+++ b/tests/test_default_device_override.py
@@ -10,6 +10,7 @@ Docker deploy can use it too.
 import json
 
 from pixlstash.server import Server
+from pixlstash.server_config_io import DEVICE_ON_DISK_KEY, persist_server_config
 
 DEVICE_ENV = "PIXLSTASH_DEFAULT_DEVICE"
 
@@ -85,6 +86,39 @@ class TestDefaultDeviceOverride:
             "banana" in r.message and "PIXLSTASH_DEFAULT_DEVICE" in r.message
             for r in caplog.records
         ), "Invalid override should be logged with a warning"
+
+    def test_the_override_never_reaches_the_file(self, tmp_path, monkeypatch):
+        """One boot under the CPU-only runtime used to write "cpu" into the
+        shared config, and every later launch without the variable read it as
+        the owner's choice: CPU inference on a CUDA machine."""
+        path = tmp_path / "server-config.json"
+        _write_config(path, default_device="auto")
+        monkeypatch.setenv(DEVICE_ENV, "cpu")
+
+        cfg = Server.init_server_config(str(path))
+        assert cfg["default_device"] == "cpu", "in memory the runtime wins"
+        assert cfg[DEVICE_ON_DISK_KEY] == "auto"
+
+        cfg["daily_snapshots"] = False  # some later settings save
+        persist_server_config(str(path), cfg)
+
+        with open(path) as f:
+            written = json.load(f)
+        assert written["default_device"] == "auto", "the file keeps the owner's value"
+        assert written["daily_snapshots"] is False, "other settings still land"
+        assert not [k for k in written if k.startswith("_")]
+
+    def test_without_an_override_the_file_is_written_as_is(self, tmp_path, monkeypatch):
+        path = tmp_path / "server-config.json"
+        _write_config(path, default_device="cuda")
+        monkeypatch.delenv(DEVICE_ENV, raising=False)
+
+        cfg = Server.init_server_config(str(path))
+        assert DEVICE_ON_DISK_KEY not in cfg
+        persist_server_config(str(path), cfg)
+
+        with open(path) as f:
+            assert json.load(f)["default_device"] == "cuda"
 
     def test_gpu_override_accepted(self, tmp_path, monkeypatch):
         """'gpu' is a known value (mapped to cuda by StartupChecks) and accepted."""


### PR DESCRIPTION
## The bug

The desktop shell passes `PIXLSTASH_DEFAULT_DEVICE` so the backend uses the device its active runtime supports. The backend wrote that value into the in-memory config and then, at boot and on every settings save, wrote the whole config back to disk. One boot under the CPU-only runtime therefore left `"default_device": "cpu"` in the shared file, and every later launch without the variable (a developer's own environment, a Docker deploy) read it as the owner's choice and ran CPU inference on a CUDA machine. Seen today on a dev launch: `forced_cpu=True` with CUDA torch installed.

## What changed

- New `pixlstash/server_config_io.py` with `persist_server_config(path, config)`: restores `default_device` to the on-disk value when an override is active and drops every `_`-prefixed key before writing.
- `Server.init_server_config` remembers the file's `default_device` under `_default_device_on_disk` when the override applies. In memory the runtime still wins.
- All four writers of the file (boot in `server.py`, the two settings routes in `routes/config.py`, the legacy-credential cleanup in `auth.py`) go through the helper.

## Tests

`tests/test_default_device_override.py`: an override never reaches the file while other settings still land, and without an override the file is written as-is. Scrapheap-retention route tests (one of the writers) still green.
