### PR TITLE
Setup rail: the folder name is text, not markup

### DIFF
--- a/electron/src/renderer/setup.js
+++ b/electron/src/renderer/setup.js
@@ -193,27 +193,45 @@ function renderSteps() {
   questionSteps().forEach((step, i) => {
     const cell = document.getElementById(`value-${step}`);
     if (!cell) return;
-    cell.innerHTML = i < at || (i === at && step === 'library') ? answerFor(step) : '';
+    const answer = i < at || (i === at && step === 'library') ? answerFor(step) : null;
+    // The icon is a constant declared in this file, so it goes in as markup.
+    // The label is not: for the library step it is the owner's own folder name,
+    // and a folder may legally be called `<img src=x onerror=...>` on every
+    // platform PixlStash runs on. It goes in as text, the way every other
+    // dynamic value in this renderer already does (see `renderLines`).
+    cell.innerHTML = answer ? answer.icon : '';
+    if (answer) {
+      const label = document.createElement('span');
+      label.textContent = answer.text;
+      cell.appendChild(label);
+    }
   });
 }
 
+/**
+ * The answer shown beside a completed step, as `{icon, text}` or null.
+ *
+ * Split rather than returned as one HTML string so the caller can put the icon
+ * in as markup and the label in as text. Returning markup made the folder name
+ * an HTML injection point.
+ */
 function answerFor(step) {
   if (step === 'library') {
-    if (!mode) return '';
+    if (!mode) return null;
     const icon = mode === 'open' && inspection && inspection.isLibrary ? LOGO : FOLDER_ICON;
     // The folder's own name, clipped by CSS when even that is long. The whole
     // path is on the row, because the name alone cannot tell two "Pictures"
     // apart.
-    return `${icon}<span>${basename(els.folder.value)}</span>`;
+    return { icon, text: basename(els.folder.value) };
   }
   if (step === 'compute') {
-    return `${CHIP_ICON}<span>${selectedComputeLabel()}</span>`;
+    return { icon: CHIP_ICON, text: selectedComputeLabel() };
   }
   if (step === 'privacy') {
     const opt = PRIVACY_OPTIONS[privacyVariant].find((o) => o.key === privacyChoice);
-    return opt ? `${barsMark(opt.bars)}<span>${opt.name}</span>` : '';
+    return opt ? { icon: barsMark(opt.bars), text: opt.name } : null;
   }
-  return '';
+  return null;
 }
 
 function barsMark(lit) {

--- a/electron/test/setupFolderNameEscaping.test.ts
+++ b/electron/test/setupFolderNameEscaping.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+const rendererDir = join(__dirname, '..', '..', 'src', 'renderer');
+
+/**
+ * The step rail shows the chosen folder's name. That name is the owner's, and
+ * a folder may legally be called `<img src=x onerror=...>` on every platform
+ * PixlStash runs on, so it must reach the DOM as text and never as markup.
+ *
+ * It used to be interpolated into a template literal that `answerFor` returned
+ * and the caller assigned to `innerHTML` (CodeQL: "DOM text reinterpreted as
+ * HTML"). The CSP blocks inline execution, so this was defence in depth rather
+ * than a live hole - but it is a privileged renderer and the escape belongs at
+ * the sink.
+ *
+ * Source-text assertions because `setup.js` is a plain renderer script with no
+ * module boundary to import, the same way `setupConsentAssets.test.ts` checks
+ * this file.
+ */
+describe('the setup rail never renders the folder name as markup', () => {
+  const script = readFileSync(join(rendererDir, 'setup.js'), 'utf8');
+
+  it('never interpolates basename() into a template literal', () => {
+    // The regression itself: `${icon}<span>${basename(...)}</span>`.
+    assert.doesNotMatch(
+      script,
+      /`[^`]*\$\{\s*basename\(/,
+      'basename() must not be interpolated into a string that reaches innerHTML',
+    );
+  });
+
+  it('answerFor hands back the icon and the text separately', () => {
+    assert.match(
+      script,
+      /return\s*\{\s*icon,\s*text:\s*basename\(els\.folder\.value\)\s*\}/,
+      'the library step must return {icon, text}, not one HTML string',
+    );
+  });
+
+  it('the label is written with textContent, not innerHTML', () => {
+    assert.match(script, /label\.textContent\s*=\s*answer\.text/);
+    // The icon is a constant from this file and stays markup; what must not
+    // come back is the label going in the same way.
+    assert.doesNotMatch(script, /cell\.innerHTML\s*=\s*[^;]*answerFor\(/);
+  });
+});


### PR DESCRIPTION
Closes the CodeQL "DOM text reinterpreted as HTML" finding on
`electron/src/renderer/setup.js`. Same issue the 1.11.0 release review filed as
item 15 of #1177 (chunk F, D6).

## The problem

`answerFor()` returned one HTML string per step, which the caller assigned to
`cell.innerHTML`:

```js
return `${icon}<span>${basename(els.folder.value)}</span>`;
```

`els.folder.value` is the folder the owner picked. A folder may legally be
named `<img src=x onerror=...>` on Linux, macOS and Windows alike, so the step
rail turned a filename into markup in a privileged renderer.

**Severity: low, deliberately stated.** The CSP is `script-src 'self'` with no
`'unsafe-inline'`, so an injected handler does not execute. This is defence in
depth at the sink, not a live hole — but the sink is where the escape belongs,
and CodeQL will keep flagging it until it is fixed there.

## Scope: one sink, checked rather than assumed

`setup.js` has eleven `innerHTML` assignments. I traced all of them instead of
patching the flagged line:

- `renderLines` (`:563`) already does it right — a static skeleton, then
  `textContent` for `name`, `value` and `note`. That is the pattern this change
  copies.
- Every `setVerdict` caller passes `count(...)`, `humanBytes(...)` and string
  literals; `titleHtml` is always `WORDMARK` (a constant in this file) plus
  literal text. No owner input reaches those.
- The step skeleton at `:184` interpolates `STEP_LABELS[step] || step`, from a
  fixed constant.

`basename(els.folder.value)` is the only owner-controlled string that reached
markup anywhere in the file.

## The change

`answerFor` returns `{icon, text}` (or `null`) instead of one string. The caller
puts the icon in as markup — it is a constant declared in this file — and the
label in with `textContent`.

24 insertions, 6 deletions. No behaviour change: the rail renders exactly as
before for every folder name that was not trying to be markup.

## Tests

Three, in the source-text style `setupConsentAssets.test.ts` already uses for
this file (a plain renderer script with no module boundary to import):

- `basename()` never appears inside a template literal — the regression itself
- `answerFor` hands the icon and text back separately
- the label is written with `textContent`, and `cell.innerHTML` is never
  assigned from `answerFor(...)`

**All three fail against `electron/src/renderer/setup.js` at `origin/develop`**
and pass on this branch. Electron suite: 194/194.