### PR TITLE
Setup and add-a-library: no failure without a way out

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -908,6 +908,35 @@ reproduces it with a *slow* inspect mock on purpose: with one that settles
 inside the blur's own `nextTick` the test passes either way, which is how such a
 bug survives being "covered".
 
+**A read that stops leaves the pane usable.** The path field and `Browse…` are
+disabled while a read runs, so a failed one used to freeze the whole pane with
+`Cancel` as its only live control — reached most often by a *resumed* entry,
+since the server keeps one read slot and the saved task is usually gone by the
+time "Finish organising…" is pressed. `FolderMappingScanStep` emits
+`read-failed`, which un-disables the picker while leaving the card on screen,
+and swaps its permanently-disabled `Set up my library` for `Try again`. That
+retry starts a **new** read rather than reattaching to `resumeTaskId`, which is
+precisely what failed. Pointing the field somewhere else instead drops the card
+— after the `lastAsked` guard, so the `mousedown → blur → click` on `Try again`
+does not unmount the button before the click lands. The equivalent on the
+Preview step is `Back to the mapping`: it re-fetches the read's result before
+switching, because the mapping step cannot render without one and pressing it
+after the mount poll had failed swapped the Preview for an empty dialog. If the
+read is genuinely gone it says so and stays put, keeping `Organise later` and
+`Cancel`.
+
+The read's summary states `skipped_folders` and `face_signal_ran` alongside
+`truncated` and `unreadable_folders` (integration_architecture.md §20). All four
+mean *this map is not the whole library*; `face_signal_ran: false` is the one
+that explains a People count of zero on a machine with no inference engine, and
+dropping it made the same tree read differently depending on whether models
+happened to be loaded.
+
+The Preview's "N are created or matched" sums the **per-kind** buckets. A set of
+names across kinds counted an `Alice` person and an `Alice` set once between
+them, and the sentence beside it is built from `FACET_KINDS` so a facet cannot
+be counted and left unnamed the way `tag` was.
+
 The switch confirmation is the global
 `ConfirmDialog.vue` host for `useConfirm`: it focuses the primary action, handles
 Enter/Escape through `AppDialog`, restores invoking focus on cancel, and names

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -916,6 +916,13 @@ async function startWithOverlayFallback(
  * the reason never reached the person choosing the folder. Declining puts the
  * setup screen back rather than quitting - the answer to "I will not use that
  * folder" is to choose another one.
+ *
+ * **A decline throws, and does not reload the setup page.** The window is still
+ * on `setup.html` (the failure happens inside the launch, before anything
+ * navigates), so reloading it destroyed the renderer that was awaiting this
+ * call: the message below never arrived, and every answer the person had given
+ * went with it. Throwing rejects `setup:commit` on the live page, which keeps
+ * the install step up, prints the message, and re-enables Back and Try again.
  */
 async function startFromSetup(accel: Accel | null, navigate: boolean): Promise<void> {
   try {
@@ -926,7 +933,6 @@ async function startFromSetup(accel: Accel | null, navigate: boolean): Promise<v
     // folder" is the answer, and here it is one click away.
     if (isVaultUnusable(caught)) {
       if (!(await offerVaultRecreation(caught, 'Choose Another Folder'))) {
-        await mainWindow?.loadFile(join(__dirname, 'renderer', 'setup.html'));
         throw new Error(
           'PixlStash could not open the library database in that folder. Choose another folder, or let PixlStash start a new one there.',
         );
@@ -936,7 +942,6 @@ async function startFromSetup(accel: Accel | null, navigate: boolean): Promise<v
     }
     if (!isPermissionRepairRequired(caught)) throw caught;
     if (!(await offerPermissionRepair(caught))) {
-      await mainWindow?.loadFile(join(__dirname, 'renderer', 'setup.html'));
       throw new Error(
         'PixlStash will not open a library with those permissions. Choose another folder, or allow the repair.',
       );
@@ -1358,6 +1363,7 @@ function registerIpc(): void {
               2,
             ),
           ),
+        clearConfig: () => rmSync(serverConfigPath(), { force: true }),
         parkTelemetry: writePendingTelemetry,
         parkMapping: writePendingMapping,
         setActiveAccel: (accel) => manager.setActiveAccel(accel),
@@ -1381,6 +1387,7 @@ function registerIpc(): void {
               )
             : null,
         announceReading: () => sendPhase({ phase: 'reading' }),
+        announceInstallFailed: (message) => sendPhase({ phase: 'installFailed', message }),
       });
     },
   );

--- a/electron/src/renderer/setup.html
+++ b/electron/src/renderer/setup.html
@@ -228,7 +228,9 @@
             <div class="panel">
               <ol class="phases" id="phases"></ol>
             </div>
-            <div id="error" class="error hidden"></div>
+            <!-- Every failure on this screen lands here, and the screen it
+                 lands on has no other running commentary: announce it. -->
+            <div id="error" class="error hidden" role="alert"></div>
           </div>
         </div>
 

--- a/electron/src/renderer/setup.js
+++ b/electron/src/renderer/setup.js
@@ -147,8 +147,11 @@ function hide(el) {
   el.classList.add('hidden');
 }
 function showError(msg) {
-  els.error.textContent = msg;
+  // Shown BEFORE the text goes in: `.hidden` is `display: none`, so a live
+  // region filled while it is still hidden is filled outside the accessibility
+  // tree and announces nothing.
   show(els.error);
+  els.error.textContent = msg;
 }
 
 /**

--- a/electron/src/renderer/setup.js
+++ b/electron/src/renderer/setup.js
@@ -131,9 +131,14 @@ let privacyChoice = null;
 // True once the runtime install has reported anything, which is also when the
 // backend is already up reading the library behind it.
 let reading = false;
-// A commit that came back with an error. The install step keeps it on screen
+// A step that came back with an error. The install step keeps it on screen
 // rather than dropping the user at the first question with nothing to read.
 let failed = false;
+// What the "Try again" button retries. A commit failure retries the commit; a
+// probe that never answered retries the probe, because there are no answers to
+// commit yet. Never null while `failed` is true - a screen that says something
+// went wrong and offers nothing to press is the bug this exists to prevent.
+let retry = commit;
 
 function show(el) {
   el.classList.remove('hidden');
@@ -144,6 +149,26 @@ function hide(el) {
 function showError(msg) {
   els.error.textContent = msg;
   show(els.error);
+}
+
+/**
+ * The one shape every failure on this screen takes.
+ *
+ * A message the person can read, one line saying which part stopped, and a live
+ * "Try again" that retries THAT part. Written once because it was written
+ * twice-and-a-half and one of the copies (the probe's) left the install step
+ * with both controls hidden and nothing to do.
+ */
+function fail(message, { line, hint, retryWith }) {
+  busy = false;
+  failed = true;
+  retry = retryWith;
+  lines = [{ id: 'failed', name: line, note: '', value: '', state: 'todo', fraction: -1 }];
+  renderLines();
+  showError(message);
+  render();
+  els.next.disabled = false;
+  els.hint.textContent = hint;
 }
 
 /** Human-readable bytes, in the units a person reads a disk in. */
@@ -661,23 +686,11 @@ async function commit() {
     // question hid the message on a screen that was no longer shown, which is
     // how "the backend refuses this folder's permissions" reached the user as
     // an unexplained trip back to the beginning.
-    busy = false;
-    failed = true;
-    els.next.disabled = false;
-    lines = [
-      {
-        id: 'failed',
-        name: 'Setup could not finish',
-        note: '',
-        value: '',
-        state: 'todo',
-        fraction: -1,
-      },
-    ];
-    renderLines();
-    showError((e && e.message) || String(e));
-    render();
-    els.hint.textContent = 'Change an answer, or try again.';
+    fail((e && e.message) || String(e), {
+      line: 'Setup could not finish',
+      hint: 'Change an answer, or try again.',
+      retryWith: commit,
+    });
   }
 }
 
@@ -707,6 +720,7 @@ els.back.addEventListener('click', () => {
   if (busy) return;
   hide(els.error);
   failed = false;
+  retry = commit;
   lines = [];
   renderLines();
   go(at - 1);
@@ -714,7 +728,8 @@ els.back.addEventListener('click', () => {
 
 els.next.addEventListener('click', () => {
   if (busy || els.next.disabled) return;
-  if (failed || at >= steps.length - 2) commit();
+  if (failed) retry();
+  else if (at >= steps.length - 2) commit();
   else go(at + 1);
 });
 
@@ -779,6 +794,13 @@ api.onPhase((p) => {
     } else {
       setLine('server', { name: 'Starting PixlStash', state: 'running' });
     }
+  } else if (p.phase === 'installFailed' && p.message) {
+    // The download is over and the read is not: setup will not settle until the
+    // read finishes, which on a big library is minutes. Stop the runtime bar and
+    // say why NOW rather than letting it draw a download that already failed;
+    // the controls come back with the rejection, as for any other failure.
+    setLine('runtime', { state: 'todo', note: '', value: 'Failed', fraction: -1 });
+    showError(String(p.message));
   } else if (p.phase === 'error' && p.message) {
     showError(String(p.message));
   }
@@ -827,9 +849,41 @@ setInterval(() => {
   dots.forEach((el, i) => el.classList.toggle('is-on', i === slide));
 }, 4000);
 
-init().catch((e) => {
+/**
+ * The probe never answered, so there are no questions to ask and no answers to
+ * commit - only the one step that can hold a message. Retrying the probe is the
+ * only move there is, so it is the one the button makes: without it this landed
+ * on the install step with Back and Continue both hidden, an error to read and
+ * nothing at all to press.
+ */
+function probeFailed(e) {
   steps = ['install'];
   at = 0;
+  fail((e && e.message) || String(e), {
+    line: 'PixlStash could not work out what to ask you',
+    hint: 'Try again, or quit PixlStash and reopen it.',
+    retryWith: retryProbe,
+  });
+}
+
+function retryProbe() {
+  hide(els.error);
+  failed = false;
+  retry = commit;
+  lines = [
+    { id: 'probe', name: 'Asking PixlStash what it needs', state: 'running', note: '', value: '', fraction: -1 },
+  ];
+  renderLines();
+  // Nothing is pressable while the probe is out; `init` renders the real
+  // questions when it answers, and `probeFailed` puts the controls back.
+  busy = true;
   render();
-  showError((e && e.message) || String(e));
-});
+  init()
+    .then(() => {
+      busy = false;
+      render();
+    })
+    .catch(probeFailed);
+}
+
+init().catch(probeFailed);

--- a/electron/src/setup/RunSetup.ts
+++ b/electron/src/setup/RunSetup.ts
@@ -107,7 +107,7 @@ export async function runFirstRunSetup<Accel>(
   deps.writeConfig(imageRoot);
 
   try {
-    await install(imageRoot, choices, deps);
+    await afterConfig(imageRoot, choices, deps);
   } catch (error) {
     // Everything above this point refuses BEFORE writing a config, and every
     // refusal below has already written one. A config is what tells the next
@@ -120,8 +120,8 @@ export async function runFirstRunSetup<Accel>(
   }
 }
 
-/** Everything a written config has to be rolled back for. */
-async function install<Accel>(
+/** Everything after the config is written, and everything it is rolled back for. */
+async function afterConfig<Accel>(
   imageRoot: string,
   choices: SetupChoices,
   deps: SetupDeps<Accel>,

--- a/electron/src/setup/RunSetup.ts
+++ b/electron/src/setup/RunSetup.ts
@@ -33,6 +33,16 @@ export type SetupDeps<Accel> = {
   prepareLegacyIdentity: (source: string) => Promise<unknown>;
   /** Write the desktop's own server config. */
   writeConfig: (imageRoot: string) => void;
+  /**
+   * Remove the config this run wrote, for a setup that then could not finish.
+   *
+   * The config outlives the process, and launch shows the wizard only when
+   * there ISN'T one. A config left behind by a setup that failed therefore
+   * removes the folder picker from every later launch, and the folder it names
+   * is exactly the one the failure was about - declining the recreate offer
+   * trapped the choice it was asking you to change.
+   */
+  clearConfig: () => void;
   /** Park the privacy answer for the app, or clear a stale one with null. */
   parkTelemetry: (patch: Record<string, boolean> | null) => void;
   /** Park a finished folder read for the app, or clear one with null. */
@@ -50,6 +60,14 @@ export type SetupDeps<Accel> = {
   readFolder: (imageRoot: string) => Promise<Record<string, unknown> | null>;
   /** Tell the setup screen the reading has begun. */
   announceReading: () => void;
+  /**
+   * Tell the setup screen the download failed, at the moment it failed.
+   *
+   * The read still has to finish before anything restarts, and on a large
+   * library that is minutes - minutes the screen otherwise spent drawing a
+   * download that was already over.
+   */
+  announceInstallFailed: (message: string) => void;
 };
 
 /**
@@ -88,6 +106,26 @@ export async function runFirstRunSetup<Accel>(
   // The config is written only once any requested preparation has succeeded.
   deps.writeConfig(imageRoot);
 
+  try {
+    await install(imageRoot, choices, deps);
+  } catch (error) {
+    // Everything above this point refuses BEFORE writing a config, and every
+    // refusal below has already written one. A config is what tells the next
+    // launch there is nothing to ask, so leaving one behind for a setup that
+    // never finished takes away the folder picker - and the folder it names is
+    // the one the person was being asked to change.
+    deps.clearConfig();
+    deps.parkTelemetry(null);
+    throw error;
+  }
+}
+
+/** Everything a written config has to be rolled back for. */
+async function install<Accel>(
+  imageRoot: string,
+  choices: SetupChoices,
+  deps: SetupDeps<Accel>,
+): Promise<void> {
   // The privacy answer belongs to an owner record that does not exist yet, so
   // it waits here for the app. After the config, so a setup that failed earlier
   // leaves no answer to a question the user may be asked again.
@@ -125,12 +163,19 @@ export async function runFirstRunSetup<Accel>(
 
   try {
     await deps.installOverlay(gpu);
-  } finally {
-    // Whichever finished first, the read gets to end before the restart takes
-    // its server away - including when the install threw, so a failed setup
-    // does not leave a read writing into a process that is going down.
+  } catch (error) {
+    // Say it now. The read still has to finish (below), and on a big library
+    // that is minutes; without this the screen spent them drawing a download
+    // that had already failed, and the message arrived with the wait's end
+    // rather than with the failure.
+    deps.announceInstallFailed(error instanceof Error ? error.message : String(error));
     await read;
+    throw error;
   }
+  // Whichever finished first, the read gets to end before the restart takes its
+  // server away - and on the failure path above too, because the retry the
+  // screen offers starts a new backend over this one.
+  await read;
 
   await deps.setActiveAccel(gpu);
   await deps.startBackend(gpu, true);

--- a/electron/test/runSetup.test.ts
+++ b/electron/test/runSetup.test.ts
@@ -41,6 +41,7 @@ function makeDeps(overrides: Partial<SetupDeps<Accel>> = {}): SetupDeps<Accel> {
       log.push(`prepareIdentity:${source}`);
     },
     writeConfig: (imageRoot) => log.push(`config:${imageRoot}`),
+    clearConfig: () => log.push('clearConfig'),
     parkTelemetry: (patch) => {
       log.push('parkTelemetry');
       parkedTelemetry.push(patch);
@@ -61,6 +62,7 @@ function makeDeps(overrides: Partial<SetupDeps<Accel>> = {}): SetupDeps<Accel> {
       return READ_RESULT;
     },
     announceReading: () => log.push('announceReading'),
+    announceInstallFailed: (message) => log.push(`installFailed:${message}`),
     ...overrides,
   };
 }
@@ -184,6 +186,30 @@ describe('first-run setup, with a GPU runtime to install', () => {
     assert.ok(log.includes('read'), 'the read still ran, and still got to finish');
   });
 
+  it('says the download failed before waiting the read out', async () => {
+    // The read can have minutes left in it. Announcing after it is announcing
+    // when the wait ends, which is not when the thing failed.
+    const read = deferred<Record<string, unknown> | null>();
+    const setup = runFirstRunSetup(
+      CHOICES,
+      makeDeps({
+        readFolder: () => read.promise,
+        installOverlay: async () => {
+          throw new Error('no wheels for this CUDA generation');
+        },
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+
+    assert.ok(
+      log.includes('installFailed:no wheels for this CUDA generation'),
+      `said nothing while the read was still going: ${log.join(' → ')}`,
+    );
+
+    read.resolve(null);
+    await assert.rejects(setup, /no wheels/);
+  });
+
   it('records the install location before anything downloads into it', async () => {
     await runFirstRunSetup({ ...CHOICES, installLocation: '/mnt/big' }, makeDeps());
 
@@ -261,9 +287,6 @@ describe('first-run setup that must refuse', () => {
   });
 
   it('leaves the privacy answer unparked when the backend will not start', async () => {
-    // The answer is parked before the start, so a refusal here leaves one
-    // behind: it is cleared by the next attempt's own park, and the app takes
-    // it only once. What must not happen is a config written and no answer.
     await assert.rejects(
       runFirstRunSetup(
         CHOICES,
@@ -275,7 +298,47 @@ describe('first-run setup that must refuse', () => {
       ),
       /unsafe file permissions/,
     );
-    assert.deepEqual(parkedTelemetry, [null]);
+    assert.deepEqual(parkedTelemetry, [null, null], 'parked, then rolled back');
+  });
+
+  it('takes the config back off disk when the setup it was written for fails', async () => {
+    // Launch shows the wizard only when there is NO config, so one left behind
+    // by a failed setup removes the folder picker from every later launch - and
+    // the folder it names is the one the failure was about. Declining the
+    // recreate offer trapped the choice it was asking you to change.
+    await assert.rejects(
+      runFirstRunSetup(
+        CHOICES,
+        makeDeps({
+          startBackend: async () => {
+            throw new Error('could not open the library database');
+          },
+        }),
+      ),
+      /library database/,
+    );
+    assert.ok(log.indexOf('config:/home/me/Pictures') < log.indexOf('clearConfig'));
+    assert.ok(log.includes('clearConfig'), log.join(' → '));
+  });
+
+  it('rolls the config back when the GPU download is what failed', async () => {
+    await assert.rejects(
+      runFirstRunSetup(
+        CHOICES,
+        makeDeps({
+          installOverlay: async () => {
+            throw new Error('no wheels for this CUDA generation');
+          },
+        }),
+      ),
+      /no wheels/,
+    );
+    assert.ok(log.includes('clearConfig'), log.join(' → '));
+  });
+
+  it('leaves the config alone when the setup finished', async () => {
+    await runFirstRunSetup(CHOICES, makeDeps());
+    assert.ok(!log.includes('clearConfig'), log.join(' → '));
   });
 });
 

--- a/frontend/src/components/folders/FolderMappingChooseStep.test.js
+++ b/frontend/src/components/folders/FolderMappingChooseStep.test.js
@@ -38,7 +38,10 @@ import {
   inspectLibraryPath,
   setActiveLibrary,
 } from "../../api/libraries";
-import { startFolderStructureRead } from "../../api/folderStructure";
+import {
+  getFolderStructureReadStatus,
+  startFolderStructureRead,
+} from "../../api/folderStructure";
 import {
   useLibrariesStore,
   useLibrarySwitchStore,
@@ -460,6 +463,128 @@ describe("resuming a saved read", () => {
     );
     expect(wrapper.find(".scan-step").exists()).toBe(true);
     expect(wrapper.emitted("task")[0][0]).toBe("task-7");
+  });
+});
+
+// A resumed read is the commonest way to reach a failed one: the server keeps
+// one read slot, so the saved task is usually gone by the time the row is
+// pressed. The pane used to freeze on it - the folder field and Browse are
+// disabled while a read runs, and the scan card's only enabled button was
+// Cancel.
+describe("a read that stopped", () => {
+  const RESUME = {
+    taskId: "task-7",
+    path: PICTURES.path,
+    label: "Generations",
+    mode: "local_import",
+  };
+
+  async function failedResume() {
+    getFolderStructureReadStatus.mockRejectedValue(new Error("Task not found"));
+    return settle(mountDialog({ resume: RESUME }));
+  }
+
+  it("says so and stops drawing progress", async () => {
+    const wrapper = await failedResume();
+
+    expect(wrapper.find(".scan-step__error").text()).toContain(
+      "Could not read that folder",
+    );
+    expect(wrapper.find(".scan-step__bar").exists()).toBe(false);
+  });
+
+  it("puts the folder field and Browse back", async () => {
+    const wrapper = await failedResume();
+
+    expect(
+      wrapper.find(".choose-step__field .app-input__field").element.disabled,
+    ).toBe(false);
+    expect(wrapper.find(".choose-step__browse").attributes("disabled")).toBe(
+      undefined,
+    );
+  });
+
+  it("offers a fresh read of the same folder, not the dead task again", async () => {
+    const wrapper = await failedResume();
+    startFolderStructureRead.mockResolvedValue({ task_id: "task-8" });
+
+    const again = wrapper
+      .findAll(".scan-step button")
+      .find((button) => button.text().trim() === "Try again");
+    expect(again.attributes("disabled")).toBe(undefined);
+    await again.trigger("click");
+    await settle(wrapper);
+
+    expect(startFolderStructureRead).toHaveBeenCalledWith(PICTURES.path, {
+      matchExisting: true,
+    });
+    expect(wrapper.emitted("task").at(-1)[0]).toBe("task-8");
+  });
+
+  it("drops the card when the owner points somewhere else instead", async () => {
+    const wrapper = await failedResume();
+    inspectLibraryPath.mockResolvedValue(structuredClone(VAULT));
+
+    await typePath(wrapper, "/home/me/Pictures/Elsewhere");
+
+    expect(wrapper.find(".scan-step").exists()).toBe(false);
+    expect(wrapper.find(".choose-step__verdict").exists()).toBe(true);
+  });
+});
+
+// Both fields mean "this map is not the whole library", which is the one thing
+// a summary must not leave out. `face_signal_ran: false` in particular explains
+// the People count that would otherwise read as "nobody lives here".
+describe("what the finished read says about itself", () => {
+  function completed(result) {
+    getFolderStructureReadStatus.mockResolvedValue({
+      status: "completed",
+      stage: "done",
+      processed: 3,
+      total: 3,
+      result: {
+        picture_count: 12,
+        folder_count: 3,
+        truncated: false,
+        unreadable_folders: 0,
+        skipped_folders: { hidden: 0, restricted: 0 },
+        face_signal_ran: true,
+        levels: [],
+        ...result,
+      },
+    });
+    return settle(
+      mountDialog({
+        resume: { taskId: "task-7", path: PICTURES.path, mode: "local_import" },
+      }),
+    );
+  }
+
+  it("counts the folders it left out on purpose", async () => {
+    const wrapper = await completed({
+      skipped_folders: { hidden: 4, restricted: 2 },
+    });
+
+    expect(wrapper.find(".scan-step__stats").text()).toContain("6");
+    expect(wrapper.text()).toContain("left out on purpose");
+  });
+
+  it("says nothing about them when there were none", async () => {
+    const wrapper = await completed({});
+
+    expect(wrapper.text()).not.toContain("left out on purpose");
+  });
+
+  it("says when nobody could be read as a Person", async () => {
+    const wrapper = await completed({ face_signal_ran: false });
+
+    expect(wrapper.text()).toContain("the face signal did not run");
+  });
+
+  it("says nothing about the face signal when it ran", async () => {
+    const wrapper = await completed({ face_signal_ran: true });
+
+    expect(wrapper.text()).not.toContain("the face signal did not run");
   });
 });
 

--- a/frontend/src/components/folders/FolderMappingChooseStep.vue
+++ b/frontend/src/components/folders/FolderMappingChooseStep.vue
@@ -70,6 +70,15 @@ const browserOpen = ref(false);
 const pathInput = ref(null);
 /** The scan card has replaced the verdict card; the path is now fixed. */
 const scanning = ref(Boolean(props.resume));
+/**
+ * The scan card is showing a read that stopped.
+ *
+ * The card stays (it owns the message and its own Try again), but the path
+ * field and Browse come back: a read that failed on a resumed entry - the
+ * commonest case, its task long gone with the server that held it - otherwise
+ * left the whole pane frozen, with Cancel the only live control in it.
+ */
+const readFailed = ref(false);
 
 /** The path the current verdict describes, so a stale answer is never acted on.
     A ref, not a plain `let`: `canAdd` reads it. */
@@ -107,6 +116,13 @@ async function inspect() {
   // nothing at all. The button silently failed on its first press, every time.
   if (candidate && candidate === lastAsked && !inspectError.value) return;
   lastAsked = candidate;
+
+  // Past the guard, so this is a genuinely different folder: the failed scan
+  // card describes the old one, so it goes. (The guard is also what keeps the
+  // card's own Try again alive - a mousedown on it blurs this field first, and
+  // an unguarded drop would unmount the button before the click landed.)
+  scanning.value = false;
+  readFailed.value = false;
 
   verdict.value = null;
   inspectError.value = "";
@@ -191,7 +207,7 @@ onMounted(() => {
         label="Folder"
         placeholder="/home/me/Pictures"
         icon="folder-outline"
-        :disabled="scanning"
+        :disabled="scanning && !readFailed"
         @enter="inspect"
         @blur="inspect"
       />
@@ -200,7 +216,7 @@ onMounted(() => {
         class="choose-step__browse"
         size="sm"
         variant="secondary"
-        :disabled="scanning"
+        :disabled="scanning && !readFailed"
         @click="browserOpen = true"
       >
         Browse…
@@ -218,6 +234,7 @@ onMounted(() => {
       :match-existing="Boolean(resume)"
       @task="emit('task', $event)"
       @ready="emit('ready', $event)"
+      @read-failed="readFailed = $event"
       @cancel="emit('cancel')"
     />
 

--- a/frontend/src/components/folders/FolderMappingPreviewStep.test.js
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.test.js
@@ -110,4 +110,83 @@ describe("FolderMappingPreviewStep", () => {
       null,
     );
   });
+
+  // "N are created or matched" is the only number on the screen that says how
+  // much the commit changes, and it is arithmetic nobody re-checks by eye.
+  describe("the count under 'what happens when you press the button'", () => {
+    function factText(wrapper) {
+      return wrapper
+        .findAll(".preview-step__fact")
+        .map((el) => el.text())
+        .find((text) => text.includes("created or matched"));
+    }
+
+    it("counts a name reused across two kinds once per kind", async () => {
+      // A `Wedding` set inside a `Wedding` project is two entities, and the
+      // commit creates two. Collapsing them to a single name undercounted
+      // exactly the libraries that name a folder after the thing above it.
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [
+          { kind: "project", relative_path: "2024/Wedding" },
+          { kind: "set", relative_path: "2024/Wedding/Wedding" },
+        ],
+      });
+      await flushPromises();
+
+      expect(factText(wrapper)).toContain("2 ");
+    });
+
+    it("counts tags, and names them", async () => {
+      // Tags were counted by the number and left out of the sentence beside
+      // it, so a mapping of nothing but tags read as "0 ... are created".
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [
+          { kind: "tag", relative_path: "beach" },
+          { kind: "tag", relative_path: "sunset" },
+        ],
+      });
+      await flushPromises();
+
+      const text = factText(wrapper);
+      expect(text).toContain("2 ");
+      expect(text).toContain("tags");
+    });
+
+    it("still collapses the same name repeated within one kind", async () => {
+      // Two `Alice` folders at different depths are one Person, and always were.
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [
+          { kind: "person", relative_path: "2023/Alice" },
+          { kind: "person", relative_path: "2024/Alice" },
+        ],
+      });
+      await flushPromises();
+
+      expect(factText(wrapper)).toContain("1 ");
+    });
+
+    it("names every facet it counts", async () => {
+      // The sentence is built from FACET_KINDS so a fifth facet cannot be
+      // counted and left unnamed the way Tag was.
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [
+          { kind: "project", relative_path: "p" },
+          { kind: "set", relative_path: "s" },
+          { kind: "person", relative_path: "a" },
+          { kind: "tag", relative_path: "t" },
+        ],
+      });
+      await flushPromises();
+
+      const text = factText(wrapper);
+      expect(text).toContain("4 ");
+      for (const noun of ["projects", "sets", "people", "tags"]) {
+        expect(text).toContain(noun);
+      }
+    });
+  });
 });

--- a/frontend/src/components/folders/FolderMappingPreviewStep.test.js
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.test.js
@@ -168,6 +168,38 @@ describe("FolderMappingPreviewStep", () => {
       expect(factText(wrapper)).toContain("1 ");
     });
 
+    it("names only the kinds the mapping has, and agrees its verb", async () => {
+      // "1 projects, sets, people and tags are created or matched" named three
+      // kinds that were not in the mapping and disagreed with its own count.
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [{ kind: "project", relative_path: "2024/Wedding" }],
+      });
+      await flushPromises();
+
+      const text = factText(wrapper);
+      expect(text).toContain("1 project is created or matched");
+      for (const absent of ["sets", "people", "tags"]) {
+        expect(text).not.toContain(absent);
+      }
+    });
+
+    it("names every kind when the mapping has none of them", async () => {
+      // Everything mapped to "just a folder" creates nothing, and "0 projects,
+      // sets, people and tags" is true of every kind at once.
+      const wrapper = mountStep({
+        commitOnMount: false,
+        assignments: [{ kind: "folder", relative_path: "2024" }],
+      });
+      await flushPromises();
+
+      const text = factText(wrapper);
+      expect(text).toContain("0 ");
+      for (const noun of ["projects", "sets", "people", "tags"]) {
+        expect(text).toContain(noun);
+      }
+    });
+
     it("names every facet it counts", async () => {
       // The sentence is built from FACET_KINDS so a fifth facet cannot be
       // counted and left unnamed the way Tag was.

--- a/frontend/src/components/folders/FolderMappingPreviewStep.vue
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.vue
@@ -96,13 +96,27 @@ const lastFact = computed(() =>
     : "no folder is created inside your library",
 );
 
-const ungroupedCount = computed(() => {
-  const named = new Set();
-  for (const [, bucket] of grouped.value) {
-    for (const name of bucket.keys()) named.add(name);
-  }
-  return named;
+/**
+ * How many entities the commit creates or matches.
+ *
+ * The sum of the per-kind buckets, NOT a set of names across them: `grouped`
+ * has already collapsed same-named folders WITHIN a kind (two `Alice` folders
+ * are one Person), and collapsing across kinds as well made a `Alice` person
+ * and an `Alice` set count once between them. The number under "what happens
+ * when you press the button" then undercounted exactly the libraries that
+ * reuse a name at two levels, which is most of them.
+ */
+const entityCount = computed(() => {
+  let total = 0;
+  for (const [, bucket] of grouped.value) total += bucket.size;
+  return total;
 });
+
+// Named from FACET_KINDS rather than written out, so a facet cannot be counted
+// by the number above and left out of the sentence beside it - which is what
+// happened to Tag.
+const FACET_NAMES = FACET_KINDS.map((kind) => kind.plural.toLowerCase());
+const entityKinds = `${FACET_NAMES.slice(0, -1).join(", ")} and ${FACET_NAMES.at(-1)}`;
 
 async function poll(taskId) {
   if (disposed) return;
@@ -269,7 +283,7 @@ onUnmounted(() => {
           <span class="preview-step__fact-mark preview-step__fact-mark--yes"
             >✓</span
           >
-          {{ ungroupedCount.size }} project(s), set(s) and people are created or
+          {{ entityCount.toLocaleString() }} {{ entityKinds }} are created or
           matched
         </div>
         <div class="preview-step__fact">

--- a/frontend/src/components/folders/FolderMappingPreviewStep.vue
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.vue
@@ -112,11 +112,28 @@ const entityCount = computed(() => {
   return total;
 });
 
-// Named from FACET_KINDS rather than written out, so a facet cannot be counted
-// by the number above and left out of the sentence beside it - which is what
-// happened to Tag.
-const FACET_NAMES = FACET_KINDS.map((kind) => kind.plural.toLowerCase());
-const entityKinds = `${FACET_NAMES.slice(0, -1).join(", ")} and ${FACET_NAMES.at(-1)}`;
+/**
+ * The kinds this mapping actually has, named for the sentence beside the count.
+ *
+ * Read from the same `grouped` buckets the total is summed from, so a facet
+ * cannot be counted by the number and left out of the sentence - which is what
+ * happened to Tag. Only the non-empty ones: a single mapped project used to
+ * read "1 projects, sets, people and tags are created", naming three kinds that
+ * were not there and disagreeing with its own verb.
+ *
+ * Nothing mapped is the exception, and it is not a special case: "0 projects,
+ * sets, people and tags" is true of every kind at once, so all four are named.
+ */
+const entityKinds = computed(() => {
+  const present = FACET_KINDS.filter(
+    (kind) => grouped.value.get(kind.value)?.size,
+  );
+  const names = (present.length ? present : FACET_KINDS).map((kind) =>
+    (entityCount.value === 1 ? kind.label : kind.plural).toLowerCase(),
+  );
+  if (names.length === 1) return names[0];
+  return `${names.slice(0, -1).join(", ")} and ${names.at(-1)}`;
+});
 
 async function poll(taskId) {
   if (disposed) return;
@@ -283,8 +300,8 @@ onUnmounted(() => {
           <span class="preview-step__fact-mark preview-step__fact-mark--yes"
             >✓</span
           >
-          {{ entityCount.toLocaleString() }} {{ entityKinds }} are created or
-          matched
+          {{ entityCount.toLocaleString() }} {{ entityKinds }}
+          {{ entityCount === 1 ? "is" : "are" }} created or matched
         </div>
         <div class="preview-step__fact">
           <span class="preview-step__fact-mark"> - </span>

--- a/frontend/src/components/folders/FolderMappingScanStep.vue
+++ b/frontend/src/components/folders/FolderMappingScanStep.vue
@@ -7,7 +7,7 @@
  * completion. Cancelling the read is the wizard's job - it is the one that
  * knows whether there is anything else to undo.
  */
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { VProgressCircular } from "vuetify/components";
 
 import {
@@ -28,7 +28,7 @@ const props = defineProps({
   matchExisting: { type: Boolean, default: true },
 });
 
-const emit = defineEmits(["task", "ready", "cancel"]);
+const emit = defineEmits(["task", "ready", "cancel", "read-failed"]);
 
 const taskId = ref("");
 const status = ref("");
@@ -37,14 +37,48 @@ const processed = ref(0);
 const total = ref(0);
 const result = ref(null);
 const loadError = ref("");
+/**
+ * Reattach to `resumeTaskId` on the next `begin()`.
+ *
+ * False from the first retry onwards: a resumed read that failed usually failed
+ * because its task is gone (the server keeps one slot, and a restart empties
+ * it), so re-asking for the same id fails identically forever. A retry starts a
+ * new read of the same folder.
+ */
+const reattaching = ref(Boolean(props.resumeTaskId));
 
 let pollTimer = null;
 let disposed = false;
+
+// The picker above this card is disabled while the read runs, so a failed read
+// left the owner with a message and only Cancel. Tell the parent, which puts
+// the folder field back: "pick another folder, or try this one again".
+watch(loadError, (message) => emit("read-failed", Boolean(message)));
 
 const isDone = computed(() => status.value === "completed" || status.value === "cancelled");
 const isIndeterminate = computed(() => stage.value === "walking" || total.value === 0);
 const progressPercent = computed(() =>
   total.value ? Math.min(100, Math.round((processed.value / total.value) * 100)) : 0,
+);
+
+/**
+ * Folders the walk deliberately did not enter (dot-folders, and directories on
+ * the system blocklist found below the root). Ordinary, and not a warning - but
+ * counted rather than dropped, for the same reason `unreadable_folders` is: a
+ * map that omits a subtree must not present itself as the whole library.
+ */
+const skippedFolders = computed(() => {
+  const skipped = result.value?.skipped_folders;
+  return (skipped?.hidden || 0) + (skipped?.restricted || 0);
+});
+
+/**
+ * The face signal never ran (no inference engine), so no folder could come back
+ * as a Person. Without saying so, the same tree reads as "nobody lives here"
+ * depending on whether models happened to be loaded.
+ */
+const faceSignalMissing = computed(
+  () => Boolean(result.value) && result.value.face_signal_ran === false,
 );
 
 const summary = computed(() => {
@@ -95,7 +129,7 @@ async function poll() {
 async function begin() {
   loadError.value = "";
   try {
-    if (props.resumeTaskId) {
+    if (reattaching.value) {
       taskId.value = props.resumeTaskId;
     } else {
       const started = await startFolderStructureRead(props.path, {
@@ -115,6 +149,20 @@ function proceed() {
   emit("ready", { taskId: taskId.value, result: result.value });
 }
 
+/** Read the same folder again, from scratch. */
+function retry() {
+  if (pollTimer) clearTimeout(pollTimer);
+  pollTimer = null;
+  reattaching.value = false;
+  taskId.value = "";
+  status.value = "";
+  stage.value = "";
+  processed.value = 0;
+  total.value = 0;
+  result.value = null;
+  begin();
+}
+
 onMounted(begin);
 onUnmounted(() => {
   disposed = true;
@@ -127,14 +175,23 @@ onUnmounted(() => {
     <p v-if="loadError" class="scan-step__error" role="alert">{{ loadError }}</p>
 
     <FolderMappingCard
-      :title="isDone ? 'What it found' : 'Working out what your folders mean'"
+      :title="
+        loadError
+          ? 'The read stopped'
+          : isDone
+            ? 'What it found'
+            : 'Working out what your folders mean'
+      "
       :lead="
-        isDone
+        isDone || loadError
           ? ''
           : 'Reading up to 20 pictures from each folder: who is in them, which have caption files beside them, which names repeat.'
       "
+      :warn="Boolean(loadError)"
     >
-      <template v-if="!isDone">
+      <!-- A bar still moving under a message saying the read stopped is the
+           screen contradicting itself. -->
+      <template v-if="!isDone && !loadError">
         <div class="scan-step__bar">
           <VProgressCircular
             v-if="isIndeterminate"
@@ -167,6 +224,14 @@ onUnmounted(() => {
             <div class="scan-step__stat-value">{{ result.unreadable_folders }}</div>
             <div class="scan-step__stat-label">folder(s) could not be read</div>
           </div>
+          <!-- Not a warning: skipping a vault's own caches is the walk working.
+               Shown because a map that leaves a subtree out must say so. -->
+          <div v-if="skippedFolders" class="scan-step__stat">
+            <div class="scan-step__stat-value">{{ skippedFolders.toLocaleString() }}</div>
+            <div class="scan-step__stat-label">
+              hidden or system folder(s) left out on purpose
+            </div>
+          </div>
         </div>
         <ul v-if="summary" class="scan-step__summary">
         <li v-if="summary.tallies.person">✓ {{ summary.tallies.person }} folder(s) read as Person</li>
@@ -179,13 +244,25 @@ onUnmounted(() => {
           <li v-if="summary.silent" class="scan-step__summary-muted">
             - {{ summary.silent }} with nothing to say
           </li>
+          <!-- Why there are no People, when there might well be. -->
+          <li v-if="faceSignalMissing" class="scan-step__summary-muted">
+            - no folder could be read as a Person: the face signal did not run
+            on this machine
+          </li>
         </ul>
       </template>
 
       <template #actions>
+        <!-- A failed read replaces the button it can never enable. Without
+             this the card offered a permanently disabled "Set up my library"
+             and Cancel, and the folder field above was disabled too. -->
+        <AppButton v-if="loadError" variant="primary" @click="retry">
+          Try again
+        </AppButton>
         <AppButton
+          v-else
           variant="primary"
-          :loading="!isDone && !loadError"
+          :loading="!isDone"
           :disabled="!isDone"
           @click="proceed"
         >

--- a/frontend/src/components/folders/FolderMappingWizard.test.js
+++ b/frontend/src/components/folders/FolderMappingWizard.test.js
@@ -519,6 +519,48 @@ describe("the branches nobody walks on purpose", () => {
     wrapper.unmount();
   });
 
+  it("asks once more before sending Back to a step it cannot draw", async () => {
+    // The mount poll failed; the retry on the press succeeds. Without it, the
+    // one control offered after a failed resumed commit swapped the Preview
+    // for nothing at all.
+    getFolderStructureReadStatus.mockRejectedValueOnce(new Error("gone"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    useFolderMappingStore().save(resumed);
+    const wrapper = mountWizard({ resume: resumed });
+    await settle();
+
+    getFolderStructureReadStatus.mockResolvedValue({
+      status: "completed",
+      result: READ_RESULT,
+    });
+    wrapper.findComponent(FolderMappingPreviewStep).vm.$emit("back");
+    await settle();
+
+    expect(wrapper.find(".tree-stub").exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("stays on the Preview and says why when the read is really gone", async () => {
+    // An empty dialog is the one outcome that must not happen: the Preview
+    // keeps Organise later and Cancel, and both still work.
+    getFolderStructureReadStatus.mockRejectedValue(new Error("gone"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    useFolderMappingStore().save(resumed);
+    const wrapper = mountWizard({ resume: resumed });
+    await settle();
+
+    wrapper.findComponent(FolderMappingPreviewStep).vm.$emit("back");
+    await settle();
+
+    expect(wrapper.findComponent(FolderMappingPreviewStep).exists()).toBe(true);
+    expect(wrapper.find(".mapping-wizard__error").text()).toContain(
+      "nothing to go back to",
+    );
+
+    wrapper.unmount();
+  });
+
   it("refuses to close once a commit has started", async () => {
     // A commit runs to completion server-side and cannot be un-started, so a
     // dialog that closed over it would leave the work invisible.

--- a/frontend/src/components/folders/FolderMappingWizard.vue
+++ b/frontend/src/components/folders/FolderMappingWizard.vue
@@ -110,21 +110,45 @@ watch(
     if (!entry) librariesStore.refresh();
     // The read's result did not survive the reload; "Back to the mapping"
     // after a failed commit needs it, and one poll brings it back.
-    if (autoCommit.value && entry.taskId) {
-      getFolderStructureReadStatus(entry.taskId)
-        .then((body) => {
-          if (body.result) readResult.value = body.result;
-        })
-        .catch((error) => {
-          console.warn("Could not reload the folder-structure read", {
-            taskId: entry.taskId,
-            error,
-          });
-        });
-    }
+    if (autoCommit.value && entry.taskId) loadReadResult(entry.taskId);
   },
   { immediate: true },
 );
+
+/** Fetch the read's result back from its task. Resolves either way. */
+async function loadReadResult(taskId) {
+  try {
+    const body = await getFolderStructureReadStatus(taskId);
+    if (body.result) readResult.value = body.result;
+  } catch (error) {
+    console.warn("Could not reload the folder-structure read", {
+      taskId,
+      error,
+    });
+  }
+}
+
+/**
+ * "Back to the mapping", from the Preview step.
+ *
+ * The mapping step cannot render without `readResult`, so pressing this when
+ * the fetch above had failed swapped the Preview for nothing at all: an empty
+ * dialog, after a commit that had just failed. Ask once more, and if the read
+ * is genuinely gone say so and stay on the Preview, whose Organise later and
+ * Cancel are both still live.
+ */
+async function backToMapping() {
+  if (!readResult.value && readTaskId.value) {
+    await loadReadResult(readTaskId.value);
+  }
+  if (readResult.value) {
+    buildError.value = "";
+    step.value = "mapping";
+    return;
+  }
+  buildError.value =
+    "The folder read this mapping came from is gone, so there is nothing to go back to. Organise later brings the pictures in and leaves naming the folders for another day.";
+}
 
 const title = computed(() => {
   switch (step.value) {
@@ -303,7 +327,7 @@ function onCommitted(result) {
       :picture-count="pictureCount"
       :library-exists="libraryExists"
       :commit-on-mount="autoCommit"
-      @back="step = 'mapping'"
+      @back="backToMapping"
       @build="build"
       @commit-started="onCommitStarted"
       @cancel="close"


### PR DESCRIPTION
Closes #1177 items 35-42.

Eight findings, one shape: **a failure path that removes, or never offers, the
control that would let you act on the message it just wrote.** Fixed as one rule
— every failure state leaves at least one live control that changes the thing
that failed — applied at each of the six places it was broken, plus two places
where the screen dropped a fact the API had given it.

### The dead ends

**35 — a first-run refusal reloaded the wizard** (`main.ts`). Declining the
recreate offer, or the permission repair, called `loadFile(setup.html)` and then
threw. The window was already on `setup.html` (the failure happens inside the
launch, before anything navigates), so the reload destroyed the renderer that
was awaiting the IPC call: the message never arrived, and every answer went with
it. Now it just throws, which rejects `setup:commit` on the live page — the
install step stays up, prints the message, and re-enables Back and Try again.

**36 — declining the recreate offer trapped the folder choice** (`RunSetup.ts`).
The config is written before the backend starts, and launch shows the wizard
only when there *is no* config. A failed setup therefore left one behind naming
the very folder the failure was about, and no later launch offered a picker.
Everything after `writeConfig` now runs under a rollback that takes the config
back off disk and clears the parked privacy answer.

**37 — a failing `setup:probe` left the wizard with no controls**
(`renderer/setup.js`). The catch dropped to the install step without setting
`failed`, and `render()` hides both buttons there. Now it takes the same failure
shape as a failed commit, with a Try again that retries the *probe* — there are
no answers to commit yet. The shape itself is now one `fail()` helper instead of
two-and-a-half copies.

**38 — a failed GPU install waited out the folder read before saying so**
(`RunSetup.ts`). The read still has to finish before anything restarts, and on a
large library that is minutes the screen spent drawing a download that had
already failed. The failure is announced when it happens; the read still gets to
end before the throw, because the retry the screen offers starts a new backend
over this one.

**39 — a failed read dead-ended the choose step**
(`FolderMappingChooseStep.vue`, `FolderMappingScanStep.vue`). The path field and
Browse are disabled while a read runs, so a failed one froze the pane with
Cancel as its only live control — reached most often by a *resumed* entry, since
the server keeps one read slot and the saved task is usually gone by the time
"Finish organising…" is pressed. The scan card now emits `read-failed`, which
un-disables the picker while keeping the card, and swaps its permanently
disabled "Set up my library" for "Try again". That retry starts a **new** read
rather than reattaching to the task id that just failed. Pointing the field
elsewhere drops the card instead — after the `lastAsked` guard, so the
`mousedown → blur → click` on Try again does not unmount the button before the
click lands.

**40 — "Back to the mapping" could render an empty dialog**
(`FolderMappingWizard.vue`). The mapping step cannot render without
`readResult`, so pressing it after a failed resumed commit — when the mount poll
that refetches the result had itself failed — swapped the Preview for nothing at
all. It now re-asks once before switching, and if the read is genuinely gone it
says so and stays on the Preview, whose Organise later and Cancel are both live.

### The dropped facts

**41 — the scan card dropped `face_signal_ran` and `skipped_folders`**
(`FolderMappingScanStep.vue`). Both mean *this map is not the whole library*,
which is why the API reports them (integration_architecture.md §20). Skipped
folders join truncated/unreadable as a plain stat, not a warning — skipping a
vault's own caches is the walk working. `face_signal_ran: false` gets a summary
line, because it is the only thing that explains a People count of zero on a
machine with no inference engine.

**42 — the preview's entity count deduped across kinds and omitted tags**
(`FolderMappingPreviewStep.vue`). It built a `Set` of names across every kind,
so a `Wedding` set inside a `Wedding` project counted once, undercounting
exactly the libraries that name a folder after the thing above it. It now sums
the per-kind buckets (which still collapse a repeated name *within* a kind, as
intended), and the sentence beside it is built from `FACET_KINDS` so a facet
cannot be counted and left unnamed the way `tag` was.

### Checks

- `electron/test/runSetup.test.ts`: the config rollback (on a refused backend
  and on a failed download), that a finished setup leaves it alone, and that the
  install failure is announced while the read is still outstanding.
- `FolderMappingPreviewStep.test.js`: four cases pinning the count arithmetic —
  reused-across-kinds, tags counted and named, same-name-within-a-kind still
  collapsed, every facet named. Verified red against the old logic before being
  committed.
- `FolderMappingChooseStep.test.js`: the failed-resume recovery (message, no
  progress bar, picker back, Try again starts a new read, pointing elsewhere
  drops the card) and the two read facts in both directions.
- `FolderMappingWizard.test.js`: Back re-asks and gets there; Back with the read
  really gone stays on the Preview with a reason.

`electron`: 198 tests green, `tsc --noEmit` clean. `frontend`: 3888 tests green,
eslint clean.

**Not verified here:** none of items 35-38 can be exercised without a real
first-run Electron boot — no config on disk, a library folder the backend
refuses, and (for 38) a GPU download that fails. The unit tests drive
`runFirstRunSetup` through fakes and prove the ordering and the rollback; they
cannot prove the renderer's Try again is reachable on a real first run, and the
renderer itself has no test harness.
