### PR TITLE
Keep folder-derived tags when the tagger reaches the picture

### DIFF
--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -77,6 +77,7 @@ from pixlstash.services.project_membership_service import (
     set_picture_set_projects,
 )
 from pixlstash.services.set_lock_service import locked_picture_ids
+from pixlstash.utils.service.label_ledger import POS, record_human_label
 from pixlstash.utils.sql_chunking import chunked
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
@@ -999,6 +1000,15 @@ def _link_pictures(
                 existing_sets.add((set_id, pic.id))
                 session.add(PictureSetMember(set_id=set_id, picture_id=pic.id))
             for tag_name in tag_names:
+                # The owner accepted this folder as a tag, so it is a human POS
+                # and belongs in the label ledger. Without it the tag does not
+                # survive: these pictures still carry TAG_PENDING_SENTINEL, and
+                # when TagTask reaches one it deletes every Tag row and rewrites
+                # the picture from `model_tags | human_POS - human_NEG`. The
+                # general upsert, not `record_human_label_if_relevant`: a folder
+                # tag is usually outside the tagger's anomaly vocabulary, which
+                # is exactly the case that variant declines to record.
+                record_human_label(session, pic.id, tag_name, POS)
                 if (pic.id, tag_name) in existing_tags:
                     continue
                 existing_tags.add((pic.id, tag_name))

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -722,6 +722,64 @@ def test_a_picture_frozen_by_a_locked_set_is_skipped_not_filed(owner_env):
     assert frozen_id not in tagged, "a picture frozen by a locked set must be skipped"
 
 
+def test_a_folder_tag_survives_the_tagger_reaching_the_picture(owner_env):
+    """The commit runs while the tagger is still draining the import.
+
+    Every freshly indexed picture carries TAG_PENDING_SENTINEL, and when
+    `TagTask` reaches one it deletes the picture's whole Tag set and rewrites
+    it from `model_tags | human_POS - human_NEG`. A folder tag the owner just
+    accepted is not a model tag, so unless the commit records it in the human
+    label ledger the tagger silently deletes it minutes later. Without the
+    `record_human_label` call in `_link_pictures` this test fails on the
+    "gallery" assertion: only the model's own tag comes back.
+    """
+    from pixlstash.db_models.picture import Picture
+    from pixlstash.db_models.tag import Tag, TAG_PENDING_SENTINEL
+    from pixlstash.services.folder_structure_commit_service import (
+        Assignment,
+        CommitResult,
+        _link_pictures,
+    )
+    from pixlstash.tasks.tag_task import TagTask
+    from sqlmodel import select
+
+    server = owner_env["server"]
+    image_root = server.vault.image_root
+
+    def scenario(session):
+        pic = Picture(file_path="tag-survives-tagger/gallery/kept.jpg")
+        session.add(pic)
+        session.flush()
+        # Exactly what the indexing step leaves behind for the tagger.
+        session.add(Tag(picture_id=pic.id, tag=TAG_PENDING_SENTINEL))
+        session.flush()
+
+        _link_pictures(
+            session,
+            [pic],
+            [Assignment(relative_path="gallery", kind="tag")],
+            os.path.join(image_root, "tag-survives-tagger"),
+            image_root,
+            CommitResult(),
+        )
+        session.commit()
+
+        # The tagger reaching this picture, with a model call that knows
+        # nothing about the folder the owner filed it under.
+        TagTask._add_tags_bulk(session, [{"pic_id": pic.id, "tags": ["outdoor"]}])
+
+        return pic.id, set(
+            session.exec(select(Tag.tag).where(Tag.picture_id == pic.id)).all()
+        )
+
+    pic_id, tags = server.vault.db.run_task(scenario)
+    assert "gallery" in tags, f"the tagger erased the folder tag on {pic_id}: {tags}"
+    assert "outdoor" in tags, "the tagger's own tag must still be applied"
+    assert TAG_PENDING_SENTINEL not in tags, (
+        "the tagger clears the sentinel it acted on"
+    )
+
+
 def test_a_person_lands_on_faces_extracted_before_the_mapping(owner_env):
     """Workers start while the import is still indexing, so a picture's faces
     routinely exist BEFORE the mapping assigns its folder to a person. The


### PR DESCRIPTION
The folder-structure commit inserts a `Tag` row for each folder mapped to the
Tag kind, but the picture still carries `TAG_PENDING_SENTINEL`, so
`MissingTagFinder` hands it to the tagger. `TagTask._add_tags_bulk` then
computes `effective = model_tags | human_POS - human_NEG`, deletes every `Tag`
row for the picture and re-inserts only `effective`. The folder tag is not in
`human_POS`, so it is dropped, and nothing re-applies it: the durable record is
`done` and the read is `committed`.

The loss is per-picture and racy — pictures the tagger drained before the
commit keep their tag, everything it reaches afterwards loses it — so on any
library the tagger cannot drain during indexing, most of the accepted tags
disappear silently some minutes later. `tags_created` reports success either
way.

`_link_pictures` now records a human POS label for each folder tag, the same
mechanism `POST /pictures/{id}/tags` already relies on. Clearing the sentinel
instead would have suppressed auto-tagging for the whole imported library,
which is the wrong trade.

The synthetic `model_version="manual"` rows this creates for content tags are
inert elsewhere: `smart_score` reads anomaly tags only, the `model_disputes`
figure in `tag_health` counts human POS below `EST_WRONG_MAX_CONF` and these
are written at `confidence=1.0`, and `tag_prediction_service` already writes
rows of this shape for arbitrary tags.

Covered by `test_a_folder_tag_survives_the_tagger_reaching_the_picture` in the
existing module-scoped environment; disabling the new call turns it red.

Found by the 1.11.0 develop-to-main review, chunk A1.
