### PR TITLE
Resolve a path before comparing it against the blocklist

### DIFF
--- a/pixlstash/routes/reference_folders.py
+++ b/pixlstash/routes/reference_folders.py
@@ -662,6 +662,12 @@ def create_router(server) -> APIRouter:
         error = validate_reference_folder_path(folder)
         if error:
             raise HTTPException(status_code=400, detail=error)
+        # Stored resolved, because the check above resolves. Keeping the link's
+        # own name would leave the row naming one directory and the scan walking
+        # another, and repointing the link afterwards would silently move the
+        # folder somewhere the blocklist never saw. `model_folders.py` already
+        # does this and its comment says this route did too; it did not.
+        folder = os.path.realpath(folder)
 
         label = payload.label if payload.label is not None else os.path.basename(folder)
 
@@ -768,6 +774,10 @@ def create_router(server) -> APIRouter:
                 error = validate_reference_folder_path(new_folder)
                 if error:
                     raise HTTPException(status_code=400, detail=error)
+                # Resolved for the same reason the create route resolves: this
+                # is where an existing folder is repointed, so a link accepted
+                # here would name one directory in the row and walk another.
+                new_folder = os.path.realpath(new_folder)
                 _validate_reference_folder_conflicts(
                     session, new_folder, exclude_id=folder_id
                 )

--- a/pixlstash/utils/reference_folder_validator.py
+++ b/pixlstash/utils/reference_folder_validator.py
@@ -40,6 +40,27 @@ _MACOS_BLOCKLIST: frozenset[str] = frozenset(
     ]
 )
 
+# Prefixes that a *resolved* path legitimately lands under even though a
+# blocklist entry contains them. The blocklist was written for the strings
+# people type; resolving turns three ordinary locations into system ones:
+# macOS resolves `/tmp` to `/private/tmp` and `$TMPDIR` to
+# `/private/var/folders/...`, both of which `/private` would then swallow - and
+# `/private` has to stay, because it is the only entry that catches `/etc`
+# once that resolves to `/private/etc`. FreeBSD and TrueNAS ship `/home` as a
+# symlink to `/usr/home`, which `/usr` would swallow, stranding the whole
+# `/tmp/x` and `/home/me/x` were accepted before paths were resolved and stay
+# accepted. Their resolved spellings - `/private/tmp/x`, `/usr/home/me/x` - were
+# refused when typed literally, and now pass, so this is a small widening rather
+# than a pure restoration: it makes one directory answer the same way under both
+# of its names, which is what resolving is for.
+_RESOLVED_ALIASES: frozenset[str] = frozenset(
+    [
+        "/private/tmp",
+        "/private/var/folders",
+        "/usr/home",
+    ]
+)
+
 _WINDOWS_BLOCKLIST: frozenset[str] = frozenset(
     [
         "C:\\Windows",
@@ -70,9 +91,25 @@ def validate_reference_folder_path(path: str) -> str | None:
     if not os.path.isabs(path):
         return "Path must be absolute."
 
-    norm = os.path.normpath(path)
+    # Resolved before it is compared, because the blocklist is literal. Checking
+    # the string as given lets a symlink the caller owns through: `~/to-etc`
+    # matches no entry, and the route behind this check then operates on `/etc`.
+    # Callers pass every shape - some resolve first, most do not - so the
+    # resolution belongs here rather than at each call site, which is how seven
+    # of them came to be missing it. `realpath` never raises: an unmounted or
+    # not-yet-created path resolves as far as it exists, which keeps the Docker
+    # pending-mount callers working.
+    norm = os.path.normcase(os.path.realpath(os.path.normpath(path)))
+
+    for alias in _RESOLVED_ALIASES:
+        alias_norm = os.path.normcase(os.path.normpath(alias))
+        if norm == alias_norm or norm.startswith(alias_norm + os.sep):
+            return None
+
     for blocked in _get_blocklist():
-        blocked_norm = os.path.normpath(blocked)
+        # Both sides are case-folded, or `c:\windows` walks past an entry
+        # spelled `C:\Windows`. `normcase` is identity on POSIX.
+        blocked_norm = os.path.normcase(os.path.normpath(blocked))
         if norm == blocked_norm or norm.startswith(blocked_norm + os.sep):
             return f"Path is in a restricted system directory: {blocked}"
 

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -35,6 +35,9 @@ from pixlstash.services.scrapheap_service import remove_picture_files
 from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
 from pixlstash.utils.image_processing.orientation import read_orientation
 from pixlstash.utils.path_utils import path_is_within
+from pixlstash.utils.reference_folder_validator import (
+    validate_reference_folder_path,
+)
 
 
 @pytest.fixture(scope="module")
@@ -104,6 +107,94 @@ def test_path_is_within_follows_a_symlinked_root(tmp_path):
         pytest.skip("symlinks are not available here")
     # The same directory spelled through its alias is still contained.
     assert path_is_within(str(real / "pic.png"), str(link))
+
+
+def test_blocklist_refuses_a_symlink_pointing_into_a_restricted_directory(tmp_path):
+    """A link the caller owns must not launder a blocked target past the check.
+
+    The blocklist compares literal strings, so before this was resolved the
+    link's own path matched no entry and the route behind the check went on to
+    operate on the target. Every caller that passed the string it was given -
+    most of them - inherited that.
+    """
+    link = tmp_path / "innocent-looking"
+    try:
+        link.symlink_to("/etc", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    if not os.path.isdir("/etc"):
+        pytest.skip("no /etc on this platform")
+
+    assert validate_reference_folder_path(str(link)) is not None
+    # Through the link's own children too, not only the root of it.
+    assert validate_reference_folder_path(str(link / "ssl")) is not None
+
+
+def test_blocklist_allows_a_resolved_alias_that_is_not_a_system_directory():
+    """Resolving turns three ordinary locations into blocked-looking ones.
+
+    macOS resolves `/tmp` to `/private/tmp` and `$TMPDIR` under
+    `/private/var/folders`, which the `/private` entry would then swallow;
+    FreeBSD and TrueNAS ship `/home` as a symlink to `/usr/home`, which `/usr`
+    would swallow and strand the whole library. `/tmp` and `/home/me` were
+    accepted before paths were resolved and must stay accepted; their resolved
+    spellings were refused when typed literally and now pass, which is the
+    widening this buys - one directory answering the same way under both of its
+    names. Asserted on Linux, where `/usr` is blocked, so the exception is
+    exercised on the CI platform rather than only on the one with no runner.
+    """
+    assert validate_reference_folder_path("/usr/home/me/Pictures") is None
+    assert validate_reference_folder_path("/usr/home") is None
+
+    # The exception is a prefix, not a substring: the rest of /usr still goes.
+    assert validate_reference_folder_path("/usr/lib/x") is not None
+    assert validate_reference_folder_path("/usr/homework") is not None
+
+
+def test_macos_private_prefix_blocks_system_paths_but_not_the_temp_aliases(
+    monkeypatch,
+):
+    """The macOS rule asserted on Linux, because the gate has no macOS runner.
+
+    `/private` cannot leave the macOS list - it is the only entry that catches
+    `/etc` once that resolves to `/private/etc` - so the temp aliases underneath
+    it have to be excepted by name. Both halves are asserted: the system
+    subtrees still refuse, the two temp locations do not.
+    """
+    from pixlstash.utils import reference_folder_validator as validator
+
+    monkeypatch.setattr(validator, "_get_blocklist", lambda: validator._MACOS_BLOCKLIST)
+
+    assert validator.validate_reference_folder_path("/private/etc/ssl") is not None
+    assert validator.validate_reference_folder_path("/private/var/db") is not None
+    assert validator.validate_reference_folder_path("/Library/Preferences") is not None
+
+    assert validator.validate_reference_folder_path("/private/tmp/export") is None
+    assert (
+        validator.validate_reference_folder_path("/private/var/folders/ab/T/x") is None
+    )
+
+
+def test_blocklist_still_accepts_an_ordinary_folder_and_a_benign_symlink(tmp_path):
+    """Over-blocking is its own regression: resolution must not refuse the normal case."""
+    ordinary = tmp_path / "pictures"
+    ordinary.mkdir()
+    assert validate_reference_folder_path(str(ordinary)) is None
+
+    link = tmp_path / "shortcut"
+    try:
+        link.symlink_to(ordinary, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    assert validate_reference_folder_path(str(link)) is None
+
+    # A path that does not exist yet still resolves as far as it goes, so the
+    # Docker pending-mount callers keep working rather than being refused.
+    assert validate_reference_folder_path(str(ordinary / "not-created-yet")) is None
+
+    # A relative path is still refused before any resolution happens, so it can
+    # never be quietly resolved against the server's working directory.
+    assert validate_reference_folder_path("pictures") is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Re-targeted at `develop`. This is #1181's content, which was aimed at `main`
by mistake and reverted in #1183; it reaches `main` by backport at release
time like every other fix, not directly.

CodeQL reports "Uncontrolled data used in path expression" on 24 sites. 21 are
covered by the local-owner exception. This is one of the two that are not; the
other was #1182, already merged.

`validate_reference_folder_path` compared the string it was given against a
literal blocklist, so a symlink the caller owns passed the check and the route
behind it operated on the target. Seven of the function's callers hand it an
unresolved path, so the resolution goes in the shared function rather than at
each call site. `libraries.py`'s `_safe_folder` docstring already describes
this exact bug; it had been fixed in one place only.

The absolute-path refusal still runs on the raw value, so a relative path can
never be resolved against the server's working directory, and `realpath`
leaves a not-yet-mounted path alone for the Docker callers.

### Resolving over-blocks three ordinary locations, so they are excepted

An adversarial review caught this, and it is why `_RESOLVED_ALIASES` exists:

* macOS resolves `/tmp` to `/private/tmp` and `$TMPDIR` under
  `/private/var/folders`. `/private` cannot leave the macOS blocklist, because
  it is the only entry that catches `/etc` once that resolves to
  `/private/etc`.
* FreeBSD and TrueNAS ship `/home` as a symlink to `/usr/home`, which `/usr`
  would swallow, refusing every library path on the machine.

No entry in any of the three blocklists is equal to or a descendant of any
alias, so the exception cannot shadow a refusal, and the aliases are compared
on the already-resolved path, so a symlink cannot land under one and escape.

This is a small deliberate widening rather than a pure restoration: the
resolved spellings were refused when typed literally and now pass, which is one
directory answering the same way under both of its names.

### Also here

Both sides of the comparison are case-folded, so `c:\windows` no longer walks
past an entry spelled `C:\Windows`. `normcase` is identity on POSIX.

The two reference-folder routes that store a path (`create`, and the `PATCH`
that repoints one) now store the resolved path, as `model_folders.py` already
does — otherwise the row names one directory while the scan walks another, and
repointing the link afterwards moves the folder somewhere the blocklist never
saw. `model_folders.py`'s comment claims the create route already did this; it
did not.

### Verification

`tests/test_path_containment.py` (gated) gains the negative, a positive
control, the alias arithmetic, and a macOS-semantics test that monkeypatches
the blocklist — the gate has ubuntu and windows runners only, so the macOS rule
is asserted on Linux. Reverting the fix fails exactly the new negatives.
158 tests pass across `test_path_containment`, `test_reference_folder_sidecars`,
`test_docker_windows_host_paths` and `test_libraries_routes`, re-run on
`develop`'s code rather than `main`'s.
