### PR TITLE
Hub start-up: keep the owner's folder modes, never rename an unreadable vault, boot past a name collision

### DIFF
--- a/changelog.d/1200.md
+++ b/changelog.d/1200.md
@@ -1,0 +1,8 @@
+- Fixed: adding a library to a folder of pictures you already had no longer
+  changes that folder's permissions. The library database inside it is kept
+  private either way; the folder is left exactly as PixlStash found it.
+- Fixed: a library database PixlStash cannot read at that moment - locked by
+  another program, on a disk that is full, or with its permissions changed -
+  is no longer offered "start over with an empty library database". PixlStash
+  now says what to fix and leaves the file alone. A database that really is
+  damaged still gets the offer.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2792,6 +2792,23 @@ instead of an offer deletes the file by hand to get the app started. A
 *fingerprint conflict* is not this case — that vault loads fine, and the answer
 is to put the right one back.
 
+**A failure about the machine is never turned into that offer**
+(release-review item 27). `_ENVIRONMENTAL_SQLITE_FAILURES` — locked, disk I/O,
+cannot open, full, read-only, permission denied, malformed image, out of memory
+— names the findings that say nothing about what the file contains, and
+`_is_environmental_failure` is the one classifier all three paths to the offer
+now ask: `unusable_vault_from_open_failure` (a migration that raised),
+`_vault_is_loadable` (the recovery in `_offer_a_usable_library`, reached on
+*every* start-up after the first) and the first-run `attach`. Before v1.11.1
+only the first of the three asked it, and `validate_vault_folder` reports "not
+a vault" and "this machine could not read it" as the same `NotAVaultError`, so a
+vault left mode 0000 by a bad restore, or held by another process, was offered
+"start over with an empty library database" — and `PIXLSTASH_RECREATE_VAULT=1`
+would then rename a perfectly good catalogue aside. The environmental cases now
+raise a plain `HubBootstrapError` saying what to fix; `SQLITE_NOTADB` is
+deliberately not in the list, because "this file is not a database" is exactly
+what the offer is for.
+
 Hub loss therefore does not re-import the blank legacy identity or deadlock
 registration. A recreated hub mints a fresh immutable registry UUID, records
 the vault fingerprint only as advisory evidence, creates an unclaimed hub
@@ -3272,7 +3289,7 @@ indexing the same pictures.
 **The two routes that take a path resolve it before they validate it.**
 `validate_reference_folder_path` compares against a literal blocklist, so
 checking the string the caller sent lets `~/link-to-etc` through — and `POST
-/libraries` then chmods that folder 0700 and writes a database into it. The
+/libraries` then writes a database into whatever folder that names. The
 sibling that gets this right is `validate_reference_folder_accessible`, which
 realpaths first; `_safe_folder` follows it, not `GET /filesystem/browse`'s
 ordering. A relative path is refused explicitly before resolution, because
@@ -3340,14 +3357,19 @@ Two placements in it are load-bearing:
   adds of one name both pass. `create`'s early call is the deliberate exception
   and is advisory — its job is to fail before a vault is built.
 
-**`register_pending` opts out** (`unique_name=False`). Its caller is start-up:
-`bootstrap._register_first_library` passes the hardcoded `"Library 1"` and does
-not catch `LibraryExistsError`, so refusing there would turn a duplicate label —
-a nuisance — into a server that will not boot. `record_legacy_preparation`
-writes its row directly and is outside the check for the same reason. The rule
-is *verbs a person types a name at refuse; start-up records what it was given*,
-and the ceiling that leaves is the pre-existing one: a hub can still hold a
-duplicate, and `get` by name still refuses both.
+**Start-up opts out** (`unique_name=False`). Its caller is
+`bootstrap._register_first_library`, which passes the hardcoded `"Library 1"`
+and does not catch `LibraryExistsError`, so refusing there would turn a
+duplicate label — a nuisance — into a server that will not boot. That function
+has **two** registration calls, one per branch, and the flag belongs on both:
+`register_pending` when the folder holds no vault yet, and `attach` when it
+already does. `attach` carried the check until v1.11.1 (release-review item 28),
+which meant the same hardcoded label refused to boot a hub that already held it
+— the branch where the library *exists* being the one that failed.
+`record_legacy_preparation` writes its row directly and is outside the check for
+the same reason. The rule is *verbs a person types a name at refuse; start-up
+records what it was given*, and the ceiling that leaves is the pre-existing one:
+a hub can still hold a duplicate, and `get` by name still refuses both.
 
 `GET /libraries` returns an `active_share_links` count on every library entry.
 It is owner metadata with no host path sensitivity and is available before the

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -2793,9 +2793,12 @@ instead of an offer deletes the file by hand to get the app started. A
 is to put the right one back.
 
 **A failure about the machine is never turned into that offer**
-(release-review item 27). `_ENVIRONMENTAL_SQLITE_FAILURES` — locked, disk I/O,
-cannot open, full, read-only, permission denied, malformed image, out of memory
-— names the findings that say nothing about what the file contains, and
+(release-review item 27). `_ENVIRONMENTAL_SQLITE_FAILURES` — `database is
+locked`, `disk I/O error`, `unable to open database file`, `database or disk is
+full`, `readonly database`, `permission denied`, `database disk image is
+malformed`, `out of memory`, all in SQLite's own wording (the "image" in the
+last one is the database file, nothing to do with a picture) — names the
+findings that say nothing about what the file contains, and
 `_is_environmental_failure` is the one classifier all three paths to the offer
 now ask: `unusable_vault_from_open_failure` (a migration that raised),
 `_vault_is_loadable` (the recovery in `_offer_a_usable_library`, reached on

--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -32,6 +32,7 @@ from pixlstash.hub.registry import (
     validate_vault_folder,
 )
 from pixlstash.pixl_logging import get_logger
+from pixlstash.startup_permissions import mkdir_private
 from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 from pixlstash.services.portable_identity import sanitize_vault_connection
 
@@ -89,6 +90,21 @@ _ENVIRONMENTAL_SQLITE_FAILURES = (
 # statement about the file, which is exactly what the offer is for.
 
 
+def _is_environmental_failure(reason: object) -> bool:
+    """True when a failure is about the machine rather than the file's content.
+
+    One classifier for every start-up path that can end at "start over with an
+    empty library database". The three of them - the first-run ``attach``, the
+    recovery in :func:`_offer_a_usable_library`, and
+    :func:`unusable_vault_from_open_failure` - reach the same offer from three
+    different exception types, so the question they all have to ask lives here
+    rather than in the one that happened to be written first. Takes an exception
+    or a message, because the recovery path keeps only the reason string.
+    """
+    lowered = str(reason).lower()
+    return any(marker in lowered for marker in _ENVIRONMENTAL_SQLITE_FAILURES)
+
+
 def unusable_vault_from_open_failure(
     library: Library, exc: BaseException
 ) -> "UnusableVaultError | None":
@@ -104,8 +120,7 @@ def unusable_vault_from_open_failure(
     reason quotes it, and the recovery renames rather than deletes. Returns
     None for a failure that is about the machine - those must keep failing.
     """
-    lowered = str(exc).lower()
-    if any(marker in lowered for marker in _ENVIRONMENTAL_SQLITE_FAILURES):
+    if _is_environmental_failure(exc):
         return None
     # SQLAlchemy's own message is often a bare identifier - `NoSuchTableError:
     # user` reads as "user" on its own - so the reason says what the failure
@@ -357,7 +372,13 @@ def _register_first_library(
     registry: LibraryRegistry,
     image_root: str,
 ) -> Library:
-    os.makedirs(image_root, mode=0o700, exist_ok=True)
+    # Every missing component 0700, and nothing that already exists touched:
+    # `image_root` is routinely a picture folder the owner has had for years,
+    # and start-up is not the moment to take read access to it away from the
+    # rest of their machine. `registry.create` uses the same helper for the same
+    # reason; a directory this call did not make is the owner's, and the guarded
+    # open needs it not to be group/world-*writable*, not to be 0700.
+    mkdir_private(Path(image_root))
     vault_path = os.path.join(image_root, VAULT_FILENAME)
     exists = os.path.isfile(vault_path)
 
@@ -368,8 +389,25 @@ def _register_first_library(
             image_root,
         )
         try:
-            return registry.attach(image_root, "Library 1")
+            # `unique_name=False`: the name is this function's own hardcoded
+            # label, not something a person typed, and a hub already holding a
+            # "Library 1" must not be a hub that cannot boot.
+            return registry.attach(image_root, "Library 1", unique_name=False)
         except NotAVaultError as exc:
+            if _is_environmental_failure(exc):
+                # Locked, unreadable, full: the file may be perfectly good and
+                # this machine simply cannot read it right now. Offering to
+                # start over here would rename a working catalogue away over a
+                # transient condition, so say what is wrong and stop.
+                logger.error(
+                    "Could not read the library database at %s: %s", vault_path, exc
+                )
+                raise HubBootstrapError(
+                    f"{vault_path} could not be read: {exc}. That looks like a "
+                    "permissions, locking or disk problem rather than a damaged "
+                    "library, so nothing was changed. Fix it and start "
+                    "PixlStash again."
+                ) from exc
             # The file is there and is not something we can open. That is a
             # decision for a human - the only way forward loses whatever the
             # file holds - so raise a typed error the caller can put a question
@@ -385,10 +423,6 @@ def _register_first_library(
             set_aside_unusable_vault(vault_path)
             return registry.register_pending(image_root, "Library 1")
 
-    # This process is creating the SQLite namespace, so establish the trust
-    # boundary now instead of inheriting a permissive umask-created directory.
-    if os.name != "nt":
-        os.chmod(image_root, 0o700)
     return registry.register_pending(image_root, "Library 1")
 
 
@@ -563,11 +597,19 @@ def _vault_is_loadable(library: Library) -> bool:
     Read-only, and about the file rather than the registration: a vault that
     passes here but still fails to open is a different problem with a different
     answer, and must not be offered the recreate-it recovery.
+
+    ``validate_vault_folder`` reports one ``NotAVaultError`` for two very
+    different findings: "this file is not a vault", and "this machine could not
+    read it" - a mode of 0000, a lock another process holds, a full or failing
+    disk. Only the first is an answer about the file. The second reports
+    loadable, because the caller's sole use for a False is to offer starting
+    over, and renaming somebody's only catalogue on the strength of a
+    permissions glitch is the recovery being a catastrophe.
     """
     try:
         validate_vault_folder(library.path)
-    except NotAVaultError:
-        return False
+    except NotAVaultError as exc:
+        return _is_environmental_failure(exc)
     return True
 
 

--- a/pixlstash/hub/bootstrap.py
+++ b/pixlstash/hub/bootstrap.py
@@ -32,7 +32,6 @@ from pixlstash.hub.registry import (
     validate_vault_folder,
 )
 from pixlstash.pixl_logging import get_logger
-from pixlstash.startup_permissions import mkdir_private
 from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 from pixlstash.services.portable_identity import sanitize_vault_connection
 
@@ -372,13 +371,16 @@ def _register_first_library(
     registry: LibraryRegistry,
     image_root: str,
 ) -> Library:
-    # Every missing component 0700, and nothing that already exists touched:
-    # `image_root` is routinely a picture folder the owner has had for years,
-    # and start-up is not the moment to take read access to it away from the
-    # rest of their machine. `registry.create` uses the same helper for the same
-    # reason; a directory this call did not make is the owner's, and the guarded
-    # open needs it not to be group/world-*writable*, not to be 0700.
-    mkdir_private(Path(image_root))
+    # Creation only, and it must still raise on a path that is not one: an
+    # empty string or an existing *file* has to end start-up here rather than
+    # be registered as a library, which is why this is `makedirs` and not
+    # `mkdir_private` (that one no-ops on both). What it creates is 0700; what
+    # was already there keeps the mode the owner gave it, because `image_root`
+    # is routinely a picture folder they have had for years and start-up is not
+    # the moment to take read access to it away from the rest of their machine.
+    # The guarded open needs it not to be group/world-*writable*, not to be
+    # 0700, and `startup_permissions` offers that repair with their consent.
+    os.makedirs(image_root, mode=0o700, exist_ok=True)
     vault_path = os.path.join(image_root, VAULT_FILENAME)
     exists = os.path.isfile(vault_path)
 
@@ -592,7 +594,12 @@ def prevalidate_library_fingerprint(library: Library) -> None:
 
 
 def _vault_is_loadable(library: Library) -> bool:
-    """True when the file at ``vault_path`` is one this build could open.
+    """False only when the file at ``vault_path`` is decisively not a vault.
+
+    **True does not promise the database opens** - it promises the caller has
+    no grounds to offer starting over, which is the only decision this answers.
+    A vault this machine merely could not read reports True for that reason;
+    see below.
 
     Read-only, and about the file rather than the registration: a vault that
     passes here but still fails to open is a different problem with a different

--- a/pixlstash/hub/registry.py
+++ b/pixlstash/hub/registry.py
@@ -410,7 +410,9 @@ class LibraryRegistry:
                 overlaps.append(library)
         return overlaps
 
-    def attach(self, folder: str, name: str | None = None) -> Library:
+    def attach(
+        self, folder: str, name: str | None = None, *, unique_name: bool = True
+    ) -> Library:
         """Register an existing library folder.
 
         Validates that the folder holds a vault, then records it. Any
@@ -418,13 +420,26 @@ class LibraryRegistry:
         being read: a library copied in from elsewhere must not import
         somebody's credentials.
 
+        Args:
+            unique_name: Refuse a name another attached library holds. True for
+                every verb a person types a name at. False only for start-up,
+                which is `register_pending`'s rule and applies here for the same
+                reason: `bootstrap._register_first_library` reaches this method
+                with the hardcoded ``"Library 1"`` whenever the folder already
+                holds a vault, and does not catch `LibraryExistsError`. A
+                duplicate label is a nuisance; a server that will not boot
+                because of one is not.
+
         Raises:
             NotAVaultError: The folder is not a vault.
-            LibraryExistsError: The path or name is already registered.
+            LibraryExistsError: The path is already registered, or the name is
+                and *unique_name* is set.
         """
         resolved = resolve_path(folder)
         validate_vault_folder(resolved)
-        return self._register(resolved, name or os.path.basename(resolved))
+        return self._register(
+            resolved, name or os.path.basename(resolved), unique_name=unique_name
+        )
 
     def register_pending(
         self,
@@ -477,10 +492,16 @@ class LibraryRegistry:
         # Every MISSING component 0700, not only the leaf (W21: makedirs'
         # mode stops at the leaf, so a deep new path left 0775 intermediates
         # under umask 002 and the guarded open refused them). Existing
-        # directories keep their modes.
+        # directories keep their modes: `POST /libraries` starts a library in a
+        # folder of pictures the owner already had, and narrowing that folder to
+        # 0700 behind their back takes read access away from every other account
+        # and every other program that had it. Nothing needs it - the vault file
+        # itself is created 0600, and `TrustedSQLiteLocation` refuses only a
+        # group/world-*writable* directory, which the startup permission scan
+        # offers to repair with the owner's consent (`startup_permissions.py`).
+        # `mkdir(mode=0o700)` is not raised by a umask, so what this call
+        # creates is 0700 without a chmod after it.
         mkdir_private(Path(resolved))
-        if os.name != "nt":
-            os.chmod(resolved, 0o700)
 
         # Local import: pulls in the ORM and the image stack (numpy, PIL), which
         # `list`, `attach` and `detach` have no use for. Importing it at module

--- a/pixlstash/routes/libraries.py
+++ b/pixlstash/routes/libraries.py
@@ -307,7 +307,7 @@ def create_router(server) -> APIRouter:
         **Resolved first, then validated.** ``validate_reference_folder_path``
         compares against a literal blocklist, so checking the string the caller
         sent would let ``/home/me/link-to-etc`` through and hand ``/etc`` to a
-        route that chmods the folder 0700 and writes a database into it. The
+        route that writes a database into the folder it names. The
         sibling that gets this right is
         ``validate_reference_folder_accessible``, which realpaths before it
         checks; this follows it, not ``filesystem/browse``'s ordering.
@@ -549,11 +549,11 @@ def create_router(server) -> APIRouter:
             "fresh library in it when it does not. No file is moved, renamed or "
             "copied either way. The folder must already exist - the picker's "
             "`New folder` button makes one, so this route never creates a "
-            "directory the owner did not point at - and starting a fresh "
-            "library there restricts it to the owner (0700), because it is "
-            "about to hold the vault database. The folder is re-inspected here "
-            "rather than trusted from the picker's answer, so one that became "
-            "covered in between is still refused."
+            "directory the owner did not point at - and its permissions are "
+            "left exactly as they are: the vault database inside it is created "
+            "owner-only whatever the folder allows. The folder is re-inspected "
+            "here rather than trusted from the picker's answer, so one that "
+            "became covered in between is still refused."
         ),
         tags=["libraries"],
         response_model=LibraryResponse,

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -328,6 +328,51 @@ class TestFreshInstall:
         TrustedSQLiteLocation.open(str(image_root / "vault.db")).close()
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_bootstrap_keeps_an_existing_image_roots_mode(self, tmp_path):
+        """The same creation-only rule, at the registration that runs first.
+
+        `Vault.__init__` has left an existing image_root alone for releases
+        (see the test above); `_register_first_library` runs before it and was
+        still chmodding the folder 0700, so pointing a first run at a picture
+        folder the owner already had took read access to it away from the rest
+        of their machine.
+        """
+        image_root = tmp_path / "my-pictures"
+        image_root.mkdir()
+        os.chmod(image_root, 0o755)
+
+        result = bootstrap_hub(str(image_root), str(tmp_path / "hub.db"))
+        result.hub.close()
+
+        assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o755
+
+    def test_a_hub_already_holding_library_1_still_starts(self, tmp_path):
+        """A name collision is not a reason to refuse to bring a library back.
+
+        `_register_first_library` passes its own hardcoded label, so the hub
+        deciding it is taken is a nuisance the owner cannot even see, and used
+        to be a server that would not boot.
+        """
+        hub_path = str(tmp_path / "hub.db")
+        occupied = make_vault(str(tmp_path / "occupied"))
+        wanted = make_vault(str(tmp_path / "wanted"))
+        hub = HubDatabase(hub_path)
+        LibraryRegistry(hub).attach(occupied, "Library 1")
+        # The state this needs is "attached rows, none of them active": a hub
+        # restored or edited outside PixlStash, since `detach` refuses the
+        # active library and nothing else clears the flag.
+        with hub.transaction() as conn:
+            conn.execute("UPDATE library SET is_active = 0")
+        hub.close()
+
+        result = bootstrap_hub(wanted, hub_path)
+        try:
+            assert result.library.path == os.path.realpath(wanted)
+            assert result.library.name == "Library 1"
+        finally:
+            result.hub.close()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
     def test_a_loose_existing_ancestor_is_kept_and_still_reported(
         self, tmp_path, caplog
     ):
@@ -1918,6 +1963,75 @@ class TestAVaultThatWillNotOpen:
         finally:
             result.engine.close()
             result.hub.close()
+
+
+unreadable_files_work = pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="needs POSIX mode bits and an account they apply to",
+)
+
+
+class TestAVaultThisMachineCannotRead:
+    """A vault that will not open because of the machine, not its content.
+
+    `validate_vault_folder` reports "not a PixlStash vault" and "this account
+    cannot read the file" as the same `NotAVaultError`, so a vault left mode
+    0000 by a bad restore - or held by another process, or on a full disk -
+    used to be offered the one recovery that renames it away.
+    """
+
+    @staticmethod
+    def _stamped(folder, fingerprint):
+        make_vault(folder)
+        vault = os.path.join(folder, "vault.db")
+        conn = sqlite3.connect(vault)
+        conn.execute("UPDATE library_settings SET library_uuid = ?", (fingerprint,))
+        conn.commit()
+        conn.close()
+        return vault
+
+    @unreadable_files_work
+    def test_the_first_run_reports_it_instead_of_offering_to_start_over(self, tmp_path):
+        folder = str(tmp_path / "library")
+        make_vault(folder)
+        vault = os.path.join(folder, "vault.db")
+        os.chmod(vault, 0o000)
+
+        with pytest.raises(HubBootstrapError) as raised:
+            bootstrap_hub(folder, str(tmp_path / "hub.db"))
+
+        assert not isinstance(raised.value, UnusableVaultError), (
+            "a locked or unreadable vault must never be offered 'start over'"
+        )
+        assert "could not be read" in str(raised.value)
+        assert os.listdir(folder) == ["vault.db"], "nothing may be moved aside"
+        os.chmod(vault, 0o600)
+
+    @unreadable_files_work
+    def test_a_later_run_does_not_rename_it_even_once_authorised(
+        self, tmp_path, monkeypatch
+    ):
+        """The authorisation was given for a *different* diagnosis.
+
+        `PIXLSTASH_RECREATE_VAULT=1` says yes to the question about a file this
+        build cannot make sense of. A vault nobody could read was never that
+        question, so the yes must not reach `set_aside_unusable_vault`.
+        """
+        folder = str(tmp_path / "library")
+        hub_path = str(tmp_path / "hub.db")
+        vault = self._stamped(folder, "00000000-0000-4000-8000-0000000000aa")
+        hub = HubDatabase(hub_path)
+        LibraryRegistry(hub).attach(folder, "Library 1")
+        hub.close()
+        os.chmod(vault, 0o000)
+        monkeypatch.setenv("PIXLSTASH_RECREATE_VAULT", "1")
+
+        with pytest.raises(HubBootstrapError) as raised:
+            bootstrap_hub(folder, hub_path)
+
+        assert not isinstance(raised.value, UnusableVaultError)
+        assert sorted(os.listdir(folder)) == ["vault.db"]
+        os.chmod(vault, 0o600)
 
 
 def sqlalchemy_operational_error(message):

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -1997,15 +1997,21 @@ class TestAVaultThisMachineCannotRead:
         vault = os.path.join(folder, "vault.db")
         os.chmod(vault, 0o000)
 
-        with pytest.raises(HubBootstrapError) as raised:
-            bootstrap_hub(folder, str(tmp_path / "hub.db"))
+        try:
+            with pytest.raises(HubBootstrapError) as raised:
+                bootstrap_hub(folder, str(tmp_path / "hub.db"))
 
-        assert not isinstance(raised.value, UnusableVaultError), (
-            "a locked or unreadable vault must never be offered 'start over'"
-        )
-        assert "could not be read" in str(raised.value)
-        assert os.listdir(folder) == ["vault.db"], "nothing may be moved aside"
-        os.chmod(vault, 0o600)
+            assert not isinstance(raised.value, UnusableVaultError), (
+                "a locked or unreadable vault must never be offered 'start over'"
+            )
+            assert "could not be read" in str(raised.value)
+            assert sorted(os.listdir(folder)) == ["vault.db"], (
+                "nothing may be moved aside"
+            )
+        finally:
+            # In the `finally` because a failing assertion above would otherwise
+            # leave a 0000 file behind for whatever runs next in this shard.
+            os.chmod(vault, 0o600)
 
     @unreadable_files_work
     def test_a_later_run_does_not_rename_it_even_once_authorised(
@@ -2026,12 +2032,14 @@ class TestAVaultThisMachineCannotRead:
         os.chmod(vault, 0o000)
         monkeypatch.setenv("PIXLSTASH_RECREATE_VAULT", "1")
 
-        with pytest.raises(HubBootstrapError) as raised:
-            bootstrap_hub(folder, hub_path)
+        try:
+            with pytest.raises(HubBootstrapError) as raised:
+                bootstrap_hub(folder, hub_path)
 
-        assert not isinstance(raised.value, UnusableVaultError)
-        assert sorted(os.listdir(folder)) == ["vault.db"]
-        os.chmod(vault, 0o600)
+            assert not isinstance(raised.value, UnusableVaultError)
+            assert sorted(os.listdir(folder)) == ["vault.db"]
+        finally:
+            os.chmod(vault, 0o600)
 
 
 def sqlalchemy_operational_error(message):

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -373,6 +373,46 @@ class TestAttachAndList:
             assert mode == 0o700, f"{directory} is {oct(mode)}, expected 0o700"
         TrustedSQLiteLocation.open(os.path.join(library.path, "vault.db")).close()
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_create_leaves_an_existing_folders_permissions_alone(
+        self, registry, tmp_path
+    ):
+        """`POST /libraries` over a folder of pictures must not narrow it.
+
+        The `pictures` verdict lands here, so the folder is one the owner has
+        had for years with whatever mode they gave it. Chmodding it 0700 takes
+        read access away from every other account and program that had it, and
+        buys nothing: the vault file itself is created 0600, and the guarded
+        open refuses only a group/world-*writable* directory.
+        """
+        folder = tmp_path / "already-mine"
+        folder.mkdir()
+        os.chmod(folder, 0o755)
+        (folder / "holiday.jpg").write_bytes(b"not really a jpeg")
+
+        registry.create(str(folder))
+
+        assert stat.S_IMODE(os.lstat(folder).st_mode) == 0o755
+        vault_db = folder / "vault.db"
+        assert stat.S_IMODE(os.lstat(vault_db).st_mode) == 0o600
+
+    def test_attach_can_be_asked_not_to_enforce_a_unique_name(self, registry, tmp_path):
+        """Start-up's own opt-out: a name collision must not refuse a library.
+
+        `bootstrap._register_first_library` reaches `attach` with a hardcoded
+        "Library 1", and a hub that already holds that name is a nuisance, not a
+        reason to refuse to bring an existing library back.
+        """
+        registry.attach(make_vault_folder(tmp_path, "first"), "Library 1")
+        second = make_vault_folder(tmp_path, "second")
+
+        with pytest.raises(LibraryExistsError):
+            registry.attach(second, "Library 1")
+
+        library = registry.attach(second, "Library 1", unique_name=False)
+        assert library.name == "Library 1"
+        assert library.path == os.path.realpath(second)
+
     def test_unreachable_library_is_listed_and_flagged(self, registry, tmp_path):
         folder = make_vault_folder(tmp_path, "removable")
         library = registry.attach(folder)


### PR DESCRIPTION
v1.11.1 backlog (#1177), items 10, 27 and 28. Batched because all three live in
the hub start-up/registry pair.

### 10 — `POST /libraries` over an existing folder chmodded it 0700

`registry.create` called `mkdir_private(resolved)` and then `os.chmod(resolved,
0o700)`. `mkdir_private` creates every missing component at 0700 and documents
that it never touches an existing directory; a umask can only clear bits from a
`mkdir(mode=0o700)`, so the chmod could never affect a directory this call made.
Its only effect was on directories it did **not** make — and the `pictures`
verdict of `POST /libraries` is exactly that case: a folder the owner has had
for years, silently losing read access for every other account and program.

Nothing needed it. The vault file is created 0600 by `VaultDatabase`, and
`TrustedSQLiteLocation` refuses only a group/world-*writable* directory, which
the start-up permission scan already offers to repair with the owner's consent
(and repairs to 0755, not 0700). `Vault.__init__` has followed the same
creation-only rule for releases — `test_an_existing_loose_image_root_keeps_its_mode`
asserts it — so this aligns the two registration paths with the rule the vault
already had.

`bootstrap._register_first_library` carried the identical line and is fixed with
it; it also now uses `mkdir_private` rather than `os.makedirs(mode=)`, whose
mode reaches only the leaf (the W21 shape).

### 27 — start-up offered "start over" for environmental SQLite failures

`validate_vault_folder` raises one `NotAVaultError` for two unrelated findings:
"this file is not a vault", and "this process could not read it" — a mode of
0000 from a bad restore, a lock another process holds, a full or failing disk.
Both reached `UnusableVaultError`, whose only recovery is to rename the vault
aside and start with an empty database.

Two sites, one of them on the path taken by **every** start-up after the first:

- `_offer_a_usable_library` → `_vault_is_loadable`. With
  `PIXLSTASH_RECREATE_VAULT=1` already set this did not even stop to ask — the
  new test reproduces it renaming a perfectly good vault away over a
  permissions failure.
- `_register_first_library`'s `attach`, on a first run.

`unusable_vault_from_open_failure` already classified this correctly for the
migration path. That check is now `_is_environmental_failure`, and all three
paths to the offer ask it. Environmental cases raise a plain
`HubBootstrapError` naming what to fix; `SQLITE_NOTADB` stays deliberately out
of the list, because "this file is not a database" is what the offer is for.

### 28 — start-up `attach` still enforced unique names

`register_pending` opts out of the duplicate-name check with a comment stating
why: start-up passes the hardcoded `"Library 1"` and does not catch
`LibraryExistsError`, so refusing there turns a duplicate label into a server
that will not boot. `_register_first_library` has **two** registration calls,
one per branch, and only that one had the flag — `attach`, the branch where the
library already exists, still refused. `attach` takes the same keyword-only
`unique_name` and start-up passes `False`; every other caller is unchanged.

### Tests

Six added to the two existing gated modules (no new files, so no `ci.yml`
change). Each was confirmed red against the pre-fix code and green after:

- `test_create_leaves_an_existing_folders_permissions_alone`
- `test_attach_can_be_asked_not_to_enforce_a_unique_name`
- `test_bootstrap_keeps_an_existing_image_roots_mode`
- `test_a_hub_already_holding_library_1_still_starts`
- `TestAVaultThisMachineCannotRead::test_the_first_run_reports_it_instead_of_offering_to_start_over`
- `TestAVaultThisMachineCannotRead::test_a_later_run_does_not_rename_it_even_once_authorised`

`test_hub_registry.py`, `test_hub_bootstrap.py`, `test_libraries_routes.py` and
`test_architecture_guardrails.py` pass locally (265 tests). No route, schema or
authz-registry change.

### Behaviour worth a reviewer's eye

A library added on a folder that is group/world-*writable* is no longer silently
tightened, so the guarded open refuses it later and the start-up permission scan
offers the consented repair — the designed path, but a louder one than the
silent chmod. `_ENVIRONMENTAL_SQLITE_FAILURES` is used as its author wrote it,
which classifies `SQLITE_CORRUPT` ("database disk image is malformed") as
environmental; that grouping predates this change and is left alone.