### PR TITLE
Hold the view-changed pill while the tagger runs

### DIFF
--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -17,6 +17,7 @@ import { useSnapshotsStore } from "../stores/useSnapshotsStore";
 import { useDedupStore } from "../stores/useDedupStore";
 import { useMovesStore } from "../stores/useMovesStore";
 import { useNoticeStore } from "../stores/useNoticeStore";
+import { useTasksStore } from "../stores/useTasksStore";
 import {
   isFullRestoreRequestInFlight,
   prepareForFullRestoreTransition,
@@ -133,6 +134,7 @@ export function useUpdatesSocket({
   refreshSidebarPicturesDebounced,
 }) {
   const wsStore = useWsStore();
+  const tasksStore = useTasksStore();
   const gridStore = useGridStore();
   const sortStore = useSortStore();
   const filterStore = useFilterStore();
@@ -235,8 +237,7 @@ export function useUpdatesSocket({
     refreshStackFacets: (ids) => gridContainer.value?.refreshStackFacets?.(ids),
     refreshThumbnailUrls: (ids) =>
       gridContainer.value?.refreshThumbnailUrls?.(ids),
-    applyRotatedCards: (ids) =>
-      gridContainer.value?.applyRotatedCards?.(ids),
+    applyRotatedCards: (ids) => gridContainer.value?.applyRotatedCards?.(ids),
     repositionImageByScore: (id, score) =>
       gridContainer.value?.repositionImageByScore?.(id, score),
     repositionImageBySmartScore: (id) =>
@@ -576,12 +577,34 @@ export function useUpdatesSocket({
   // tag change under an active tag filter (instead of reshuffling the filtered
   // grid under the user). Skip ids already queued in the "new pictures" pill so a
   // just-imported batch being tagged doesn't double-pill.
+  //
+  // While the tagger is running the ids are held instead: a pass over a
+  // library changes tags in eight-picture batches, and raising the pill per
+  // batch had it back on screen seconds after every refresh for as long as the
+  // run lasted. One pill when the run ends says the same thing once.
+  let heldSortChangedIds = [];
   function onFlagSortChanged(ids) {
     if (!Array.isArray(ids) || !ids.length) return;
+    if (tasksStore.taggingActive) {
+      const held = new Set(heldSortChangedIds);
+      for (const id of ids) held.add(id);
+      heldSortChangedIds = Array.from(held);
+      return;
+    }
     const pending = new Set(wsStore.pendingExternalImportIds);
     const fresh = ids.filter((id) => !pending.has(id));
     if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
   }
+
+  watch(
+    () => tasksStore.taggingActive,
+    (active) => {
+      if (active || !heldSortChangedIds.length) return;
+      const ids = heldSortChangedIds;
+      heldSortChangedIds = [];
+      onFlagSortChanged(ids);
+    },
+  );
 
   // The backend only sends events this client's current view could care about,
   // so any change to what the view is has to be re-announced.
@@ -604,6 +627,7 @@ export function useUpdatesSocket({
     () => {
       wsStore.clearPendingExternalImportIds();
       wsStore.clearSortChangedExternalIds();
+      heldSortChangedIds = [];
     },
   );
 

--- a/frontend/src/composables/useUpdatesSocket.test.js
+++ b/frontend/src/composables/useUpdatesSocket.test.js
@@ -57,6 +57,9 @@ import {
   vramOomNotice,
 } from "./useUpdatesSocket";
 import { useNoticeStore } from "../stores/useNoticeStore";
+import { useWsStore } from "../stores/useWsStore";
+import { useTasksStore } from "../stores/useTasksStore";
+import { useGridStore } from "../stores/useGridStore";
 import { API_BASE_URL } from "../utils/apiClient";
 
 describe("updates socket close lifecycle", () => {
@@ -406,7 +409,6 @@ describe("useUpdatesSocket: the GPU out-of-memory notice", () => {
   });
 });
 
-
 describe("vramOomNotice names the process holding the card", () => {
   it("names the largest other process when the backend could see it", () => {
     const notice = vramOomNotice({
@@ -431,6 +433,61 @@ describe("vramOomNotice names the process holding the card", () => {
       recovered: false,
       other_processes: [],
     });
-    expect(notice.text).toContain("another program is probably holding the card");
+    expect(notice.text).toContain(
+      "another program is probably holding the card",
+    );
+  });
+});
+
+describe("the view-changed pill while the tagger runs", () => {
+  /** Mount the composable and hand back its API plus the stores it drives. */
+  function mountApi() {
+    let api = null;
+    host = mount({
+      setup() {
+        api = useUpdatesSocket({
+          gridContainer: ref(null),
+          refreshSidebar: vi.fn(),
+          refreshSidebarPicturesDebounced: vi.fn(),
+        });
+        return () => null;
+      },
+    });
+    return { api, wsStore: useWsStore(), tasksStore: useTasksStore() };
+  }
+
+  it("holds the ids while tagging runs and raises one pill when it ends", async () => {
+    const { api, wsStore, tasksStore } = mountApi();
+    tasksStore.workerSnapshots = { TagTask: { active: true, total: 800 } };
+    await host.vm.$nextTick();
+    expect(tasksStore.taggingActive).toBe(true);
+
+    api.onFlagSortChanged([1, 2]);
+    api.onFlagSortChanged([2, 3]);
+    expect(wsStore.sortChangedExternalIds).toEqual([]);
+
+    tasksStore.workerSnapshots = { TagTask: { active: false, total: 800 } };
+    await host.vm.$nextTick();
+    expect(tasksStore.taggingActive).toBe(false);
+    expect([...wsStore.sortChangedExternalIds].sort()).toEqual([1, 2, 3]);
+  });
+
+  it("raises the pill at once when nothing is tagging", () => {
+    const { api, wsStore } = mountApi();
+    api.onFlagSortChanged([7]);
+    expect(wsStore.sortChangedExternalIds).toEqual([7]);
+  });
+
+  it("drops held ids when the grid rebuilds", async () => {
+    const { api, wsStore, tasksStore } = mountApi();
+    tasksStore.workerSnapshots = { TagTask: { active: true, total: 8 } };
+    await host.vm.$nextTick();
+    api.onFlagSortChanged([5]);
+
+    useGridStore().gridVersion += 1;
+    await host.vm.$nextTick();
+    tasksStore.workerSnapshots = {};
+    await host.vm.$nextTick();
+    expect(wsStore.sortChangedExternalIds).toEqual([]);
   });
 });

--- a/frontend/src/stores/useTasksStore.js
+++ b/frontend/src/stores/useTasksStore.js
@@ -202,6 +202,16 @@ export const useTasksStore = defineStore("tasks", () => {
   const activeCount = computed(() => activeEntries.value.length);
   const hasActiveTasks = computed(() => activeCount.value > 0);
 
+  // The tagger's worker key is its TaskType value. While it is running, a
+  // tag-filtered grid would otherwise be offered a "View changed externally"
+  // pill after every eight-picture batch; readers hold theirs until this
+  // goes false. Same grace window as the Tasks tab row, so a pass idling
+  // between batches still counts as running.
+  const TAGGER_WORKER_KEY = "TagTask";
+  const taggingActive = computed(() =>
+    activeWorkerEntries.value.some((entry) => entry.key === TAGGER_WORKER_KEY),
+  );
+
   // ── Rate helpers (read by the Tasks tab for sparklines / "/s" labels) ──────
   // Progress made across the window divided by the time it took, which is the
   // throughput the label claims to show.
@@ -391,6 +401,7 @@ export const useTasksStore = defineStore("tasks", () => {
     activeWorkerEntries,
     activeCount,
     hasActiveTasks,
+    taggingActive,
     // rate helpers
     getLatestRate,
     // polling lifecycle


### PR DESCRIPTION
## The behaviour

Under an active tag filter, an external tag change raises the "View changed externally" pill instead of reshuffling the grid under the user. That contract is right, but a tagging pass over a library changes tags in eight-picture batches, so the pill was back on screen seconds after every refresh for as long as the run lasted.

## What changed

- `useTasksStore` exposes `taggingActive`: the tagger worker is in the active list, with the same grace window the Tasks tab row uses, so a pass idling between batches still counts as running.
- `useUpdatesSocket.onFlagSortChanged` holds the ids while that is true and raises one pill with all of them when the tagger goes idle. Held ids are dropped when the grid rebuilds, like the pill ids themselves.
- Nothing changes when no tagger is running: the pill is raised at once as before.

## Tests

`useUpdatesSocket.test.js`: held while tagging and raised once at the end with the union of ids, raised at once when nothing is tagging, held ids dropped on a grid rebuild. The tasks-store grace and realtime-sync suites still pass.
