### PR TITLE
Changelog fragments: one file per change, assembled at release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -494,6 +494,23 @@ Mandatory for any change touching authentication, authorization, or access-scope
 - **External:** Uses OpenCV, NumPy, PIL, FastAPI, rapidfuzz, and Vue 3.
 - **Cross-component:** Backend serves REST API; frontend consumes API and displays images/metrics.
 
+## Never edit `CHANGELOG.md` on a branch
+
+Every branch appended to the same few lines at the top of the same file, so any
+two open PRs conflicted there even when they touched nothing else in common, and
+the conflict came back on every re-merge of `develop`. **A branch writes a file
+under `changelog.d/` instead**, named for its branch or PR number and containing
+the changelog lines themselves. `scripts/assemble_changelog.py <version>` folds
+them into one version section when the release is cut; that script is the only
+thing that writes `CHANGELOG.md`. Full format in `changelog.d/README.md`.
+
+**Write a fragment only for a user-visible change** — what someone would want to
+read in the release notes of an app they use. A bug introduced and fixed inside
+the same development cycle never reached anybody, so it gets no entry, and
+neither does a refactor, a test fix, a CI repair or a doc edit. Most branches
+need no fragment and nothing fails when one is missing; a wrong entry is worse
+than a missing one, because it makes the release notes longer and less true.
+
 ## Always Run Ruff on Python code before considering the job complete
 
 Do ruff format and ruff check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.11.1]
-
-- `libraries backup` now counts picture files in the library folder that have
-  no PixlStash record and asks whether to include them. Enter keeps them, so a
-  restore puts back exactly what was there; `--skip-orphans` leaves them out
-  without asking, and `--yes` includes them.
-
 # [1.11.0] [Security:High]
 
 - Settings → Libraries: add, rename and stop using libraries without the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,10 @@ is public knowledge:
 3. **Prepare the fix** — use the temporary private fork GitHub can create for you
    from within the advisory, or work locally. Do not push to a public branch until
    the release is ready.
-4. **Land the fix and tag the release** — merge the fix, update `CHANGELOG.md`
-   with a `[Security: LEVEL]` tag on the version header (see the Changelog
-   Convention section below), and publish the release on GitHub/PyPI.
+4. **Land the fix and tag the release** — merge the fix, cut the changelog with
+   `python scripts/assemble_changelog.py <version> --security LEVEL` so the
+   version header carries the tag (see the Changelog Convention section below),
+   and publish the release on GitHub/PyPI.
 5. **Publish the advisory** — only after the fixed release is live. This makes the
    GHSA public, activates the CVE, triggers Dependabot alerts for downstream
    users, and pushes the advisory to osv.dev and the PyPI advisory feeds.
@@ -146,7 +147,20 @@ is public knowledge:
 
 ## Changelog Convention
 
-When adding a new entry to `CHANGELOG.md`, use this format for the version header:
+**Do not edit `CHANGELOG.md` in a feature branch.** Every branch appending to
+the same lines at the top of the same file made it a conflict magnet, on PRs
+that had nothing else in common. A change that deserves a changelog line drops
+a file in `changelog.d/` instead, and the release folds them all in with
+`scripts/assemble_changelog.py`. See `changelog.d/README.md` for the format.
+
+Write a fragment only for a **user-visible** change — something worth reading in
+the release notes of an app you use. A bug introduced and fixed inside the same
+development cycle never reached a user, so it gets no entry; neither do
+refactors, test fixes, CI repairs or doc edits. Most PRs need no fragment.
+
+The rest of this section is the release's job, not a branch's.
+
+The version header written by the release uses this format:
 
 ```
 # [VERSION]

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,67 @@
+# `changelog.d/` — one file per user-visible change
+
+`CHANGELOG.md` was a conflict magnet: every branch appended to the same few
+lines at the top of the same file, so any two open PRs collided there even when
+they touched nothing else in common, and the collision came back on every
+re-merge of `develop`. Nothing about those conflicts was ever a real
+disagreement about the product.
+
+So nothing writes `CHANGELOG.md` any more except a release. A change that
+deserves a changelog line drops a file here instead; `scripts/assemble_changelog.py`
+folds them into one version section when the release is cut, and deletes them.
+Two branches adding two files conflict in nothing.
+
+## Whether to write one at all
+
+**A fragment is for a user-visible change — the thing you would want to read in
+the release notes of an app you use.** A new capability, a changed default, a
+control that moved, a bug that a released version actually shows you.
+
+**Not for anything that only existed inside this development cycle.** A bug
+introduced and fixed before it ever shipped never happened as far as a user is
+concerned; a refactor, a test fix, a CI repair, a doc edit and a typo in a
+string nobody released are all the same. Writing those up makes the release
+notes longer and less true. Most PRs need no fragment, and that is the normal
+case, not an oversight — nothing fails if a branch adds none.
+
+If the change fixes something a released version does, it is user-visible even
+when the code is a one-liner. If it fixes something last week's branch broke,
+it is not.
+
+## Writing one
+
+One file per change, named for its branch or PR number so two of them never
+collide:
+
+```
+changelog.d/library-root-scan.md
+changelog.d/1166.md
+```
+
+The file is the changelog entry itself: markdown list items, exactly as they
+should read in the release notes, wrapped at 80 columns. No heading, no
+version, no date — the release supplies those.
+
+```markdown
+- PixlStash now watches your library folder itself, not only the folders you
+  point it at. Rename a picture in your file manager and it keeps its tags,
+  score, people and sets.
+```
+
+Write it in the product's voice, for someone who does not know the code: what
+they can now do, in their words. `- Fixed: ...` is the convention for a fix.
+Several related lines can share one file; unrelated changes want separate ones.
+
+## Cutting a release
+
+```
+python scripts/assemble_changelog.py 1.11.1
+python scripts/assemble_changelog.py 1.11.1 --security High
+```
+
+That prepends one `# [1.11.1]` section to `CHANGELOG.md` with every fragment's
+lines under it, then removes the fragments. Read the assembled section before
+committing it — ordering is by filename, so a release worth reading usually
+wants a hand-edit afterwards to group the entries and lead with the ones that
+matter. `--security` writes the `[Security: LEVEL]` tag the release workflow
+reads off the top heading to publish `latest-version.json`.

--- a/changelog.d/backup-orphans-ask.md
+++ b/changelog.d/backup-orphans-ask.md
@@ -1,0 +1,4 @@
+- `libraries backup` now counts picture files in the library folder that have
+  no PixlStash record and asks whether to include them. Enter keeps them, so a
+  restore puts back exactly what was there; `--skip-orphans` leaves them out
+  without asking, and `--yes` includes them.

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Fold ``changelog.d/`` fragments into ``CHANGELOG.md`` as one version section.
+
+Run when a release is cut, from the root of the checkout being released::
+
+    python scripts/assemble_changelog.py 1.11.1
+    python scripts/assemble_changelog.py 1.11.1 --security High
+
+Every branch writes its own file under ``changelog.d/`` instead of appending to
+the top of ``CHANGELOG.md``, so two open PRs never collide there. This is the
+one thing that writes ``CHANGELOG.md``; see ``changelog.d/README.md`` for when a
+change deserves a fragment at all.
+
+The fragments are deleted once folded in. Read the assembled section before
+committing it: ordering is by filename, which is deterministic but not
+editorial.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRAGMENT_DIR = REPO_ROOT / "changelog.d"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+SECURITY_LEVELS = ("Critical", "High", "Moderate", "Low")
+
+
+def fragments() -> list[Path]:
+    """Every fragment file, in the order their lines will appear.
+
+    ``README.md`` documents the directory rather than describing a change, so it
+    is never a fragment.
+    """
+    return sorted(p for p in FRAGMENT_DIR.glob("*.md") if p.name != "README.md")
+
+
+def read_entries(paths: list[Path]) -> list[str]:
+    """The list items from *paths*, one string per fragment file.
+
+    Raises:
+        ValueError: If a fragment does not start with a markdown list item. The
+            file is pasted verbatim under a version heading, so anything else
+            would land in the release notes as it stands.
+    """
+    entries = []
+    for path in paths:
+        body = path.read_text(encoding="utf-8").strip()
+        if not body.startswith("- "):
+            raise ValueError(
+                f"{path.name} does not start with a markdown "
+                "list item ('- '); a fragment is the changelog lines themselves, "
+                "with no heading and no version."
+            )
+        entries.append(body)
+    return entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("version", help="Version being released, e.g. 1.11.1")
+    parser.add_argument(
+        "--security",
+        choices=SECURITY_LEVELS,
+        help=(
+            "Tag the heading '[Security: LEVEL]'. The release workflow reads "
+            "this off the top heading to publish latest-version.json."
+        ),
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Leave the fragments in place instead of deleting them.",
+    )
+    args = parser.parse_args(argv)
+
+    paths = fragments()
+    if not paths:
+        print(f"No fragments in {FRAGMENT_DIR.relative_to(REPO_ROOT)}; nothing to do.")
+        return 1
+
+    entries = read_entries(paths)
+    heading = f"# [{args.version}]"
+    if args.security:
+        heading += f" [Security: {args.security}]"
+
+    existing = CHANGELOG.read_text(encoding="utf-8")
+    CHANGELOG.write_text(
+        f"{heading}\n\n" + "\n".join(entries) + "\n\n" + existing, encoding="utf-8"
+    )
+
+    if not args.keep:
+        for path in paths:
+            path.unlink()
+
+    print(f"{heading}\n")
+    for path in paths:
+        print(f"  folded in {path.relative_to(REPO_ROOT)}")
+    print(
+        "\nRead the new section in CHANGELOG.md before committing: the order is "
+        "by filename, not by what matters."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -17,6 +17,7 @@ editorial.
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -24,6 +25,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 FRAGMENT_DIR = REPO_ROOT / "changelog.d"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 SECURITY_LEVELS = ("Critical", "High", "Moderate", "Low")
+
+#: An ATX heading, by CommonMark: one to six ``#`` then whitespace or the end of
+#: the line. Leading indentation is stripped before this is applied, because
+#: indenting a heading does not stop it being one - to CommonMark, and to
+#: ``release-version.yml``, which strips each line before testing it for ``#``.
+#: ``#1234`` is deliberately not a heading: no space after the hashes, so a
+#: continuation line citing an issue number stays legal.
+_ATX_HEADING = re.compile(r"^#{1,6}(?:\s|$)")
 
 
 def fragments() -> list[Path]:
@@ -49,16 +58,30 @@ def read_entries(paths: list[Path]) -> list[str]:
     below and is then pasted as ``"- thing"`` - a fragment silently edited on
     its way into the release notes, which is exactly what "verbatim" rules out.
 
+    A heading is refused wherever it sits, including indented under a list
+    item, and that check runs *before* the continuation rule: two spaces is a
+    legal continuation and ``  # [1.2.3]`` is still a heading, so the
+    continuation rule on its own let exactly the thing this function exists to
+    refuse through the middle of a fragment.
+
     Raises:
-        ValueError: If any line is neither a markdown list item, an indented
-            continuation of one, nor blank, or if the fragment does not open on
-            a list item.
+        ValueError: If any line is a heading, or is neither a markdown list
+            item, an indented continuation of one, nor blank, or if the
+            fragment does not open on a list item.
     """
     entries = []
     for path in paths:
         body = path.read_text(encoding="utf-8").rstrip()
         for number, line in enumerate(body.splitlines(), start=1):
-            if not line.strip() or line.startswith(("- ", "  ")):
+            stripped = line.strip()
+            if _ATX_HEADING.match(stripped):
+                raise ValueError(
+                    f"{path.name} line {number} is a heading: {line!r}. A "
+                    "fragment is the changelog lines themselves; a heading "
+                    "pasted into the release notes becomes a version section "
+                    "of its own, and indenting it does not stop it being one."
+                )
+            if not stripped or line.startswith(("- ", "  ")):
                 continue
             raise ValueError(
                 f"{path.name} line {number} is neither a list item nor an "

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -43,13 +43,20 @@ def read_entries(paths: list[Path]) -> list[str]:
     release notes as a version of its own and pushes everything below it into the
     wrong release.
 
+    Only trailing whitespace is removed, never leading. Stripping both would
+    both hide a malformed fragment and quietly rewrite it: ``"  - thing"`` is
+    not a list item at the top level, but leading-stripped it passes the check
+    below and is then pasted as ``"- thing"`` - a fragment silently edited on
+    its way into the release notes, which is exactly what "verbatim" rules out.
+
     Raises:
         ValueError: If any line is neither a markdown list item, an indented
-            continuation of one, nor blank.
+            continuation of one, nor blank, or if the fragment does not open on
+            a list item.
     """
     entries = []
     for path in paths:
-        body = path.read_text(encoding="utf-8").strip()
+        body = path.read_text(encoding="utf-8").rstrip()
         for number, line in enumerate(body.splitlines(), start=1):
             if not line.strip() or line.startswith(("- ", "  ")):
                 continue

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -38,19 +38,31 @@ def fragments() -> list[Path]:
 def read_entries(paths: list[Path]) -> list[str]:
     """The list items from *paths*, one string per fragment file.
 
+    Every line is checked, not just the first: the file is pasted verbatim under
+    a version heading, so a stray ``# heading`` on line three lands in the
+    release notes as a version of its own and pushes everything below it into the
+    wrong release.
+
     Raises:
-        ValueError: If a fragment does not start with a markdown list item. The
-            file is pasted verbatim under a version heading, so anything else
-            would land in the release notes as it stands.
+        ValueError: If any line is neither a markdown list item, an indented
+            continuation of one, nor blank.
     """
     entries = []
     for path in paths:
         body = path.read_text(encoding="utf-8").strip()
+        for number, line in enumerate(body.splitlines(), start=1):
+            if not line.strip() or line.startswith(("- ", "  ")):
+                continue
+            raise ValueError(
+                f"{path.name} line {number} is neither a list item nor an "
+                f"indented continuation of one: {line!r}. A fragment is the "
+                "changelog lines themselves, with no heading and no version."
+            )
         if not body.startswith("- "):
             raise ValueError(
-                f"{path.name} does not start with a markdown "
-                "list item ('- '); a fragment is the changelog lines themselves, "
-                "with no heading and no version."
+                f"{path.name} does not start with a markdown list item ('- '); "
+                "a fragment is the changelog lines themselves, with no heading "
+                "and no version."
             )
         entries.append(body)
     return entries
@@ -75,19 +87,20 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     paths = fragments()
-    if not paths:
-        print(f"No fragments in {FRAGMENT_DIR.relative_to(REPO_ROOT)}; nothing to do.")
-        return 1
-
     entries = read_entries(paths)
     heading = f"# [{args.version}]"
     if args.security:
         heading += f" [Security: {args.security}]"
 
+    # The heading is written even with nothing under it. `release-version.yml`
+    # reads `[Security: LEVEL]` off whatever heading is at the top of the
+    # released tag's CHANGELOG.md, so a release that skipped this step would
+    # publish the PREVIOUS release's security level as its own. A release with
+    # no user-visible change is a real thing - an rc bump, a cycle of internal
+    # fixes - and it still needs its own heading.
     existing = CHANGELOG.read_text(encoding="utf-8")
-    CHANGELOG.write_text(
-        f"{heading}\n\n" + "\n".join(entries) + "\n\n" + existing, encoding="utf-8"
-    )
+    section = f"{heading}\n\n" + ("\n".join(entries) + "\n\n" if entries else "")
+    CHANGELOG.write_text(section + existing, encoding="utf-8")
 
     if not args.keep:
         for path in paths:
@@ -96,6 +109,14 @@ def main(argv: list[str] | None = None) -> int:
     print(f"{heading}\n")
     for path in paths:
         print(f"  folded in {path.relative_to(REPO_ROOT)}")
+    if not paths:
+        print(
+            f"  no fragments in {FRAGMENT_DIR.relative_to(REPO_ROOT)} - the "
+            "section is empty, which says no user-visible change shipped in it.\n"
+            "  If that is wrong, the fragments were never written; add them and "
+            "run this again."
+        )
+        return 0
     print(
         "\nRead the new section in CHANGELOG.md before committing: the order is "
         "by filename, not by what matters."

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2714,8 +2714,16 @@ def test_every_changelog_fragment_is_a_markdown_list():
         "# [1.2.3]\n\n- something\n",
         "- something\n\n# [1.2.3]\n",
         "not a list item at all\n",
+        "  - something\n",
+        "\n\n- something\n",
     ],
-    ids=["leading heading", "trailing heading", "bare prose"],
+    ids=[
+        "leading heading",
+        "trailing heading",
+        "bare prose",
+        "opens indented",
+        "opens blank",
+    ],
 )
 def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
     """The check above can still fail - the mutation that proves it is alive.
@@ -2723,6 +2731,10 @@ def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
     The trailing case is the one a first-line-only check misses: pasted under
     the release's heading, that stray `# [1.2.3]` becomes a version section of
     its own and every entry below it moves into the wrong release.
+
+    The last two are the ones a leading `strip()` masks: both open on something
+    that is not a top-level list item, and stripping the front turns each into a
+    fragment that passes and is then pasted in edited form.
     """
     assemble_changelog = _assemble_changelog_module()
 

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2678,13 +2678,19 @@ def test_frontend_import_extensions_match_the_staging_allowlist():
 
 
 def _assemble_changelog_module():
-    """The release's changelog assembler, imported from ``scripts/``."""
-    import sys
+    """The release's changelog assembler, loaded from ``scripts/`` by path.
 
-    sys.path.insert(0, str(REPO_ROOT / "scripts"))
-    import assemble_changelog
+    By path rather than by ``sys.path`` insertion: this file shares a process
+    with the rest of a gate shard, and a leftover entry pointing at ``scripts/``
+    would silently change what every later test imports.
+    """
+    import importlib.util
 
-    return assemble_changelog
+    path = REPO_ROOT / "scripts" / "assemble_changelog.py"
+    spec = importlib.util.spec_from_file_location("assemble_changelog", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_every_changelog_fragment_is_a_markdown_list():
@@ -2702,13 +2708,27 @@ def test_every_changelog_fragment_is_a_markdown_list():
         pytest.fail(str(exc))
 
 
-def test_a_fragment_that_is_not_a_list_is_refused(tmp_path):
-    """The check above can still fail - the mutation that proves it is alive."""
+@pytest.mark.parametrize(
+    "body",
+    [
+        "# [1.2.3]\n\n- something\n",
+        "- something\n\n# [1.2.3]\n",
+        "not a list item at all\n",
+    ],
+    ids=["leading heading", "trailing heading", "bare prose"],
+)
+def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
+    """The check above can still fail - the mutation that proves it is alive.
+
+    The trailing case is the one a first-line-only check misses: pasted under
+    the release's heading, that stray `# [1.2.3]` becomes a version section of
+    its own and every entry below it moves into the wrong release.
+    """
     assemble_changelog = _assemble_changelog_module()
 
     bad = tmp_path / "bad.md"
-    bad.write_text("# [1.2.3]\n\n- something\n", encoding="utf-8")
-    with pytest.raises(ValueError, match="markdown list item"):
+    bad.write_text(body, encoding="utf-8")
+    with pytest.raises(ValueError):
         assemble_changelog.read_entries([bad])
 
 

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2716,6 +2716,8 @@ def test_every_changelog_fragment_is_a_markdown_list():
         "not a list item at all\n",
         "  - something\n",
         "\n\n- something\n",
+        "- something\n  # [1.2.3]\n",
+        "- something\n    ## still a heading\n",
     ],
     ids=[
         "leading heading",
@@ -2723,6 +2725,8 @@ def test_every_changelog_fragment_is_a_markdown_list():
         "bare prose",
         "opens indented",
         "opens blank",
+        "indented heading",
+        "deeply indented heading",
     ],
 )
 def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
@@ -2732,9 +2736,15 @@ def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
     the release's heading, that stray `# [1.2.3]` becomes a version section of
     its own and every entry below it moves into the wrong release.
 
-    The last two are the ones a leading `strip()` masks: both open on something
-    that is not a top-level list item, and stripping the front turns each into a
-    fragment that passes and is then pasted in edited form.
+    The `opens` pair are the ones a leading `strip()` masks: both open on
+    something that is not a top-level list item, and stripping the front turns
+    each into a fragment that passes and is then pasted in edited form.
+
+    The indented pair are the ones the continuation rule masks. Two spaces is a
+    legal continuation of a list item and `  # [1.2.3]` is still a heading -
+    to CommonMark, and to `release-version.yml`, which strips each line before
+    testing it for `#`. Indenting the heading was all it took to put a version
+    section nobody released into the middle of the file.
     """
     assemble_changelog = _assemble_changelog_module()
 
@@ -2742,6 +2752,24 @@ def test_a_fragment_that_is_not_a_list_is_refused(tmp_path, body):
     bad.write_text(body, encoding="utf-8")
     with pytest.raises(ValueError):
         assemble_changelog.read_entries([bad])
+
+
+def test_a_continuation_line_may_cite_an_issue_number(tmp_path):
+    """The over-refusal control for the heading check above.
+
+    `#1234` is not a heading - CommonMark wants whitespace after the hashes -
+    and citing an issue on a wrapped line is the obvious thing a fragment does.
+    A heading rule that refused it would be found here rather than by whoever
+    is cutting the release.
+    """
+    assemble_changelog = _assemble_changelog_module()
+
+    good = tmp_path / "good.md"
+    good.write_text("- Fixed the thing\n  #1234 was the culprit.\n", encoding="utf-8")
+
+    assert assemble_changelog.read_entries([good]) == [
+        "- Fixed the thing\n  #1234 was the culprit."
+    ]
 
 
 def test_the_changelog_opens_on_a_released_version_heading():

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2675,3 +2675,51 @@ def test_frontend_import_extensions_match_the_staging_allowlist():
         "A client-only extension uploads the whole file and then fails the "
         "commit; a server-only one is refused before it is ever offered."
     )
+
+
+def _assemble_changelog_module():
+    """The release's changelog assembler, imported from ``scripts/``."""
+    import sys
+
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    import assemble_changelog
+
+    return assemble_changelog
+
+
+def test_every_changelog_fragment_is_a_markdown_list():
+    """A fragment is pasted verbatim under the release's version heading.
+
+    Nothing reads it before then, so a fragment carrying its own heading, a
+    version, or a stray paragraph is only discovered when the release notes are
+    already written. The parser that will consume it runs here instead.
+    """
+    assemble_changelog = _assemble_changelog_module()
+
+    try:
+        assemble_changelog.read_entries(assemble_changelog.fragments())
+    except ValueError as exc:
+        pytest.fail(str(exc))
+
+
+def test_a_fragment_that_is_not_a_list_is_refused(tmp_path):
+    """The check above can still fail - the mutation that proves it is alive."""
+    assemble_changelog = _assemble_changelog_module()
+
+    bad = tmp_path / "bad.md"
+    bad.write_text("# [1.2.3]\n\n- something\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="markdown list item"):
+        assemble_changelog.read_entries([bad])
+
+
+def test_the_changelog_opens_on_a_released_version_heading():
+    """`.github/workflows/release-version.yml` reads `[Security: LEVEL]` off the
+    first heading in the released tag's CHANGELOG.md to publish
+    latest-version.json. Only ``scripts/assemble_changelog.py`` writes that file;
+    an unreleased section left at the top by hand would hand the workflow the
+    wrong version's security level."""
+    first = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8").lstrip()
+    assert re.match(r"# \[\d+\.\d+\.\d+[^\]]*\]", first), (
+        "CHANGELOG.md does not open on a version heading: "
+        f"{first.splitlines()[0] if first else '(empty)'}"
+    )


### PR DESCRIPTION
`CHANGELOG.md` was a conflict magnet. Every branch appended to the same few
lines at the top of the same file, so two open PRs collided there even when
they touched nothing else in common, and the collision came back on every
re-merge of `develop`. #1166 hit it three times in a row without its own
content ever being in dispute.

Nothing writes `CHANGELOG.md` on a branch any more.

- `changelog.d/` takes one file per change, named for its branch or PR, holding
  the changelog lines themselves. Two branches adding two files conflict in
  nothing.
- `scripts/assemble_changelog.py <version> [--security LEVEL]` prepends one
  version section built from every fragment and deletes them. It is the only
  thing that writes `CHANGELOG.md`, and it is run when the release is cut.
- The unreleased 1.11.1 section moves into a fragment, so the file opens on
  1.11.0 again — which is also what `release-version.yml` expects when it reads
  `[Security: LEVEL]` off the top heading of a released tag.

**A fragment is only for a user-visible change** — what someone would want to
read in the release notes of an app they use. A bug introduced and fixed inside
the same development cycle never reached anybody, and neither a refactor, a test
fix, a CI repair nor a doc edit earns a line. Most branches need no fragment and
nothing fails when one is missing; a wrong entry makes the release notes longer
and less true.

Written into `CONTRIBUTING.md`, `.github/copilot-instructions.md` and
`changelog.d/README.md`, since the convention only works if the next branch
knows about it.

Three guardrails in `tests/test_architecture_guardrails.py`: every fragment
parses as a markdown list, that check can still fail, and `CHANGELOG.md` opens
on a version heading.

No fragment for this PR: it changes how the changelog is written, not the
product.