### PR TITLE
Folder-structure commit: resumable records, shared conflict and prune rules, bounded assigning cost

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -6151,26 +6151,71 @@ does the only filesystem *read* left: indexing every file into a `Picture`
 row, in place, exactly as it does for any other reference folder.
 `register_reference_folder` is deliberately **not** the same function as
 `routes.reference_folders.create_reference_folder` — it is a smaller,
-one-directional insert kept separate because the two entry points validate
-different things upstream (that route re-derives accessibility from a
-caller-supplied path and checks conflicts against every other registered
-folder, and accepts `host_path`/sidecar-suffix/Docker-mode fields this one has
-no UI for; this one starts from a path a settled read already walked) — and
-because their **conflict answers differ**. `create_reference_folder` 409s
-outright on an existing path. `register_reference_folder`'s `fetch_or_create`
-is narrower: it reuses an existing row **only** when that row has never
-completed a scan (`last_scanned is None`) — the shape of a commit that
-registered the folder and then crashed before the first scan finished, safe to
-resume because nothing has been indexed under it yet that a fresh wait could
-miss. A row that **has** completed a scan — an unrelated pre-existing
-reference folder, or an earlier commit of this same path from a since-cancelled
-read run again — is refused with a `CommitError` rather than silently reused,
-because reusing it would apply this mapping to whatever happens to be indexed
-under it already, not to what the read the owner just accepted actually found.
-"Cancel and organise later" during `Main` or `MapTree` therefore leaves
-nothing committed and nothing registered at all — there is no reference folder
-row yet at that point for a resumed commit to collide with — and the narrow
-crash-recovery case above is the only path re-use is safe.
+one-directional insert kept separate because the two entry points start from
+different places (that route re-derives accessibility from a caller-supplied
+path, and accepts `host_path`/sidecar-suffix/Docker-mode fields this one has no
+UI for; this one starts from a path a settled read already walked).
+
+**The conflict rule is not one of those differences.** Both call
+`utils.reference_folder_validator.validate_reference_folder_conflicts` — a root
+may not equal, contain, or sit inside `image_root` or any other registered
+reference folder. This path used to check *nothing*, so a root that contained
+`image_root` (the commit route's own guard only refuses one equal to or inside
+it) or that swallowed another reference folder was accepted, and two scan tasks
+then each indexed the same files believing they owned them.
+
+What does still differ is the answer to **an existing row at the same path**.
+`create_reference_folder` 409s outright. `register_reference_folder` reuses one
+in exactly two shapes, and refuses every other:
+
+- the row has never completed a scan (`last_scanned is None`) — a commit that
+  registered the folder and crashed before the first scan finished; nothing has
+  been indexed under it that a fresh wait could miss;
+- the row is **this commit's own**, which `_commit_owns_this_root` decides from
+  the durable record rather than from the path: the `FolderMappingCommit` for
+  this `task_id` is still `pending` and its `stage` has left `registering`,
+  which it does only once `register_reference_folder` has already returned once.
+  The mapping provably did not run — assigning settles the record inside its own
+  transaction — so this is a commit interrupted *after* its scan completed, and
+  finishing it is the entire purpose of the record. Refusing it (which is what
+  the `last_scanned` test alone did) wedged the record `pending` for ever:
+  every start-up resumed it and failed identically.
+
+Anything else — an unrelated pre-existing reference folder, or an earlier
+*settled* commit of this same path from a since-cancelled read run again — is
+refused with a `CommitError` rather than silently reused, because reusing it
+would apply this mapping to whatever happens to be indexed under it already,
+not to what the read the owner just accepted actually found. "Cancel and
+organise later" during `Main` or `MapTree` leaves nothing committed and nothing
+registered at all, so there is no row at that point for a resumed commit to
+collide with.
+
+### The newest accepted mapping is the only resumable one
+
+`FolderMappingCommit` promises "at most one row is `pending`", and the endpoint's
+in-memory single-slot rule is not enough to keep it: a commit that *fails*
+deliberately leaves its record pending (the failure is usually transient and
+losing the intent is what the record exists to prevent) while clearing the
+in-memory slot, so the owner can legitimately accept a second mapping over the
+first. `record_pending_commit` therefore marks every older pending row
+`STATE_SUPERSEDED` as it writes the new one. Without it both rows are pending:
+the next start-up resumes the newest, and the start-up *after that* resumes the
+older one and re-applies a mapping the owner has already replaced.
+
+### One pruning rule for every walk of a tree
+
+§24's read prunes dot-folders (a vault's own `.pixlstash-thumbnails/`, the older
+`.ref_thumbs/`, `.pixlstash` sidecar stores, anything the owner hid) and so does
+`local_import_pictures`; `ReferenceFolderScanTask` did not. Since a
+reference-mode commit is precisely the read and that scan looking at one root,
+the two disagreed about what was in it — the read's `picture_count` excluded the
+cache and the scan indexed every file in it as a picture, which the mapping then
+filed. The rule is `utils.media_files.is_hidden_entry`, now called by all three.
+The scan additionally keeps rows under a newly-pruned dot-folder out of
+`removed_paths` (`has_hidden_component`), for the reason the views-tree prune
+beside it spells out: "absent from `disk_paths`" is what that task hard-deletes a
+`Picture` for, and a path it never looked for says nothing about whether the file
+is still there.
 
 `wait_for_first_scan` polls `ReferenceFolder.last_scanned`, which is exactly
 the field the model's own docstring names as "unix timestamp of the last
@@ -6190,6 +6235,21 @@ workers started the same second the commit reported `done`. A `vault.wake()`
 per chunk (`_BUILD_CHUNK_SIZE` = 128 pictures) has faces, quality and the rest
 running on the first chunk while the walk continues; it is a scheduler poke,
 not an event, so the SPA is still told about the import once, at the end.
+
+### The assigning step costs a bounded number of statements
+
+`_link_pictures` resolves every folder first and only then links, because with
+the answers in hand the human-label ledger can be written in **one batched
+pass** (`label_ledger.record_human_labels`) rather than one indexed `SELECT` per
+`(picture, tag)`. On a fresh `local_import` no predictions exist yet, so the
+per-pair shape was a round trip per picture per tag-mapped folder. The `IN`
+lists either side of it — `local_import_pictures`'s existing-`file_path` load
+and `apply_local_mapping`'s id load — are chunked through
+`utils.sql_chunking.chunked` for the separate reason that unchunked they are the
+whole import and cross SQLite's bound-parameter cap.
+`tests/test_folder_structure_commit.py::test_linking_a_large_import_costs_a_bounded_number_of_statements`
+pins it by counting statements at two import sizes: twenty times the pictures
+must not cost more statements.
 
 ### A read commits once, enforced
 

--- a/pixlstash/db_models/folder_mapping_commit.py
+++ b/pixlstash/db_models/folder_mapping_commit.py
@@ -14,8 +14,16 @@ settled inside the assigning transaction itself, so the two cannot disagree:
 either the assignments landed and this row says ``done`` in the same commit, or
 neither happened and it still says ``pending`` for the next start-up to pick up.
 
-**At most one row is ``pending``**, which is the same single-slot rule the
-commit endpoint already enforces in memory (``server.folder_structure_commit``).
+**At most one row is ``pending``, and it is always the newest.** That is the
+same single-slot rule the commit endpoint enforces in memory
+(``server.folder_structure_commit``), but memory is not enough on its own: a
+commit that FAILS leaves its record pending on purpose and clears the in-memory
+slot, so the owner can accept a second mapping while the first is still on
+file. `record_pending_commit` therefore marks every older pending row
+:data:`STATE_SUPERSEDED` as it writes the new one. Without that the newest is
+resumed first and the older one is resumed at the start-up after it, filing
+pictures under the folders the owner has already re-mapped.
+
 Settled rows are kept: they are the answer to "what happened to that import",
 and there are only ever a handful.
 """
@@ -35,8 +43,12 @@ STATE_ABANDONED = "abandoned"
 #: deliberately not applied. Distinct from ``done`` because the library is
 #: usable but unorganised, and from ``abandoned`` because nothing was refused.
 STATE_DEFERRED = "deferred"
+#: A newer mapping was accepted while this one was still unfinished, so this
+#: one is not what the owner wants any more. Never resumed - see the
+#: newest-wins rule below.
+STATE_SUPERSEDED = "superseded"
 
-SETTLED_STATES = (STATE_DONE, STATE_ABANDONED, STATE_DEFERRED)
+SETTLED_STATES = (STATE_DONE, STATE_ABANDONED, STATE_DEFERRED, STATE_SUPERSEDED)
 
 
 def _now() -> datetime:
@@ -67,7 +79,8 @@ class FolderMappingCommit(SQLModel, table=True):
             its phase, since indexing is idempotent by ``file_path`` and
             assigning is one transaction.
         state: :data:`STATE_PENDING`, :data:`STATE_DONE`,
-            :data:`STATE_ABANDONED` or :data:`STATE_DEFERRED`.
+            :data:`STATE_ABANDONED`, :data:`STATE_DEFERRED` or
+            :data:`STATE_SUPERSEDED`.
         started_at: When the commit was first accepted.
         updated_at: When this row last changed.
     """

--- a/pixlstash/routes/folder_structure.py
+++ b/pixlstash/routes/folder_structure.py
@@ -565,8 +565,11 @@ def create_router(server) -> APIRouter:
                     server, picture_ids, assignments, root_path, task_id=task_id
                 )
             else:
+                # task_id, so a resume can tell the folder THIS commit
+                # registered (adopt it and finish the mapping) from one that
+                # was already there (refuse).
                 rf = commit_service.register_reference_folder(
-                    server, root_path, label=label
+                    server, root_path, label=label, task_id=task_id
                 )
                 _commit_progress(task_id, "indexing", 0, expected_pictures)
                 commit_service.record_commit_stage(server, task_id, "indexing")

--- a/pixlstash/routes/reference_folders.py
+++ b/pixlstash/routes/reference_folders.py
@@ -36,6 +36,7 @@ from pixlstash.utils.library_layout import (
     parse_layout,
 )
 from pixlstash.utils.reference_folder_validator import (
+    validate_reference_folder_conflicts,
     validate_reference_folder_path,
     validate_reference_folder_accessible,
 )
@@ -358,37 +359,18 @@ def create_router(server) -> APIRouter:
         *,
         exclude_id: int | None = None,
     ) -> None:
-        image_root = os.path.normpath(getattr(server.vault, "image_root", "") or "")
-        if image_root:
-            if (
-                folder == image_root
-                or folder.startswith(image_root + os.sep)
-                or image_root.startswith(folder + os.sep)
-            ):
-                raise HTTPException(
-                    status_code=409,
-                    detail="Path conflicts with the PixlStash data folder.",
-                )
-        all_folders = list(session.exec(select(ReferenceFolder)).all())
-        for other in all_folders:
-            if exclude_id is not None and other.id == exclude_id:
-                continue
-            other_norm = os.path.normpath(other.folder)
-            if folder == other_norm:
-                raise HTTPException(
-                    status_code=409,
-                    detail="A reference folder with this path already exists.",
-                )
-            if folder.startswith(other_norm + os.sep):
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Path is inside an existing reference folder: {other.folder}",
-                )
-            if other_norm.startswith(folder + os.sep):
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"An existing reference folder is inside this path: {other.folder}",
-                )
+        # The rule itself lives in `reference_folder_validator`, shared with the
+        # folder-structure commit's own `register_reference_folder`: this route
+        # is not the only thing that registers a root, and the two answering
+        # differently is what let a commit accept a root containing image_root.
+        error = validate_reference_folder_conflicts(
+            session,
+            folder,
+            os.path.normpath(getattr(server.vault, "image_root", "") or ""),
+            exclude_id=exclude_id,
+        )
+        if error:
+            raise HTTPException(status_code=409, detail=error)
 
     def _sidecar_suffix_for_move(image_path: str, sidecar_path: str) -> str | None:
         if not sidecar_path:

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -438,7 +438,11 @@ def _commit_owns_this_root(
         row is not None
         and row.state == STATE_PENDING
         and row.stage != "registering"
-        and os.path.normpath(row.root_path) == root_path
+        # Both sides resolved: `register_reference_folder` resolves the root it
+        # is handed, so comparing a merely-normalised record path against it
+        # would make a resumed commit under a symlinked root fail to recognise
+        # its own row and refuse to finish.
+        and os.path.realpath(os.path.normpath(row.root_path)) == root_path
     )
 
 
@@ -467,7 +471,16 @@ def register_reference_folder(
             one. It is what lets a resumed commit adopt the row it registered
             itself - see `_commit_owns_this_root`.
     """
-    root_path = os.path.normpath(root_path)
+    # Resolved, not merely normalised, for the reason
+    # `routes.reference_folders.create_reference_folder` gives where it does the
+    # same: the row is what the scan walks, so storing a link's own name would
+    # leave the row naming one directory and the scan walking another, and
+    # repointing the link afterwards would move the folder somewhere no check
+    # ever saw. It also makes this row comparable with the ones that route
+    # writes - `validate_reference_folder_conflicts` resolves both sides now,
+    # but a row stored under an alias would still read back wrong everywhere
+    # else.
+    root_path = os.path.realpath(os.path.normpath(root_path))
     error = validate_reference_folder_path(root_path)
     if error:
         raise CommitError(error)

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -20,11 +20,12 @@ place anything from the mapping screen is written.
   already held loose files. Those pictures already live where the library
   keeps its own, so they become ordinary MANAGED pictures (relative
   ``file_path``, same shape as any other import) rather than reference-folder
-  ones. Routing this case through ``mode="reference"`` instead would either
-  bypass or have to reimplement the exact conflict guard
-  ``routes.reference_folders._validate_reference_folder_conflicts`` already
-  enforces - a reference folder may never equal or contain ``image_root`` -
-  which is the proof the two need to stay two commit modes, not one.
+  ones. Routing this case through ``mode="reference"`` instead is not merely
+  wrong, it is refused: ``utils.reference_folder_validator``'s shared conflict
+  rule, which both this module and the ``/reference-folders`` routes go
+  through, says a reference folder may never equal, contain or sit inside
+  ``image_root`` - which is the proof the two need to stay two commit modes,
+  not one.
   ``local_import_pictures`` does the read this mode's own filesystem step
   (there is no already-shipped scan task for "index my own image_root in
   place"); ``apply_local_mapping`` then reuses the same entity-resolution code
@@ -64,6 +65,7 @@ from pixlstash.db_models.folder_mapping_commit import (
     FolderMappingCommit,
     STATE_DONE,
     STATE_PENDING,
+    STATE_SUPERSEDED,
 )
 from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.picture_project import PictureProjectMember
@@ -77,15 +79,16 @@ from pixlstash.services.project_membership_service import (
     set_picture_set_projects,
 )
 from pixlstash.services.set_lock_service import locked_picture_ids
-from pixlstash.utils.service.label_ledger import POS, record_human_label
+from pixlstash.utils.service.label_ledger import POS, record_human_labels
 from pixlstash.utils.sql_chunking import chunked
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.library_layout import Facet
-from pixlstash.utils.media_files import is_supported_media_file
+from pixlstash.utils.media_files import is_hidden_entry, is_supported_media_file
 from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.reference_folder_validator import (
     validate_reference_folder_accessible,
+    validate_reference_folder_conflicts,
     validate_reference_folder_path,
 )
 
@@ -230,9 +233,30 @@ def record_pending_commit(
     Before, deliberately. A record written afterwards would not exist for the
     window this whole mechanism is about - the crash that lands between "the
     owner pressed the button" and "the pictures are organised".
+
+    Accepting a mapping also **supersedes** every older pending one: the newest
+    record is the only resumable one. A failed commit deliberately leaves its
+    record pending while clearing the in-memory slot, so a second mapping can
+    legitimately be accepted over an unfinished first - and without this the
+    older row survives its successor and is resumed at the next start-up,
+    re-applying folders the owner has already replaced.
     """
 
     def write(session: Session) -> None:
+        for stale in session.exec(
+            select(FolderMappingCommit).where(
+                FolderMappingCommit.state == STATE_PENDING
+            )
+        ).all():
+            logger.info(
+                "Folder-mapping commit %s superseded by the newly accepted %s; "
+                "it will not be resumed.",
+                stale.task_id,
+                task_id,
+            )
+            stale.state = STATE_SUPERSEDED
+            stale.updated_at = datetime.now(timezone.utc)
+            session.add(stale)
         session.add(
             FolderMappingCommit(
                 task_id=task_id,
@@ -255,6 +279,11 @@ def pending_commit(server) -> Optional[dict]:
 
     Returns the recorded arguments in the shape `_run_commit` takes, with
     ``assignments`` already parsed back into `Assignment` rows.
+
+    Newest first, though `record_pending_commit` supersedes the older ones as
+    it writes: the ordering is what makes a row left pending by a version
+    without that rule resolve to the owner's latest intent rather than their
+    oldest.
     """
 
     def read(session: Session) -> Optional[dict]:
@@ -378,8 +407,47 @@ def _resolve_folder(
     return project, person, set_, tags
 
 
+def _commit_owns_this_root(
+    session: Session, task_id: Optional[str], root_path: str
+) -> bool:
+    """True when the pending record *task_id* already registered *root_path*.
+
+    The one question that separates the two ways a fully-scanned reference
+    folder can turn up under a commit's root:
+
+    * a folder that was **already there** - an unrelated reference folder, or
+      an earlier settled commit of this same path. Reusing it would apply this
+      mapping to whatever happens to be indexed under it rather than to what
+      the read found, so it is refused;
+    * the row **this very commit** registered, whose scan then completed
+      before the process died. The mapping provably did not run (assigning
+      settles the record inside its own transaction, so a record still pending
+      never got there), and finishing it is the entire purpose of the durable
+      record - so the row is reused rather than refused.
+
+    ``stage`` answers it without a column of its own: it leaves
+    ``"registering"`` only once `register_reference_folder` has returned, so
+    anything past that means the row at this root is this commit's own work.
+    """
+    if not task_id:
+        return False
+    row = session.exec(
+        select(FolderMappingCommit).where(FolderMappingCommit.task_id == task_id)
+    ).first()
+    return (
+        row is not None
+        and row.state == STATE_PENDING
+        and row.stage != "registering"
+        and os.path.normpath(row.root_path) == root_path
+    )
+
+
 def register_reference_folder(
-    server, root_path: str, *, label: Optional[str] = None
+    server,
+    root_path: str,
+    *,
+    label: Optional[str] = None,
+    task_id: Optional[str] = None,
 ) -> ReferenceFolder:
     """Register *root_path* for in-place indexing, or return it if it already is.
 
@@ -387,40 +455,50 @@ def register_reference_folder(
     (or a retry of a stalled one) does not fight the row it made last time.
     Mirrors ``routes.reference_folders.create_reference_folder``'s essential
     shape; kept separate rather than sharing that closure because the two
-    entry points validate different things upstream (that route re-derives
-    accessibility from a caller-supplied path with its own conflict checks
-    against every other registered folder; this one starts from a path a
-    settled folder-structure read already walked).
+    entry points start from different places (that route re-derives
+    accessibility from a caller-supplied path; this one starts from a path a
+    settled folder-structure read already walked). The conflict rule is *not*
+    one of the differences - both go through
+    `validate_reference_folder_conflicts`, or this path accepts a root that
+    contains ``image_root`` or overlaps another registered folder.
+
+    Args:
+        task_id: The durable record this registration belongs to, when there is
+            one. It is what lets a resumed commit adopt the row it registered
+            itself - see `_commit_owns_this_root`.
     """
     root_path = os.path.normpath(root_path)
     error = validate_reference_folder_path(root_path)
     if error:
         raise CommitError(error)
+    image_root = os.path.normpath(getattr(server.vault, "image_root", "") or "")
 
     def fetch_or_create(session: Session) -> ReferenceFolder:
         existing = session.exec(
             select(ReferenceFolder).where(ReferenceFolder.folder == root_path)
         ).first()
+        conflict = validate_reference_folder_conflicts(
+            session,
+            root_path,
+            image_root,
+            # Its own row is not a conflict with itself; whether that row may
+            # be reused is the separate question decided just below.
+            exclude_id=existing.id if existing is not None else None,
+        )
+        if conflict:
+            raise CommitError(conflict)
         if existing is not None:
-            if existing.last_scanned is not None:
-                # A row with a completed scan pass is either an unrelated
-                # reference folder the owner already had, or an EARLIER
-                # commit of this same path (a fresh read run again over a
-                # folder that was already organised once) - either way,
-                # reusing it here without re-scanning would silently apply
-                # this mapping to whatever pictures happen to be indexed
-                # already, not to what the read the owner just accepted
-                # actually found. Refuse cleanly rather than under-apply.
+            if existing.last_scanned is not None and not _commit_owns_this_root(
+                session, task_id, root_path
+            ):
                 raise CommitError(
                     f"{root_path} is already a reference folder. Remove it "
                     "first, or edit its mapping from the sidebar instead of "
                     "committing this read."
                 )
-            # last_scanned is None: registered but its first scan has not
-            # completed yet - a retry of a commit that crashed after
-            # registering but before the scan finished. Safe to keep waiting
-            # on the same row rather than erroring, since nothing has been
-            # indexed under it that this wait could miss.
+            # Either the first scan has not completed yet (a crash after
+            # registering, nothing indexed a wait could miss), or this commit
+            # registered the row itself and only the assigning step is left.
             return existing
         access_error = validate_reference_folder_accessible(root_path)
         status = (
@@ -467,9 +545,9 @@ def validate_local_import_root(server, root_path: str) -> None:
 
     `local_import` turns pictures already on disk into ordinary MANAGED
     pictures - the mirror image of `register_reference_folder`, which
-    `routes.reference_folders._validate_reference_folder_conflicts` already
-    refuses for exactly this path (a reference folder may never equal or
-    contain `image_root`). This is the same rule read the other way: a folder
+    `validate_reference_folder_conflicts` refuses for exactly this path (a
+    reference folder may never equal, contain or sit inside `image_root`).
+    This is the same rule read the other way: a folder
     outside `image_root` must never be walked by `local_import`, only ever
     registered as a reference folder.
 
@@ -614,11 +692,11 @@ def local_import_pictures(
         dirnames[:] = [
             name
             for name in dirnames
-            if not name.startswith(".")
+            if not is_hidden_entry(name)
             and os.path.realpath(os.path.join(dirpath, name)) not in own
         ]
         for name in filenames:
-            if not name.startswith(".") and is_supported_media_file(name):
+            if not is_hidden_entry(name) and is_supported_media_file(name):
                 file_paths.append(os.path.join(dirpath, name))
     rel_by_abs = {
         path: os.path.relpath(path, image_root).replace(os.sep, "/")
@@ -627,12 +705,19 @@ def local_import_pictures(
     total = expected_pictures or len(file_paths)
 
     def load_existing(session: Session) -> dict[str, int]:
-        rows = session.exec(
-            select(Picture.file_path, Picture.id).where(
-                Picture.file_path.in_(rel_by_abs.values())
+        # Chunked: this list is every supported file in the import, so an
+        # unchunked IN crosses SQLite's bound-parameter cap on any real library
+        # and fails the whole commit at execution time.
+        found: dict[str, int] = {}
+        for chunk in chunked(list(rel_by_abs.values())):
+            found.update(
+                session.exec(
+                    select(Picture.file_path, Picture.id).where(
+                        Picture.file_path.in_(list(chunk))
+                    )
+                ).all()
             )
-        ).all()
-        return {rel: pid for rel, pid in rows}
+        return found
 
     existing_by_rel = server.vault.db.run_immediate_read_task(load_existing)
 
@@ -968,7 +1053,13 @@ def _link_pictures(
 
     tag_created: set[str] = set()
 
-    for folder_relpath, folder_pictures in by_folder.items():
+    # Resolve every folder first, then link. The order is what keeps the cost
+    # of this step bounded: with the answers in hand the human-label ledger can
+    # be written in one batched pass below rather than one round trip per
+    # (picture, tag), which on a fresh import is one per picture.
+    resolved: dict[str, tuple[Optional[int], Optional[int], Optional[int], list[str]]]
+    resolved = {}
+    for folder_relpath in by_folder:
         project_a, person_a, set_a, tag_as = _resolve_folder(folder_relpath, by_path)
         project_id = get_project(project_a) if project_a else None
         character_id = get_character(person_a, project_id) if person_a else None
@@ -980,7 +1071,29 @@ def _link_pictures(
             if tag_name not in tag_created:
                 tag_created.add(tag_name)
                 result.tags_created += 1
+        resolved[folder_relpath] = (project_id, character_id, set_id, tag_names)
 
+    # The owner accepted these folders as tags, so every pair is a human POS and
+    # belongs in the label ledger. Without it the tags do not survive: these
+    # pictures still carry TAG_PENDING_SENTINEL, and when TagTask reaches one it
+    # deletes every Tag row and rewrites the picture from
+    # `model_tags | human_POS - human_NEG`. The general upsert, not
+    # `record_human_label_if_relevant`: a folder tag is usually outside the
+    # tagger's anomaly vocabulary, which is exactly the case that variant
+    # declines to record.
+    record_human_labels(
+        session,
+        (
+            (pic.id, tag_name)
+            for folder_relpath, (_, _, _, tag_names) in resolved.items()
+            for tag_name in tag_names
+            for pic in by_folder[folder_relpath]
+        ),
+        POS,
+    )
+
+    for folder_relpath, folder_pictures in by_folder.items():
+        project_id, character_id, set_id, tag_names = resolved[folder_relpath]
         for pic in folder_pictures:
             if project_id is not None:
                 pic.project_id = project_id
@@ -1000,15 +1113,8 @@ def _link_pictures(
                 existing_sets.add((set_id, pic.id))
                 session.add(PictureSetMember(set_id=set_id, picture_id=pic.id))
             for tag_name in tag_names:
-                # The owner accepted this folder as a tag, so it is a human POS
-                # and belongs in the label ledger. Without it the tag does not
-                # survive: these pictures still carry TAG_PENDING_SENTINEL, and
-                # when TagTask reaches one it deletes every Tag row and rewrites
-                # the picture from `model_tags | human_POS - human_NEG`. The
-                # general upsert, not `record_human_label_if_relevant`: a folder
-                # tag is usually outside the tagger's anomaly vocabulary, which
-                # is exactly the case that variant declines to record.
-                record_human_label(session, pic.id, tag_name, POS)
+                # The ledger entry for this pair was written by the batched
+                # pass above; this is only the Tag row itself.
                 if (pic.id, tag_name) in existing_tags:
                     continue
                 existing_tags.add((pic.id, tag_name))
@@ -1078,11 +1184,15 @@ def apply_local_mapping(
     image_root = os.path.normpath(server.vault.image_root)
 
     def commit(session: Session) -> CommitResult:
-        pictures = (
-            list(session.exec(select(Picture).where(Picture.id.in_(picture_ids))).all())
-            if picture_ids
-            else []
-        )
+        # Chunked for the same reason `local_import_pictures` chunks its own
+        # load: this id list is the whole import.
+        pictures = [
+            picture
+            for chunk in chunked(picture_ids)
+            for picture in session.exec(
+                select(Picture).where(Picture.id.in_(list(chunk)))
+            ).all()
+        ]
         result = CommitResult(pictures_indexed=len(pictures))
         _link_pictures(session, pictures, assignments, root_path, image_root, result)
         if task_id:
@@ -1117,13 +1227,12 @@ def resolve_pending_people_with_faces(server, picture_ids: list[int]) -> int:
     def fetch(session: Session) -> list[int]:
         found: list[int] = []
         # Chunked: SQLite bounds the number of bound parameters per statement.
-        for start in range(0, len(picture_ids), 500):
-            chunk = picture_ids[start : start + 500]
-            extracted = select(Face.id).where(Face.picture_id == Picture.id).exists()
+        extracted = select(Face.id).where(Face.picture_id == Picture.id).exists()
+        for chunk in chunked(picture_ids):
             found.extend(
                 session.exec(
                     select(Picture.id).where(
-                        Picture.id.in_(chunk),
+                        Picture.id.in_(list(chunk)),
                         Picture.pending_character_id.is_not(None),
                         extracted,
                     )

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -87,6 +87,7 @@ from pixlstash.utils.library_layout import Facet
 from pixlstash.utils.media_files import is_hidden_entry, is_supported_media_file
 from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.reference_folder_validator import (
+    canonical_path,
     validate_reference_folder_accessible,
     validate_reference_folder_conflicts,
     validate_reference_folder_path,
@@ -438,11 +439,12 @@ def _commit_owns_this_root(
         row is not None
         and row.state == STATE_PENDING
         and row.stage != "registering"
-        # Both sides resolved: `register_reference_folder` resolves the root it
-        # is handed, so comparing a merely-normalised record path against it
-        # would make a resumed commit under a symlinked root fail to recognise
-        # its own row and refuse to finish.
-        and os.path.realpath(os.path.normpath(row.root_path)) == root_path
+        # Both sides through `canonical_path`, the same spelling
+        # `validate_reference_folder_conflicts` compares by. Comparing a
+        # merely-normalised record path would make a resumed commit under a
+        # symlinked root - or, on Windows, one whose root is spelled in another
+        # case - fail to recognise its own row and refuse to finish.
+        and canonical_path(row.root_path) == canonical_path(root_path)
     )
 
 

--- a/pixlstash/services/folder_structure_service.py
+++ b/pixlstash/services/folder_structure_service.py
@@ -66,6 +66,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.library_layout import Facet
 from pixlstash.utils.media_files import (
     SUPPORTED_IMAGE_EXTS,
+    is_hidden_entry,
     is_pixlstash_thumbnail,
     is_supported_media_file,
 )
@@ -453,7 +454,7 @@ class FolderStructureRead:
             self._checkpoint()
             kept = []
             for name in sorted(dirnames):
-                if name.startswith("."):
+                if is_hidden_entry(name):
                     # `.pixlstash` sidecars and a vault's own thumbnail cache.
                     # Counted, because §24's whole argument against `os.walk`'s
                     # default is that a silently omitted subtree reads as a
@@ -510,13 +511,13 @@ class FolderStructureRead:
             folder.direct_media = sum(
                 1
                 for f in filenames
-                if not f.startswith(".") and is_supported_media_file(f)
+                if not is_hidden_entry(f) and is_supported_media_file(f)
             )
             folder.direct_pictures = sorted(
                 f
                 for f in filenames
                 if os.path.splitext(f)[1].lower() in _IMAGE_EXTS
-                and not f.startswith(".")
+                and not is_hidden_entry(f)
                 and not is_pixlstash_thumbnail(f)
             )
             for picture in folder.direct_pictures:

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -32,7 +32,11 @@ from pixlstash.utils.caption_file_utils import (
 )
 from pixlstash.utils.image_processing.image_utils import ImageUtils, THUMBNAIL_EXTENSION
 from pixlstash.utils.image_processing.video_utils import VideoUtils
-from pixlstash.utils.media_files import is_supported_media_file
+from pixlstash.utils.media_files import (
+    has_hidden_component,
+    is_hidden_entry,
+    is_supported_media_file,
+)
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.layout_move_service import (
     claim_own_moves,
@@ -207,8 +211,18 @@ class ReferenceFolderScanTask(BaseTask):
         views_roots: list[str] = []
         for root, dirs, files in os.walk(resolved, topdown=True):
             # Prune subdirectories that are roots of other reference folders so
-            # their files are only indexed by their own scan task.
-            dirs[:] = [d for d in dirs if os.path.join(root, d) not in other_roots]
+            # their files are only indexed by their own scan task, and
+            # dot-folders, which are nobody's pictures - a vault's own caches
+            # or something the owner hid. The Phase 2 folder-structure read
+            # prunes those too, and this pass indexes the same root right after
+            # a reference-mode commit accepts it: two passes over one tree that
+            # disagree about what is in it means the read's count excludes a
+            # cache the scan then indexes as pictures and the mapping files.
+            dirs[:] = [
+                d
+                for d in dirs
+                if not is_hidden_entry(d) and os.path.join(root, d) not in other_roots
+            ]
             # Prune a PixlStash Views tree. Every file under it is a link to a
             # picture indexed somewhere else already, and os.walk lists a
             # symlinked *file* in ``files`` -- only symlinked directories are
@@ -228,7 +242,7 @@ class ReferenceFolderScanTask(BaseTask):
                 views_roots.append(root)
                 continue
             for file_name in files:
-                if file_name.endswith(_thumb_suffix):
+                if is_hidden_entry(file_name) or file_name.endswith(_thumb_suffix):
                     continue
                 full_path = os.path.join(root, file_name)
                 if _is_supported_file(full_path):
@@ -300,6 +314,21 @@ class ReferenceFolderScanTask(BaseTask):
             }
             override_path_shas = set()
         removed_paths = set(existing_by_path.keys()) - disk_paths
+        # Same reasoning as the views prune, for the dot-folders pruned above:
+        # a path that was never looked for says nothing about whether its file
+        # is still there, and "absent from disk_paths" is what this task
+        # hard-deletes a row for. A folder indexed before the prune existed
+        # keeps its pictures instead of losing them on the next scan.
+        hidden_kept = {p for p in removed_paths if has_hidden_component(p, resolved)}
+        if hidden_kept:
+            logger.info(
+                "Reference folder %s: %d indexed pictures lie under a hidden "
+                "folder that is no longer scanned, so their records are kept "
+                "rather than removed.",
+                self._folder_path,
+                len(hidden_kept),
+            )
+            removed_paths -= hidden_kept
         if views_roots:
             # A path under a pruned views tree was not looked for, so its
             # absence from disk_paths says nothing about whether the file is

--- a/pixlstash/utils/media_files.py
+++ b/pixlstash/utils/media_files.py
@@ -52,6 +52,34 @@ def is_pixlstash_thumbnail(name_or_path: str) -> bool:
     return name_or_path.lower().endswith(THUMBNAIL_SUFFIX)
 
 
+def is_hidden_entry(name: str) -> bool:
+    """True for a dot-prefixed file or directory name.
+
+    The one rule every walk of a picture tree has to agree on: the Phase 2
+    folder-structure read, ``local_import_pictures``, and
+    ``ReferenceFolderScanTask``. A dot-folder is either a vault's own cache
+    (``.pixlstash-thumbnails/``, the older ``.ref_thumbs/``, ``.pixlstash``
+    sidecar stores) or something the owner deliberately hid; neither is content
+    to index. Two of the three pruned them and the scan did not, so a
+    reference-mode commit's read and its indexing pass disagreed about what was
+    under one root - the read's count excluded the cache and the scan indexed
+    it as pictures, which the mapping then filed.
+    """
+    return name.startswith(".")
+
+
+def has_hidden_component(path: str, root: str) -> bool:
+    """True when *path* is, or lies under, a hidden entry below *root*.
+
+    The pruning rule asked of a whole path rather than one name, for the caller
+    that has to decide what a *pruned* walk did not look at. *root* itself is
+    not examined: a library whose own folder happens to be dotted is still a
+    library.
+    """
+    relative = os.path.relpath(path, root)
+    return any(is_hidden_entry(part) for part in relative.split(os.sep))
+
+
 def is_supported_media_file(name_or_path: str) -> bool:
     """True when *name_or_path* names an image or video PixlStash can index.
 

--- a/pixlstash/utils/media_files.py
+++ b/pixlstash/utils/media_files.py
@@ -75,8 +75,22 @@ def has_hidden_component(path: str, root: str) -> bool:
     that has to decide what a *pruned* walk did not look at. *root* itself is
     not examined: a library whose own folder happens to be dotted is still a
     library.
+
+    Two spellings ``relpath`` produces that are not names at all:
+
+    * ``path == root`` gives ``"."``, which is dot-prefixed and so read as
+      hidden - the exact opposite of the sentence above. Answered ``False``
+      explicitly rather than left to ``is_hidden_entry``.
+    * a *path outside root* gives leading ``".."`` components, also read as
+      hidden. That one is left as ``True`` on purpose. The caller subtracts
+      this set from the rows it is about to hard-delete, so ``True`` means
+      "keep the row"; a path the walk never covered is exactly the case where
+      absence from the walk's results proves nothing, and answering ``False``
+      would turn a keep into a delete.
     """
     relative = os.path.relpath(path, root)
+    if relative == os.curdir:
+        return False
     return any(is_hidden_entry(part) for part in relative.split(os.sep))
 
 

--- a/pixlstash/utils/reference_folder_validator.py
+++ b/pixlstash/utils/reference_folder_validator.py
@@ -2,6 +2,14 @@
 
 import os
 import sys
+from typing import TYPE_CHECKING
+
+from sqlmodel import select
+
+from pixlstash.db_models.reference_folder import ReferenceFolder
+
+if TYPE_CHECKING:
+    from sqlmodel import Session
 
 # Paths that must never be used as reference folder roots.
 # Applied on both Linux and macOS; extended lists handle platform differences.
@@ -113,6 +121,54 @@ def validate_reference_folder_path(path: str) -> str | None:
         if norm == blocked_norm or norm.startswith(blocked_norm + os.sep):
             return f"Path is in a restricted system directory: {blocked}"
 
+    return None
+
+
+def validate_reference_folder_conflicts(
+    session: "Session",
+    folder: str,
+    image_root: str,
+    *,
+    exclude_id: int | None = None,
+) -> str | None:
+    """Check a candidate root against the library's storage and every other root.
+
+    One definition, because the two entry points that register a root have to
+    answer this identically: ``routes.reference_folders`` (the "add a reference
+    folder" routes) and
+    ``services.folder_structure_commit_service.register_reference_folder`` (a
+    reference-mode folder-structure commit). The commit path used to check
+    nothing at all, so a root that *contains* ``image_root``, or that contains
+    - or sits inside - another reference folder, was accepted and then indexed
+    by two scans that each believe they own the files.
+
+    Args:
+        session: Open session, used to read the registered folders.
+        folder: Candidate root, already ``normpath``-ed.
+        image_root: The active library's own storage; ``""`` when unset.
+        exclude_id: A reference folder row to ignore - the one being edited, or
+            the row a resumed commit registered for itself.
+
+    Returns:
+        An error message, or ``None`` when the path is free to use.
+    """
+    if image_root:
+        if (
+            folder == image_root
+            or folder.startswith(image_root + os.sep)
+            or image_root.startswith(folder + os.sep)
+        ):
+            return "Path conflicts with the PixlStash data folder."
+    for other in session.exec(select(ReferenceFolder)).all():
+        if exclude_id is not None and other.id == exclude_id:
+            continue
+        other_norm = os.path.normpath(other.folder)
+        if folder == other_norm:
+            return "A reference folder with this path already exists."
+        if folder.startswith(other_norm + os.sep):
+            return f"Path is inside an existing reference folder: {other.folder}"
+        if other_norm.startswith(folder + os.sep):
+            return f"An existing reference folder is inside this path: {other.folder}"
     return None
 
 

--- a/pixlstash/utils/reference_folder_validator.py
+++ b/pixlstash/utils/reference_folder_validator.py
@@ -124,13 +124,25 @@ def validate_reference_folder_path(path: str) -> str | None:
     return None
 
 
-def _resolved(path: str) -> str:
+def canonical_path(path: str) -> str:
     """One canonical spelling of *path*, for comparing two paths as strings.
 
     ``realpath`` never raises: an unmounted or not-yet-created path resolves as
     far as it exists, which keeps the Docker pending-mount callers working.
+
+    ``normcase`` last, and it is not cosmetic: Windows and macOS spell one
+    directory in several cases, so without it ``C:\\Photos`` and ``c:\\photos``
+    compare unequal and every containment check below walks straight past a
+    registered root - the overlap this function exists to catch, reached by
+    spelling instead of by symlink. It is identity on POSIX, so the gate cannot
+    see the difference; ``views_service._resolved`` case-folds for the same
+    reason and says so.
+
+    Comparison only. The value is never stored or shown: a row keeps the real
+    case so the scan walks the directory the owner named, and every refusal
+    message quotes the caller's own spelling.
     """
-    return os.path.realpath(os.path.normpath(path))
+    return os.path.normcase(os.path.realpath(os.path.normpath(path)))
 
 
 def validate_reference_folder_conflicts(
@@ -171,9 +183,9 @@ def validate_reference_folder_conflicts(
     Returns:
         An error message, or ``None`` when the path is free to use.
     """
-    folder = _resolved(folder)
+    folder = canonical_path(folder)
     if image_root:
-        image_root = _resolved(image_root)
+        image_root = canonical_path(image_root)
         if (
             folder == image_root
             or folder.startswith(image_root + os.sep)
@@ -183,7 +195,7 @@ def validate_reference_folder_conflicts(
     for other in session.exec(select(ReferenceFolder)).all():
         if exclude_id is not None and other.id == exclude_id:
             continue
-        other_norm = _resolved(other.folder)
+        other_norm = canonical_path(other.folder)
         if folder == other_norm:
             return "A reference folder with this path already exists."
         if folder.startswith(other_norm + os.sep):

--- a/pixlstash/utils/reference_folder_validator.py
+++ b/pixlstash/utils/reference_folder_validator.py
@@ -124,6 +124,15 @@ def validate_reference_folder_path(path: str) -> str | None:
     return None
 
 
+def _resolved(path: str) -> str:
+    """One canonical spelling of *path*, for comparing two paths as strings.
+
+    ``realpath`` never raises: an unmounted or not-yet-created path resolves as
+    far as it exists, which keeps the Docker pending-mount callers working.
+    """
+    return os.path.realpath(os.path.normpath(path))
+
+
 def validate_reference_folder_conflicts(
     session: "Session",
     folder: str,
@@ -142,9 +151,19 @@ def validate_reference_folder_conflicts(
     - or sits inside - another reference folder, was accepted and then indexed
     by two scans that each believe they own the files.
 
+    Every path is resolved before it is compared, for the reason
+    `validate_reference_folder_path` resolves its own: these are string
+    comparisons, and two names for one directory do not compare equal. The
+    "add a reference folder" route stores rows resolved, the commit path did
+    not, so a symlink to a registered root - or to one containing
+    ``image_root`` - matched no row and was accepted as a free path, and two
+    scans then indexed the same files each believing it owned them. Resolving
+    here rather than at each call site is the same argument that comment makes:
+    a call site is where it gets forgotten.
+
     Args:
         session: Open session, used to read the registered folders.
-        folder: Candidate root, already ``normpath``-ed.
+        folder: Candidate root. Any shape; resolved here.
         image_root: The active library's own storage; ``""`` when unset.
         exclude_id: A reference folder row to ignore - the one being edited, or
             the row a resumed commit registered for itself.
@@ -152,7 +171,9 @@ def validate_reference_folder_conflicts(
     Returns:
         An error message, or ``None`` when the path is free to use.
     """
+    folder = _resolved(folder)
     if image_root:
+        image_root = _resolved(image_root)
         if (
             folder == image_root
             or folder.startswith(image_root + os.sep)
@@ -162,7 +183,7 @@ def validate_reference_folder_conflicts(
     for other in session.exec(select(ReferenceFolder)).all():
         if exclude_id is not None and other.id == exclude_id:
             continue
-        other_norm = os.path.normpath(other.folder)
+        other_norm = _resolved(other.folder)
         if folder == other_norm:
             return "A reference folder with this path already exists."
         if folder.startswith(other_norm + os.sep):

--- a/pixlstash/utils/service/label_ledger.py
+++ b/pixlstash/utils/service/label_ledger.py
@@ -171,19 +171,26 @@ def record_human_labels(
     tags = sorted({tag for _, tag in wanted})
     picture_ids = sorted({picture_id for picture_id, _ in wanted})
 
-    # Both lists are bound parameters of the same statement, so the id chunk
-    # leaves room for the tags sitting beside it.
+    # Both lists are bound parameters of the SAME statement, so neither can be
+    # left whole: shrinking only the id chunk still overran the cap once there
+    # were more distinct tags than the cap itself, however small that chunk got,
+    # and a folder-structure commit's tags are one per tag-mapped folder - the
+    # library decides how many there are, not this code. Tags take at most half
+    # the budget so the ids always keep the other half; the two lists together
+    # can never exceed SQLITE_ID_CHUNK.
     existing: dict[tuple[int, str], TagPrediction] = {}
-    for chunk in chunked(picture_ids, max(1, SQLITE_ID_CHUNK - len(tags))):
-        existing.update(
-            ((pred.picture_id, pred.tag), pred)
-            for pred in session.exec(
-                select(TagPrediction).where(
-                    TagPrediction.picture_id.in_(list(chunk)),
-                    TagPrediction.tag.in_(tags),
-                )
-            ).all()
-        )
+    for tag_group in chunked(tags, max(1, SQLITE_ID_CHUNK // 2)):
+        id_chunk = max(1, SQLITE_ID_CHUNK - len(tag_group))
+        for picture_group in chunked(picture_ids, id_chunk):
+            existing.update(
+                ((pred.picture_id, pred.tag), pred)
+                for pred in session.exec(
+                    select(TagPrediction).where(
+                        TagPrediction.picture_id.in_(list(picture_group)),
+                        TagPrediction.tag.in_(list(tag_group)),
+                    )
+                ).all()
+            )
 
     now = datetime.utcnow()
     for picture_id, tag in wanted:

--- a/pixlstash/utils/service/label_ledger.py
+++ b/pixlstash/utils/service/label_ledger.py
@@ -16,7 +16,7 @@ clobber a human label.
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from sqlalchemy import or_
 from sqlmodel import select
@@ -26,6 +26,7 @@ from pixlstash.db_models.tag import (
     DEFAULT_TAG_MERGES,
 )
 from pixlstash.db_models.tag_prediction import TagPrediction
+from pixlstash.utils.sql_chunking import SQLITE_ID_CHUNK, chunked
 
 if TYPE_CHECKING:
     from sqlmodel import Session
@@ -107,28 +108,90 @@ def record_human_label(
 
     now = datetime.utcnow()
     if pred is None:
-        # No prediction on file: a pure-manual decision with nothing to snapshot.
-        pred = TagPrediction(
-            picture_id=picture_id,
-            tag=tag,
-            confidence=1.0 if state == POS else 0.0,
-            model_version=MANUAL_MODEL_VERSION,
-            status="CONFIRMED" if state == POS else "REJECTED",
-            predicted_at=now,
-        )
+        pred = _manual_prediction(picture_id, tag, state, now)
         session.add(pred)
-    else:
-        # Snapshot what the human adjudicated, but only when it was a real tagger
-        # prediction (not our own synthetic 'manual' row) so re-recording is stable.
-        if pred.model_version and pred.model_version != MANUAL_MODEL_VERSION:
-            pred.label_model_version = pred.model_version
-            pred.label_confidence = pred.confidence
-        pred.status = "CONFIRMED" if state == POS else "REJECTED"
+    _mark_human(pred, state, now)
+    return pred
 
+
+def _manual_prediction(
+    picture_id: int, tag: str, state: str, now: datetime
+) -> TagPrediction:
+    """A synthetic prediction row for a tag the tagger never predicted.
+
+    No prediction on file means a pure-manual decision with nothing to
+    snapshot, so ``model_version`` records that this row is our own rather than
+    a tagger's - which is what stops :func:`_mark_human` snapshotting it as if
+    it were something a human adjudicated.
+    """
+    return TagPrediction(
+        picture_id=picture_id,
+        tag=tag,
+        confidence=1.0 if state == POS else 0.0,
+        model_version=MANUAL_MODEL_VERSION,
+        predicted_at=now,
+    )
+
+
+def _mark_human(pred: TagPrediction, state: str, now: datetime) -> None:
+    """Stamp the human decision on *pred*, in place and uncommitted."""
+    # Snapshot what the human adjudicated, but only when it was a real tagger
+    # prediction (not our own synthetic 'manual' row) so re-recording is stable.
+    if pred.model_version and pred.model_version != MANUAL_MODEL_VERSION:
+        pred.label_model_version = pred.model_version
+        pred.label_confidence = pred.confidence
+    pred.status = "CONFIRMED" if state == POS else "REJECTED"
     pred.label_state = state
     pred.label_source = HUMAN
     pred.labeled_at = now
-    return pred
+
+
+def record_human_labels(
+    session: "Session", pairs: Iterable[tuple[int, str]], state: str
+) -> None:
+    """:func:`record_human_label` over many pairs, in bounded statements. No commit.
+
+    Identical ledger semantics per pair; only the probe differs. One indexed
+    ``SELECT`` per ``(picture, tag)`` is one round trip per pair, and the caller
+    this exists for - the folder-structure commit's tag assignment - has one
+    pair per picture per tag-mapped folder, so on a fresh import that is a
+    statement per picture. Here it is one ``SELECT`` per chunk of pictures
+    instead, whatever the size of the import.
+
+    Args:
+        session: Active DB session (caller commits).
+        pairs: ``(picture_id, tag)`` pairs; repeats collapse.
+        state: :data:`POS` or :data:`NEG`, for every pair.
+    """
+    if state not in (POS, NEG):
+        raise ValueError(f"label state must be POS or NEG, got {state!r}")
+    wanted = {(int(picture_id), tag) for picture_id, tag in pairs}
+    if not wanted:
+        return
+    tags = sorted({tag for _, tag in wanted})
+    picture_ids = sorted({picture_id for picture_id, _ in wanted})
+
+    # Both lists are bound parameters of the same statement, so the id chunk
+    # leaves room for the tags sitting beside it.
+    existing: dict[tuple[int, str], TagPrediction] = {}
+    for chunk in chunked(picture_ids, max(1, SQLITE_ID_CHUNK - len(tags))):
+        existing.update(
+            ((pred.picture_id, pred.tag), pred)
+            for pred in session.exec(
+                select(TagPrediction).where(
+                    TagPrediction.picture_id.in_(list(chunk)),
+                    TagPrediction.tag.in_(tags),
+                )
+            ).all()
+        )
+
+    now = datetime.utcnow()
+    for picture_id, tag in wanted:
+        pred = existing.get((picture_id, tag))
+        if pred is None:
+            pred = _manual_prediction(picture_id, tag, state, now)
+            session.add(pred)
+        _mark_human(pred, state, now)
 
 
 def record_human_label_if_relevant(

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -1298,3 +1298,285 @@ def test_a_switch_refused_by_a_running_commit_says_why(owner_env):
     # With nothing running there is nothing to name, and the caller falls back
     # to the coordinator's own words rather than inventing a reason.
     assert server.library_switch._what_is_holding_the_library() is None
+
+
+def _insert_reference_folder(server, folder: str, *, last_scanned):
+    """A registered reference folder row, without running a scan for it.
+
+    Direct, because every case below is about what `register_reference_folder`
+    decides when a row is *already* there, and a real scan would make the state
+    under test arrive whenever the planner got to it.
+    """
+    from pixlstash.db_models.reference_folder import (
+        ReferenceFolder,
+        ReferenceFolderStatus,
+    )
+
+    def write(session):
+        row = ReferenceFolder(
+            folder=folder,
+            label=os.path.basename(folder),
+            status=ReferenceFolderStatus.ACTIVE,
+            last_scanned=last_scanned,
+        )
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        return row.id
+
+    return server.vault.db.run_task(write)
+
+
+def _forget_reference_folder(server, folder_id: int) -> None:
+    from pixlstash.db_models.reference_folder import ReferenceFolder
+
+    def write(session):
+        row = session.get(ReferenceFolder, folder_id)
+        if row is not None:
+            session.delete(row)
+            session.commit()
+
+    server.vault.db.run_task(write)
+
+
+def test_a_commit_interrupted_after_its_scan_finished_is_still_resumable(owner_env):
+    """#1177 item 17. A reference-mode commit killed between "the scan is done"
+    and "the mapping is applied" used to wedge for ever: the resume called
+    `register_reference_folder` again, found its own row with `last_scanned`
+    set, and refused it as if it belonged to somebody else - so the record
+    stayed `pending` and every start-up failed the same way.
+
+    The rule that separates the two: only a record that got past
+    ``registering`` owns the row at its root. Both directions asserted, because
+    a resume that adopts anything it finds would silently apply the mapping to
+    whatever is indexed under a folder the owner already had.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+
+    server = owner_env["server"]
+    root = os.path.join(owner_env["tmp"], "resumable-after-scan")
+    _make_tree(root, {"Anna": ["a.jpg"]})
+    folder_id = _insert_reference_folder(server, root, last_scanned=time.time())
+    svc.record_pending_commit(
+        server,
+        task_id="resume-after-scan",
+        root_path=root,
+        mode="reference",
+        label=None,
+        expected_pictures=1,
+        assignments=svc.parse_assignments(
+            [{"relative_path": "Anna", "kind": "person"}]
+        ),
+    )
+    try:
+        # Still at `registering`: nothing here registered that folder, so it is
+        # someone else's and the refusal stands.
+        with pytest.raises(svc.CommitError, match="already a reference folder"):
+            svc.register_reference_folder(server, root, task_id="resume-after-scan")
+
+        # Past it: this commit registered the row itself and only the assigning
+        # step is left, which is the whole reason the record exists.
+        svc.record_commit_stage(server, "resume-after-scan", "indexing")
+        adopted = svc.register_reference_folder(
+            server, root, task_id="resume-after-scan"
+        )
+        assert adopted.id == folder_id
+
+        # And it is the record that decides, not the path: another commit's id
+        # over the same root is refused exactly as an unknown one is.
+        with pytest.raises(svc.CommitError, match="already a reference folder"):
+            svc.register_reference_folder(server, root, task_id="some-other-commit")
+    finally:
+        svc.settle_pending_commit(server, "resume-after-scan", "abandoned")
+        _forget_reference_folder(server, folder_id)
+
+
+def test_a_newer_accepted_mapping_supersedes_the_older_pending_one(owner_env):
+    """#1177 item 18. A failed commit leaves its record pending on purpose and
+    clears the in-memory slot, so the owner can accept a second mapping over
+    the same library. Both rows were then pending: the newest was resumed
+    first, and the start-up after that resumed the older one and re-applied a
+    mapping the owner had already replaced.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+
+    server = owner_env["server"]
+    root = os.path.join(owner_env["tmp"], "superseded-record")
+    _make_tree(root, {"Anna": ["a.jpg"]})
+    common = dict(
+        root_path=root,
+        mode="local_import",
+        label=None,
+        expected_pictures=1,
+    )
+    svc.record_pending_commit(
+        server,
+        task_id="older-mapping",
+        assignments=svc.parse_assignments(
+            [{"relative_path": "Anna", "kind": "person"}]
+        ),
+        **common,
+    )
+    svc.record_pending_commit(
+        server,
+        task_id="newer-mapping",
+        assignments=svc.parse_assignments([{"relative_path": "Anna", "kind": "tag"}]),
+        **common,
+    )
+    try:
+        assert _record_for(server, "older-mapping")["state"] == "superseded"
+        pending = svc.pending_commit(server)
+        assert pending is not None and pending["task_id"] == "newer-mapping"
+    finally:
+        svc.settle_pending_commit(server, "newer-mapping", "abandoned")
+
+    # The point of the whole item: with the newer one settled, the older must
+    # not become resumable again.
+    resumable = svc.pending_commit(server)
+    assert resumable is None or resumable["task_id"] != "older-mapping", resumable
+
+
+def test_a_reference_commit_refuses_a_root_that_swallows_another(owner_env):
+    """#1177 item 19. `register_reference_folder` ran no conflict check at all,
+    so a reference-mode commit accepted a root that CONTAINS `image_root` (the
+    route only refuses one equal to or inside it) or that contains, or sits
+    inside, another registered folder - two scan tasks each believing they own
+    the same files. Both entry points share
+    `validate_reference_folder_conflicts` now.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+
+    server = owner_env["server"]
+    outer = os.path.join(owner_env["tmp"], "swallowing-root")
+    inner = os.path.join(outer, "already-registered")
+    _make_tree(inner, {"": ["a.jpg"]})
+    folder_id = _insert_reference_folder(server, inner, last_scanned=time.time())
+    try:
+        with pytest.raises(svc.CommitError, match="inside this path"):
+            svc.register_reference_folder(server, outer)
+        with pytest.raises(svc.CommitError, match="inside an existing reference"):
+            svc.register_reference_folder(server, os.path.join(inner, "deeper-still"))
+    finally:
+        _forget_reference_folder(server, folder_id)
+
+    # The direction the commit route's own guard misses: a root ABOVE the
+    # library's own storage, which would index every managed picture a second
+    # time under an absolute path.
+    with pytest.raises(svc.CommitError, match="PixlStash data folder"):
+        svc.register_reference_folder(
+            server, os.path.dirname(os.path.normpath(server.vault.image_root))
+        )
+
+
+def test_the_read_and_the_reference_scan_agree_about_dot_folders(owner_env):
+    """#1177 item 20. The Phase 2 read prunes dot-folders; the reference scan
+    that indexes the very same root did not, so the two passes over one tree
+    disagreed about what was in it - the read's count excluded a vault's own
+    cache and the scan indexed every file in it as a picture, which the
+    mapping then filed.
+    """
+    from sqlmodel import select
+
+    from pixlstash.db_models.picture import Picture
+
+    owner, server = owner_env["owner"], owner_env["server"]
+    root = os.path.join(owner_env["tmp"], "dot-folder-parity")
+    _make_tree(root, {"visible": ["a.jpg"]})
+    hidden = os.path.join(root, ".pixlstash-thumbnails")
+    os.makedirs(hidden, exist_ok=True)
+    from PIL import Image
+
+    Image.new("RGB", (16, 16), (9, 9, 9)).save(os.path.join(hidden, "cached.webp"))
+
+    started = owner.post(_READ, json={"path": root})
+    assert started.status_code == 200, started.text
+    read_task_id = started.json()["task_id"]
+    read = _drain_read(owner, read_task_id)
+    assert read["status"] == "completed", read
+    assert read["result"]["picture_count"] == 1, "the read counts only the visible one"
+
+    commit_started = owner.post(
+        _COMMIT, json={"task_id": read_task_id, "assignments": []}
+    )
+    assert commit_started.status_code == 200, commit_started.text
+    body = _drain_commit(owner, commit_started.json()["task_id"], timeout_s=60.0)
+    assert body["status"] == "completed", body
+
+    indexed = server.vault.db.run_immediate_read_task(
+        lambda s: [
+            p
+            for p in s.exec(select(Picture.file_path)).all()
+            if p and p.startswith(root)
+        ]
+    )
+    assert indexed == [os.path.join(root, "visible", "a.jpg")], indexed
+
+
+def test_linking_a_large_import_costs_a_bounded_number_of_statements(owner_env):
+    """#1177 items 21 and 55. Nothing pinned this step's cost, and it was one
+    indexed SELECT per (picture, tag) plus unchunked IN lists over the whole
+    import. Counted rather than timed: a statement count is the thing that
+    actually changed, and it does not depend on the machine.
+
+    The two sizes are the assertion. An absolute bound would pass a
+    per-picture implementation on a small enough tree; twenty times the
+    pictures costing the same handful of statements is what "batched" means.
+    """
+    from sqlalchemy import event
+    from sqlmodel import select
+
+    from pixlstash.db_models.picture import Picture
+    from pixlstash.db_models.tag import Tag
+    from pixlstash.services.folder_structure_commit_service import (
+        Assignment,
+        CommitResult,
+        _link_pictures,
+    )
+
+    server = owner_env["server"]
+    image_root = server.vault.image_root
+
+    def measure(session, count: int) -> tuple[int, int]:
+        prefix = f"bounded-{count}"
+        pictures = [
+            Picture(file_path=f"{prefix}/gallery/{index}.jpg") for index in range(count)
+        ]
+        session.add_all(pictures)
+        session.flush()
+
+        statements: list[str] = []
+        connection = session.connection()
+
+        def before(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        event.listen(connection, "before_cursor_execute", before)
+        try:
+            _link_pictures(
+                session,
+                pictures,
+                [Assignment(relative_path="gallery", kind="tag")],
+                os.path.join(image_root, prefix),
+                image_root,
+                CommitResult(),
+            )
+        finally:
+            event.remove(connection, "before_cursor_execute", before)
+        session.commit()
+        tagged = len(
+            session.exec(
+                select(Tag).where(
+                    Tag.picture_id.in_([p.id for p in pictures]), Tag.tag == "gallery"
+                )
+            ).all()
+        )
+        return len(statements), tagged
+
+    small, small_tagged = server.vault.db.run_task(lambda s: measure(s, 20))
+    large, large_tagged = server.vault.db.run_task(lambda s: measure(s, 400))
+    assert (small_tagged, large_tagged) == (20, 400), "every picture must be tagged"
+    assert large <= small + 2, (
+        f"the link step still scales with the import: {small} statements for 20 "
+        f"pictures, {large} for 400"
+    )
+    assert large < 20, f"{large} statements to link 400 pictures"

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -1508,57 +1508,6 @@ def test_a_reference_commit_refuses_a_symlink_to_a_registered_root(owner_env):
         _forget_reference_folder(server, rf.id)
 
 
-def test_a_reference_commit_case_folds_the_roots_it_compares(owner_env, monkeypatch):
-    """The same conflict as the symlink above, reached by spelling.
-
-    Windows and macOS spell one directory in several cases, so a registered
-    root compared as a raw string matches nothing under another spelling: the
-    path is accepted as free and two scans then index the same files. That is
-    what `validate_reference_folder_conflicts` exists to prevent, and
-    ``normcase`` is what makes it see the two names as one.
-
-    ``normcase`` is identity on this POSIX gate - `/tmp/CaseRoot` and
-    `/tmp/CASEROOT` really are two directories here - so folding is forced on
-    for the two calls that need it, the way `test_hub_engine` forces ``os.name``
-    to exercise the Windows carve-out. Without that the test passes on Linux
-    with or without the fix and pins nothing.
-
-    Both directions, because over-refusing is its own regression.
-
-    It lands on the conflict message rather than the reuse one: the row lookup
-    a few lines earlier is a SQL string equality, so under another spelling it
-    finds nothing and the conflict check answers instead. That is the safe way
-    round - refused, not duplicated - but it does mean a Windows owner who
-    respells their own root cannot resume that commit; they get a refusal.
-    Making the lookup fold too is a stored-column change, not this one.
-    """
-    from pixlstash.services import folder_structure_commit_service as svc
-    from pixlstash.utils import reference_folder_validator
-
-    server = owner_env["server"]
-    real = os.path.join(owner_env["tmp"], "CaseRoot")
-    _make_tree(real, {"Anna": ["a.jpg"]})
-    shouted = os.path.join(owner_env["tmp"], "CASEROOT")
-
-    folder_id = _insert_reference_folder(server, real, last_scanned=time.time())
-    try:
-        # The negative: refused under the other spelling rather than accepted
-        # as a free path. Folding is confined to this call - the module-scoped
-        # server's workers share the process, and `os.path` is one object.
-        with monkeypatch.context() as folded:
-            folded.setattr(reference_folder_validator.os.path, "normcase", str.lower)
-            with pytest.raises(svc.CommitError, match="already exists"):
-                svc.register_reference_folder(server, shouted)
-
-        # The positive control, unfolded: a different directory that merely
-        # looks similar is still free, so the refusal above is the case rule
-        # firing and not this root swallowing its neighbours.
-        rf = svc.register_reference_folder(server, shouted)
-        _forget_reference_folder(server, rf.id)
-    finally:
-        _forget_reference_folder(server, folder_id)
-
-
 def test_the_read_and_the_reference_scan_agree_about_dot_folders(owner_env):
     """#1177 item 20. The Phase 2 read prunes dot-folders; the reference scan
     that indexes the very same root did not, so the two passes over one tree

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -1468,6 +1468,46 @@ def test_a_reference_commit_refuses_a_root_that_swallows_another(owner_env):
         )
 
 
+def test_a_reference_commit_refuses_a_symlink_to_a_registered_root(owner_env):
+    """The conflict check is a string comparison, and two names for one
+    directory do not compare equal. The "add a reference folder" route stores
+    rows resolved and the commit path stored them merely normalised, so a
+    symlink pointing at a registered root matched no row, was accepted as a
+    free path, and left two scan tasks indexing the same files. Both sides are
+    resolved before they are compared now, and the row this path writes is
+    stored resolved like the route's.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+
+    server = owner_env["server"]
+    real = os.path.join(owner_env["tmp"], "the-real-root")
+    _make_tree(real, {"": ["a.jpg"]})
+    link = os.path.join(owner_env["tmp"], "a-link-to-it")
+    try:
+        os.symlink(real, link, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"this filesystem will not make a symlink: {exc}")
+
+    folder_id = _insert_reference_folder(server, real, last_scanned=time.time())
+    try:
+        # Refused as the scanned root it resolves to, rather than accepted as a
+        # free path. Which of the two refusals it is does not matter; that it is
+        # refused at all is the whole finding.
+        with pytest.raises(svc.CommitError, match="already a reference folder"):
+            svc.register_reference_folder(server, link)
+    finally:
+        _forget_reference_folder(server, folder_id)
+
+    # And with nothing registered, the row it writes names the directory the
+    # scan will walk - not the link, which could be repointed afterwards at
+    # somewhere no check ever saw.
+    rf = svc.register_reference_folder(server, link)
+    try:
+        assert rf.folder == os.path.realpath(real)
+    finally:
+        _forget_reference_folder(server, rf.id)
+
+
 def test_the_read_and_the_reference_scan_agree_about_dot_folders(owner_env):
     """#1177 item 20. The Phase 2 read prunes dot-folders; the reference scan
     that indexes the very same root did not, so the two passes over one tree

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -1508,6 +1508,57 @@ def test_a_reference_commit_refuses_a_symlink_to_a_registered_root(owner_env):
         _forget_reference_folder(server, rf.id)
 
 
+def test_a_reference_commit_case_folds_the_roots_it_compares(owner_env, monkeypatch):
+    """The same conflict as the symlink above, reached by spelling.
+
+    Windows and macOS spell one directory in several cases, so a registered
+    root compared as a raw string matches nothing under another spelling: the
+    path is accepted as free and two scans then index the same files. That is
+    what `validate_reference_folder_conflicts` exists to prevent, and
+    ``normcase`` is what makes it see the two names as one.
+
+    ``normcase`` is identity on this POSIX gate - `/tmp/CaseRoot` and
+    `/tmp/CASEROOT` really are two directories here - so folding is forced on
+    for the two calls that need it, the way `test_hub_engine` forces ``os.name``
+    to exercise the Windows carve-out. Without that the test passes on Linux
+    with or without the fix and pins nothing.
+
+    Both directions, because over-refusing is its own regression.
+
+    It lands on the conflict message rather than the reuse one: the row lookup
+    a few lines earlier is a SQL string equality, so under another spelling it
+    finds nothing and the conflict check answers instead. That is the safe way
+    round - refused, not duplicated - but it does mean a Windows owner who
+    respells their own root cannot resume that commit; they get a refusal.
+    Making the lookup fold too is a stored-column change, not this one.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+    from pixlstash.utils import reference_folder_validator
+
+    server = owner_env["server"]
+    real = os.path.join(owner_env["tmp"], "CaseRoot")
+    _make_tree(real, {"Anna": ["a.jpg"]})
+    shouted = os.path.join(owner_env["tmp"], "CASEROOT")
+
+    folder_id = _insert_reference_folder(server, real, last_scanned=time.time())
+    try:
+        # The negative: refused under the other spelling rather than accepted
+        # as a free path. Folding is confined to this call - the module-scoped
+        # server's workers share the process, and `os.path` is one object.
+        with monkeypatch.context() as folded:
+            folded.setattr(reference_folder_validator.os.path, "normcase", str.lower)
+            with pytest.raises(svc.CommitError, match="already exists"):
+                svc.register_reference_folder(server, shouted)
+
+        # The positive control, unfolded: a different directory that merely
+        # looks similar is still free, so the refusal above is the case rule
+        # firing and not this root swallowing its neighbours.
+        rf = svc.register_reference_folder(server, shouted)
+        _forget_reference_folder(server, rf.id)
+    finally:
+        _forget_reference_folder(server, folder_id)
+
+
 def test_the_read_and_the_reference_scan_agree_about_dot_folders(owner_env):
     """#1177 item 20. The Phase 2 read prunes dot-folders; the reference scan
     that indexes the very same root did not, so the two passes over one tree

--- a/tests/test_label_ledger.py
+++ b/tests/test_label_ledger.py
@@ -423,3 +423,52 @@ def test_retag_updates_live_confidence_on_rejected_human_row():
         server.close()
         temp_dir.cleanup()
         gc.collect()
+
+
+def test_record_human_labels_never_binds_more_parameters_than_sqlite_takes():
+    """Both lists go into one statement, so both have to be chunked.
+
+    The picture ids were chunked against a budget the tag list was subtracted
+    from, which bounds nothing once there are more distinct tags than the budget
+    itself: the id chunk floors at 1 and the tag list carries the statement past
+    the cap on its own. A folder-structure commit's tags are one per tag-mapped
+    folder, so it is the library that decides how many there are.
+
+    Asserted on the parameter count rather than on a raised error: the cap is a
+    build-time SQLite constant (999 on older builds, 32766 since 3.32), so
+    whether the overrun actually raises depends on the machine.
+    """
+    from sqlalchemy import create_engine, event
+    from sqlmodel import Session, SQLModel
+
+    from pixlstash.utils.service.label_ledger import POS, record_human_labels
+    from pixlstash.utils.sql_chunking import SQLITE_ID_CHUNK
+
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    widest = 0
+
+    def watch(conn, cursor, statement, parameters, context, executemany):
+        nonlocal widest
+        if not executemany:
+            widest = max(widest, len(parameters or ()))
+
+    event.listen(engine, "before_cursor_execute", watch)
+    try:
+        with Session(engine) as session:
+            pairs = [
+                (picture_id, f"tag-{index}")
+                for picture_id in range(1, 4)
+                for index in range(SQLITE_ID_CHUNK + 50)
+            ]
+            record_human_labels(session, pairs, POS)
+            session.commit()
+    finally:
+        # The listener outlives the engine otherwise, and this file shares a
+        # process with the rest of a gate shard.
+        event.remove(engine, "before_cursor_execute", watch)
+        engine.dispose()
+
+    assert widest <= SQLITE_ID_CHUNK, (
+        f"a statement bound {widest} parameters, over the {SQLITE_ID_CHUNK} cap"
+    )

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -34,6 +34,7 @@ from pixlstash.services.operation_log_service import apply_orientation
 from pixlstash.services.scrapheap_service import remove_picture_files
 from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
 from pixlstash.utils.image_processing.orientation import read_orientation
+from pixlstash.utils.media_files import has_hidden_component
 from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.reference_folder_validator import (
     canonical_path,
@@ -223,6 +224,35 @@ class _CaseFoldingOs:
 
     def __getattr__(self, name):
         return getattr(os, name)
+
+
+def test_has_hidden_component_answers_for_the_root_and_for_outside_it():
+    """#1194 review. The helper decides which picture rows a reference-folder
+    scan *keeps* instead of hard-deleting, so both of `relpath`'s non-name
+    answers have to be deliberate rather than fall through `is_hidden_entry`.
+
+    `path == root` gives `"."`, which is dot-prefixed: the helper called its own
+    root hidden, contradicting the one thing its docstring promises. A path
+    outside root gives `".."`, also dot-prefixed, and that one stays `True` on
+    purpose - the caller subtracts this set from the rows it is about to
+    delete, so it is the answer that keeps a row the walk never covered.
+    """
+    # The root is not examined, however it is spelled.
+    assert has_hidden_component("/a/b", "/a/b") is False
+    assert has_hidden_component("/a/b", "/a/b/") is False
+    # ...including a library whose own folder is dotted, which is the sentence
+    # the docstring makes and the case the "." answer used to break.
+    assert has_hidden_component("/a/.hidden", "/a/.hidden") is False
+    assert has_hidden_component("/a/.hidden/pics/x.jpg", "/a/.hidden") is False
+
+    # Ordinary containment, both directions.
+    assert has_hidden_component("/a/b/pics/x.jpg", "/a/b") is False
+    assert has_hidden_component("/a/b/.cache/x.jpg", "/a/b") is True
+
+    # Outside the root: kept, not deleted. Asserted so that flipping it to
+    # False - which reads like a tidy-up - has to be a deliberate choice about
+    # a hard-delete rather than a quiet consequence.
+    assert has_hidden_component("/a/c/x.jpg", "/a/b") is True
 
 
 def test_canonical_path_folds_case_where_the_filesystem_does(tmp_path, monkeypatch):

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -36,6 +36,7 @@ from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
 from pixlstash.utils.image_processing.orientation import read_orientation
 from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.reference_folder_validator import (
+    canonical_path,
     validate_reference_folder_path,
 )
 
@@ -195,6 +196,58 @@ def test_blocklist_still_accepts_an_ordinary_folder_and_a_benign_symlink(tmp_pat
     # A relative path is still refused before any resolution happens, so it can
     # never be quietly resolved against the server's working directory.
     assert validate_reference_folder_path("pictures") is not None
+
+
+class _CaseFoldingOsPath:
+    """``os.path`` with ``normcase`` folding, as it does on Windows and macOS."""
+
+    normcase = staticmethod(str.lower)
+
+    def __getattr__(self, name):
+        return getattr(os.path, name)
+
+
+class _CaseFoldingOs:
+    """``os`` carrying the folding ``path`` above; everything else falls through.
+
+    The validator module's own ``os`` name is swapped for this, rather than
+    ``os.path.normcase`` being patched in place. ``os.path`` is one object for
+    the whole process, and the gate's servers run background workers that walk
+    paths, so folding it globally would change their behaviour for as long as
+    the patch was up. Falling through by ``__getattr__`` rather than listing the
+    attributes keeps a validator function this test does not call from dying on
+    a missing name if one runs concurrently.
+    """
+
+    path = _CaseFoldingOsPath()
+
+    def __getattr__(self, name):
+        return getattr(os, name)
+
+
+def test_canonical_path_folds_case_where_the_filesystem_does(tmp_path, monkeypatch):
+    """#1194 review. `canonical_path` is how two reference folder roots are
+    compared, and Windows and macOS spell one directory in several cases. Left
+    case-sensitive, a registered root matches nothing under another spelling:
+    the path is accepted as free and two scans then index the same files.
+
+    `normcase` is identity on this POSIX gate - `CaseRoot` and `CASEROOT` really
+    are two directories here - so the folding platform is simulated. Without
+    that the assertion passes with or without the fix and pins nothing.
+    """
+    from pixlstash.utils import reference_folder_validator
+
+    real = tmp_path / "CaseRoot"
+    real.mkdir()
+    shouted = str(tmp_path / "CASEROOT")
+
+    # Identity on POSIX, which is the over-refusal control: two directories that
+    # differ only in case are two directories here, and must stay distinct.
+    assert canonical_path(str(real)) != canonical_path(shouted)
+
+    monkeypatch.setattr(reference_folder_validator, "os", _CaseFoldingOs())
+
+    assert canonical_path(str(real)) == canonical_path(shouted)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Six findings from the 1.11.0 release review (#1177 items **17, 18, 19, 20, 21** and
**55**) that all live in the folder-structure commit path. One PR because they
interact and because re-testing the large-import path six times is the waste
being avoided.

### 17 — an interrupted commit that got past its scan could never be resumed

`register_reference_folder` reused an existing row only when `last_scanned is
None`. A commit killed *after* its scan completed therefore met its own
reference folder on resume, refused it as somebody else's, and left the record
`pending`: every start-up resumed it and failed identically, for ever.

The rule now distinguishes the two cases instead of guessing from
`last_scanned` alone. `_commit_owns_this_root` asks the durable record, not the
path: the `FolderMappingCommit` for this `task_id` is still `pending` and its
`stage` has left `registering`, which happens only once
`register_reference_folder` has already returned once. The mapping provably did
not run — assigning settles the record inside its own transaction — so the row
is adopted and the commit finishes. Anything else is still refused. No new
column; the route passes its `task_id` through.

### 18 — an older pending record outlived the newer one that replaced it

A *failed* commit deliberately leaves its record pending while clearing the
in-memory slot, so a second mapping can legitimately be accepted over the
first. Both rows were then pending: the next start-up resumed the newest, and
the one after that resumed the older and re-applied a mapping the owner had
already replaced. `record_pending_commit` now marks every older pending row
`STATE_SUPERSEDED` as it writes the new one — newest wins, which is the rule
`FolderMappingCommit`'s docstring already claimed.

### 19 — the commit path ran no conflict check at all

The route's guard only refuses a root equal to or *inside* `image_root`, and
`register_reference_folder` checked nothing, so a root that **contains**
`image_root`, or that contains — or sits inside — another reference folder, was
accepted and then indexed by two scan tasks each believing they owned the
files. The rule moved to `utils/reference_folder_validator.py` as
`validate_reference_folder_conflicts`; the `/reference-folders` route and the
commit service both call it. Same messages, same 409s — the route's local copy
is deleted rather than duplicated.

### 20 — two passes over one root disagreed about what was in it

The Phase 2 read prunes dot-folders (a vault's own caches, `.pixlstash` sidecar
stores, anything the owner hid) and so does `local_import_pictures`;
`ReferenceFolderScanTask` did not — so a reference-mode commit's read excluded
the cache from its count and the scan indexed every file in it as a picture,
which the mapping then filed. One predicate now, `media_files.is_hidden_entry`,
called by all three.

The scan additionally keeps rows under a newly-pruned dot-folder out of
`removed_paths`, for the reason the views-tree prune beside it already spells
out: "absent from `disk_paths`" is what that task hard-deletes a `Picture` for,
and a path it never looked for says nothing about whether the file is there.
Without that, adding the prune would have deleted pictures a previous version
had indexed.

### 21 + 55 — the assigning step cost a statement per picture

`record_human_label()` was called per `(picture, tag)` inside `_link_pictures`'s
loop — one indexed `SELECT` plus an `INSERT` per pair, which on a fresh
`local_import` is every pair. Alongside it, `local_import_pictures`'s
existing-`file_path` load and `apply_local_mapping`'s id load built `IN` lists
over the whole import, unchunked, which crosses SQLite's bound-parameter cap on
any real library.

`_link_pictures` now resolves every folder first and then links, so the ledger
can be written in one batched pass (`label_ledger.record_human_labels`, chunked
probe); the `IN` lists go through `utils.sql_chunking.chunked`, as does the
hand-rolled 500-id loop in `resolve_pending_people_with_faces`.

Measured with a statement counter around `_link_pictures`, at two import sizes:

| pictures linked | statements before | after |
|---|---|---|
| 20 | 50 | 12 |
| 400 | 810 | 12 |

A statement count rather than a wall clock: it is the thing that actually
changed, and it does not depend on the machine.

### Tests

Five new checks in `tests/test_folder_structure_commit.py` (existing
module-scoped `Server`, no new fixture, no new file):

- a scan-completed-then-interrupted commit resumes — and both negative
  directions, so a resume that adopted anything it found would fail;
- a superseded pending record is not resumable, before or after its successor
  settles;
- a containing root, a contained root and a root above `image_root` are each
  refused;
- the read and the reference scan agree about dot-folders, end to end through
  the commit route;
- the bounded-statement-count assertion above, at two sizes — an absolute bound
  alone would pass a per-picture implementation on a small enough tree.

`docs/backend_architecture.md` §25 is updated in the same change: it documented
the `last_scanned`-only reuse rule that item 17 is about.

Closes nothing on its own — six lines of #1177.
