### PR TITLE
Layout dialog: never choose a layout on the owner's behalf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@
   local network or Tailscale, not from further away.
 - The empty-library screen offers three ways to fill it, leading with pointing
   PixlStash at a folder you already have.
-- PixlStash Views: publish sets, people and projects as folders of links, from
-  Settings → Libraries. Links, not copies: deleting a view folder loses no
-  picture. A destination Views cannot use (inside the library, a reference
-  folder, a cloud-synced folder, or a drive without link support) is refused
-  with the reason.
 - Folder layouts: give a library a layout such as Project / Person or Set and
   new pictures are filed accordingly. Choosing a layout moves nothing that
   already exists. "Move to match" is offered, counted first, and undoable as one
@@ -27,6 +22,13 @@
 - The desktop app's first run asks which library to open before anything else.
   The telemetry question moves there too.
 - Tagger plugins can now produce tag predictions, not only the built-in tagger.
+- Export a selection to a folder on the machine running PixlStash, sidecars
+  included, and the folder opens when it is done. The destination must be
+  empty, so an export never writes over anything you already have there.
+- Writing a tagger or image plugin no longer starts with the git legwork.
+  `pixlstash-cli plugins create` asks what you are building and leaves a
+  checkout with the folder, the template and the branch ready; `plugins submit`
+  runs the repository's own checks and opens the pull request.
 - Fixed: sorting by likeness to a person took seconds per page on a large
   library, and the likeness pill had been missing from the grid since 1.10.0.
 - Fixed: a library last opened by a newer PixlStash is explained in plain words,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
   empty, so an export never writes over anything you already have there.
 - Writing a tagger or image plugin no longer starts with the git legwork.
   `pixlstash-cli plugins create` asks what you are building and leaves a
-  checkout with the folder, the template and the branch ready; `plugins submit`
-  runs the repository's own checks and opens the pull request.
+  checkout with the folder, the template and the branch ready;
+  `pixlstash-cli plugins submit` runs the repository's own checks and opens the pull request.
 - Fixed: sorting by likeness to a person took seconds per page on a large
   library, and the likeness pill had been missing from the grid since 1.10.0.
 - Fixed: a library last opened by a newer PixlStash is explained in plain words,

--- a/frontend/src/components/settings/LibraryLayoutDialog.test.js
+++ b/frontend/src/components/settings/LibraryLayoutDialog.test.js
@@ -206,34 +206,70 @@ describe("LibraryLayoutDialog", () => {
     }
   });
 
-  it("refuses to clear the last level, because a layout with none moves nothing", async () => {
+  it("clearing the last level turns the layout off, sending layout: null", async () => {
+    // Turning a layout OFF has to be reachable. `LibrarySettings.layout` being
+    // non-NULL is the gate on the whole layout tracker
+    // (`database.py::_library_has_layout`), so a library that can never send
+    // `layout: null` can never stop LayoutMoveTask renaming its files. This
+    // used to be refused outright.
+    vi.useFakeTimers();
+    // The real PATCH answers with the settings as stored, so the builder is
+    // re-applied from the response. A fixed mock would snap the cleared level
+    // back and the second clear would never reach an empty layout.
+    setLayoutSettings.mockImplementation((patch) =>
+      Promise.resolve({
+        layout: patch.layout ?? null,
+        layout_unfiled: "Unassigned",
+      }),
+    );
     const wrapper = mountDialog();
     await flushPromises();
     setLayoutSettings.mockClear();
 
     // Two levels: clearing one is fine, the other becomes level 1.
     editLevel(wrapper, 1, []);
+    await vi.advanceTimersByTimeAsync(600);
     await flushPromises();
     expect(
       wrapper.findAllComponents({ name: "v-select" })[0].props("modelValue"),
     ).toEqual(["project"]);
 
-    // Now clear the only one left: refused, and the select keeps its value.
+    // Now clear the only one left: saved as `null`, not refused.
     setLayoutSettings.mockClear();
     editLevel(wrapper, 0, []);
+    await vi.advanceTimersByTimeAsync(600);
     await flushPromises();
-    expect(setLayoutSettings).not.toHaveBeenCalled();
-    expect(
-      wrapper.findAllComponents({ name: "v-select" })[0].props("modelValue"),
-    ).toEqual(["project"]);
-    expect(wrapper.text()).toContain("Keep at least one level");
+    expect(setLayoutSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ layout: null }),
+    );
   });
 
-  it("opens a library with no layout on Project, one level, not two", async () => {
-    // The builder grows one level at a time, so an unset library is proposed
-    // the first level rather than the two-level DEFAULT_LAYOUT. It is written
-    // through the normal save path, which is what puts folders in the tree
-    // instead of an empty state; a layout on its own moves no existing file.
+  it("opening a library with no layout writes NOTHING", async () => {
+    // The regression this file exists to pin. Opening the dialog used to seed
+    // `[["project"]]` through the normal save path, PATCHing a layout onto the
+    // library as a side effect of looking at the screen. Because
+    // `LibrarySettings.layout` being non-NULL arms the layout tracker, that
+    // turned a browse into a standing decision to move the owner's files.
+    getLayoutSettings.mockResolvedValue({
+      layout: null,
+      layout_unfiled: "Unassigned",
+      default_layout: "project/person,set",
+    });
+    vi.useFakeTimers();
+    const wrapper = mountDialog();
+    await flushPromises();
+    // Well past SAVE_DEBOUNCE_MS: a debounced write would have fired by now.
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushPromises();
+
+    expect(setLayoutSettings).not.toHaveBeenCalled();
+    // One empty slot to grow into, nothing chosen.
+    const selects = wrapper.findAllComponents({ name: "v-select" });
+    expect(selects).toHaveLength(1);
+    expect(selects[0].props("modelValue")).toEqual([]);
+  });
+
+  it("a library with no layout only writes once the owner picks a level", async () => {
     getLayoutSettings.mockResolvedValue({
       layout: null,
       layout_unfiled: "Unassigned",
@@ -243,18 +279,14 @@ describe("LibraryLayoutDialog", () => {
     vi.useFakeTimers();
     const wrapper = mountDialog();
     await flushPromises();
+    expect(setLayoutSettings).not.toHaveBeenCalled();
+
+    editLevel(wrapper, 0, ["project"]);
     await vi.advanceTimersByTimeAsync(600);
     await flushPromises();
-
     expect(setLayoutSettings).toHaveBeenCalledWith(
       expect.objectContaining({ layout: "project" }),
     );
-    const selects = wrapper.findAllComponents({ name: "v-select" });
-    // One filled level plus the single empty slot to grow into: two boxes, one
-    // chosen facet. Seeding the two-level default would show two filled.
-    expect(selects).toHaveLength(2);
-    expect(selects[0].props("modelValue")).toEqual(["project"]);
-    expect(selects[1].props("modelValue")).toEqual([]);
   });
 
   it("leaves a library that already has a layout alone", async () => {

--- a/frontend/src/components/settings/LibraryLayoutDialog.vue
+++ b/frontend/src/components/settings/LibraryLayoutDialog.vue
@@ -80,9 +80,6 @@ import { errorDetail } from "../../utils/apiError";
  */
 const MAX_LEVELS = LAYOUT_FACETS.length;
 
-/** What a library with no layout of its own is proposed when the dialog opens. */
-const DEFAULT_FACET = "project";
-
 const props = defineProps({
   open: { type: Boolean, default: false },
 });
@@ -121,8 +118,6 @@ const blocked = computed(
 );
 const unavailable = computed(() => blocked.value || refused.value);
 const isOn = computed(() => segments.value.length > 0);
-/** Set when an edit that would leave no level at all was refused. */
-const atLeastOneLevel = ref(false);
 const layoutText = computed(() =>
   segments.value.map((segment) => describeSegment(segment)).join(" / "),
 );
@@ -168,20 +163,16 @@ async function load() {
   try {
     applySettings(await getLayoutSettings());
     loaded.value = true;
-    if (segments.value.length === 0) {
-      // A library with no layout opens on Project rather than an empty slot.
-      // One level, not the two-level DEFAULT_LAYOUT: levels are added one at a
-      // time, so the builder proposes the first and the owner decides whether
-      // there is a second. Routed through `scheduleSave` so seeding is an edit
-      // like any other - it writes the layout and re-reads the preview, which
-      // is what puts folders in the tree instead of an empty state.
-      //
-      // Writing on open is safe in the way that matters: a layout decides where
-      // the NEXT picture is written and never moves a file that is already
-      // here. Moving those is the button below, and a separate yes.
-      scheduleSave([[DEFAULT_FACET]]);
-      return;
-    }
+    // A library with no layout opens on an empty slot, and the dialog writes
+    // NOTHING until the owner picks a level.
+    //
+    // This used to seed `[["project"]]` through `scheduleSave`, which PATCHed
+    // a layout onto the library as a side effect of opening the dialog. That
+    // is not a safe default: `LibrarySettings.layout` being non-NULL is the
+    // gate on the whole layout tracker (`database.py::_library_has_layout`),
+    // so the seed armed `LayoutMoveTask` for every later reassignment - the
+    // dialog decided, on the owner's behalf, that their files may be moved.
+    // Opening a settings screen to read it must never be a decision.
     await refreshPreview();
   } catch (err) {
     refused.value = err?.response?.status === 403;
@@ -285,15 +276,13 @@ function setLevel(index, facets) {
   // removed, not an empty folder to draw: dropping it is what the grammar does
   // anyway, and keeping it would send a layout with a hole in it.
   const kept = next.filter((segment) => segment.length > 0);
-  if (kept.length === 0) {
-    // Every level cleared is a layout that names no folder at all, which makes
-    // the tree, the count and the move below it meaningless. Refused rather
-    // than saved: `segments` is unchanged, so the select snaps back on its own.
-    // The hint is what stops that reading as a broken dropdown.
-    atLeastOneLevel.value = true;
-    return;
-  }
-  atLeastOneLevel.value = false;
+  // Clearing the last level is how the owner turns the layout OFF, and it must
+  // stay reachable: `formatLayout([])` is `null`, the PATCH the backend takes
+  // to mean "no layout", which is what un-gates `_library_has_layout` and stops
+  // LayoutMoveTask touching files again. This used to be refused, so a library
+  // that had a layout could never be put back to not having one from the UI.
+  // `refreshPreview` clears the count and the move bar on its own once `isOn`
+  // goes false.
   scheduleSave(kept);
 }
 
@@ -645,11 +634,6 @@ function netDelta(row) {
         </template>
       </div>
 
-      <p v-if="atLeastOneLevel" class="layout-level__hint" role="status">
-        Keep at least one level. A layout with none names no folder, so there is
-        nothing to draw and nothing to move.
-      </p>
-
       <!-- The unfiled folder is where a picture with nothing to file it by is
            written, sweep or no sweep; the sweep is only whether the ones
            already here are moved there too. -->
@@ -878,15 +862,6 @@ function netDelta(row) {
   line-height: var(--leading-snug);
   color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
   margin: 0 0 var(--space-5);
-}
-
-/* Only ever on screen after an edit was refused, so it sits in the gap the
-   builder already leaves rather than reserving height of its own. */
-.layout-level__hint {
-  font-size: var(--text-xs);
-  line-height: var(--leading-snug);
-  color: rgb(var(--v-theme-warning));
-  margin: calc(-1 * var(--space-3)) 0 var(--space-4);
 }
 
 .layout-dlg__error {


### PR DESCRIPTION
Found by the 1.11.0 develop -> main release review.

## The problem

`LibraryLayoutDialog.load()` seeded `[["project"]]` through `scheduleSave` when
a library had no layout, so **opening the dialog PATCHed a layout onto the
library**. No button was pressed, and the dialog is `:open`-bound rather than
`v-if`, so Escape did not cancel the pending timer.

That is not a cosmetic default. `LibrarySettings.layout` being non-NULL is the
gate on the entire layout tracker (`database.py::_library_has_layout`): once
set, every flush that dirties a picture stamps `Picture.layout_check_due_at`,
`LayoutMoveFinder` queues `LayoutMoveTask`, and the task renames files on disk.

`setLevel` then refused to save an empty layout, so although the PATCH accepts
`layout: null`, no UI path could send it. Browsing into the dialog and closing
it left the library on a layout permanently, with every later project, person
or set reassignment moving files.

The old code argued it was safe because "a layout decides where the NEXT
picture is written and never moves a file that is already here". That holds
only at the instant of setting; the release notes say the rest themselves --
"A picture moves only when its folder stops being true."

## The change

- `load()` seeds nothing. A library with no layout opens on the empty slot the
  builder already draws, and writes only when the owner picks a level.
- `setLevel` no longer refuses an empty layout. `formatLayout([])` is already
  `null`, so clearing the last level turns the layout off, which is what
  un-gates the tracker.
- Removes the now-dead `atLeastOneLevel` state, its hint and its CSS.

Net 17 insertions, 42 deletions in the component.

## Tests

Two tests pinned the old behaviour and now assert the new. One added.
Both regression tests were confirmed to **fail against the component at
`origin/develop`** and pass against this branch:

- `opening a library with no layout writes NOTHING` -- advances well past the
  debounce and asserts `setLayoutSettings` was never called.
- `clearing the last level turns the layout off, sending layout: null`
- `a library with no layout only writes once the owner picks a level`

`LibraryLayoutDialog.test.js` 23/23; `src/components/settings` 93/93; eslint
clean.

One test mock changed to echo the patch it was sent, which is what the real
PATCH does -- a fixed mock snapped the cleared level back and made an
empty layout unreachable in the test.

## Also here

The 1.11.0 changelog entry for PixlStash Views is removed: the feature is
postponed to 1.12.0 and its settings pane is deliberately not wired up, so the
notes were sending users to a screen that will not have it. Export-to-folder
and `plugins create` / `plugins submit` shipped in 1.11.0 with no entry, and
are added.

No backend change. The mover itself was reviewed separately and is sound.