### PR TITLE
Global folder for unprojected pictures, and a layout dialog that explains the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
   delete one and it is gone from the grid. A move into a folder named after a
   project, person or set is offered in the pending-moves review, as it already
   was for reference folders.
+- Folder layouts: a picture with no project now goes into a `Global` folder at
+  the project level instead of sitting one level higher. Every person and set
+  folder is at the same depth, and a picture that later gains a project moves
+  out of `Global` on its own.
+- The layout dialog now says which of project, person, set and tag actually
+  files a picture under the layout you picked, and its folder preview lists the
+  library folder itself, so the pictures nothing files are visible instead of
+  missing from the tree.
 - `libraries backup` now counts picture files in the library folder that have
   no PixlStash record and asks whether to include them. Enter keeps them, so a
   restore puts back exactly what was there; `--skip-orphans` leaves them out

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3135,13 +3135,28 @@ detail, so this section is the map rather than a second copy of it.
 
 A `Layout` is an ordered list of segments, one folder level each. A segment
 holds one or more `Facet`s (`PROJECT`, `PERSON`, `SET`, `TAG`) and the first the
-picture has a value for wins; a segment nothing fills is **skipped rather than
-left as an empty folder**, which keeps the tree two deep instead of five. A new
-library starts on `DEFAULT_LAYOUT`, `Project` then `Person or Set`.
+picture has a value for wins. A segment nothing fills becomes `GLOBAL_FOLDER`
+(`Global`) **when a later segment is filled**, and is dropped when none is: under
+`Project` then `Person or Set` a picture with only a person is `Global/Mira` and
+one with only a project is `Nordvik`, never `Nordvik/Global`. That keeps the
+tree two deep instead of five while putting every person folder at one depth,
+and — the reason `Global` is in the layout's *language* rather than being
+decoration — it gives an unprojected picture a folder to move **out of** when a
+project arrives (#1161). A new library starts on `DEFAULT_LAYOUT`, `Project`
+then `Person or Set`.
+
+`_walk` therefore reads `Global` at every segment whatever the picture is, and
+treats it as the picture's own only where nothing fills that segment. Reading it
+only where the picture has nothing would make it unparseable in exactly the case
+that has to move. The cost, stated once: a folder of the owner's own literally
+named `Global` at a layout level is adopted by the layout instead of being the
+permanent override an unreadable name would be. A picture that fills no segment
+at all still answers `layout.unfiled`, not `Global`, which is what keeps the
+migration's unfiled sweep an opt-in rather than something `Global` does anyway.
 
 | Function | Answers |
 |---|---|
-| `render(facets, layout)` | The folder the picture should be in, relative to the library root. A picture nothing files goes to `layout.unfiled`, defaulting to `Unassigned` — never the library root, which is where an unmigrated flat library lives. |
+| `render(facets, layout)` | The folder the picture should be in, relative to the library root. An unfilled segment with a filled one after it becomes `Global`; trailing ones are dropped. A picture nothing files goes to `layout.unfiled`, defaulting to `Unassigned` — never the library root, which is where an unmigrated flat library lives. |
 | `is_true(folder, facets, layout, known_names)` | Whether the folder it is *actually* in still describes it. Takes the **folder**, not the file path: guessing which trailing component was a file name would silently flip the answer for a path written with a trailing separator. A path carrying `.` or `..` is refused whole rather than normalised — tidying one would fabricate a level the path does not have. |
 
 The release rests on `is_true`, and on one property of it: **a path that does
@@ -6773,6 +6788,14 @@ returns a `ReconciledMove(outcome, removals, additions)`:
    deliberate "nothing files this" signal, not as an unreadable destination —
    the one component check `reconcile_move` makes before the general
    off-layout test.
+5. **Arriving under `Global`** is the same signal for one segment rather than
+   for the whole path. `read_named_components` consumes a `Global` component,
+   names nothing for it and carries on, so dragging a picture from
+   `Nordvik/Mira` to `Global/Mira` reads as "leave the project, still Mira" and
+   comes back as a removal; a real entity actually named `Global` wins, because
+   the facet lookup runs first. A bare `Global/` names nothing at all, so it
+   skips the off-layout test the same way the unfiled folder does — otherwise
+   the project the owner just dragged the picture out of would never come off.
 
 Measured on the owner's four real libraries (~59,000 pictures, DECISIONS.md):
 91–100% of assigned pictures have exactly one project or set, so `AMBIGUOUS`

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -781,7 +781,20 @@ is spent on the one thing that needs it. One pane, no steps:
   only part that shrinks (`flex: 0 1 auto` + ellipsis); the leaf identifies the
   row and always shows in full, and `title` carries the whole stored path.
   `have` renders a dash off `is_new`, not off `have == 0`, because a real folder
-  can legitimately hold nothing.
+  can legitimately hold nothing. **The library root is one of the rows** since
+  #1161 — `path: ""`, drawn as *Library root* at indent 0 with no breadcrumb.
+  It is in the list under the same non-zero rule as every other row, so it
+  appears only while pictures are actually in it, which with the unfiled sweep
+  off is exactly where the pictures the layout cannot place stay. Drawing every
+  folder except that one read as "nothing was left behind".
+- **The pane says what files a picture.** `filingHint` is derived from
+  `segments`, never written down, so it cannot drift from the builder above it:
+  it names the facets that are in the layout, the ones that are not ("a Tag does
+  not"), that an unfilled level becomes `Global`, and that a picture nothing
+  files at all has no folder and stays in the library root unless the sweep box
+  is ticked. The builder showed which facets were *in* the layout and nothing
+  said which were not, so an owner whose pictures were all tagged and none of
+  them in a project read the empty tree as a bug (#1161).
 - **The layout is frozen for the duration of a move**, in `scheduleSave`, every
   edit routes through it, so one guard covers the model, the debounce and the
   write. Editing mid-run makes later passes re-plan against a new layout, so

--- a/frontend/src/components/settings/LibraryLayoutDialog.test.js
+++ b/frontend/src/components/settings/LibraryLayoutDialog.test.js
@@ -437,6 +437,52 @@ describe("LibraryLayoutDialog", () => {
     );
   });
 
+  it("draws the library root as a row of its own (#1161)", async () => {
+    getLayoutMigrationPreview.mockResolvedValue({
+      ...WOULD_MOVE,
+      tree: [
+        {
+          path: "",
+          name: "",
+          depth: 0,
+          have: 903,
+          arriving: 0,
+          leaving: 0,
+          is_new: false,
+        },
+        ...WOULD_MOVE.tree,
+      ],
+    });
+
+    const wrapper = mountDialog();
+    await flushPromises();
+
+    const rows = wrapper.findAll(".layout-tree__row");
+    // Named, not blank: the pictures the layout cannot place stay here with
+    // the sweep off, and a nameless row is what made them invisible.
+    expect(rows[0].find(".layout-tree__label").text()).toBe("Library root");
+    expect(rows[0].find(".layout-tree__have").text()).toBe("903");
+    expect(rows[0].find(".layout-tree__crumbs").exists()).toBe(false);
+    expect(rows[0].find(".layout-tree__name").attributes("style")).toContain(
+      "0 * var(--indent-step)",
+    );
+    // Everything else still says what it said.
+    expect(rows[1].find(".layout-tree__label").text()).toBe("Harbour Nights");
+  });
+
+  it("says what files a picture, and what does not (#1161)", async () => {
+    const wrapper = mountDialog();
+    await flushPromises();
+
+    const hint = wrapper.find(".layout-filing").text();
+    // Derived from the layout on screen (`project/person,set`), so the facet
+    // it leaves out is named rather than left for the owner to infer.
+    expect(hint).toContain("Only a Project, Person or Set files a picture");
+    expect(hint).toContain("a Tag does not");
+    expect(hint).toContain("no Project is filed under Global");
+    expect(hint).toContain("stays in the library root");
+  });
+
   it("lists every folder rather than a count of the ones it left out", async () => {
     const wrapper = mountDialog();
     await flushPromises();

--- a/frontend/src/components/settings/LibraryLayoutDialog.vue
+++ b/frontend/src/components/settings/LibraryLayoutDialog.vue
@@ -336,6 +336,19 @@ const treeRows = computed(() => {
   const rows = preview.value?.tree || [];
   const present = new Set(rows.map((row) => row.path));
   return rows.map((row) => {
+    // The library root is `path: ""` and has no name of its own. It is in the
+    // response (#1161) because with the unfiled sweep off it is where the
+    // pictures the layout cannot place stay, and a tree that drew every folder
+    // except that one read as "nothing was left behind".
+    if (!row.path) {
+      return {
+        ...row,
+        name: "Library root",
+        title: "The library folder itself",
+        crumbs: "",
+        indent: 0,
+      };
+    }
     const parts = (row.path || row.name || "").split("/");
     // How many leading components are covered by an ancestor that is a row.
     let anchored = parts.length - 1;
@@ -344,6 +357,7 @@ const treeRows = computed(() => {
     }
     return {
       ...row,
+      title: row.path,
       // Muted, and only what no row above already says. Empty when the parent
       // is present, which is when the indent alone is enough.
       crumbs: parts.slice(anchored, -1).join(" / "),
@@ -351,6 +365,36 @@ const treeRows = computed(() => {
     };
   });
 });
+/**
+ * What actually files a picture, said out loud (#1161).
+ *
+ * The builder shows which facets are *in* the layout and nothing said which
+ * were not, so an owner whose pictures are all tagged and none of them in a
+ * project read the empty tree as a bug. Derived from `segments` rather than
+ * written down, so it cannot drift from the layout above it.
+ */
+const filingHint = computed(() => {
+  if (!isOn.value) return "";
+  const used = new Set(segments.value.flat());
+  const list = (words) =>
+    words.length < 2
+      ? words[0]
+      : `${words.slice(0, -1).join(", ")} or ${words[words.length - 1]}`;
+  const inside = LAYOUT_FACETS.filter((f) => used.has(f.value)).map(
+    (f) => f.label,
+  );
+  const outside = LAYOUT_FACETS.filter((f) => !used.has(f.value)).map(
+    (f) => f.label,
+  );
+  const first = describeSegment(segments.value[0]);
+  return [
+    `Only a ${list(inside)} files a picture under this layout` +
+      (outside.length ? `; a ${list(outside)} does not.` : "."),
+    `A level nothing fills becomes “Global”, so a picture with no ${first} is filed under Global.`,
+    `A picture nothing files at all has no folder of its own: it stays in the library root unless the box above is ticked.`,
+  ].join(" ");
+});
+
 /** Refusals worth naming, whichever half of the flow produced them. */
 const refusals = computed(() => {
   const counts = { ...(preview.value?.skipped_counts || {}) };
@@ -659,6 +703,7 @@ function netDelta(row) {
       </div>
 
       <template v-if="isOn">
+        <p class="layout-filing">{{ filingHint }}</p>
         <div class="layout-tree__head">
           <span>{{
             migrating ? "Filling in" : "Your folders, as this layout draws them"
@@ -672,7 +717,7 @@ function netDelta(row) {
         >
           <div
             v-for="row in treeRows"
-            :key="row.path"
+            :key="row.path || '/'"
             class="layout-tree__row"
             :class="{ 'layout-tree__row--new': row.is_new }"
             role="row"
@@ -681,7 +726,7 @@ function netDelta(row) {
               class="layout-tree__name"
               role="cell"
               :style="treeIndent(row.indent)"
-              :title="row.path"
+              :title="row.title"
             >
               <v-icon size="14">mdi-folder-outline</v-icon>
               <span class="layout-tree__path">
@@ -974,6 +1019,14 @@ function netDelta(row) {
   padding-inline: var(--space-3);
   min-height: 34px;
   font-size: var(--text-sm);
+}
+
+/* ---- what files a picture ------------------------------------------------ */
+.layout-filing {
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
+  margin: 0 0 var(--space-3);
 }
 
 /* ---- the tree ------------------------------------------------------------ */

--- a/pixlstash/services/layout_migration_service.py
+++ b/pixlstash/services/layout_migration_service.py
@@ -392,9 +392,13 @@ def _folder_tree(
 ) -> list:
     """The library as this layout would draw it, every folder of it.
 
-    A folder is in it when anything about it is non-zero, which is why the
-    library root is not: it has no row of its own to show, and a synthetic one
-    would draw a level the owner does not have. Uncapped on purpose: an earlier
+    A folder is in it when anything about it is non-zero, **and the library root
+    is one of them** (#1161). It has no name of its own, which is why it was
+    left out originally, but leaving it out made the pictures the layout cannot
+    place invisible: with the unfiled sweep off they stay in the root, and a
+    tree that draws every folder except the one they are in reads as "nothing
+    stayed behind". It is not synthetic - it is a row only when pictures are
+    actually in it, the same rule as every other row. Uncapped on purpose: an earlier
     version kept the sixty busiest and counted the rest, and on a library filed
     by date that was "...and 299 more folders" over the rows the owner needed
     to check. A few thousand rows is a list; a count of the rows withheld is
@@ -407,7 +411,6 @@ def _folder_tree(
     and that is the inclusion rule, not a cap.
     """
     paths = set(have) | set(arriving) | set(leaving)
-    paths.discard("")
     return [
         {
             "path": path,

--- a/pixlstash/utils/library_layout.py
+++ b/pixlstash/utils/library_layout.py
@@ -2,8 +2,10 @@
 
 A layout is an ordered list of segments, one folder level each. A segment holds
 one or more facets and the first that applies wins; a segment with nothing to
-fill it is skipped rather than left as an empty folder. A new library starts on
-``DEFAULT_LAYOUT``, ``Project`` then ``Person or Set``.
+fill it becomes ``Global`` when a later segment is filled and is dropped when
+none is, so ``Project`` then ``Person or Set`` puts a picture with only a person
+in ``Global/Mira`` and one with only a project in ``Nordvik``. A new library
+starts on ``DEFAULT_LAYOUT``, ``Project`` then ``Person or Set``.
 
 ``render`` gives the folder a picture should be in. ``is_true`` says whether the
 folder it *is* in still describes it, and that one is the release: **a path that
@@ -48,6 +50,15 @@ _WINDOWS_RESERVED = frozenset(
 
 # What a name collapses to when sanitising leaves nothing of it at all.
 _EMPTY_FOLDER_NAME = "_unnamed"
+
+# The folder a segment gets when nothing fills it but a later segment is filled.
+# `Project / Person or Set` without the project is `Global/Mira`, not `Mira`, so
+# every person folder sits at one depth and a picture that gains a project has a
+# folder to move out of. Part of the layout's language rather than a decoration:
+# `_walk` reads it at every segment, which is what lets `Global/Mira` stop being
+# true. The cost is that a folder of the owner's own literally named `Global` is
+# adopted by the layout instead of being a permanent override.
+GLOBAL_FOLDER = "Global"
 
 
 class Facet(str, Enum):
@@ -200,17 +211,30 @@ def render(facets: FacetValues, layout: Layout) -> str:
             that is missing or empty simply does not fill a segment.
         layout: The layout to place it under.
 
+    A segment nothing fills is written as :data:`GLOBAL_FOLDER` when a later
+    segment is filled, and dropped when none is. So under ``Project`` then
+    ``Person or Set`` a picture with only a person lands in ``Global/Mira``
+    rather than ``Mira`` - every person folder at one depth, and a folder for
+    the picture to move *out of* when it gains a project. Trailing empties are
+    still dropped, so a project with no person is ``Nordvik``, not
+    ``Nordvik/Global``, and a picture nothing files at all still answers
+    ``layout.unfiled`` - which is what keeps the migration's unfiled sweep an
+    opt-in rather than something ``Global`` quietly does anyway.
+
     Returns:
         A ``/``-separated relative folder path, never absolute and never empty:
         a picture that fills no segment at all gets ``layout.unfiled``.
         Components never contain ``/`` themselves, so splitting is safe.
     """
-    parts = []
-    for segment in layout.segments:
-        value = _segment_value(segment, facets)
-        if value is not None:
-            parts.append(folder_name(value))
-    return "/".join(parts) if parts else layout.unfiled
+    parts: list[str | None] = [
+        None if value is None else folder_name(value)
+        for value in (_segment_value(segment, facets) for segment in layout.segments)
+    ]
+    while parts and parts[-1] is None:
+        parts.pop()
+    if not parts:
+        return layout.unfiled
+    return "/".join(part if part is not None else GLOBAL_FOLDER for part in parts)
 
 
 def _components(folder: str) -> tuple[str, ...]:
@@ -306,8 +330,20 @@ def _walk(
         Everything from ``owned`` on is the owner's own and travels with the
         picture unchanged.
     """
-    vocab = [_segment_keys(segment, known_names) for segment in layout.segments]
-    mine = [_segment_keys(segment, facets) for segment in layout.segments]
+    # ``Global`` is readable at every segment, whatever the picture is, because
+    # that is what lets ``Global/Mira`` stop being true when a project arrives:
+    # reading it only where the picture has nothing would make it unparseable
+    # exactly in the case that has to move. It is the picture's own only where
+    # nothing fills the segment - which is exactly where ``render`` writes it.
+    global_key = _match_key(GLOBAL_FOLDER)
+    vocab = [
+        _segment_keys(segment, known_names) | {global_key}
+        for segment in layout.segments
+    ]
+    mine = []
+    for segment in layout.segments:
+        keys = _segment_keys(segment, facets)
+        mine.append(keys or {global_key})
 
     still_true = True
     owned = 0
@@ -584,6 +620,7 @@ def read_named_components(
             key: name for key, name in keyed.items() if name is not _AMBIGUOUS
         }
     result: list[tuple[Facet, str]] = []
+    global_key = _match_key(GLOBAL_FOLDER)
     next_segment = 0
     for component in components:
         key = _match_key(component)
@@ -596,6 +633,15 @@ def read_named_components(
                     break
             if found is not None:
                 break
+        if found is None and key == global_key and next_segment < len(layout.segments):
+            # ``Global`` consumes its segment and names nothing. An owner who
+            # drags a picture into ``Global/Mira`` is saying "no project, and
+            # Mira's", so the segment has to be consumed for ``Mira`` to be read
+            # one level down - and the project the picture left then falls out
+            # of this read as a removal, which is the whole point. A real entity
+            # named ``Global`` wins: the facet search above runs first.
+            next_segment += 1
+            continue
         if found is None:
             break
         index, facet, name = found
@@ -648,7 +694,12 @@ def reconcile_move(
         new_read: list[tuple[Facet, str]] = []
     else:
         new_read = read_named_components(new_components, layout, known_names)
-        if not new_read:
+        # A bare ``Global/`` names nothing and is still an arrival the layout
+        # understands - "no project" - exactly as the unfiled folder is. Without
+        # this it would read as off-layout and the project the picture just left
+        # would never come off.
+        leads_with_global = _match_key(new_components[0]) == _match_key(GLOBAL_FOLDER)
+        if not new_read and not leads_with_global:
             # Names nothing the layout's vocabulary knows. The path was
             # already followed by the scan; nothing here is an override to
             # correct, so nothing is touched.

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -126,10 +126,67 @@ def test_render_fills_both_segments():
     assert render(picture, DEFAULT_LAYOUT) == "2024 Shoots/Mira"
 
 
-def test_a_segment_with_nothing_to_fill_it_is_skipped_not_left_empty():
-    """No empty folder level: the set picture sits one deep, not two."""
-    assert render(facets(sets=["mira-lora-v3"]), DEFAULT_LAYOUT) == "mira-lora-v3"
+def test_an_unfilled_segment_becomes_global_only_when_a_later_one_is_filled():
+    """The set picture gets a Global project level; the project picture does not.
+
+    Both directions matter. Writing the placeholder is what puts every person
+    and set folder at one depth and gives an unprojected picture a folder to
+    move out of; dropping the trailing one is what keeps a project with no
+    person as ``2024 Shoots`` rather than ``2024 Shoots/Global``.
+    """
+    assert (
+        render(facets(sets=["mira-lora-v3"]), DEFAULT_LAYOUT) == "Global/mira-lora-v3"
+    )
     assert render(facets(projects=["2024 Shoots"]), DEFAULT_LAYOUT) == "2024 Shoots"
+
+
+def test_a_picture_nothing_files_is_unfiled_rather_than_global():
+    """The unfiled sweep stays an opt-in: Global must not swallow its case."""
+    assert render(facets(), DEFAULT_LAYOUT) == DEFAULT_LAYOUT.unfiled
+    assert migrate_destination("2024", facets(), DEFAULT_LAYOUT) is None
+
+
+def test_global_stops_being_true_when_a_project_arrives():
+    """The whole reason Global is in the layout's language rather than decoration."""
+    vocab = {Facet.PROJECT: ["Client · Nordvik"], Facet.PERSON: ["Mira"]}
+    mira = {Facet.PERSON: ["Mira"]}
+    assert is_true("Global/Mira", mira, LAYOUT, vocab)
+    assert relocate("Global/Mira", mira, LAYOUT, vocab) is None
+
+    projected = {Facet.PROJECT: ["Client · Nordvik"], Facet.PERSON: ["Mira"]}
+    assert not is_true("Global/Mira", projected, LAYOUT, vocab)
+    assert relocate("Global/Mira", projected, LAYOUT, vocab) == "Client · Nordvik/Mira"
+    # The owner's own tail below the layout travels, as it does for any move.
+    assert (
+        relocate("Global/Mira/2026-08", projected, LAYOUT, vocab)
+        == "Client · Nordvik/Mira/2026-08"
+    )
+
+
+def test_an_existing_person_folder_at_the_old_depth_still_reads_true():
+    """No churn for a library laid out before Global existed."""
+    mira = {Facet.PERSON: ["Mira"]}
+    vocab = {Facet.PROJECT: ["Client · Nordvik"], Facet.PERSON: ["Mira"]}
+    assert is_true("Mira", mira, LAYOUT, vocab)
+    assert relocate("Mira", mira, LAYOUT, vocab) is None
+
+
+def test_moving_a_picture_into_global_takes_its_project_off():
+    """The mirror of render: Global reads as "no project", not as off-layout."""
+    vocab = {Facet.PROJECT: ["Client · Nordvik"], Facet.PERSON: ["Mira"]}
+    held = {Facet.PROJECT: ["Client · Nordvik"], Facet.PERSON: ["Mira"]}
+    moved = reconcile_move("Client · Nordvik/Mira", "Global/Mira", held, LAYOUT, vocab)
+    assert moved.outcome is MoveOutcome.UNAMBIGUOUS
+    assert moved.removals == ((Facet.PROJECT, "Client · Nordvik"),)
+    assert moved.additions == ()
+
+    # And back out of it, which is an addition and nothing else.
+    back = reconcile_move(
+        "Global/Mira", "Client · Nordvik/Mira", {Facet.PERSON: ["Mira"]}, LAYOUT, vocab
+    )
+    assert back.outcome is MoveOutcome.UNAMBIGUOUS
+    assert back.additions == ((Facet.PROJECT, "Client · Nordvik"),)
+    assert back.removals == ()
 
 
 def test_the_first_facet_that_applies_wins_within_a_segment():
@@ -360,7 +417,9 @@ def test_an_off_layout_folder_is_a_permanent_override():
 
 def test_the_unfiled_folder_empties_itself_when_something_files_the_picture():
     assert relocate("Unassigned", {}, LAYOUT, VOCAB) is None
-    assert relocate("Unassigned", {Facet.PERSON: ["Mira"]}, LAYOUT, VOCAB) == "Mira"
+    assert (
+        relocate("Unassigned", {Facet.PERSON: ["Mira"]}, LAYOUT, VOCAB) == "Global/Mira"
+    )
 
 
 def test_losing_every_assignment_files_the_picture_as_unfiled():
@@ -2114,6 +2173,17 @@ def test_the_preview_draws_the_tree_the_layout_would_make(library):
 
     assert tree == [
         {
+            # The library root itself. Three pictures sit here and two leave;
+            # without this row that was invisible (#1161).
+            "path": "",
+            "name": "",
+            "depth": 0,
+            "have": 3,
+            "arriving": 0,
+            "leaving": 2,
+            "is_new": False,
+        },
+        {
             "path": "00 Loose",
             "name": "00 Loose",
             "depth": 0,
@@ -2161,15 +2231,24 @@ def test_the_preview_draws_the_tree_the_layout_would_make(library):
     ]
 
 
-def test_the_tree_has_no_row_for_the_library_root(library):
-    """Three pictures sit at the root and two of them leave it, and none of that
-    is a row: the root is what every path is relative to, so a row for it would
-    draw a level the owner does not have."""
+def test_the_tree_draws_the_library_root_when_pictures_are_in_it(library):
+    """Three pictures sit at the root and two of them leave it, and that is a row.
+
+    It was left out until #1161 on the grounds that the root is what every path
+    is relative to. But with the unfiled sweep off the root is exactly where the
+    pictures the layout cannot place stay, and a tree drawing every folder
+    except that one read as "nothing was left behind". It is still not
+    synthetic: it is a row only while pictures are actually in it, which is the
+    same rule every other row is in the list under.
+    """
     session, root = library["session"], library["root"]
     _drawable_library(library)
 
     tree = migration.preview_in_session(session, root)["tree"]
-    assert all(entry["path"] for entry in tree)
+    (root_row,) = [entry for entry in tree if entry["path"] == ""]
+    assert root_row["have"] == 3
+    assert root_row["leaving"] == 2
+    assert root_row["is_new"] is False
     assert [entry["path"] for entry in tree] == sorted(
         entry["path"] for entry in tree
     ), "path order is what lets the screen indent on depth without re-sorting"


### PR DESCRIPTION
Fixes #1161.

With `Project / Person or Set`, a picture with no project sat one level up from every other picture, and one with no project, set or named person stayed in the library root with nothing on screen saying why — the preview tree had no root row, so those pictures were simply absent from the argument the dialog makes.

### The layout change

`render` writes `GLOBAL_FOLDER` (`Global`) for a segment nothing fills **when a later segment is filled**, and drops it when none is:

| picture | before | after |
|---|---|---|
| project + person | `Nordvik/Mira` | `Nordvik/Mira` |
| person only | `Mira` | `Global/Mira` |
| project only | `Nordvik` | `Nordvik` |
| nothing | `Unassigned` | `Unassigned` |

The last row is the one that matters for safety: a picture nothing files still answers `layout.unfiled`, so the migration's unfiled sweep stays the opt-in it was rather than something `Global` quietly does anyway.

`Global` is in the layout's *language*, not decoration. `_walk` reads it at every segment whatever the picture is — reading it only where the picture has nothing would make it unparseable in exactly the case that has to move — and treats it as the picture's own only where nothing fills that segment. That is what makes `Global/Mira` stop being true when a project arrives and relocate to `Nordvik/Mira`, tail carried. `read_named_components` consumes a `Global` component and names nothing for it, so an owner dragging `Nordvik/Mira` → `Global/Mira` outside PixlStash reads back as "leave the project, still Mira"; a real entity named `Global` wins, because the facet lookup runs first.

**Existing libraries do not churn.** A person folder at the old depth (`Mira/`) still reads true and does not move — only `render` and the explicit migration place at the new depth. The one behaviour cost, stated in the module and in §13: a folder of the owner's own literally named `Global` at a layout level is now adopted by the layout instead of being a permanent override.

### The dialog

- The migration preview includes the library root (`path: ""`), drawn as *Library root*, under the same non-zero rule as every other row — so it appears exactly when pictures are actually in it.
- A sentence derived from `segments` (never written down, so it cannot drift from the builder) names what files a picture, what does not, that an unfilled level becomes `Global`, and that a picture nothing files stays in the root unless the sweep box is ticked.

### Tests

`tests/test_library_layout.py`: Global written only ahead of a filled segment, unfiled untouched by it, `Global/Mira` false once a project arrives (with the tail carried), an old-depth folder still true, and the reconciliation both directions. `LibraryLayoutDialog.test.js`: the root row and the sentence. Two existing tests asserted the old behaviour and are updated in place; one inverted test kept its reasoning in the docstring.

`tests/test_architecture_guardrails.py::test_no_unsanctioned_private_address_literal` fails on this branch and on `develop` alike — it is reading a local `electron/node_modules` and is not from this diff.