### PR TITLE
Refuse a views root the rest of the app would refuse

### DIFF
--- a/pixlstash/routes/config.py
+++ b/pixlstash/routes/config.py
@@ -1220,7 +1220,15 @@ def create_router(server) -> APIRouter:
             "Mode. Sending `views_root: null` removes the published tree and "
             "leaves the folder itself alone."
         ),
-        responses={400: {"description": "The views folder cannot hold the tree."}},
+        responses={
+            400: {"description": "The views folder cannot hold the tree."},
+            403: {
+                "description": (
+                    "The views folder is outside every configured "
+                    "`filesystem_roots` entry."
+                )
+            },
+        },
     )
     def patch_views_config(request: Request, body: ViewsConfigPatch):
         _ensure_secure_when_required(request)
@@ -1237,6 +1245,34 @@ def create_router(server) -> APIRouter:
                 views_service.remove(previous_root)
             library_settings_service.set_views_config(server.vault.db, None, [])
             return _views_payload()
+
+        # An operator who confined the folder picker to a set of roots did not
+        # mean "except for the route that creates a tree of links". Honoured
+        # here rather than in `check_views_root`, which is a pure path rule and
+        # has no server config to read.
+        roots = [
+            os.path.realpath(root)
+            for root in (server._server_config.get("filesystem_roots") or [])
+            if isinstance(root, str) and root
+        ]
+        # Only a path the sink would itself accept is compared. `~` is NOT
+        # expanded and a relative value is skipped rather than resolved:
+        # `os.path.realpath("")` is the server's working directory, which could
+        # sit inside a configured root and pass a check it was never meant to.
+        # Both shapes are refused downstream by `check_views_root`, which is the
+        # one place that decides what a views root may be.
+        candidate = body.views_root.strip()
+        if roots and os.path.isabs(candidate):
+            resolved_views_root = os.path.realpath(candidate)
+            if not any(
+                resolved_views_root == root
+                or resolved_views_root.startswith(root + os.sep)
+                for root in roots
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Path is not within any configured filesystem root.",
+                )
 
         if previous_root and views_service.roots_overlap(
             previous_root, body.views_root

--- a/pixlstash/services/views_service.py
+++ b/pixlstash/services/views_service.py
@@ -52,6 +52,9 @@ from pixlstash.db_models.project import Project
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.path_utils import path_is_within, resolve_path_within
+from pixlstash.utils.reference_folder_validator import (
+    validate_reference_folder_path,
+)
 
 logger = get_logger(__name__)
 
@@ -291,6 +294,8 @@ def check_views_root(root: str, vault, other_library_roots: Iterable[str] = ()) 
       second time under its view path.
     * **Containing the library.** The same two problems, reached from the other
       side, plus a rebuild that would delete into the library.
+    * **A restricted system directory**, by the shared blocklist, resolved first
+      so a symlink cannot launder one past it.
     * **A cloud-sync folder.** The client follows links and uploads the content,
       which duplicates the library rather than referencing it. This one is a
       **precaution, not a measurement**: no sync client was available to test
@@ -300,6 +305,21 @@ def check_views_root(root: str, vault, other_library_roots: Iterable[str] = ()) 
     """
     if not root or not os.path.isabs(root):
         raise ViewsError("Choose a full path for the views folder.")
+
+    # The same blocklist every other path-taking route applies, on the resolved
+    # path. Without it this function's refusals were all *relative* - inside the
+    # library, inside a reference folder, a sync folder - and a root that was
+    # none of those was accepted anywhere on the disk, including a system
+    # directory the rest of the app refuses outright. `_prepare_root` then
+    # creates the folder and writes the marker into it.
+    # `os.path.realpath`, not this module's `_resolved`: that one applies
+    # `normcase`, which lowercases on Windows, and the blocklist entries are
+    # spelled `C:\Windows`. Passing a case-folded path made the check match
+    # nothing on Windows - a refusal that never fires is worse than none,
+    # because the coverage matrix records it as present.
+    blocked = validate_reference_folder_path(os.path.realpath(os.path.abspath(root)))
+    if blocked:
+        raise ViewsError(blocked)
 
     image_root = getattr(vault, "image_root", None)
     if image_root:

--- a/tests/test_views_links.py
+++ b/tests/test_views_links.py
@@ -720,6 +720,38 @@ def test_an_ordinary_folder_beside_the_library_is_allowed(tmp_path, library):
     views_service.check_views_root(str(tmp_path / "_PixlStash Views"), vault)
 
 
+def test_a_views_root_in_a_restricted_system_directory_is_refused(tmp_path, library):
+    """Every refusal here used to be relative to the library, so anywhere else passed.
+
+    A root that is not inside the library, not inside a reference folder and not
+    synced was accepted anywhere on the disk, and `_prepare_root` then created
+    the folder and wrote the marker into it.
+    """
+    image_root, _paths = library
+    vault = _FakeVault(image_root)
+
+    with pytest.raises(views_service.ViewsError, match="restricted system directory"):
+        views_service.check_views_root("/etc/pixlstash-views", vault)
+
+
+def test_a_symlink_into_a_restricted_directory_is_refused_as_a_views_root(
+    tmp_path, library
+):
+    """The blocklist is literal, so the root is resolved before it is compared."""
+    image_root, _paths = library
+    vault = _FakeVault(image_root)
+    link = tmp_path / "looks-ordinary"
+    try:
+        link.symlink_to("/etc", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    if not os.path.isdir("/etc"):
+        pytest.skip("no /etc on this platform")
+
+    with pytest.raises(views_service.ViewsError, match="restricted system directory"):
+        views_service.check_views_root(str(link / "pixlstash-views"), vault)
+
+
 def test_a_relative_views_root_is_refused(tmp_path, library):
     image_root, _paths = library
     vault = _FakeVault(image_root)
@@ -856,6 +888,30 @@ def test_patch_publishes_the_tree_and_get_reports_it(_env, _seeded, tmp_path):
     assert os.path.isdir(os.path.join(views_root, "People", "Mira"))
     assert os.path.isdir(os.path.join(views_root, "Projects", "Editorial"))
     assert client.get(f"{API}/server-config/views").json()["views_root"] == views_root
+
+
+def test_a_views_root_outside_the_configured_filesystem_roots_is_refused(
+    _env, _seeded, tmp_path, monkeypatch
+):
+    """An operator who confined the picker did not exempt the route that makes links."""
+    client, server, _tmp = _env
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setitem(server._server_config, "filesystem_roots", [str(allowed)])
+
+    outside = client.patch(
+        f"{API}/server-config/views",
+        json={"views_root": str(tmp_path / "outside"), "kinds": ["sets"]},
+    )
+    assert outside.status_code == 403, outside.text
+    assert not os.path.exists(str(tmp_path / "outside"))
+
+    # Over-blocking is its own regression: inside the root still publishes.
+    inside = client.patch(
+        f"{API}/server-config/views",
+        json={"views_root": str(allowed / "views"), "kinds": ["sets"]},
+    )
+    assert inside.status_code == 200, inside.text
 
 
 def test_a_refused_folder_never_becomes_the_recorded_one(_env, _seeded, tmp_path):


### PR DESCRIPTION
The second of the two CodeQL path-expression alerts not covered by the
local-owner exception. 14 of the 24 alerts are in this file.

`check_views_root` only ever asked where the root sat *relative* to something:
inside the library, inside a reference folder, containing either, or synced by
a cloud client. A root that was none of those was accepted anywhere on the
disk, including a directory the rest of the app refuses outright.
`PATCH /server-config/views {"views_root": "/etc/pixlstash-views"}` reached
`os.makedirs` and wrote the marker file into it.

The delete sinks were already bounded — `_prune_all` joins the root only with
the constant kind-folder names, a symlink standing where a kind folder goes is
unlinked rather than descended, and `_prepare_root` refuses a non-empty folder
with no `.pixlstash-views` marker — so the blast radius was creating empty
directories and a marker where policy forbids writing, not data loss.

### The fix

`check_views_root` now applies the shared blocklist to the resolved root, and
the route honours `filesystem_roots` the way every other path-taking route
does: an operator who confined the folder picker did not mean "except for the
route that creates a tree of links".

The blocklist is handed a plain `realpath`, **not** this module's `_resolved`.
An adversarial review caught that `_resolved` applies `normcase`, which
lowercases on Windows while the blocklist entries are spelled `C:\Windows`, so
the check would have matched nothing there. A refusal that never fires is worse
than no refusal, because the coverage matrix then records it as present.

The route compares only a value the sink would itself accept: a relative or
empty root is left to `check_views_root` rather than resolved, since
`os.path.realpath("")` is the server's working directory and could sit inside a
configured root. `~` is deliberately not expanded, so the route and the sink no
longer disagree about which path they mean. `403` is declared in `responses`.

### Verification

`tests/test_views_links.py` (gated) gains a system-directory refusal, a
symlink-into-one refusal, and a `filesystem_roots` route test with a positive
control. Removing the new check fails exactly the two new refusals and leaves
the other 53 green. 56 pass.

`publish` has one production caller, so there is no scheduled rebuild or
grandfathered path that reaches the sinks without the new check.

Based on `develop`: `views_service.py` does not exist on `main`.
