### PR TITLE
Validate the accelerator the accel:* IPC handlers receive

### DIFF
--- a/electron/src/backend/BackendManager.ts
+++ b/electron/src/backend/BackendManager.ts
@@ -12,6 +12,7 @@ import {
   activeAccelPath,
   bundledInterpreter,
   installLogPath,
+  isAccel,
   overlayDir,
   overlayMarkerPath,
   pipIndexUrl,
@@ -384,7 +385,10 @@ export class BackendManager {
   async getActiveAccel(): Promise<Accel | null> {
     try {
       const state = JSON.parse(await readFile(activeAccelPath(), 'utf8'));
-      return typeof state.accel === 'string' ? (state.accel as Accel) : null;
+      // isAccel, not `typeof === 'string'`: this value becomes a path segment
+      // under backendsRoot() and lands on the backend's PYTHONPATH, so a file
+      // holding anything but a known accelerator is treated as "no overlay".
+      return isAccel(state.accel) ? state.accel : null;
     } catch {
       return null;
     }

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -18,6 +18,27 @@ export function isAccel(value: unknown): value is Accel {
 }
 
 /**
+ * Narrow an accelerator that crossed a trust boundary, or throw.
+ *
+ * SECURITY: an `Accel` is a path segment ({@link overlayDir} joins it under
+ * {@link backendsRoot}) and that directory is both deleted (`accel:remove`) and
+ * put on the backend's PYTHONPATH (`accel:use`). A TypeScript parameter type is
+ * erased at runtime, so anything arriving over IPC is an arbitrary string until
+ * it passes through here: `../..` would escape the overlay root, making the
+ * removal an arbitrary recursive delete and the launch an arbitrary-PYTHONPATH
+ * code-execution primitive. Every renderer-supplied accelerator MUST go through
+ * this before it reaches BackendManager.
+ */
+export function requireAccel(value: unknown): Accel {
+  if (!isAccel(value)) {
+    throw new Error(
+      `Unknown accelerator ${JSON.stringify(value)}; expected one of ${ACCEL_VALUES.join(', ')}`,
+    );
+  }
+  return value;
+}
+
+/**
  * Parse the developer/CI hardware-detection override. The override fakes which
  * GPU the machine appears to have so the backend-download/overlay flow can be
  * exercised on hardware that lacks the matching GPU. It is read from, in order

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -31,9 +31,14 @@ export function isAccel(value: unknown): value is Accel {
  */
 export function requireAccel(value: unknown): Accel {
   if (!isAccel(value)) {
-    throw new Error(
-      `Unknown accelerator ${JSON.stringify(value)}; expected one of ${ACCEL_VALUES.join(', ')}`,
-    );
+    // Never JSON.stringify the value: it throws on a BigInt, and Electron IPC
+    // carries BigInt through the structured clone, so a renderer could swap the
+    // documented "Unknown accelerator" rejection for a TypeError raised while
+    // building the message. Never String() it either - that calls a `toString`
+    // the caller supplied. A string is shown (it is the realistic case: a typo
+    // like 'cuda128'), anything else is named by type only.
+    const shown = typeof value === 'string' ? JSON.stringify(value) : typeof value;
+    throw new Error(`Unknown accelerator ${shown}; expected one of ${ACCEL_VALUES.join(', ')}`);
   }
   return value;
 }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -49,6 +49,7 @@ import {
   overlayDir,
   parseForcedBackend,
   readRuntimeInfo,
+  requireAccel,
   serverConfigPath,
   serverLogPath,
   setBackendsRoot,
@@ -1567,7 +1568,11 @@ function registerIpc(): void {
     return { dir: backendsRoot(), default: defaultBackendsRoot() };
   });
 
-  ipcMain.handle('accel:install', async (_e, accel: Accel) => {
+  // The three handlers below take an accelerator straight from the renderer, and
+  // an `Accel` is a path segment (see requireAccel). Validate at the boundary,
+  // before the value can reach a directory join.
+  ipcMain.handle('accel:install', async (_e, raw: unknown) => {
+    const accel = requireAccel(raw);
     if (!runtime) throw new Error('No bundled runtime available');
     // installOverlay wipes the target directory first, and a backend running on
     // this overlay holds its DLLs open - on Windows that wipe fails outright.
@@ -1589,7 +1594,9 @@ function registerIpc(): void {
     return acceleratorState();
   });
 
-  ipcMain.handle('accel:use', async (_e, accel: Accel | null) => {
+  ipcMain.handle('accel:use', async (_e, raw: unknown) => {
+    // null means "back to the bundled env"; anything else must be a known Accel.
+    const accel = raw === null || raw === undefined ? null : requireAccel(raw);
     // setActiveAccel BEFORE the start is fine only because the fallback wrapper
     // guarantees a failed overlay start ends with the active state cleared
     // (deactivateOverlay) and a CPU backend running - and acceleratorState() is
@@ -1600,8 +1607,8 @@ function registerIpc(): void {
     return acceleratorState();
   });
 
-  ipcMain.handle('accel:remove', async (_e, accel: Accel) => {
-    await manager.remove(accel);
+  ipcMain.handle('accel:remove', async (_e, raw: unknown) => {
+    await manager.remove(requireAccel(raw));
     // Relaunch on whatever remains active (another overlay or null). A remaining
     // overlay that fails to start falls back to CPU; a null start failure
     // rethrows to the IPC caller unchanged, as before.

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1595,7 +1595,10 @@ function registerIpc(): void {
   });
 
   ipcMain.handle('accel:use', async (_e, raw: unknown) => {
-    // null means "back to the bundled env"; anything else must be a known Accel.
+    // null - and undefined, which is what an argument-less invoke() sends -
+    // means "back to the bundled env". Anything else must be a known Accel.
+    // Deactivating is the safe reading of a missing argument: it is the one
+    // outcome that puts no renderer-supplied segment on a path or a PYTHONPATH.
     const accel = raw === null || raw === undefined ? null : requireAccel(raw);
     // setActiveAccel BEFORE the start is fine only because the fallback wrapper
     // guarantees a failed overlay start ends with the active state cleared

--- a/electron/test/accelIpcValidation.test.ts
+++ b/electron/test/accelIpcValidation.test.ts
@@ -31,12 +31,17 @@ describe('requireAccel', () => {
       null,
       undefined,
       123,
+      // Structured clone carries a BigInt over IPC, and JSON.stringify throws
+      // on one: building the rejection message with it would swap this Error
+      // for a TypeError raised inside the validator.
+      1n,
+      // A caller-supplied toString must never be called to describe the value.
       { toString: () => 'cpu' },
     ]) {
       assert.throws(
         () => requireAccel(bad),
         /Unknown accelerator/,
-        `${JSON.stringify(bad)} must not be accepted as an accelerator`,
+        `${String(bad)} must not be accepted as an accelerator`,
       );
     }
   });

--- a/electron/test/accelIpcValidation.test.ts
+++ b/electron/test/accelIpcValidation.test.ts
@@ -38,10 +38,14 @@ describe('requireAccel', () => {
       // A caller-supplied toString must never be called to describe the value.
       { toString: () => 'cpu' },
     ]) {
+      // Described the way requireAccel describes it, and for its reasons: a
+      // bare String() would call the `toString` the entry below supplies, and
+      // JSON.stringify throws on the BigInt above.
+      const shown = typeof bad === 'string' ? JSON.stringify(bad) : typeof bad;
       assert.throws(
         () => requireAccel(bad),
         /Unknown accelerator/,
-        `${String(bad)} must not be accepted as an accelerator`,
+        `${shown} must not be accepted as an accelerator`,
       );
     }
   });

--- a/electron/test/accelIpcValidation.test.ts
+++ b/electron/test/accelIpcValidation.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { ACCEL_VALUES, requireAccel } from '../src/config';
+
+/**
+ * The `accel:*` IPC handlers take an accelerator from the renderer. An `Accel`
+ * is a path segment: `overlayDir()` joins it under `backendsRoot()`, and that
+ * directory is deleted outright by `accel:remove` and put on the spawned
+ * backend's PYTHONPATH by `accel:use`. The parameter's TypeScript type is erased
+ * at runtime, so before this guard the renderer could send `../../..` and turn
+ * either handler into an arbitrary-path primitive (CWE-22 / CWE-20).
+ */
+describe('requireAccel', () => {
+  it('returns every known accelerator unchanged', () => {
+    for (const a of ACCEL_VALUES) assert.equal(requireAccel(a), a);
+  });
+
+  it('rejects traversal, wrong types and near-misses', () => {
+    for (const bad of [
+      '..',
+      '../..',
+      '../../../../home/me/Pictures',
+      'cu128/../..',
+      '/etc',
+      'C:\\Windows',
+      'cuda',
+      'CPU',
+      '',
+      null,
+      undefined,
+      123,
+      { toString: () => 'cpu' },
+    ]) {
+      assert.throws(
+        () => requireAccel(bad),
+        /Unknown accelerator/,
+        `${JSON.stringify(bad)} must not be accepted as an accelerator`,
+      );
+    }
+  });
+});
+
+/**
+ * Source-text assertions because `main.ts` registers its handlers as a side
+ * effect of an Electron app boot and exposes no module boundary to import - the
+ * same reason `setupFolderNameEscaping.test.ts` reads `setup.js` as text.
+ *
+ * What is being pinned is the *shape*: the renderer's value must be named `raw`
+ * (i.e. untyped) and reach `requireAccel` before anything else. Declaring the
+ * parameter `accel: Accel` again is exactly the regression, and it type-checks.
+ */
+describe('the accel:* IPC handlers validate before they use the value', () => {
+  // __dirname is dist-test/test at run time; the sources are two levels up.
+  const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
+
+  for (const channel of ['accel:install', 'accel:use', 'accel:remove']) {
+    it(`${channel} takes an unknown and narrows it with requireAccel`, () => {
+      const start = main.indexOf(`ipcMain.handle('${channel}'`);
+      assert.ok(start >= 0, `${channel} handler not found`);
+      const next = main.indexOf('ipcMain.handle(', start + 1);
+      const body = main.slice(start, next === -1 ? undefined : next);
+      assert.match(
+        body,
+        /\(_e,\s*raw:\s*unknown\)/,
+        `${channel} must accept the renderer's value as unknown, not as a bare Accel`,
+      );
+      assert.match(body, /requireAccel\(raw\)/, `${channel} must narrow via requireAccel`);
+    });
+  }
+
+  it('no accel:* handler still declares its parameter as an Accel', () => {
+    assert.doesNotMatch(
+      main,
+      /ipcMain\.handle\('accel:[a-z]+',\s*async\s*\(_e,\s*\w+:\s*Accel/,
+      'a renderer-supplied accelerator must never be typed straight into the handler',
+    );
+  });
+});


### PR DESCRIPTION
Closes item 13 of #1177.

## The vulnerability

`accel:install`, `accel:use` and `accel:remove` declared their payload as
`Accel`, but a TypeScript parameter type is erased at runtime: whatever the
renderer sends arrives as-is. An `Accel` is a **path segment** - `overlayDir()`
joins it under `backendsRoot()` - so an unvalidated string is a path-traversal
primitive (CWE-20 unvalidated input into CWE-22 path traversal):

- `accel:remove` -> `BackendManager.remove()` -> `rm(overlayDir(accel), { recursive: true, force: true })`.
  An arbitrary recursive delete anywhere the user can write.
- `accel:use` -> `setActiveAccel()` persists the string, then `overlayFor()`
  puts `overlayDir(accel)` on the spawned backend Python process PYTHONPATH.
  An attacker-chosen PYTHONPATH entry is a code-execution primitive (`site`
  imports `sitecustomize` from any sys.path entry), and because the value is
  written to `active-accel.json` it survives a restart.
- `accel:install` was already safe: `installOverlay()` rejects anything outside
  `OVERLAY_ACCELS` before touching a path. It is validated here anyway so the
  three siblings share one rule.

Reachable from anything that can run script in the app window - the window
loads the local server, and the server can be bound to all interfaces via the
remote-access setting. Not a 1.11.0 regression; the shape predates it.

The repo already had the right validator (`isAccel`, described in `config.ts`
as "the single source of truth for validating any externally supplied
accelerator string") and already applied it to the *other* external boundary,
`--force-backend` / `PIXLSTASH_FORCE_BACKEND`. The IPC boundary was simply
never wired to it. That is the root cause, not the individual sinks.

## The fix

- `requireAccel(value: unknown): Accel` in `config.ts`, next to `isAccel`:
  narrow or throw. One place, so the message and the rule cannot drift.
- All three `accel:*` handlers now take `raw: unknown` and narrow through it
  before the value can reach a directory join. `accel:use` still accepts `null`
  (back to the bundled env).
- `BackendManager.getActiveAccel()` validates what it reads back off disk with
  `isAccel` instead of `typeof === "string"`, so a malformed `active-accel.json`
  is treated as "no overlay" rather than becoming a PYTHONPATH entry.

## Check

`electron/test/accelIpcValidation.test.ts` (gated: the `checks` job runs
`npm test` in `electron/`). Behavioural assertions on `requireAccel`
(traversal, wrong types, near-misses), plus source-text assertions that each
`accel:*` handler takes an `unknown` and narrows it - `main.ts` registers its
handlers as a side effect of an Electron boot and exposes no module boundary to
import, the same reason `setupFolderNameEscaping.test.ts` reads its target as
text. Restoring the old `accel: Accel` signature on any one handler fails the
suite.

## Noted, not fixed here

`backend:setLocation` and `setup:commit` take arbitrary filesystem paths from
the renderer, and `changeBackendsLocation` -> `moveDir` does `rm(to, {
recursive: true, force: true })` on `<caller-chosen root>/<accel>`. Narrower
(the final segment is a validated accelerator) and a different root cause -
those handlers are *meant* to take a user-chosen path, so the fix is proving
the path came from the native dialog, not an allowlist. Out of scope for this
diff.