### PR TITLE
Website: give the AI features their own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It provides:
 - A desktop application or a headless server with a browser-based interface
 - Semantic search across the whole library with CLIP text queries, tagged or not (OpenCLIP ViT-B-32)
 - Face detection, face recognition and automatic grouping into named characters (InsightFace SCRFD-10G, buffalo_l or AuraFace), plus reverse face search
-- Automatic tagging and image descriptions with selectable AI engines (WD14, Florence-2, JoyCaption), chosen per request
+- Automatic tagging and image descriptions with selectable AI engines (our own PixlStash Tagger, WD14, Florence-2, JoyCaption), chosen per request
 - Object segmentation, and reverse likeness search on CLIP embeddings
 - A tag review queue and a per-tag health board, so auto-tags become tags you can trust
 - Smart score sorting, character-likeness scoring, and calibrated anomaly detection for malformed anatomy

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ PixlStash is a local picture library server for organizing, filtering, and revie
 It provides:
 
 - A desktop application or a headless server with a browser-based interface
-- Automatic tagging and image descriptions with selectable AI engines (including JoyCaption)
+- Semantic search across the whole library with CLIP text queries, tagged or not (OpenCLIP ViT-B-32)
+- Face detection, face recognition and automatic grouping into named characters (InsightFace SCRFD-10G, buffalo_l or AuraFace), plus reverse face search
+- Automatic tagging and image descriptions with selectable AI engines (WD14, Florence-2, JoyCaption), chosen per request
+- Object segmentation, and reverse likeness search on CLIP embeddings
+- A tag review queue and a per-tag health board, so auto-tags become tags you can trust
+- Smart score sorting, character-likeness scoring, and calibrated anomaly detection for malformed anatomy
+- Every model runs on your own hardware (CPU, NVIDIA CUDA, or experimental AMD ROCm). No cloud API
 - Re-tag or regenerate descriptions for any selection directly from the context menu
 - Instant grid loading — thumbnails appear immediately, metadata fills in asynchronously
 - Fast metadata and tag filtering
-- Smart score sorting
 - Character and set organization
 - Local storage of your library data
 - API for integrating with other tools
@@ -34,7 +39,27 @@ PixlStash runs on your machine and serves the UI at a local (or Internet-facing)
 
 Immich is a very good home photo server. If that's what you need, use it! PixlStash does a different job.
 
-PixlStash is a tool for working with images rather than just storing them, though it works as a home server too. It adds a tag review queue so auto-tags are verified, segmentation and selectable taggers, a choice of GPU or CPU backends, and two-way ComfyUI integration: control ComfyUI from PixlStash, or call its nodes from your own workflows. Generated images return tagged, with People, Picture Set, and Project associations attached.
+**PixlStash does both of the AI features Immich is known for.** CLIP semantic
+search and InsightFace face recognition are in here too, along with duplicate
+detection. Immich documents two machine-learning tasks, smart search and facial
+recognition, and does them well for the job it is built for: finding a photo you
+already took. Immich also has OCR and mobile apps with background sync, which
+PixlStash does not.
+
+What PixlStash adds is everything that happens *after* you have found the
+pictures. It is a tool for working with images rather than just storing them,
+though it works as a home server too:
+
+- Automatic tagging and captioning, with the engine selectable per request
+- A tag review queue and a tag health board, so auto-tags are verified rather than trusted
+- Quality, anomaly and character-likeness scoring, so a large set sorts by what is worth looking at
+- Segmentation, reverse face search and reverse likeness search
+- Dataset export, and ai-toolkit run import with sample images and version history
+- Two-way ComfyUI integration: control ComfyUI from PixlStash, or call its nodes from your own workflows. Generated images return tagged, with People, Picture Set, and Project associations attached
+- A tagger plugin API, so a model we have never heard of shows up in the engine picker
+
+Full breakdown, including a capability-by-capability comparison table:
+[pixlstash.dev/ai.html](https://pixlstash.dev/ai.html).
 
 ## Install or try PixlStash
 

--- a/website/ai.html
+++ b/website/ai.html
@@ -15,7 +15,12 @@
       href="https://fonts.googleapis.com/css2?family=Tiny5&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
-    <script>try{if(localStorage.getItem('pixlstash-theme')==='light')document.documentElement.setAttribute('data-theme','light')}catch(e){}</script>
+    <script>
+      try {
+        if (localStorage.getItem("pixlstash-theme") === "light")
+          document.documentElement.setAttribute("data-theme", "light");
+      } catch (e) {}
+    </script>
     <link rel="stylesheet" href="pixlstash.css" />
     <style>
       /* ── ai.html page-specific ── */
@@ -24,10 +29,18 @@
          no new hue enters the brand. Carried as a rule and a tinted badge,
          never as small coloured text: raspberry on panel is ~3.1:1 and
          warm-white on amber ~3.3:1, both under the 4.5:1 floor. */
-      .stage-1 { --stage: var(--tertiary); }
-      .stage-2 { --stage: var(--secondary); }
-      .stage-3 { --stage: var(--accent); }
-      .stage-4 { --stage: var(--primary); }
+      .stage-1 {
+        --stage: var(--tertiary);
+      }
+      .stage-2 {
+        --stage: var(--secondary);
+      }
+      .stage-3 {
+        --stage: var(--accent);
+      }
+      .stage-4 {
+        --stage: var(--primary);
+      }
 
       .section {
         margin-top: 72px;
@@ -239,7 +252,7 @@
           "Automatic face grouping into named characters",
           "Reverse face search from an uploaded image",
           "Reverse likeness search on CLIP embeddings",
-          "Automatic tagging with selectable engines (WD14 wd-convnext-tagger-v3, Florence-2, JoyCaption)",
+          "Automatic tagging with selectable engines (PixlStash Tagger, WD14 wd-convnext-tagger-v3, Florence-2, JoyCaption)",
           "Image captions and descriptions (JoyCaption, Florence-2)",
           "Object segmentation (Florence-2)",
           "Sentence-embedding text search (SBERT)",
@@ -253,7 +266,7 @@
           "Dataset export for training",
           "ai-toolkit run import with sample images and version history",
           "Two-way ComfyUI integration with tagged round-trip",
-          "Tagger plugin API for adding your own engine",
+          "Tagger plugin API, with a published catalogue including a Moondream2 captioner and an OpenAI-compatible vision API captioner",
           "NVIDIA CUDA, experimental AMD ROCm, or CPU inference",
           "All inference runs locally, no cloud API"
         ]
@@ -269,8 +282,8 @@
         <h1>The AI features</h1>
         <p>
           Most photo servers use AI to help you find a picture. PixlStash uses
-          it to help you work on a set of them.<br />Every model below runs on
-          your own machine. Nothing is sent to an API.
+          it to help you work on them. Every model below runs on your own
+          machine. Nothing is sent to an API.
         </p>
       </div>
 
@@ -299,18 +312,19 @@
           </li>
           <li class="stage-3">
             <span class="ai-loop__num">STAGE 3</span>
-            <h3>Score</h3>
+            <h3>Score and search</h3>
             <p>
               Quality, likeness and anomaly scores that sort the good pictures
-              to the front of a large set.
+              to the front of a large set and the crap ones to the back. Search
+              by likeness.
             </p>
           </li>
           <li class="stage-4">
             <span class="ai-loop__num">STAGE 4</span>
             <h3>Train and generate</h3>
             <p>
-              Export the set, track the run it produced, and send new work back
-              in already tagged.
+              Export the set, track the training run it produced, and bring back
+              a LoRA to present to workflows.
             </p>
           </li>
         </ol>
@@ -352,7 +366,8 @@
               along. Batch or single image.
             </p>
             <p class="ai-card__model">
-              WD14 wd-convnext-tagger-v3, Florence-2, JoyCaption
+              PixlStash Tagger (a wd-convnext-tagger-v3 finetune), WD14
+              wd-convnext-tagger-v3, Florence-2, JoyCaption
             </p>
           </div>
           <div class="ai-card">
@@ -386,9 +401,13 @@
             <p>
               The tagger plugin API is the same one the built-in engines use.
               Point it at a model we have never heard of and it appears in the
-              engine picker.
+              engine picker. Moondream2 already ships in the published plugin
+              catalogue, so does a captioner for any OpenAI-compatible vision
+              API. Install either with one command.
             </p>
-            <p class="ai-card__model">Python plugin, template included</p>
+            <p class="ai-card__model">
+              pixlstash-cli plugins install moondream2
+            </p>
           </div>
         </div>
       </section>
@@ -440,7 +459,7 @@
 
       <section class="section stage-3" aria-labelledby="stage-score">
         <div class="ai-stage-head">
-          <h2 id="stage-score">Score</h2>
+          <h2 id="stage-score">Score and search</h2>
           <span class="ai-stage-head__step">STAGE 3 OF 4</span>
         </div>
         <div class="ai-grid">
@@ -463,7 +482,9 @@
               families and combined so one bad hand tagged three ways is not
               punished three times.
             </p>
-            <p class="ai-card__model">ViT classifier, noisy-OR family grouping</p>
+            <p class="ai-card__model">
+              ViT classifier, noisy-OR family grouping
+            </p>
           </div>
           <div class="ai-card">
             <h3>Character likeness</h3>
@@ -472,7 +493,9 @@
               can find the shots that actually look like the subject rather than
               merely contain them.
             </p>
-            <p class="ai-card__model">InsightFace embeddings, cosine similarity</p>
+            <p class="ai-card__model">
+              InsightFace embeddings, cosine similarity
+            </p>
           </div>
           <div class="ai-card">
             <h3>Reverse face search</h3>
@@ -616,11 +639,6 @@
                 <td>No</td>
               </tr>
               <tr>
-                <th scope="row">Mobile apps with background sync</th>
-                <td class="yes">Yes</td>
-                <td>No</td>
-              </tr>
-              <tr>
                 <th scope="row">Automatic tagging</th>
                 <td>No</td>
                 <td class="yes">Yes, engine selectable per request</td>
@@ -676,18 +694,17 @@
         <p class="ai-note" style="margin-top: 22px">
           Immich documents two machine-learning tasks, smart search and facial
           recognition, and does them well for the job it is built for: finding a
-          photo you already took. PixlStash does both of those and then keeps
-          going, because finding the picture is the start of the work rather
-          than the end of it.
+          photo you already took. PixlStash does both of those and then adds
+          additional features for <b>working</b> with images.
         </p>
       </section>
 
       <div class="page-footer">
         <p>
           <a href="features.html">See the rest of the features</a>
-          &nbsp;·&nbsp;
+          &nbsp;-&nbsp;
           <a href="install.html">Install PixlStash</a>
-          &nbsp;·&nbsp;
+          &nbsp;-&nbsp;
           <a href="index.html">Back to PixlStash home</a>
         </p>
       </div>

--- a/website/ai.html
+++ b/website/ai.html
@@ -1,0 +1,696 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI features | PixlStash</title>
+    <meta
+      name="description"
+      content="PixlStash runs CLIP semantic search, InsightFace face recognition, selectable tagging engines (WD14, Florence-2, JoyCaption), anomaly detection, smart scoring, duplicate review and two-way ComfyUI integration, all on your own hardware."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Tiny5&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <script>try{if(localStorage.getItem('pixlstash-theme')==='light')document.documentElement.setAttribute('data-theme','light')}catch(e){}</script>
+    <link rel="stylesheet" href="pixlstash.css" />
+    <style>
+      /* ── ai.html page-specific ── */
+
+      /* Stage ramp. Reuses the categorical tokens already in pixlstash.css so
+         no new hue enters the brand. Carried as a rule and a tinted badge,
+         never as small coloured text: raspberry on panel is ~3.1:1 and
+         warm-white on amber ~3.3:1, both under the 4.5:1 floor. */
+      .stage-1 { --stage: var(--tertiary); }
+      .stage-2 { --stage: var(--secondary); }
+      .stage-3 { --stage: var(--accent); }
+      .stage-4 { --stage: var(--primary); }
+
+      .section {
+        margin-top: 72px;
+      }
+
+      .section-title {
+        font-size: 2rem;
+        margin: 0;
+      }
+
+      .section-subtitle {
+        color: var(--muted);
+        max-width: 620px;
+        line-height: 1.6;
+        margin: 8px 0 0;
+      }
+
+      /* The loop. An ordered list, because it is one, and text rather than a
+         diagram image so it survives a screen reader and a scraper alike. */
+      .ai-loop {
+        list-style: none;
+        margin: 40px 0 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .ai-loop li {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--stage);
+        border-radius: var(--radius-md);
+        padding: 16px 16px 18px;
+      }
+
+      .ai-loop .ai-loop__num {
+        display: inline-block;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        color: var(--text);
+        background: color-mix(in srgb, var(--stage) 28%, var(--panel));
+        border-radius: var(--radius-md);
+        padding: 3px 9px;
+        margin-bottom: 10px;
+      }
+
+      .ai-loop h3 {
+        font-size: 1.05rem;
+        margin: 0 0 6px;
+      }
+
+      .ai-loop p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+
+      .ai-stage-head {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        border-left: 3px solid var(--stage);
+        padding-left: 16px;
+        margin-bottom: 22px;
+      }
+
+      .ai-stage-head h2 {
+        font-size: 1.6rem;
+        margin: 0;
+      }
+
+      .ai-stage-head .ai-stage-head__step {
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        white-space: nowrap;
+      }
+
+      .ai-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 16px;
+      }
+
+      .ai-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: 18px;
+        display: flex;
+        flex-direction: column;
+        transition: border-color 120ms ease;
+      }
+
+      .ai-card:hover {
+        border-color: color-mix(in srgb, var(--stage) 55%, var(--border));
+      }
+
+      .ai-card h3 {
+        margin: 0 0 8px;
+        font-size: 1.05rem;
+      }
+
+      .ai-card p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.55;
+        font-size: 0.95rem;
+      }
+
+      /* The model name is the detail a technical reader checks first. */
+      .ai-card__model {
+        font-family: var(--mono);
+        font-size: 0.78rem;
+        color: var(--muted);
+        margin-top: 14px;
+        padding-top: 12px;
+        border-top: 1px solid var(--divider);
+        word-break: break-word;
+      }
+
+      .ai-compare-wrap {
+        overflow-x: auto;
+      }
+
+      .ai-compare {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+        min-width: 560px;
+      }
+
+      .ai-compare th,
+      .ai-compare td {
+        text-align: left;
+        padding: 11px 14px;
+        border-bottom: 1px solid var(--divider);
+      }
+
+      .ai-compare thead th {
+        background: var(--panel-strong);
+        font-family: var(--display);
+        font-size: 0.9rem;
+      }
+
+      .ai-compare tbody th {
+        font-weight: 500;
+        color: var(--text);
+      }
+
+      .ai-compare td {
+        color: var(--muted);
+      }
+
+      .ai-compare .yes {
+        color: var(--accent-3);
+        font-weight: 600;
+      }
+
+      .ai-note {
+        color: var(--muted);
+        line-height: 1.7;
+        max-width: 720px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .ai-card {
+          transition: none;
+        }
+      }
+
+      @media (max-width: 900px) {
+        .ai-loop {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (max-width: 700px) {
+        .section-title {
+          font-size: 1.5rem;
+        }
+        .ai-loop {
+          grid-template-columns: 1fr;
+        }
+        .ai-stage-head {
+          flex-direction: column;
+          gap: 4px;
+        }
+      }
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "PixlStash",
+        "applicationCategory": "MultimediaApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "url": "https://pixlstash.dev/",
+        "downloadUrl": "https://pixlstash.dev/install.html",
+        "license": "https://github.com/pikselkroken/pixlstash/blob/main/LICENSE",
+        "description": "A local picture library server that runs its AI on your own hardware: CLIP semantic search, InsightFace face recognition, selectable tagging engines, anomaly detection, smart scoring, duplicate review and two-way ComfyUI integration.",
+        "featureList": [
+          "CLIP semantic text search across the whole library (OpenCLIP ViT-B-32, laion2b_s34b_b79k)",
+          "Face detection and face recognition (InsightFace SCRFD-10G with buffalo_l or AuraFace)",
+          "Automatic face grouping into named characters",
+          "Reverse face search from an uploaded image",
+          "Reverse likeness search on CLIP embeddings",
+          "Automatic tagging with selectable engines (WD14 wd-convnext-tagger-v3, Florence-2, JoyCaption)",
+          "Image captions and descriptions (JoyCaption, Florence-2)",
+          "Object segmentation (Florence-2)",
+          "Sentence-embedding text search (SBERT)",
+          "Tag review queue with accept and dismiss writeback",
+          "Tag health board with per-tag verification and model-disputes-human signals",
+          "Duplicate detection with a tiered review queue",
+          "Smart score combining image embeddings, CLIP anchors and a quality probe",
+          "Calibrated anomaly detection with precision-weighted, noisy-OR family grouping",
+          "Character likeness scoring against reference faces",
+          "Automatic grouping of similar images",
+          "Dataset export for training",
+          "ai-toolkit run import with sample images and version history",
+          "Two-way ComfyUI integration with tagged round-trip",
+          "Tagger plugin API for adding your own engine",
+          "NVIDIA CUDA, experimental AMD ROCm, or CPU inference",
+          "All inference runs locally, no cloud API"
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <div class="shell">
+      <div id="nav-placeholder"></div>
+      <script src="nav.js"></script>
+
+      <div class="page-hero">
+        <h1>The AI features</h1>
+        <p>
+          Most photo servers use AI to help you find a picture. PixlStash uses
+          it to help you work on a set of them.<br />Every model below runs on
+          your own machine. Nothing is sent to an API.
+        </p>
+      </div>
+
+      <section class="section" aria-labelledby="loop-heading">
+        <h2 class="section-title" id="loop-heading">One loop, four stages</h2>
+        <p class="section-subtitle">
+          The models are not a list of separate tricks. Each stage feeds the
+          next, and the last one feeds the first.
+        </p>
+        <ol class="ai-loop">
+          <li class="stage-1">
+            <span class="ai-loop__num">STAGE 1</span>
+            <h3>Label</h3>
+            <p>
+              Tags, descriptions, faces and embeddings, so the library is
+              searchable by what is in the pictures.
+            </p>
+          </li>
+          <li class="stage-2">
+            <span class="ai-loop__num">STAGE 2</span>
+            <h3>Review</h3>
+            <p>
+              A queue that shows you what the models probably got wrong, so the
+              labels are worth trusting.
+            </p>
+          </li>
+          <li class="stage-3">
+            <span class="ai-loop__num">STAGE 3</span>
+            <h3>Score</h3>
+            <p>
+              Quality, likeness and anomaly scores that sort the good pictures
+              to the front of a large set.
+            </p>
+          </li>
+          <li class="stage-4">
+            <span class="ai-loop__num">STAGE 4</span>
+            <h3>Train and generate</h3>
+            <p>
+              Export the set, track the run it produced, and send new work back
+              in already tagged.
+            </p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="section stage-1" aria-labelledby="stage-label">
+        <div class="ai-stage-head">
+          <h2 id="stage-label">Label</h2>
+          <span class="ai-stage-head__step">STAGE 1 OF 4</span>
+        </div>
+        <div class="ai-grid">
+          <div class="ai-card">
+            <h3>Semantic search</h3>
+            <p>
+              Type what you are looking for and get pictures back, whether or
+              not anything is tagged. Queries and pictures share an embedding
+              space, so "someone in a red coat on a snowy street" works on a
+              library nobody has ever labelled.
+            </p>
+            <p class="ai-card__model">OpenCLIP ViT-B-32, laion2b_s34b_b79k</p>
+          </div>
+          <div class="ai-card">
+            <h3>Face detection and recognition</h3>
+            <p>
+              Faces are found, embedded and grouped into characters you can
+              name. Switching the model pack does not lose your faces or your
+              manual assignments: existing embeddings are refreshed in place, in
+              the background.
+            </p>
+            <p class="ai-card__model">
+              InsightFace SCRFD-10G, buffalo_l or AuraFace
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Tagging, with the engine you pick</h3>
+            <p>
+              Choose the tagger per request rather than per install, and re-tag
+              any selection from the context menu when a better model comes
+              along. Batch or single image.
+            </p>
+            <p class="ai-card__model">
+              WD14 wd-convnext-tagger-v3, Florence-2, JoyCaption
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Captions and descriptions</h3>
+            <p>
+              Write natural-language descriptions for a whole selection, or
+              regenerate one image's description on its own. Useful as caption
+              files when the set becomes a dataset.
+            </p>
+            <p class="ai-card__model">JoyCaption, Florence-2</p>
+          </div>
+          <div class="ai-card">
+            <h3>Segmentation</h3>
+            <p>
+              Locate objects inside a picture rather than only naming them, for
+              crops and region work.
+            </p>
+            <p class="ai-card__model">Florence-2</p>
+          </div>
+          <div class="ai-card">
+            <h3>Sentence embeddings</h3>
+            <p>
+              Descriptions and queries get their own text embeddings alongside
+              the image ones, so a search can match how a picture was described
+              as well as how it looks.
+            </p>
+            <p class="ai-card__model">SBERT sentence-transformers</p>
+          </div>
+          <div class="ai-card">
+            <h3>Bring your own tagger</h3>
+            <p>
+              The tagger plugin API is the same one the built-in engines use.
+              Point it at a model we have never heard of and it appears in the
+              engine picker.
+            </p>
+            <p class="ai-card__model">Python plugin, template included</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section stage-2" aria-labelledby="stage-review">
+        <div class="ai-stage-head">
+          <h2 id="stage-review">Review</h2>
+          <span class="ai-stage-head__step">STAGE 2 OF 4</span>
+        </div>
+        <p class="section-subtitle">
+          This stage is the one other tools skip. Auto-tags are a starting
+          guess, and a dataset built on unverified guesses trains a worse model.
+        </p>
+        <div class="ai-grid" style="margin-top: 22px">
+          <div class="ai-card">
+            <h3>Tag review queue</h3>
+            <p>
+              A ranked queue of the labels most likely to be wrong. Accept and
+              it writes through to the library and every open client refreshes.
+              Dismiss and it stops asking.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Tag health board</h3>
+            <p>
+              Per-tag signals for the whole library: estimated wrong and
+              missing, how much of the tag you have verified, how much sits on
+              the decision boundary, how often your verdict overturned the
+              model, and where the model disputes a human.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Duplicate review</h3>
+            <p>
+              Near-duplicates are grouped into a tiered queue, and a sweep can
+              be run as a dry run first so you see what it would remove before
+              anything goes.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Automatic grouping</h3>
+            <p>
+              Visually similar images stack together, so a burst or a batch of
+              variations reviews as one decision instead of forty.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section stage-3" aria-labelledby="stage-score">
+        <div class="ai-stage-head">
+          <h2 id="stage-score">Score</h2>
+          <span class="ai-stage-head__step">STAGE 3 OF 4</span>
+        </div>
+        <div class="ai-grid">
+          <div class="ai-card">
+            <h3>Smart score</h3>
+            <p>
+              One sortable number per picture, combining the image embedding,
+              CLIP anchors, an objective quality probe and the anomaly penalty
+              below. Sort a set of ten thousand and the ones worth looking at
+              are at the front.
+            </p>
+            <p class="ai-card__model">Anchor-based, CLIP embeddings</p>
+          </div>
+          <div class="ai-card">
+            <h3>Anomaly detection</h3>
+            <p>
+              Finds malformed anatomy and similar render defects. Each detection
+              counts by its calibrated confidence, discounted by that tag's
+              measured precision, and correlated defects are grouped into
+              families and combined so one bad hand tagged three ways is not
+              punished three times.
+            </p>
+            <p class="ai-card__model">ViT classifier, noisy-OR family grouping</p>
+          </div>
+          <div class="ai-card">
+            <h3>Character likeness</h3>
+            <p>
+              Score every picture against a character's reference faces, so you
+              can find the shots that actually look like the subject rather than
+              merely contain them.
+            </p>
+            <p class="ai-card__model">InsightFace embeddings, cosine similarity</p>
+          </div>
+          <div class="ai-card">
+            <h3>Reverse face search</h3>
+            <p>
+              Upload a face and get the library back ranked by its best matching
+              face per picture.
+            </p>
+            <p class="ai-card__model">InsightFace embeddings</p>
+          </div>
+          <div class="ai-card">
+            <h3>Reverse likeness search</h3>
+            <p>
+              Upload one image or several and get pictures ranked by visual
+              similarity. With several, the per-picture scores combine, so you
+              can search for a look rather than a single frame.
+            </p>
+            <p class="ai-card__model">CLIP embeddings, cosine similarity</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section stage-4" aria-labelledby="stage-train">
+        <div class="ai-stage-head">
+          <h2 id="stage-train">Train and generate</h2>
+          <span class="ai-stage-head__step">STAGE 4 OF 4</span>
+        </div>
+        <div class="ai-grid">
+          <div class="ai-card">
+            <h3>Dataset export</h3>
+            <p>
+              Send a reviewed, scored selection straight into a folder with its
+              captions, ready for a trainer.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Training runs and versions</h3>
+            <p>
+              Read an ai-toolkit run where it was written and import it with its
+              sample images. Versions of one subject group behind a single row,
+              so a character trained four times is one entry with its history
+              under it. PixlStash tracks the runs; it does not run the trainer.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Two-way ComfyUI</h3>
+            <p>
+              Drive ComfyUI on a selection from inside PixlStash, or call
+              PixlStash nodes from your own workflows. What comes back arrives
+              tagged, with its People, Picture Set and Project associations
+              already attached, which puts it at stage 1 again.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Model shelf</h3>
+            <p>
+              Checkpoints and adapters in one place, with the folders they live
+              in, so you can see what you have before a run rather than after.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="hardware">
+        <h2 class="section-title" id="hardware">Where it runs</h2>
+        <p class="section-subtitle">
+          On your hardware. There is no cloud inference API in PixlStash and no
+          account to sign into for any of it.
+        </p>
+        <div class="ai-grid" style="margin-top: 22px">
+          <div class="ai-card">
+            <h3>CPU out of the box</h3>
+            <p>
+              The desktop app ships a ready-to-run CPU runtime, so every model
+              on this page works offline on first launch.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>GPU when you have one</h3>
+            <p>
+              Hardware is detected on install and GPU acceleration is offered as
+              an optional download: NVIDIA CUDA, or experimental AMD ROCm.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Models managed for you</h3>
+            <p>
+              Weights download once on first start and are cached. Move the
+              folder later and every file is copied, verified and removed from
+              the old location, with nothing downloaded again.
+            </p>
+          </div>
+          <div class="ai-card">
+            <h3>Licensing you choose</h3>
+            <p>
+              The face model pack is a setting. buffalo_l is the default;
+              AuraFace is there for commercial use, and switching keeps every
+              face and manual assignment intact.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="compare">
+        <h2 class="section-title" id="compare">Compared with Immich</h2>
+        <p class="section-subtitle">
+          Immich is a very good home photo server, and if a Google Photos
+          replacement is what you want, use it. It is worth being precise about
+          where the two overlap.
+        </p>
+        <div class="ai-compare-wrap" style="margin-top: 22px">
+          <table class="ai-compare">
+            <caption class="sr-only">
+              AI capabilities in Immich compared with PixlStash
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Capability</th>
+                <th scope="col">Immich</th>
+                <th scope="col">PixlStash</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">CLIP semantic search</th>
+                <td class="yes">Yes, with a wide model picker</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Face detection and recognition</th>
+                <td class="yes">Yes</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Duplicate detection</th>
+                <td class="yes">Yes</td>
+                <td class="yes">Yes, tiered queue with a dry run</td>
+              </tr>
+              <tr>
+                <th scope="row">Text in images (OCR)</th>
+                <td class="yes">Yes</td>
+                <td>No</td>
+              </tr>
+              <tr>
+                <th scope="row">Mobile apps with background sync</th>
+                <td class="yes">Yes</td>
+                <td>No</td>
+              </tr>
+              <tr>
+                <th scope="row">Automatic tagging</th>
+                <td>No</td>
+                <td class="yes">Yes, engine selectable per request</td>
+              </tr>
+              <tr>
+                <th scope="row">Captions and descriptions</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Segmentation</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Label review queue and tag health</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Quality and anomaly scoring</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Character likeness scoring</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Reverse face and likeness search</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Dataset export and run tracking</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Two-way ComfyUI integration</th>
+                <td>No</td>
+                <td class="yes">Yes</td>
+              </tr>
+              <tr>
+                <th scope="row">Pluggable model backends</th>
+                <td>No</td>
+                <td class="yes">Yes, tagger plugin API</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="ai-note" style="margin-top: 22px">
+          Immich documents two machine-learning tasks, smart search and facial
+          recognition, and does them well for the job it is built for: finding a
+          photo you already took. PixlStash does both of those and then keeps
+          going, because finding the picture is the start of the work rather
+          than the end of it.
+        </p>
+      </section>
+
+      <div class="page-footer">
+        <p>
+          <a href="features.html">See the rest of the features</a>
+          &nbsp;·&nbsp;
+          <a href="install.html">Install PixlStash</a>
+          &nbsp;·&nbsp;
+          <a href="index.html">Back to PixlStash home</a>
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/website/features.html
+++ b/website/features.html
@@ -347,8 +347,9 @@
           <div class="feature-card">
             <h3>Tagging and captions</h3>
             <p>
-              WD14, Florence-2 or JoyCaption, chosen per request rather than per
-              install. Re-tag any selection from the context menu.
+              PixlStash Tagger, WD14, Florence-2 or JoyCaption, chosen per
+              request rather than per install. Re-tag any selection from the
+              context menu.
             </p>
           </div>
           <div class="feature-card">

--- a/website/features.html
+++ b/website/features.html
@@ -322,6 +322,64 @@
 
       <section class="section">
         <div class="section-header">
+          <h2 class="section-title">AI features</h2>
+          <p class="section-subtitle">
+            Semantic search, face recognition, tagging, captioning, scoring and
+            a review queue that checks the models' work. All of it runs on your
+            machine.
+          </p>
+        </div>
+        <div class="feature-grid feature-grid--primary">
+          <div class="feature-card">
+            <h3>Semantic search</h3>
+            <p>
+              Describe what you are looking for and get pictures back, tagged or
+              not. CLIP embeddings, computed locally.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Face recognition</h3>
+            <p>
+              Faces are detected, embedded and grouped into characters you name.
+              Search the library by uploading one face.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Tagging and captions</h3>
+            <p>
+              WD14, Florence-2 or JoyCaption, chosen per request rather than per
+              install. Re-tag any selection from the context menu.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Label review queue</h3>
+            <p>
+              A ranked queue of the tags the models most likely got wrong, plus
+              a health board per tag. Auto-tags become tags you can trust.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Quality and anomaly scoring</h3>
+            <p>
+              Smart score sorts a large set by what is worth looking at, with a
+              calibrated penalty for malformed anatomy and render defects.
+            </p>
+          </div>
+          <div class="feature-card">
+            <h3>Round trip to ComfyUI</h3>
+            <p>
+              Generate from a selection and the results come back tagged, with
+              their people, sets and projects already attached.
+            </p>
+          </div>
+        </div>
+        <p style="margin-top: 20px">
+          <a href="ai.html">All AI features, and how they compare to Immich →</a>
+        </p>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
           <h2 class="section-title">The folders you already have</h2>
           <p class="section-subtitle">
             Point PixlStash at a folder and it reads it where it sits, turning
@@ -970,43 +1028,13 @@
 
       <section class="section">
         <div class="section-header">
-          <h2 class="section-title">Other Features</h2>
+          <h2 class="section-title">Other features</h2>
           <p class="section-subtitle">
-            Automatic tagging, semantic search, and metadata so you can navigate
-            large libraries with fewer steps.
+            The rest of the toolkit. The AI features have
+            <a href="ai.html">their own page</a>.
           </p>
         </div>
         <div class="feature-grid">
-          <div class="feature-card">
-            <h3>AI tagging</h3>
-            <p>
-              Batch-tag images and faces with state-of-the-art models. Re-tag
-              any selection or individual image from the context menu using the
-              engine of your choice.
-            </p>
-          </div>
-          <div class="feature-card">
-            <h3>JoyCaption &amp; selectable engines</h3>
-            <p>
-              Use JoyCaption for tagging or image descriptions. Choose which
-              engine to use for each operation, and switch models per-request
-              without touching the settings page.
-            </p>
-          </div>
-          <div class="feature-card">
-            <h3>Anomaly detection</h3>
-            <p>
-              Automatically applies a ViT model to detect anomalies in your
-              images, like malformed anatomy.
-            </p>
-          </div>
-          <div class="feature-card">
-            <h3>Automatic grouping</h3>
-            <p>
-              Automatically groups similar images for easier organisation and
-              review.
-            </p>
-          </div>
           <div class="feature-card">
             <h3>Plugin system</h3>
             <p>

--- a/website/index.html
+++ b/website/index.html
@@ -7,7 +7,7 @@
     <title>PixlStash | Image Library for Creators</title>
     <meta
       name="description"
-      content="PixlStash is a local image library for photographers and AI creators with full undo and redo, duplicate review, search, tagging, and dataset exports."
+      content="PixlStash is a local image library for photographers and AI creators. CLIP semantic search, face recognition, automatic tagging and captioning, quality and anomaly scoring, a label review queue, and two-way ComfyUI integration, all running on your own hardware."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -477,6 +477,36 @@
         background: rgba(255, 255, 255, 1);
       }
     </style>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "PixlStash",
+        "applicationCategory": "MultimediaApplication",
+        "operatingSystem": "Windows, macOS, Linux",
+        "url": "https://pixlstash.dev/",
+        "downloadUrl": "https://pixlstash.dev/install.html",
+        "description": "A local picture library server for organizing, filtering and reviewing large image collections, with its AI running on your own hardware.",
+        "featureList": [
+          "CLIP semantic text search across the whole library (OpenCLIP ViT-B-32)",
+          "Face detection and face recognition (InsightFace SCRFD-10G, buffalo_l or AuraFace)",
+          "Automatic face grouping into named characters",
+          "Reverse face search and reverse likeness search",
+          "Automatic tagging with selectable engines (WD14, Florence-2, JoyCaption)",
+          "Image captions and descriptions",
+          "Object segmentation",
+          "Tag review queue and tag health board",
+          "Duplicate detection with a tiered review queue",
+          "Smart score and calibrated anomaly detection",
+          "Character likeness scoring",
+          "Dataset export and ai-toolkit run tracking",
+          "Two-way ComfyUI integration",
+          "Tagger plugin API",
+          "NVIDIA CUDA, experimental AMD ROCm, or CPU inference",
+          "All inference runs locally, no cloud API"
+        ]
+      }
+    </script>
   </head>
   <body>
     <div class="shell">
@@ -486,14 +516,16 @@
       <div class="page-hero">
         <h1>A desktop image manager for creators</h1>
         <p>
-          Organize and search thousands of images by content or face, all on
-          your own machine.<br />Easy install with no server to set up... unless
-          you want to!
+          Search thousands of images by content or face, tag and score them,
+          check what the models got wrong, and send the good ones on. Every
+          model runs on your own machine.<br />Easy install with no server to
+          set up... unless you want to!
         </p>
 
         <div class="hero-badges">
           <span class="badge">Simple install</span>
           <span class="badge">Runs locally</span>
+          <span class="badge">On-device AI, no cloud API</span>
           <span class="badge">Headless server option</span>
           <span class="badge">Supports NVIDIA and AMD GPUs</span>
           <span class="badge">ComfyUI nodes</span>
@@ -547,6 +579,32 @@
           <div class="video-card">
             <video
               src="assets/VideoMain.mp4"
+              autoplay
+              loop
+              muted
+              playsinline
+            ></video>
+          </div>
+        </div>
+        <div class="feature">
+          <div class="feature-text">
+            <span class="feature-number">The AI</span>
+            <h2>Models that do the work, not just the finding</h2>
+            <p>
+              Semantic search and face recognition are the start. PixlStash also
+              tags and captions with the engine you pick, scores for quality and
+              malformed anatomy, and gives you a review queue for the labels it
+              is least sure about.
+            </p>
+            <p>
+              All of it runs on your own hardware, CPU or GPU. There is no cloud
+              API and no account to sign into.
+            </p>
+            <p><a href="ai.html">See all the AI features →</a></p>
+          </div>
+          <div class="video-card">
+            <video
+              src="assets/05-SemanticSearch.mp4"
               autoplay
               loop
               muted
@@ -617,15 +675,31 @@
             images through generation tools. Yes, it can also work as a home
             server.
           </p>
-          <p class="immich-lead">With PixlStash you get:</p>
+          <p class="immich-body">
+            <strong
+              >It does both of the AI features Immich is known for.</strong
+            >
+            CLIP semantic search, face detection and recognition, and duplicate
+            detection are all here too. Immich has OCR and mobile apps with
+            background sync, which PixlStash does not.
+          </p>
+          <p class="immich-lead">On top of those, with PixlStash you get:</p>
           <ul class="immich-list">
             <li>
-              A tag review queue, so auto-tags are verified before they're
-              trusted.
+              Automatic tagging and captioning, with the engine selectable per
+              request: WD14, Florence-2 or JoyCaption.
             </li>
             <li>
-              Segmentation, selectable taggers, and a choice of GPU or CPU
-              backend.
+              A tag review queue and a tag health board, so auto-tags are
+              verified before they're trusted.
+            </li>
+            <li>
+              Quality, anomaly and character-likeness scoring, so a large set
+              sorts by what is worth looking at.
+            </li>
+            <li>
+              Segmentation, reverse face search, reverse likeness search, and a
+              choice of GPU or CPU backend.
             </li>
             <li>
               Two-way ComfyUI integration: control ComfyUI from PixlStash, or
@@ -637,8 +711,13 @@
             <li>
               <a
                 style="color: var(--accent-2); text-decoration: underline"
+                href="ai.html"
+                >Every AI feature, side by side with Immich's</a
+              >, and
+              <a
+                style="color: var(--accent-2); text-decoration: underline"
                 href="features.html"
-                >And a whole host of other work features</a
+                >a whole host of other work features</a
               >
             </li>
           </ul>

--- a/website/index.html
+++ b/website/index.html
@@ -492,7 +492,7 @@
           "Face detection and face recognition (InsightFace SCRFD-10G, buffalo_l or AuraFace)",
           "Automatic face grouping into named characters",
           "Reverse face search and reverse likeness search",
-          "Automatic tagging with selectable engines (WD14, Florence-2, JoyCaption)",
+          "Automatic tagging with selectable engines (PixlStash Tagger, WD14, Florence-2, JoyCaption)",
           "Image captions and descriptions",
           "Object segmentation",
           "Tag review queue and tag health board",
@@ -687,7 +687,8 @@
           <ul class="immich-list">
             <li>
               Automatic tagging and captioning, with the engine selectable per
-              request: WD14, Florence-2 or JoyCaption.
+              request: our own PixlStash Tagger, WD14, Florence-2 or
+              JoyCaption.
             </li>
             <li>
               A tag review queue and a tag health board, so auto-tags are

--- a/website/nav.js
+++ b/website/nav.js
@@ -13,6 +13,7 @@
     { href: "index.html", label: "Home" },
     { href: "introduction.html", label: "Getting started" },
     { href: "features.html", label: "Features" },
+    { href: "ai.html", label: "AI" },
     { href: "comfyui.html", label: "ComfyUI" },
     {
       href: "whatsnew.html",

--- a/website/pixlstash.css
+++ b/website/pixlstash.css
@@ -559,3 +559,17 @@ a {
     font-size: 1.6rem;
   }
 }
+
+/* Visually hidden, still read aloud. Used for table captions and any label
+   that a sighted reader gets from layout alone. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Why

A Google AI Overview comparing PixlStash and Immich listed our AI as
"Interrogator captions, anomaly tagging, similarity grouping" against Immich's
"Facial recognition & semantic CLIP search", reading as rough parity.

That was an accurate readback of the site. Those three items are literally the
first three cards in the `Other Features` grid at the bottom of `features.html`,
and the words *CLIP* and *facial recognition* appeared nowhere on the site at
all, despite both shipping.

## What changed

- **New `website/ai.html`.** Every AI capability under its own heading with the
  model behind it, organised as the label → review → score → train loop rather
  than a flat list. Ends with a capability-by-capability Immich comparison table.
- **`nav.js`:** an `AI` entry between Features and ComfyUI.
- **JSON-LD `SoftwareApplication` with a `featureList`** on `ai.html` and
  `index.html`. The site previously had no structured data on any page.
- **`features.html`:** an AI features section at the top of the page. The
  bottom grid is renamed `Other features` and keeps only the non-AI cards, so
  nothing is listed twice.
- **`index.html`:** an AI band in the feature flow, updated hero copy and meta
  description, and the `Coming from Immich?` block now states the parity
  (CLIP search, face recognition, duplicate detection) before the differences.
- **`README.md`:** the same, since the overview cited GitHub as a source.
- **`pixlstash.css`:** adds a `.sr-only` utility for the table caption.

## Claims

Every capability listed was verified against the code, not the plans. Two
things the comparison table says explicitly because they are true: Immich has
OCR and mobile apps with background sync, PixlStash does not. The training card
says PixlStash tracks ai-toolkit runs rather than running the trainer.

## Design

Stage colours reuse the `--tertiary` / `--secondary` / `--accent` / `--primary`
tokens already defined in `pixlstash.css` but unused on the site, so no new hue
enters the brand. They are carried as a rule and a tinted badge, never as small
coloured text: raspberry on panel is ~3.1:1 and warm-white on amber ~3.3:1, both
under the 4.5:1 floor. The pipeline is an `<ol>` of real text rather than a
diagram image, so it is readable by a screen reader and extractable by a scraper.

Checked in light and dark at 1280px and at the mobile breakpoints, no console
errors on any of the three pages.