### PR TITLE
v1.11.1 security lane: direct-URL requirements, a fail-open vault helper, two path IPCs and the server settings

### DIFF
--- a/changelog.d/1201.md
+++ b/changelog.d/1201.md
@@ -1,0 +1,6 @@
+- `plugins install --with-deps` now installs each dependency from the exact
+  artefact it showed you. A requirement a plugin pinned to a URL, to a VCS
+  commit, or to its own `--find-links` directory used to be re-installed by
+  looking its name up on PyPI, so the package that landed could be a different
+  project by the same name. The listing also names the URL a pinned dependency
+  comes from, before you agree to it.

--- a/changelog.d/1201.md
+++ b/changelog.d/1201.md
@@ -2,5 +2,8 @@
   artefact it showed you. A requirement a plugin pinned to a URL, to a VCS
   commit, or to its own `--find-links` directory used to be re-installed by
   looking its name up on PyPI, so the package that landed could be a different
-  project by the same name. The listing also names the URL a pinned dependency
-  comes from, before you agree to it.
+  project by the same name. The listing now also names where each dependency
+  actually comes from whenever that is not the usual package index, and warns
+  when a plugin's requirements file redirects pip somewhere else — so a plugin
+  serving its own build of a package you already have cannot present it as the
+  ordinary one.

--- a/changelog.d/1201.md
+++ b/changelog.d/1201.md
@@ -1,15 +1,7 @@
 - `plugins install --with-deps` now installs each dependency from the exact
-  artefact it showed you. A requirement a plugin pinned to a URL, to a VCS
-  commit, or to its own `--find-links` directory used to be re-installed by
-  looking its name up on PyPI, so the package that landed could be a different
-  project by the same name. The listing now also names where each dependency
-  actually comes from whenever that is not the usual package index, and warns
-  when a plugin's requirements file redirects pip somewhere else — so a plugin
-  serving its own build of a package you already have cannot present it as the
-  ordinary one.
-- `plugins install --with-deps` refuses a dependency that has to be built
-  before it can be described — one given as a URL, a source checkout, a local
-  path, or published only as source. Working out what those would install
-  means running their code first, so the question would have been put to you
-  after the answer stopped mattering. `--allow-sdist` accepts that and goes
-  ahead.
+  artefact it resolved, instead of looking the package name up again. A
+  dependency a plugin pinned to a URL, to a VCS commit, or to its own
+  `--find-links` directory used to be re-fetched by name, so what landed could
+  be a different project that happened to share it. The listing also says where
+  each dependency actually came from when that is not the usual package index,
+  so you can see what you are agreeing to.

--- a/changelog.d/1201.md
+++ b/changelog.d/1201.md
@@ -7,3 +7,9 @@
   when a plugin's requirements file redirects pip somewhere else — so a plugin
   serving its own build of a package you already have cannot present it as the
   ordinary one.
+- `plugins install --with-deps` refuses a dependency that has to be built
+  before it can be described — one given as a URL, a source checkout, a local
+  path, or published only as source. Working out what those would install
+  means running their code first, so the question would have been put to you
+  after the answer stopped mattering. `--allow-sdist` accepts that and goes
+  ahead.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3000,6 +3000,48 @@ module docstring is the design record: which actor each check is for, why the
 earlier DACL refusal was removed (it stopped the server starting on Windows,
 W6/W7/W18), and what a `private=True` open verifies instead.
 
+**Accepted risk W20 — mode bits warn, they no longer refuse.** Until #1152
+(commit `a26f765`, 2026-09-04) a group- or world-writable directory on the path
+to the hub, the vault or the library, and a credential file wider than `0600`,
+refused the open and exited the server 1. They now log a WARNING carrying the
+`chmod` that fixes them and the open proceeds. Ownership, symlink/junction and
+file-type checks still refuse, and so does an unresolvable group.
+
+*Risk and who is affected:* a POSIX user whose library or config path is
+group- or world-writable and who shares that group or machine with another
+account. That account can substitute `vault.db`, `hub.db` or pre-position a
+`-wal`/`-shm` sidecar between boots. The vault is authorization-bearing
+(`authz/membership.py` answers scope questions out of it), so the blast radius
+is the whole library plus the scope decisions taken from it — the same radius
+W17 states for Windows, now reachable on POSIX too when the owner has loosened
+the path.
+
+*Why it is accepted rather than reverted:* refusing on mode alone took the
+product down twice for nobody's benefit — a `0775` directory under a stock
+Ubuntu umask 002, then a `0755` library made by the Docker entrypoint — and in
+both cases the actor the bit implied did not exist. The precondition is that
+the *owner's own* path is already loose, which on the single-owner product this
+ships as means the machine has no second principal at all. A control that stops
+the application starting on the common case, on evidence that is a proxy rather
+than an observation, is a control that gets removed by the user (`chmod`) or by
+the maintainer; a warning that names the fix survives.
+
+*Compensating controls:* the WARNING states the exact `chmod`;
+`startup_permissions.py` finds the same paths and offers a bounded, explicit
+repair (inline on a terminal, as copy/pasteable commands otherwise, or
+unattended with `PIXLSTASH_REPAIR_PERMISSIONS=1`); new directories are created
+`0700` and new credential files `0600` by `mkdir_private`, so nothing PixlStash
+creates today needs the repair; and the `(st_dev, st_ino)` identity match across
+the open still catches a swap that happens mid-open.
+
+*What would reopen it:* multi-user, a shared or multi-tenant host, or any
+deployment where a second local principal is expected. In any of those the mode
+test stops being a proxy and becomes an observation, and this reverts to a
+refusal.
+
+Owner: lindkvis. Revisit with W17 (2026-11-08), and **immediately** if
+multi-user work starts. CSO sign-off: accepted 2026-09-06 (#1177 item 16).
+
 **Group-write is not automatically an exposure.** `mode & 0o022` is a *proxy*
 for "another principal can write here", and for the group bit that proxy is
 wrong wherever the group is the owner's own. Debian, Ubuntu and every other

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -3005,7 +3005,9 @@ W6/W7/W18), and what a `private=True` open verifies instead.
 to the hub, the vault or the library, and a credential file wider than `0600`,
 refused the open and exited the server 1. They now log a WARNING carrying the
 `chmod` that fixes them and the open proceeds. Ownership, symlink/junction and
-file-type checks still refuse, and so does an unresolvable group.
+file-type checks still refuse. An unresolvable group does **not** refuse: it
+only stops the private-group tolerance applying, and the loose mode is then
+warned about like any other.
 
 *Risk and who is affected:* a POSIX user whose library or config path is
 group- or world-writable and who shares that group or machine with another
@@ -3026,13 +3028,31 @@ the application starting on the common case, on evidence that is a proxy rather
 than an observation, is a control that gets removed by the user (`chmod`) or by
 the maintainer; a warning that names the fix survives.
 
-*Compensating controls:* the WARNING states the exact `chmod`;
-`startup_permissions.py` finds the same paths and offers a bounded, explicit
-repair (inline on a terminal, as copy/pasteable commands otherwise, or
-unattended with `PIXLSTASH_REPAIR_PERMISSIONS=1`); new directories are created
-`0700` and new credential files `0600` by `mkdir_private`, so nothing PixlStash
-creates today needs the repair; and the `(st_dev, st_ino)` identity match across
-the open still catches a swap that happens mid-open.
+*Compensating controls, and what they do not cover.* `startup_permissions.py`
+finds the same paths and offers a bounded, explicit repair, but **only a
+terminal is actually offered it**: `app.py` prompts inline on a TTY and
+otherwise prints `chmod` lines to stderr, which for the desktop app is the
+server log and for Docker is the container log. The Electron repair dialog is
+**dead code today** — it is armed only by a `PIXLSTASH_PERMISSION_REPAIR=`
+marker parsed out of a backend that *exited* (`ServerProcess.ts`,
+`StartupPermissions.ts`), and #1152 removed the Python side that emitted it, so
+a backend that now warns and continues never arms it. `permissions:request` /
+`permissions:resolve` and the `PIXLSTASH_REPAIR_PERMISSIONS=1` retry are
+unreachable from the shell until something re-emits that marker from the
+*running* server. The controls that do apply everywhere: new directories are
+created `0700` and new credential files `0600` by `mkdir_private`, so nothing
+PixlStash creates today needs the repair at all; the `(st_dev, st_ino)` identity
+match still catches a swap inside the open→verify window; and the ownership,
+symlink/junction and regular-file refusals are untouched.
+
+*Blast radius, in full.* Substitution of `vault.db` / `hub.db` or a
+pre-positioned `-wal`/`-shm`, as above. Also **deletion**: on a world-writable
+directory without the sticky bit another account can remove `vault.db-wal`
+(dropping committed transactions) or the database itself, which no ownership
+check catches because there is no file left to inspect. And the repair sweep is
+narrower than the risk — `find_startup_permission_issues` walks the config root
+and the active library, not reference-folder roots and not registered libraries
+that are not currently attached.
 
 *What would reopen it:* multi-user, a shared or multi-tenant host, or any
 deployment where a second local principal is expected. In any of those the mode
@@ -3053,16 +3073,18 @@ server 1 during startup on a stock Linux box with a library from an earlier
 release, with no recovery short of a manual `chmod`. `_is_private_group` names
 the actor instead of the bit: group-write is tolerated only when the group is the
 directory owner's own, same-named, and has no other member; any lookup failure
-is reported as shared, so the open is refused. World-write is refused exactly as
-before, and the file-level checks are unchanged — a `0664` database cannot come
-from a umask, since SQLite requests `0644`.
+is reported as shared, so the tolerance does not apply and the loose mode is
+warned about (W20: since #1152 that is a warning, not a refusal). The file-level
+checks are unchanged in *what* they inspect — a `0664` database cannot come from
+a umask, since SQLite requests `0644` — but they too now warn rather than
+refuse.
 
 A root-owned ancestor is **not** covered by this: the ownership check above
 admits `st_uid in (uid, 0)`, but the group tolerance additionally requires
 `st_uid == uid`, because for gid 0 the "owner's own group" is the administrators'
 group rather than one single owner's. `root:root 0775` directories exist in the
-wild (`/var/lib/AccountsService` on a stock Ubuntu box) and keep the blanket
-refusal.
+wild (`/var/lib/AccountsService` on a stock Ubuntu box) and are warned about
+without the tolerance ever being considered.
 
 **Accepted risk, group membership (same record as W17).** Two things the group
 answer cannot see, both stated rather than fixed:
@@ -3087,8 +3109,8 @@ process's name service.
 
 An NSS lookup on the startup path is the cost, and only for a directory that is
 already group-writable — a tightened install performs none. A lookup that fails
-is reported as shared, so the worst case is the refusal this whole section
-exists to remove, never a weaker check.
+is reported as shared, so the worst case is a warning the directory did not
+need, never a weaker check.
 
 **Accepted risk W17.** Python exposes neither owner SID nor directory DACL
 portably, so the POSIX `mode & 0o022` test — "another principal cannot write

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -74,18 +74,38 @@ export function requireAccel(value: unknown): Accel {
  */
 export type PathPurpose = 'library' | 'backends';
 
-const offeredPaths: Record<PathPurpose, Set<string>> = {
-  library: new Set(),
-  backends: new Set(),
+/**
+ * The lookup key for a path, matching the platform's own idea of path identity.
+ *
+ * Windows filesystems are case-insensitive, so `C:\\Users\\me\\Pictures` and
+ * `c:\\users\\me\\pictures` are one directory and a case-sensitive comparison
+ * would refuse a folder the user really did choose - the over-blocking failure
+ * this whole guard must not cause. POSIX is case-SENSITIVE, where `~/Pictures`
+ * and `~/pictures` are two different directories, so folding there would let a
+ * path that was never offered match one that was. Same rule, and the same
+ * `process.platform` switch, as {@link normalizeBackendsRoot}.
+ */
+export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
+  const resolved = resolve(path.trim());
+  return platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+// Key -> the path as PixlStash actually offered it. A Map rather than a Set so
+// the value that flows on is the one the main process vouched for, never the
+// renderer's own spelling of it.
+const offeredPaths: Record<PathPurpose, Map<string, string>> = {
+  library: new Map(),
+  backends: new Map(),
 };
 
 /** Record a path as offered to the renderer for *purpose*, and return it. */
 export function offerPath<T extends string | null | undefined>(
   path: T,
   purpose: PathPurpose,
+  platform: NodeJS.Platform = process.platform,
 ): T {
   if (typeof path === 'string' && path.trim()) {
-    offeredPaths[purpose].add(resolve(path.trim()));
+    offeredPaths[purpose].set(pathKey(path, platform), resolve(path.trim()));
   }
   return path;
 }
@@ -94,14 +114,16 @@ export function offerPath<T extends string | null | undefined>(
  * Narrow a folder the renderer sent back to one {@link offerPath} recorded for
  * the same *purpose*, or throw. *what* names the field for the message shown.
  *
- * Compared after `resolve` on both sides, so a trailing separator or an
- * `a/../b` spelling of an offered path is accepted while resolving to that same
- * offered path - and nothing else is.
+ * Compared by {@link pathKey} on both sides, so a trailing separator, an
+ * `a/../b` spelling, or (on Windows only) a different drive-letter or path
+ * casing is accepted while resolving to that same offered path - and nothing
+ * else is. Returns the path as it was OFFERED, not as the renderer spelled it.
  */
 export function requireOfferedPath(
   value: unknown,
   purpose: PathPurpose,
   what: string,
+  platform: NodeJS.Platform = process.platform,
 ): string {
   // Described the way requireAccel describes a value, and for its reasons: IPC
   // carries a BigInt (JSON.stringify throws on one) and an object may supply
@@ -110,14 +132,14 @@ export function requireOfferedPath(
   if (typeof value !== 'string' || !value.trim()) {
     throw new Error(`${what} must be a folder path, not ${shown}.`);
   }
-  const resolved = resolve(value.trim());
-  if (!offeredPaths[purpose].has(resolved)) {
+  const offered = offeredPaths[purpose].get(pathKey(value, platform));
+  if (offered === undefined) {
     throw new Error(
       `${what} ${shown} was not offered by PixlStash for this choice. Choose ` +
         'the folder with the Change\u2026 button and try again.',
     );
   }
-  return resolved;
+  return offered;
 }
 
 /** The backend's external-listener settings, as stored in the server config. */
@@ -153,10 +175,20 @@ export function requireServerSettings(value: unknown): ServerSettings {
       );
     }
   }
+  // The port is TYPE-checked here and RANGE-checked in writeServerSettings.
+  // Leniency about the range is what keeps a half-typed field from throwing;
+  // it was never a reason to accept a string or a missing value, which is not
+  // something the port field can produce. `typeof x === 'number'` is deliberate
+  // and Number.isFinite() would be wrong: NaN and 0 are exactly what
+  // `Number('')` and `Number('x')` hand over mid-keystroke, and both must
+  // still reach writeServerSettings to be ignored there.
+  if (typeof settings?.port !== 'number') {
+    throw new Error(`Server setting "port" must be a number, not ${typeof settings?.port}.`);
+  }
   return {
-    enabled: settings!.enabled as boolean,
-    ssl: settings!.ssl as boolean,
-    port: settings!.port as number,
+    enabled: settings.enabled as boolean,
+    ssl: settings.ssl as boolean,
+    port: settings.port,
   };
 }
 

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -62,25 +62,47 @@ export function requireAccel(value: unknown): Accel {
  * run, not a persisted policy, and the wizard's own prefilled defaults have to
  * be in it or accepting the folder on screen would be refused. It is not a
  * containment check - the user may legitimately pick anywhere - so it says only
- * "this exact folder was on offer", never "this folder is safe".
+ * "this exact folder was on offer for this question", never "this folder is
+ * safe".
+ *
+ * Kept per {@link PathPurpose} rather than as one pool, because the two
+ * questions have very different consequences and one pool lets an answer to the
+ * gentler one be replayed as an answer to the harsher one: a *library* folder
+ * accepted as the *GPU install location* makes `setBackendsRoot` point at the
+ * user's pictures, and `accel:install` then wipes `<library>/<accel>` and
+ * `backend:setLocation` recursively deletes it.
  */
-const offeredPaths = new Set<string>();
+export type PathPurpose = 'library' | 'backends';
 
-/** Record a path as offered to the renderer, and return it unchanged. */
-export function offerPath<T extends string | null | undefined>(path: T): T {
-  if (typeof path === 'string' && path.trim()) offeredPaths.add(resolve(path.trim()));
+const offeredPaths: Record<PathPurpose, Set<string>> = {
+  library: new Set(),
+  backends: new Set(),
+};
+
+/** Record a path as offered to the renderer for *purpose*, and return it. */
+export function offerPath<T extends string | null | undefined>(
+  path: T,
+  purpose: PathPurpose,
+): T {
+  if (typeof path === 'string' && path.trim()) {
+    offeredPaths[purpose].add(resolve(path.trim()));
+  }
   return path;
 }
 
 /**
- * Narrow a folder the renderer sent back to one {@link offerPath} recorded, or
- * throw. *what* names the field, for the message the wizard shows.
+ * Narrow a folder the renderer sent back to one {@link offerPath} recorded for
+ * the same *purpose*, or throw. *what* names the field for the message shown.
  *
  * Compared after `resolve` on both sides, so a trailing separator or an
  * `a/../b` spelling of an offered path is accepted while resolving to that same
  * offered path - and nothing else is.
  */
-export function requireOfferedPath(value: unknown, what: string): string {
+export function requireOfferedPath(
+  value: unknown,
+  purpose: PathPurpose,
+  what: string,
+): string {
   // Described the way requireAccel describes a value, and for its reasons: IPC
   // carries a BigInt (JSON.stringify throws on one) and an object may supply
   // its own `toString`.
@@ -89,10 +111,10 @@ export function requireOfferedPath(value: unknown, what: string): string {
     throw new Error(`${what} must be a folder path, not ${shown}.`);
   }
   const resolved = resolve(value.trim());
-  if (!offeredPaths.has(resolved)) {
+  if (!offeredPaths[purpose].has(resolved)) {
     throw new Error(
-      `${what} ${shown} was not offered by PixlStash. Choose the folder with ` +
-        'the Change\u2026 button and try again.',
+      `${what} ${shown} was not offered by PixlStash for this choice. Choose ` +
+        'the folder with the Change\u2026 button and try again.',
     );
   }
   return resolved;

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -44,6 +44,101 @@ export function requireAccel(value: unknown): Accel {
 }
 
 /**
+ * Every path this process has itself put in front of the user: a native file
+ * dialog's result, or a default it computed and sent to the setup wizard.
+ *
+ * SECURITY: `backend:setLocation` and `setup:commit` take a *destination* from
+ * the renderer, and the destination is meant to be a folder the user chose - so
+ * an allowlist of known-good directories is the wrong shape and would break the
+ * feature. What can be checked instead is provenance: only the main process can
+ * open a native dialog, so a path it never handed out did not come from one.
+ * Without that check `backend:setLocation` reaches `moveDir`, which
+ * `rm(..., { recursive: true, force: true })`s `<renderer-chosen root>/<accel>`
+ * (item 13 validated the last segment, not the root), and `setup:commit` writes
+ * a config naming an arbitrary `imageRoot` and downloads a 2.5 GB runtime into
+ * an arbitrary `installLocation`.
+ *
+ * Session-scoped and additive on purpose: it records what was offered in this
+ * run, not a persisted policy, and the wizard's own prefilled defaults have to
+ * be in it or accepting the folder on screen would be refused. It is not a
+ * containment check - the user may legitimately pick anywhere - so it says only
+ * "this exact folder was on offer", never "this folder is safe".
+ */
+const offeredPaths = new Set<string>();
+
+/** Record a path as offered to the renderer, and return it unchanged. */
+export function offerPath<T extends string | null | undefined>(path: T): T {
+  if (typeof path === 'string' && path.trim()) offeredPaths.add(resolve(path.trim()));
+  return path;
+}
+
+/**
+ * Narrow a folder the renderer sent back to one {@link offerPath} recorded, or
+ * throw. *what* names the field, for the message the wizard shows.
+ *
+ * Compared after `resolve` on both sides, so a trailing separator or an
+ * `a/../b` spelling of an offered path is accepted while resolving to that same
+ * offered path - and nothing else is.
+ */
+export function requireOfferedPath(value: unknown, what: string): string {
+  // Described the way requireAccel describes a value, and for its reasons: IPC
+  // carries a BigInt (JSON.stringify throws on one) and an object may supply
+  // its own `toString`.
+  const shown = typeof value === 'string' ? JSON.stringify(value) : typeof value;
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${what} must be a folder path, not ${shown}.`);
+  }
+  const resolved = resolve(value.trim());
+  if (!offeredPaths.has(resolved)) {
+    throw new Error(
+      `${what} ${shown} was not offered by PixlStash. Choose the folder with ` +
+        'the Change\u2026 button and try again.',
+    );
+  }
+  return resolved;
+}
+
+/** The backend's external-listener settings, as stored in the server config. */
+export interface ServerSettings {
+  enabled: boolean;
+  port: number;
+  ssl: boolean;
+}
+
+/**
+ * Narrow the object `server:setSettings` was handed, or throw.
+ *
+ * SECURITY: `enabled` and `ssl` are written straight into the server config,
+ * which decides whether a second listener binds `0.0.0.0` and whether it
+ * demands TLS. A TypeScript parameter type is erased at run time, so before
+ * this the renderer could send `ssl: 0` or `ssl: []` - falsy to the Python that
+ * reads the config, truthy to the `Boolean(cfg.require_ssl)` this shell reads
+ * it back with, i.e. a plaintext LAN listener the desktop's own toggle reports
+ * as encrypted. Rejecting rather than coercing keeps the two readings in step
+ * (CWE-20).
+ *
+ * `port` is deliberately NOT rejected here. The port field hands over
+ * `Number('')` while it is being typed, and `writeServerSettings` already
+ * ignores anything outside 1-65535 and keeps the stored port; throwing on it
+ * would turn a half-typed field into an error dialog.
+ */
+export function requireServerSettings(value: unknown): ServerSettings {
+  const settings = value as Record<string, unknown> | null | undefined;
+  for (const field of ['enabled', 'ssl'] as const) {
+    if (typeof settings?.[field] !== 'boolean') {
+      throw new Error(
+        `Server setting "${field}" must be true or false, not ${typeof settings?.[field]}.`,
+      );
+    }
+  }
+  return {
+    enabled: settings!.enabled as boolean,
+    ssl: settings!.ssl as boolean,
+    port: settings!.port as number,
+  };
+}
+
+/**
  * Parse the developer/CI hardware-detection override. The override fakes which
  * GPU the machine appears to have so the backend-download/overlay flow can be
  * exercised on hardware that lacks the matching GPU. It is read from, in order

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -23,7 +23,12 @@ import { detectHardware, gpuUpgrades, Hardware } from './backend/HardwareDetecto
 import { BackendManager, OVERLAY_ACCELS, launchWithOverlayFallback } from './backend/BackendManager';
 import { uniqueDownloadPath } from './downloads';
 import { ipcBytes, pngClipboardPayload, safeMediaFilename } from './mediaIpc';
-import { isAllowedNavigation, isBundledRendererPage, redactUrl } from './urlPolicy';
+import {
+  isAllowedNavigation,
+  isBackendOrigin,
+  isBundledRendererPage,
+  redactUrl,
+} from './urlPolicy';
 import { ServerProcess, StartupRecovery, devInterpreter } from './backend/ServerProcess';
 import {
   isPermissionRepairRequired,
@@ -1244,6 +1249,27 @@ function requireSetupRenderer(event: Electron.IpcMainInvokeEvent, channel: strin
   throw new Error(`${channel} is only available during first-run setup.`);
 }
 
+/**
+ * Refuse a channel that belongs to the running app, not to a bundled page.
+ *
+ * SECURITY: `server:setSettings` is the one that matters - it writes
+ * `external_server_enabled`, `host: '0.0.0.0'` and `require_ssl` and restarts
+ * the backend, i.e. it decides whether this machine listens on the network
+ * (#1201 F4). Item 57 validated the *shape* of that payload and left the
+ * *capability* ungated, so `{enabled: true, ssl: false}` from any renderer page
+ * still turned the listener on. The siblings are gated with it:
+ * `server:checkPort` briefly binds a caller-named port on all interfaces, and
+ * `server:getSettings` returns this machine's LAN addresses.
+ *
+ * See isBackendOrigin for what this deliberately does NOT stop.
+ */
+function requireAppRenderer(event: Electron.IpcMainInvokeEvent, channel: string): void {
+  const sender = event.senderFrame?.url ?? event.sender.getURL();
+  if (isBackendOrigin(sender, currentUrl)) return;
+  console.warn(`[ipc] refusing ${channel} from ${redactUrl(sender)}: not the app window`);
+  throw new Error(`${channel} is only available from the PixlStash app window.`);
+}
+
 function registerIpc(): void {
   ipcMain.handle('app:bootstrap', async () => ({
     version: app.getVersion(),
@@ -1590,13 +1616,20 @@ function registerIpc(): void {
 
   // External server (remote access) settings. The loopback the window uses is
   // never affected by these - only the optional second listener.
-  ipcMain.handle('server:getSettings', () => readServerSettings());
+  ipcMain.handle('server:getSettings', (event) => {
+    requireAppRenderer(event, 'server:getSettings');
+    return readServerSettings();
+  });
   // `enabled` and `ssl` decide whether a listener binds 0.0.0.0 and whether it
   // demands TLS, and both reached the config unchecked before this.
-  ipcMain.handle('server:setSettings', async (_e, raw: unknown) => {
+  ipcMain.handle('server:setSettings', async (event, raw: unknown) => {
+    requireAppRenderer(event, 'server:setSettings');
     await writeServerSettings(requireServerSettings(raw));
   });
-  ipcMain.handle('server:checkPort', (_e, port: number) => checkPortAvailable(port));
+  ipcMain.handle('server:checkPort', (event, port: number) => {
+    requireAppRenderer(event, 'server:checkPort');
+    return checkPortAvailable(port);
+  });
 
   // Custom title-bar window controls (the window is frameless).
   ipcMain.handle('window:minimize', () => mainWindow?.minimize());

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1262,6 +1262,7 @@ function registerIpc(): void {
       resolvedImportedRoot && existsSync(join(resolvedImportedRoot, 'vault.db'))
         ? resolvedImportedRoot
         : null,
+      'library',
     );
     const gpu = gpuUpgrade();
     const steps = ['library'];
@@ -1286,12 +1287,13 @@ function registerIpc(): void {
         // requireOfferedPath.
         existingRoot: offerPath(
           importedImageRoot && existsSync(importedImageRoot) ? importedImageRoot : null,
+          'library',
         ),
-        newRoot: offerPath(defaultLibraryDir()),
+        newRoot: offerPath(defaultLibraryDir(), 'library'),
         useGpu: Boolean(gpu),
         // Where the GPU runtime would install (only relevant when a GPU is
         // offered). On Windows this is inside the chosen install folder.
-        installLocation: offerPath(backendsRoot()),
+        installLocation: offerPath(backendsRoot(), 'backends'),
       },
       gpu: gpu
         ? { available: true, accel: gpu, label: ACCEL_LABELS[gpu], name: hardware?.gpuName ?? null }
@@ -1314,7 +1316,7 @@ function registerIpc(): void {
     });
     // The dialog is the provenance setup:commit checks for; recording the
     // result here is what makes the choice acceptable there.
-    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0]);
+    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0], 'library');
   });
 
   ipcMain.handle(
@@ -1345,9 +1347,9 @@ function registerIpc(): void {
 
       const validatedChoices = {
         ...choices,
-        imageRoot: requireOfferedPath(choices?.imageRoot, 'Library folder'),
+        imageRoot: requireOfferedPath(choices?.imageRoot, 'library', 'Library folder'),
         installLocation: choices?.installLocation
-          ? requireOfferedPath(choices.installLocation, 'GPU install location')
+          ? requireOfferedPath(choices.installLocation, 'backends', 'GPU install location')
           : undefined,
       };
 
@@ -1579,8 +1581,8 @@ function registerIpc(): void {
   // Where on-demand GPU overlays are stored. Lets the user keep the multi-GB
   // download off the system drive (the first-run wizard offers the same choice).
   ipcMain.handle('backend:getLocation', () => ({
-    dir: offerPath(backendsRoot()),
-    default: offerPath(defaultBackendsRoot()),
+    dir: offerPath(backendsRoot(), 'backends'),
+    default: offerPath(defaultBackendsRoot(), 'backends'),
   }));
 
   ipcMain.handle('backend:pickLocation', async (_e, current?: string) => {
@@ -1589,15 +1591,20 @@ function registerIpc(): void {
       defaultPath: current || backendsRoot(),
       properties: ['openDirectory', 'createDirectory'],
     });
-    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0]);
+    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0], 'backends');
   });
 
   // The destination reaches moveDir, which recursively deletes `<dir>/<accel>`.
   // Item 13 made the last segment a validated Accel; this makes the root one
   // PixlStash itself offered (see requireOfferedPath).
   ipcMain.handle('backend:setLocation', async (_e, raw: unknown) => {
-    await changeBackendsLocation(requireOfferedPath(raw, 'GPU install location'));
-    return { dir: offerPath(backendsRoot()), default: offerPath(defaultBackendsRoot()) };
+    await changeBackendsLocation(
+      requireOfferedPath(raw, 'backends', 'GPU install location'),
+    );
+    return {
+      dir: offerPath(backendsRoot(), 'backends'),
+      default: offerPath(defaultBackendsRoot(), 'backends'),
+    };
   });
 
   // The three handlers below take an accelerator straight from the renderer, and

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -46,10 +46,14 @@ import {
   defaultLibraryDir,
   isDevBackend,
   normalizeBackendsRoot,
+  offerPath,
   overlayDir,
   parseForcedBackend,
   readRuntimeInfo,
   requireAccel,
+  requireOfferedPath,
+  requireServerSettings,
+  ServerSettings,
   serverConfigPath,
   serverLogPath,
   setBackendsRoot,
@@ -608,12 +612,6 @@ function showServerLogs(): void {
 
 /** Port offered for the external listener when the config has none yet. */
 const DEFAULT_EXTERNAL_PORT = 9537;
-
-interface ServerSettings {
-  enabled: boolean;
-  port: number;
-  ssl: boolean;
-}
 
 /** This machine's non-loopback IPv4 addresses, for showing reachable URLs. */
 function lanAddresses(): string[] {
@@ -1258,10 +1256,13 @@ function registerIpc(): void {
     const importedImageRoot =
       typeof imported?.image_root === 'string' ? (imported.image_root as string) : null;
     const resolvedImportedRoot = importedImageRoot ? resolve(importedImageRoot) : null;
-    detectedLegacyIdentitySource =
+    // Offered as well: it comes back as `legacyIdentitySource` and the wizard's
+    // "pictures I already have" card prefills the folder field from it.
+    detectedLegacyIdentitySource = offerPath(
       resolvedImportedRoot && existsSync(join(resolvedImportedRoot, 'vault.db'))
         ? resolvedImportedRoot
-        : null;
+        : null,
+    );
     const gpu = gpuUpgrade();
     const steps = ['library'];
     // The compute question only exists on a machine that has something to
@@ -1280,13 +1281,17 @@ function registerIpc(): void {
         // "pictures I already have" answer must not: prefilling a path with
         // nothing at it invites someone to accept it and open an empty
         // library, so it is offered only when something is actually there.
-        existingRoot:
+        // offerPath on each: the wizard's fields are readonly and prefilled from
+        // here, so setup:commit has to accept a default back - see
+        // requireOfferedPath.
+        existingRoot: offerPath(
           importedImageRoot && existsSync(importedImageRoot) ? importedImageRoot : null,
-        newRoot: defaultLibraryDir(),
+        ),
+        newRoot: offerPath(defaultLibraryDir()),
         useGpu: Boolean(gpu),
         // Where the GPU runtime would install (only relevant when a GPU is
         // offered). On Windows this is inside the chosen install folder.
-        installLocation: backendsRoot(),
+        installLocation: offerPath(backendsRoot()),
       },
       gpu: gpu
         ? { available: true, accel: gpu, label: ACCEL_LABELS[gpu], name: hardware?.gpuName ?? null }
@@ -1307,29 +1312,44 @@ function registerIpc(): void {
       defaultPath: current || defaultLibraryDir(),
       properties: ['openDirectory', 'createDirectory'],
     });
-    return res.canceled || !res.filePaths[0] ? null : res.filePaths[0];
+    // The dialog is the provenance setup:commit checks for; recording the
+    // result here is what makes the choice acceptable there.
+    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0]);
   });
 
   ipcMain.handle(
     'setup:commit',
     async (
       _e,
+      // `unknown` for the two path fields: their TypeScript types are erased at
+      // run time and both become destinations - `imageRoot` is written into the
+      // server config as the library, `installLocation` becomes backendsRoot()
+      // and a 2.5 GB download lands under it.
       choices: {
-        imageRoot: string;
+        imageRoot: unknown;
         useGpu: boolean;
-        installLocation?: string;
+        installLocation?: unknown;
         importLegacyIdentity?: boolean;
         telemetry?: Record<string, boolean> | null;
       },
     ) => {
       // Answering a question the app asked for changes nothing about the
-      // install: park the answer and hand the window back.
+      // install: park the answer and hand the window back. No path is read on
+      // this branch, so the paths are validated below it rather than above.
       if (requestedStartupSteps.length) {
         writePendingTelemetry(choices?.telemetry ?? null);
         requestedStartupSteps = [];
         if (currentUrl) await mainWindow?.loadURL(currentUrl);
         return;
       }
+
+      const validatedChoices = {
+        ...choices,
+        imageRoot: requireOfferedPath(choices?.imageRoot, 'Library folder'),
+        installLocation: choices?.installLocation
+          ? requireOfferedPath(choices.installLocation, 'GPU install location')
+          : undefined,
+      };
 
       if (!runtime) throw new Error('No bundled runtime available');
 
@@ -1340,7 +1360,7 @@ function registerIpc(): void {
 
       // The order of everything below is `runFirstRunSetup`; this is the wiring
       // that gives it the real collaborators.
-      await runFirstRunSetup(choices, {
+      await runFirstRunSetup(validatedChoices, {
         gpu: gpuUpgrade() ?? null,
         legacyIdentitySource: detectedLegacyIdentitySource,
         resolvePath: (path) => resolve(path),
@@ -1538,8 +1558,10 @@ function registerIpc(): void {
   // External server (remote access) settings. The loopback the window uses is
   // never affected by these - only the optional second listener.
   ipcMain.handle('server:getSettings', () => readServerSettings());
-  ipcMain.handle('server:setSettings', async (_e, settings: ServerSettings) => {
-    await writeServerSettings(settings);
+  // `enabled` and `ssl` decide whether a listener binds 0.0.0.0 and whether it
+  // demands TLS, and both reached the config unchecked before this.
+  ipcMain.handle('server:setSettings', async (_e, raw: unknown) => {
+    await writeServerSettings(requireServerSettings(raw));
   });
   ipcMain.handle('server:checkPort', (_e, port: number) => checkPortAvailable(port));
 
@@ -1557,8 +1579,8 @@ function registerIpc(): void {
   // Where on-demand GPU overlays are stored. Lets the user keep the multi-GB
   // download off the system drive (the first-run wizard offers the same choice).
   ipcMain.handle('backend:getLocation', () => ({
-    dir: backendsRoot(),
-    default: defaultBackendsRoot(),
+    dir: offerPath(backendsRoot()),
+    default: offerPath(defaultBackendsRoot()),
   }));
 
   ipcMain.handle('backend:pickLocation', async (_e, current?: string) => {
@@ -1567,12 +1589,15 @@ function registerIpc(): void {
       defaultPath: current || backendsRoot(),
       properties: ['openDirectory', 'createDirectory'],
     });
-    return res.canceled || !res.filePaths[0] ? null : res.filePaths[0];
+    return res.canceled || !res.filePaths[0] ? null : offerPath(res.filePaths[0]);
   });
 
-  ipcMain.handle('backend:setLocation', async (_e, dir: string) => {
-    await changeBackendsLocation(dir);
-    return { dir: backendsRoot(), default: defaultBackendsRoot() };
+  // The destination reaches moveDir, which recursively deletes `<dir>/<accel>`.
+  // Item 13 made the last segment a validated Accel; this makes the root one
+  // PixlStash itself offered (see requireOfferedPath).
+  ipcMain.handle('backend:setLocation', async (_e, raw: unknown) => {
+    await changeBackendsLocation(requireOfferedPath(raw, 'GPU install location'));
+    return { dir: offerPath(backendsRoot()), default: offerPath(defaultBackendsRoot()) };
   });
 
   // The three handlers below take an accelerator straight from the renderer, and

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -23,7 +23,7 @@ import { detectHardware, gpuUpgrades, Hardware } from './backend/HardwareDetecto
 import { BackendManager, OVERLAY_ACCELS, launchWithOverlayFallback } from './backend/BackendManager';
 import { uniqueDownloadPath } from './downloads';
 import { ipcBytes, pngClipboardPayload, safeMediaFilename } from './mediaIpc';
-import { isAllowedNavigation, redactUrl } from './urlPolicy';
+import { isAllowedNavigation, isBundledRendererPage, redactUrl } from './urlPolicy';
 import { ServerProcess, StartupRecovery, devInterpreter } from './backend/ServerProcess';
 import {
   isPermissionRepairRequired,
@@ -1217,6 +1217,33 @@ function registerDownloadHandling(): void {
   });
 }
 
+/**
+ * Refuse a `setup:*` call that did not come from the first-run wizard page.
+ *
+ * SECURITY: the wizard and the library app are the same window behind the same
+ * preload (`mainWindow.loadFile(setup.html)` then `loadURL(<backend>)`), so
+ * every `setup:*` handler stayed reachable from library-served JavaScript once
+ * setup had finished. `setup:commit` alone rewrites the server config through
+ * `writeConfig` - which omits `external_server_enabled` and `port` and sets
+ * `require_ssl: false` - repoints the library, and restarts the backend
+ * (#1177 item 62). Binding to a `webContents` cannot separate them; the
+ * document loaded in the sending frame can.
+ *
+ * `startup:*` is deliberately NOT gated: `takePendingTelemetry`,
+ * `takePendingMapping` and `askQuestion` are the running app's own channels
+ * (`useAppConfig.js`, `SideBar.vue`), and gating them would break the upgrade
+ * privacy question and the folder-mapping handoff.
+ */
+function requireSetupRenderer(event: Electron.IpcMainInvokeEvent, channel: string): void {
+  // The frame, not the webContents: a frame the library page created has its
+  // own URL, while `getURL()` would report the top document's. Fall back only
+  // when the frame is already gone (it is detached mid-call).
+  const sender = event.senderFrame?.url ?? event.sender.getURL();
+  if (isBundledRendererPage(sender, RENDERER_DIR, 'setup.html')) return;
+  console.warn(`[ipc] refusing ${channel} from ${redactUrl(sender)}: not the setup screen`);
+  throw new Error(`${channel} is only available during first-run setup.`);
+}
+
 function registerIpc(): void {
   ipcMain.handle('app:bootstrap', async () => ({
     version: app.getVersion(),
@@ -1239,7 +1266,8 @@ function registerIpc(): void {
   // only that. Anything else that has to be settled before the app loads gets
   // a step id here rather than a dialog over a half-loaded library.
 
-  ipcMain.handle('setup:probe', async () => {
+  ipcMain.handle('setup:probe', async (event) => {
+    requireSetupRenderer(event, 'setup:probe');
     // A question the running app asked us to put in front of it: exactly that
     // question, no library or compute step, and no config is rewritten when it
     // is answered.
@@ -1304,11 +1332,13 @@ function registerIpc(): void {
   // What is in the folder someone picked, for the verdict under the field: a
   // library PixlStash made before, a folder of pictures, or nothing yet. Read
   // only, and bounded - see InspectFolder.
-  ipcMain.handle('setup:inspect', async (_e, path?: string) =>
-    inspectFolder(path || '', bundledInterpreter()),
-  );
+  ipcMain.handle('setup:inspect', async (event, path?: string) => {
+    requireSetupRenderer(event, 'setup:inspect');
+    return inspectFolder(path || '', bundledInterpreter());
+  });
 
-  ipcMain.handle('setup:pickFolder', async (_e, current?: string) => {
+  ipcMain.handle('setup:pickFolder', async (event, current?: string) => {
+    requireSetupRenderer(event, 'setup:pickFolder');
     const res = await dialog.showOpenDialog({
       title: 'Choose your PixlStash library folder',
       defaultPath: current || defaultLibraryDir(),
@@ -1322,7 +1352,7 @@ function registerIpc(): void {
   ipcMain.handle(
     'setup:commit',
     async (
-      _e,
+      event,
       // `unknown` for the two path fields: their TypeScript types are erased at
       // run time and both become destinations - `imageRoot` is written into the
       // server config as the library, `installLocation` becomes backendsRoot()
@@ -1335,6 +1365,7 @@ function registerIpc(): void {
         telemetry?: Record<string, boolean> | null;
       },
     ) => {
+      requireSetupRenderer(event, 'setup:commit');
       // Answering a question the app asked for changes nothing about the
       // install: park the answer and hand the window back. No path is read on
       // this branch, so the paths are validated below it rather than above.

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -68,6 +68,48 @@ export function isBundledRendererPage(
 }
 
 /**
+ * True only when `target` is a page served by the running backend itself.
+ *
+ * SECURITY: the counterpart to {@link isBundledRendererPage}, for the channels
+ * that belong to the *app* rather than to the wizard. `server:setSettings`
+ * flips `external_server_enabled` on, sets `host` to `0.0.0.0`, can clear
+ * `require_ssl`, and restarts the backend - turning a local photo application
+ * into a network service. That is the app's Settings dialog's job and nothing
+ * else's, so a bundled `file://` page (the wizard, the splash, the permission
+ * repair screen) is refused here even though the navigation guard is happy to
+ * load it.
+ *
+ * Stricter than {@link isAllowedNavigation} in the other direction: only the
+ * exact origin of the page actually loaded counts, never a `file://` URL and
+ * never the pre-backend loopback fallback. Before the backend is up there is no
+ * app, so `currentUrl` being null refuses everything.
+ *
+ * **What this does not do:** it does not defend against hostile JavaScript
+ * running *inside* the app's own origin, which would pass. Nothing at this
+ * boundary can - the app is the legitimate caller. It removes the other
+ * renderer surfaces, and the backend's own refusal to expose an external
+ * listener without an owner password (`listeners.py`) is what stands behind it.
+ */
+export function isBackendOrigin(target: string, currentUrl: string | null): boolean {
+  if (!currentUrl) return false;
+  let url: URL;
+  let current: URL;
+  try {
+    url = new URL(target);
+    current = new URL(currentUrl);
+  } catch {
+    return false;
+  }
+  // Same three rules isAllowedNavigation applies, for the same reasons: an
+  // embedded credential is never part of anything we loaded, and an opaque
+  // scheme can carry a matching origin (`blob:http://127.0.0.1:1234/x`) while
+  // being a document the page authored rather than one the backend served.
+  if (url.username || url.password) return false;
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  return url.origin === current.origin;
+}
+
+/**
  * Decide whether the window may load `target` - used by BOTH the top-level
  * navigation guard and `setWindowOpenHandler`, so the origin policy lives in one
  * place the way the scheme policy already does. The privileged

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -30,6 +30,44 @@ export function redactUrl(target: string): string {
 }
 
 /**
+ * True only when `target` is exactly the bundled renderer file `page`.
+ *
+ * SECURITY: the first-run wizard and the app share one window and one preload,
+ * so `setup.html` and the library page reach the same `ipcMain` handlers and a
+ * `webContents` binding cannot tell them apart - the only thing that differs is
+ * the document currently loaded in the sender. This answers that question for
+ * the `setup:*` channels, which are the wizard's alone: `setup:commit` rewrites
+ * the server config (dropping `external_server_enabled` and `port`, setting
+ * `require_ssl: false`), repoints the library and restarts the backend.
+ *
+ * Deliberately stricter than {@link isAllowedNavigation}, which allows the whole
+ * renderer directory because every file in it is ours to load. Here one named
+ * file is the answer, so `index.html` and `permissions.html` are refused too.
+ * The path is resolved and compared whole: a prefix test would accept a sibling
+ * directory sharing the prefix, and `fileURLToPath` is what stops a percent-
+ * encoded traversal reaching the comparison as text.
+ */
+export function isBundledRendererPage(
+  target: string,
+  rendererDir: string,
+  page: string,
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'file:') return false;
+  try {
+    const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
+    return resolve(fileURLToPath(url)) === resolve(dir, page);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Decide whether the window may load `target` - used by BOTH the top-level
  * navigation guard and `setWindowOpenHandler`, so the origin policy lives in one
  * place the way the scheme policy already does. The privileged

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { describe, it } from 'node:test';
+import { offerPath, requireOfferedPath, requireServerSettings } from '../src/config';
+
+/**
+ * `backend:setLocation` and `setup:commit` take a folder from the renderer and
+ * hand it to code that creates, writes and recursively deletes:
+ * `changeBackendsLocation` -> `moveDir` does
+ * `rm(to, { recursive: true, force: true })` on `<caller-chosen root>/<accel>`,
+ * and `setup:commit` writes the server config's `image_root` and installs a
+ * 2.5 GB runtime under `installLocation`.
+ *
+ * Both are *meant* to take a user-chosen path, so an allowlist of directories
+ * would be the wrong control and would break the feature. What is checked is
+ * provenance: only the main process can open a native dialog or compute a
+ * default, so a path it never handed out did not come from one (CWE-20, the
+ * sibling of the item 13 accelerator fix in #1190).
+ */
+describe('requireOfferedPath', () => {
+  it('accepts a path the dialog just handed out', () => {
+    const chosen = resolve(sep, 'home', 'me', 'Pictures');
+    offerPath(chosen);
+    assert.equal(requireOfferedPath(chosen, 'Library folder'), chosen);
+  });
+
+  it('accepts the same folder spelled differently', () => {
+    // The renderer trims the readonly field, and a path may arrive with a
+    // trailing separator; both must still resolve to the offered folder.
+    const chosen = resolve(sep, 'home', 'me', 'Library Two');
+    offerPath(chosen);
+    assert.equal(requireOfferedPath(`  ${chosen}${sep}  `, 'Library folder'), chosen);
+    assert.equal(requireOfferedPath(join(chosen, 'x', '..'), 'Library folder'), chosen);
+  });
+
+  it('refuses a folder nobody offered', () => {
+    for (const bad of [
+      resolve(sep, 'etc'),
+      resolve(sep, 'home', 'me'),
+      resolve(sep, 'home', 'me', 'Pictures', 'nested'),
+      '../..',
+      'C:\\Windows',
+    ]) {
+      assert.throws(
+        () => requireOfferedPath(bad, 'GPU install location'),
+        /was not offered by PixlStash/,
+        `${bad} must not be accepted as a destination`,
+      );
+    }
+  });
+
+  it('refuses anything that is not a non-empty string', () => {
+    for (const bad of [
+      null,
+      undefined,
+      '',
+      '   ',
+      123,
+      // Structured clone carries a BigInt over IPC and JSON.stringify throws on
+      // one; describing the value must not become the failure.
+      1n,
+      // A caller-supplied toString must never be called to describe the value.
+      { toString: () => resolve(sep, 'home', 'me', 'Pictures') },
+      [resolve(sep, 'home', 'me', 'Pictures')],
+    ]) {
+      assert.throws(
+        () => requireOfferedPath(bad, 'Library folder'),
+        /must be a folder path|was not offered by PixlStash/,
+        `${typeof bad} must not be accepted as a destination`,
+      );
+    }
+  });
+
+  it('offerPath returns its argument and ignores nothing-values', () => {
+    // It sits inline in the handlers' return expressions, so it must be
+    // transparent, and a `null` default (no detected legacy library) must not
+    // put an empty string on the offered set.
+    const chosen = resolve(sep, 'home', 'you', 'Pictures');
+    assert.equal(offerPath(chosen), chosen);
+    assert.equal(offerPath(null), null);
+    assert.equal(offerPath(undefined), undefined);
+    assert.throws(() => requireOfferedPath('', 'Library folder'), /must be a folder path/);
+  });
+});
+
+/**
+ * `server:setSettings` writes `enabled` and `ssl` into the backend's config.
+ * `enabled` binds a second listener on 0.0.0.0 and `ssl` decides whether it
+ * demands TLS; both were written unchecked, so a non-boolean could read false
+ * to the backend and true to the shell's own `Boolean(...)` - a plaintext LAN
+ * listener the toggle reports as encrypted.
+ */
+describe('requireServerSettings', () => {
+  it('passes a well-formed settings object through', () => {
+    const settings = { enabled: true, port: 9537, ssl: true };
+    assert.deepEqual(requireServerSettings(settings), settings);
+    assert.deepEqual(requireServerSettings({ enabled: false, port: 1, ssl: false }), {
+      enabled: false,
+      port: 1,
+      ssl: false,
+    });
+  });
+
+  it('refuses a non-boolean enabled or ssl', () => {
+    for (const bad of [
+      { enabled: 1, port: 9537, ssl: true },
+      { enabled: true, port: 9537, ssl: 0 },
+      { enabled: true, port: 9537, ssl: [] },
+      { enabled: true, port: 9537, ssl: 'false' },
+      { enabled: 'yes', port: 9537, ssl: false },
+      { enabled: true, port: 9537 },
+      { port: 9537, ssl: true },
+      {},
+      null,
+      undefined,
+      'enabled',
+    ]) {
+      assert.throws(
+        () => requireServerSettings(bad),
+        /must be true or false/,
+        `${JSON.stringify(bad) ?? String(bad)} must not be accepted`,
+      );
+    }
+  });
+
+  it('leaves a half-typed port alone rather than throwing', () => {
+    // The port field emits Number('') === 0 and Number('x') === NaN while it is
+    // being typed, and writeServerSettings already ignores anything outside
+    // 1-65535 and keeps the stored port. Refusing here would turn typing into
+    // an error dialog - over-blocking is its own regression.
+    assert.equal(requireServerSettings({ enabled: true, port: 0, ssl: false }).port, 0);
+    assert.ok(Number.isNaN(requireServerSettings({ enabled: true, port: NaN, ssl: false }).port));
+  });
+});
+
+/**
+ * Source-text assertions, because `main.ts` registers its handlers as a side
+ * effect of an Electron app boot and exposes no module boundary to import - the
+ * same reason `accelIpcValidation.test.ts` reads it as text.
+ *
+ * What is pinned is the shape. Declaring the parameter `dir: string` again is
+ * exactly the regression, and it type-checks.
+ */
+describe('the path-taking IPC handlers validate before they use the value', () => {
+  // __dirname is dist-test/test at run time; the sources are two levels up.
+  const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
+
+  it('backend:setLocation takes an unknown and narrows it', () => {
+    const start = main.indexOf("ipcMain.handle('backend:setLocation'");
+    assert.ok(start >= 0, 'backend:setLocation handler not found');
+    const body = main.slice(start, main.indexOf('ipcMain.handle(', start + 1));
+    assert.match(body, /\(_e,\s*raw:\s*unknown\)/);
+    assert.match(body, /requireOfferedPath\(raw,/);
+    assert.doesNotMatch(
+      body,
+      /changeBackendsLocation\(\s*raw\s*\)/,
+      'the raw renderer value must never reach changeBackendsLocation',
+    );
+  });
+
+  it('setup:commit narrows both of its paths before runFirstRunSetup', () => {
+    const start = main.indexOf("ipcMain.handle(\n    'setup:commit'");
+    assert.ok(start >= 0, 'setup:commit handler not found');
+    const body = main.slice(start, main.indexOf("ipcMain.handle('startup:", start));
+    assert.match(body, /imageRoot:\s*unknown/, 'imageRoot must not be typed as a string');
+    assert.match(body, /installLocation\?:\s*unknown/);
+    assert.match(body, /requireOfferedPath\(choices\?\.imageRoot,/);
+    assert.match(body, /requireOfferedPath\(choices\.installLocation,/);
+    assert.doesNotMatch(
+      body,
+      /runFirstRunSetup\(\s*choices\s*,/,
+      'the unvalidated choices object must never be the one that runs the setup',
+    );
+  });
+
+  it('every path a handler hands the renderer is recorded with offerPath', () => {
+    // The other half of the guard: a dialog result or default that is not
+    // offered is refused when it comes back, which breaks the feature rather
+    // than opening a hole - but it breaks it silently, so pin it here.
+    for (const source of [
+      "ipcMain.handle('setup:pickFolder'",
+      "ipcMain.handle('backend:pickLocation'",
+      "ipcMain.handle('backend:getLocation'",
+    ]) {
+      const start = main.indexOf(source);
+      assert.ok(start >= 0, `${source} not found`);
+      const body = main.slice(start, main.indexOf('ipcMain.handle(', start + 1));
+      assert.match(body, /offerPath\(/, `${source} must record what it hands out`);
+    }
+    // The wizard's prefilled defaults, which setup:commit must also accept.
+    const probe = main.slice(
+      main.indexOf("ipcMain.handle('setup:probe'"),
+      main.indexOf("ipcMain.handle('setup:inspect'"),
+    );
+    for (const field of ['existingRoot: offerPath(', 'newRoot: offerPath(', 'installLocation: offerPath(']) {
+      assert.ok(probe.includes(field), `setup:probe must offer ${field}`);
+    }
+  });
+
+  it('server:setSettings takes an unknown and narrows it', () => {
+    const start = main.indexOf("ipcMain.handle('server:setSettings'");
+    assert.ok(start >= 0, 'server:setSettings handler not found');
+    const body = main.slice(start, main.indexOf('ipcMain.handle(', start + 1));
+    assert.match(body, /\(_e,\s*raw:\s*unknown\)/);
+    assert.match(body, /writeServerSettings\(requireServerSettings\(raw\)\)/);
+  });
+});

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 import { describe, it } from 'node:test';
-import { offerPath, requireOfferedPath, requireServerSettings } from '../src/config';
+import { offerPath, pathKey, requireOfferedPath, requireServerSettings } from '../src/config';
 
 /**
  * `backend:setLocation` and `setup:commit` take a folder from the renderer and
@@ -23,6 +23,39 @@ describe('requireOfferedPath', () => {
     const chosen = resolve(sep, 'home', 'me', 'Pictures');
     offerPath(chosen, 'library');
     assert.equal(requireOfferedPath(chosen, 'library', 'Library folder'), chosen);
+  });
+
+  it('accepts a different casing on Windows and refuses it on POSIX', () => {
+    // Windows filesystems are case-insensitive, so a folder coming back as
+    // `c:\\users\\me` when it was offered as `C:\\Users\\me` is the SAME folder and
+    // refusing it would break the picker - the over-blocking failure this
+    // guard must never cause. POSIX is case-sensitive, where those really are
+    // two directories, so the same tolerance there would accept a path that
+    // was never offered.
+    const win = 'C:\\Users\\me\\Pictures';
+    offerPath(win, 'library', 'win32');
+    assert.equal(requireOfferedPath('c:\\users\\me\\pictures', 'library', 'Library folder', 'win32'), resolve(win));
+    // And it hands back the casing PixlStash offered, not the renderer's.
+    assert.equal(requireOfferedPath(win.toLowerCase(), 'library', 'Library folder', 'win32'), resolve(win));
+
+    const posix = resolve(sep, 'home', 'me', 'CaseSensitive');
+    offerPath(posix, 'library', 'linux');
+    assert.equal(requireOfferedPath(posix, 'library', 'Library folder', 'linux'), posix);
+    assert.throws(
+      () => requireOfferedPath(posix.toLowerCase(), 'library', 'Library folder', 'linux'),
+      /was not offered by PixlStash/,
+      'a differently-cased path is a different directory on POSIX',
+    );
+  });
+
+  it('pathKey folds case only on Windows', () => {
+    const p = resolve(sep, 'Home', 'Me', 'Pictures');
+    assert.equal(pathKey(p, 'win32'), resolve(p).toLowerCase());
+    assert.equal(pathKey(p, 'linux'), resolve(p));
+    assert.equal(pathKey(p, 'darwin'), resolve(p));
+    // Trailing separator and `..` still normalise on every platform.
+    assert.equal(pathKey(`  ${p}${sep}  `, 'linux'), resolve(p));
+    assert.equal(pathKey(join(p, 'x', '..'), 'linux'), resolve(p));
   });
 
   it('refuses a path offered for the OTHER question', () => {
@@ -145,6 +178,26 @@ describe('requireServerSettings', () => {
         () => requireServerSettings(bad),
         /must be true or false/,
         `${JSON.stringify(bad) ?? String(bad)} must not be accepted`,
+      );
+    }
+  });
+
+  it('refuses a port that is not a number at all', () => {
+    // Range leniency is for the field mid-keystroke; it was never a reason to
+    // accept a string or a missing value, neither of which the port field can
+    // produce. This is the same trust-boundary point as `enabled` and `ssl`.
+    for (const bad of [
+      { enabled: true, port: '9537', ssl: false },
+      { enabled: true, port: undefined, ssl: false },
+      { enabled: true, port: null, ssl: false },
+      { enabled: true, port: {}, ssl: false },
+      { enabled: true, port: [9537], ssl: false },
+      { enabled: true, ssl: false },
+    ]) {
+      assert.throws(
+        () => requireServerSettings(bad),
+        /"port" must be a number/,
+        `${JSON.stringify(bad)} must not be accepted`,
       );
     }
   });

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -21,17 +21,39 @@ import { offerPath, requireOfferedPath, requireServerSettings } from '../src/con
 describe('requireOfferedPath', () => {
   it('accepts a path the dialog just handed out', () => {
     const chosen = resolve(sep, 'home', 'me', 'Pictures');
-    offerPath(chosen);
-    assert.equal(requireOfferedPath(chosen, 'Library folder'), chosen);
+    offerPath(chosen, 'library');
+    assert.equal(requireOfferedPath(chosen, 'library', 'Library folder'), chosen);
+  });
+
+  it('refuses a path offered for the OTHER question', () => {
+    // One pool would let the library folder be replayed as the GPU install
+    // location, which makes setBackendsRoot point at the user's pictures and
+    // accel:install / backend:setLocation then recursively delete
+    // `<library>/<accel>` inside it.
+    const library = resolve(sep, 'home', 'me', 'Pictures');
+    const backends = resolve(sep, 'home', 'me', '.cache', 'backends');
+    offerPath(library, 'library');
+    offerPath(backends, 'backends');
+    assert.throws(
+      () => requireOfferedPath(library, 'backends', 'GPU install location'),
+      /was not offered by PixlStash for this choice/,
+    );
+    assert.throws(
+      () => requireOfferedPath(backends, 'library', 'Library folder'),
+      /was not offered by PixlStash for this choice/,
+    );
+    // Each is still accepted for its own question.
+    assert.equal(requireOfferedPath(library, 'library', 'Library folder'), library);
+    assert.equal(requireOfferedPath(backends, 'backends', 'GPU install location'), backends);
   });
 
   it('accepts the same folder spelled differently', () => {
     // The renderer trims the readonly field, and a path may arrive with a
     // trailing separator; both must still resolve to the offered folder.
     const chosen = resolve(sep, 'home', 'me', 'Library Two');
-    offerPath(chosen);
-    assert.equal(requireOfferedPath(`  ${chosen}${sep}  `, 'Library folder'), chosen);
-    assert.equal(requireOfferedPath(join(chosen, 'x', '..'), 'Library folder'), chosen);
+    offerPath(chosen, 'library');
+    assert.equal(requireOfferedPath(`  ${chosen}${sep}  `, 'library', 'Library folder'), chosen);
+    assert.equal(requireOfferedPath(join(chosen, 'x', '..'), 'library', 'Library folder'), chosen);
   });
 
   it('refuses a folder nobody offered', () => {
@@ -43,7 +65,7 @@ describe('requireOfferedPath', () => {
       'C:\\Windows',
     ]) {
       assert.throws(
-        () => requireOfferedPath(bad, 'GPU install location'),
+        () => requireOfferedPath(bad, 'backends', 'GPU install location'),
         /was not offered by PixlStash/,
         `${bad} must not be accepted as a destination`,
       );
@@ -65,7 +87,7 @@ describe('requireOfferedPath', () => {
       [resolve(sep, 'home', 'me', 'Pictures')],
     ]) {
       assert.throws(
-        () => requireOfferedPath(bad, 'Library folder'),
+        () => requireOfferedPath(bad, 'library', 'Library folder'),
         /must be a folder path|was not offered by PixlStash/,
         `${typeof bad} must not be accepted as a destination`,
       );
@@ -77,10 +99,13 @@ describe('requireOfferedPath', () => {
     // transparent, and a `null` default (no detected legacy library) must not
     // put an empty string on the offered set.
     const chosen = resolve(sep, 'home', 'you', 'Pictures');
-    assert.equal(offerPath(chosen), chosen);
-    assert.equal(offerPath(null), null);
-    assert.equal(offerPath(undefined), undefined);
-    assert.throws(() => requireOfferedPath('', 'Library folder'), /must be a folder path/);
+    assert.equal(offerPath(chosen, 'library'), chosen);
+    assert.equal(offerPath(null, 'library'), null);
+    assert.equal(offerPath(undefined, 'library'), undefined);
+    assert.throws(
+      () => requireOfferedPath('', 'library', 'Library folder'),
+      /must be a folder path/,
+    );
   });
 });
 
@@ -151,7 +176,7 @@ describe('the path-taking IPC handlers validate before they use the value', () =
     assert.ok(start >= 0, 'backend:setLocation handler not found');
     const body = main.slice(start, main.indexOf('ipcMain.handle(', start + 1));
     assert.match(body, /\(_e,\s*raw:\s*unknown\)/);
-    assert.match(body, /requireOfferedPath\(raw,/);
+    assert.match(body, /requireOfferedPath\(raw, 'backends',/);
     assert.doesNotMatch(
       body,
       /changeBackendsLocation\(\s*raw\s*\)/,
@@ -165,8 +190,8 @@ describe('the path-taking IPC handlers validate before they use the value', () =
     const body = main.slice(start, main.indexOf("ipcMain.handle('startup:", start));
     assert.match(body, /imageRoot:\s*unknown/, 'imageRoot must not be typed as a string');
     assert.match(body, /installLocation\?:\s*unknown/);
-    assert.match(body, /requireOfferedPath\(choices\?\.imageRoot,/);
-    assert.match(body, /requireOfferedPath\(choices\.installLocation,/);
+    assert.match(body, /requireOfferedPath\(choices\?\.imageRoot, 'library',/);
+    assert.match(body, /requireOfferedPath\(choices\.installLocation, 'backends',/);
     assert.doesNotMatch(
       body,
       /runFirstRunSetup\(\s*choices\s*,/,
@@ -193,7 +218,11 @@ describe('the path-taking IPC handlers validate before they use the value', () =
       main.indexOf("ipcMain.handle('setup:probe'"),
       main.indexOf("ipcMain.handle('setup:inspect'"),
     );
-    for (const field of ['existingRoot: offerPath(', 'newRoot: offerPath(', 'installLocation: offerPath(']) {
+    for (const field of [
+      'existingRoot: offerPath(',
+      "newRoot: offerPath(defaultLibraryDir(), 'library')",
+      "installLocation: offerPath(backendsRoot(), 'backends')",
+    ]) {
       assert.ok(probe.includes(field), `setup:probe must offer ${field}`);
     }
   });

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -284,7 +284,14 @@ describe('the path-taking IPC handlers validate before they use the value', () =
     const start = main.indexOf("ipcMain.handle('server:setSettings'");
     assert.ok(start >= 0, 'server:setSettings handler not found');
     const body = main.slice(start, main.indexOf('ipcMain.handle(', start + 1));
-    assert.match(body, /\(_e,\s*raw:\s*unknown\)/);
+    // `event`, not `_e`: the handler now also gates on the sending frame, so
+    // it needs the event. The payload is still narrowed before it is written.
+    assert.match(body, /\(event,\s*raw:\s*unknown\)/);
     assert.match(body, /writeServerSettings\(requireServerSettings\(raw\)\)/);
+    assert.match(
+      body,
+      /requireAppRenderer\(event, 'server:setSettings'\)/,
+      'validating the payload shape does not gate the capability',
+    );
   });
 });

--- a/electron/test/startupFramework.test.ts
+++ b/electron/test/startupFramework.test.ts
@@ -62,8 +62,13 @@ describe('the startup framework', () => {
     // A prefilled path with nothing at it is how someone accepts the wrong
     // folder and opens an empty library; "start empty" is the only answer that
     // may name a folder that does not exist yet.
-    assert.match(mainSrc, /existingRoot:\s*\n?\s*importedImageRoot && existsSync\(importedImageRoot\)/);
-    assert.match(mainSrc, /newRoot: defaultLibraryDir\(\)/);
+    // Both defaults are wrapped in offerPath (see pathIpcValidation.test.ts);
+    // what this pins is which answer gets a suggestion, not the wrapper.
+    assert.match(
+      mainSrc,
+      /existingRoot: offerPath\(\s*\n?\s*importedImageRoot && existsSync\(importedImageRoot\)/,
+    );
+    assert.match(mainSrc, /newRoot: offerPath\(defaultLibraryDir\(\)\)/);
     assert.match(script, /detectedLegacyIdentitySource \|\| defaults\.existingRoot \|\| ''/);
   });
 

--- a/electron/test/startupFramework.test.ts
+++ b/electron/test/startupFramework.test.ts
@@ -68,7 +68,7 @@ describe('the startup framework', () => {
       mainSrc,
       /existingRoot: offerPath\(\s*\n?\s*importedImageRoot && existsSync\(importedImageRoot\)/,
     );
-    assert.match(mainSrc, /newRoot: offerPath\(defaultLibraryDir\(\)\)/);
+    assert.match(mainSrc, /newRoot: offerPath\(defaultLibraryDir\(\), 'library'\)/);
     assert.match(script, /detectedLegacyIdentitySource \|\| defaults\.existingRoot \|\| ''/);
   });
 

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -3,7 +3,12 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { pathToFileURL } from 'node:url';
 import { join, resolve, sep } from 'node:path';
-import { isAllowedNavigation, isBundledRendererPage, redactUrl } from '../src/urlPolicy';
+import {
+  isAllowedNavigation,
+  isBackendOrigin,
+  isBundledRendererPage,
+  redactUrl,
+} from '../src/urlPolicy';
 
 // A plausible packaged renderer dir, resolved and separator-suffixed exactly as
 // main.ts builds RENDERER_DIR.
@@ -156,35 +161,141 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
   });
 });
 
-describe('the setup:* handlers are gated on the sending frame', () => {
+/**
+ * Every `ipcMain.handle` in main.ts, as (channel, body) pairs.
+ *
+ * The gates below are enumerated FROM THE SOURCE rather than from a list
+ * written here. A hand-written list is opt-in: the previous version of this
+ * file named three handlers by string, so a fourth one added later was gated by
+ * nobody and pinned by nothing, which is the same by-omission hole the Python
+ * side closed by making "safe by omission" a machine fact
+ * (`test_all_routes_declare_access_policy`). Deriving the set means a new
+ * `setup:*` or `server:*` channel is covered the moment it exists.
+ */
+function ipcHandlers(main: string): Array<[string, string]> {
+  const found: Array<[string, string]> = [];
+  const opener = /ipcMain\.handle\(\s*'([^']+)'/g;
+  const starts: Array<[string, number]> = [];
+  for (let m = opener.exec(main); m !== null; m = opener.exec(main)) {
+    starts.push([m[1], m.index]);
+  }
+  starts.forEach(([channel, at], i) => {
+    const end = i + 1 < starts.length ? starts[i + 1][1] : main.length;
+    found.push([channel, main.slice(at, end)]);
+  });
+  return found;
+}
+
+/**
+ * `server:setSettings` decides whether this machine listens on the network:
+ * it writes `external_server_enabled`, `host: '0.0.0.0'` and `require_ssl`,
+ * then restarts the backend. Item 57 validated the payload's shape and left the
+ * capability reachable from every renderer page (#1201 F4).
+ */
+describe('isBackendOrigin — the running app, and only it', () => {
+  const isApp = (target: string, current: string | null = BACKEND) =>
+    isBackendOrigin(target, current);
+
+  it('accepts the app the backend is actually serving', () => {
+    // The direction that must not break: this is the Settings dialog, which is
+    // the only legitimate caller (ComputeSection.vue).
+    assert.ok(isApp(BACKEND));
+    assert.ok(isApp(BACKEND + 'settings'));
+    assert.ok(isApp('http://127.0.0.1:8723/pictures?page=2'));
+  });
+
+  it('refuses our own bundled pages, which have no business here', () => {
+    assert.equal(isApp(pathToFileURL(RENDERER_DIR + 'setup.html').href), false);
+    assert.equal(isApp(pathToFileURL(RENDERER_DIR + 'index.html').href), false);
+    assert.equal(isApp(pathToFileURL(RENDERER_DIR + 'permissions.html').href), false);
+  });
+
+  it('refuses another origin, another port, and an opaque scheme', () => {
+    assert.equal(isApp('http://127.0.0.1:9999/'), false);
+    assert.equal(isApp('http://localhost:8723/'), false);
+    assert.equal(isApp('https://example.invalid/'), false);
+    // Origin matches, but the document was authored by the page, not served.
+    assert.equal(isApp('blob:http://127.0.0.1:8723/x'), false);
+    assert.equal(isApp('http://someone@127.0.0.1:8723/'), false);
+    assert.equal(isApp('not a url'), false);
+  });
+
+  it('refuses everything before the backend is up', () => {
+    // No currentUrl means there is no app yet, so nothing can be it - unlike
+    // isAllowedNavigation, which falls back to permitting loopback so an
+    // in-flight load is not broken.
+    assert.equal(isApp(BACKEND, null), false);
+    assert.equal(isApp('http://127.0.0.1:8723/', null), false);
+  });
+});
+
+describe('IPC gating is complete, not opt-in', () => {
   // __dirname is dist-test/test at run time; the sources are two levels up.
   const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
+  const handlers = ipcHandlers(main);
 
-  for (const channel of ['setup:probe', 'setup:inspect', 'setup:pickFolder', 'setup:commit']) {
-    it(`${channel} refuses a sender that is not the wizard`, () => {
-      const start = main.indexOf(`'${channel}'`);
-      assert.ok(start >= 0, `${channel} handler not found`);
-      const body = main.slice(start, start + 900);
+  it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {
+    const channels = handlers.map(([c]) => c);
+    assert.ok(channels.length > 20, `only found ${channels.length} handlers`);
+    for (const required of ['setup:commit', 'server:setSettings', 'backend:setLocation']) {
+      assert.ok(channels.includes(required), `${required} not found`);
+    }
+  });
+
+  it('EVERY setup:* channel is gated on the wizard page', () => {
+    const setup = handlers.filter(([c]) => c.startsWith('setup:'));
+    assert.ok(setup.length >= 4, `only found ${setup.length} setup:* handlers`);
+    for (const [channel, body] of setup) {
       assert.match(
         body,
         new RegExp(`requireSetupRenderer\\(event, '${channel}'\\)`),
         `${channel} must be gated before it does anything`,
       );
-    });
-  }
+    }
+  });
 
-  it('the guard reads the sending frame and compares it to setup.html', () => {
-    assert.match(main, /event\.senderFrame\?\.url \?\? event\.sender\.getURL\(\)/);
+  it('EVERY server:* channel is gated on the app window', () => {
+    // setSettings turns this machine into a network service; checkPort binds a
+    // caller-named port on all interfaces; getSettings returns LAN addresses.
+    const server = handlers.filter(([c]) => c.startsWith('server:'));
+    assert.ok(server.length >= 3, `only found ${server.length} server:* handlers`);
+    for (const [channel, body] of server) {
+      assert.match(
+        body,
+        new RegExp(`requireAppRenderer\\(event, '${channel}'\\)`),
+        `${channel} must be gated before it does anything`,
+      );
+    }
+  });
+
+  it('EVERY handler reaching a path sink narrows the path first', () => {
+    // Keyed on the sink, not on a list of channels: a new handler that calls
+    // changeBackendsLocation or runFirstRunSetup without requireOfferedPath
+    // turns this red instead of shipping ungated.
+    const sinks = /changeBackendsLocation\(|runFirstRunSetup\(|setBackendsRoot\(/;
+    const reaching = handlers.filter(([, body]) => sinks.test(body));
+    assert.ok(reaching.length >= 2, `only found ${reaching.length} path-sink handlers`);
+    for (const [channel, body] of reaching) {
+      assert.match(body, /requireOfferedPath\(/, `${channel} must narrow its path first`);
+    }
+  });
+
+  it('both guards read the sending frame rather than the webContents', () => {
+    // The wizard and the app are the same window behind the same preload, so
+    // getURL() alone would report the top document for a frame the page made.
+    const guards = main.match(/event\.senderFrame\?\.url \?\? event\.sender\.getURL\(\)/g);
+    assert.equal(guards?.length, 2, 'requireSetupRenderer and requireAppRenderer');
     assert.match(main, /isBundledRendererPage\(sender, RENDERER_DIR, 'setup\.html'\)/);
+    assert.match(main, /isBackendOrigin\(sender, currentUrl\)/);
   });
 
   it('leaves the app-renderer startup:* channels open', () => {
     // takePendingTelemetry / takePendingMapping / askQuestion are called BY the
     // library app (useAppConfig.js, SideBar.vue). Gating them would break the
     // upgrade privacy question and the folder-mapping handoff.
-    const startup = main.slice(main.indexOf("ipcMain.handle('startup:takePendingTelemetry'"));
-    const upToDesktop = startup.slice(0, startup.indexOf("ipcMain.handle('desktop:"));
-    assert.doesNotMatch(upToDesktop, /requireSetupRenderer/);
+    for (const [channel, body] of handlers.filter(([c]) => c.startsWith('startup:'))) {
+      assert.doesNotMatch(body, /requireSetupRenderer/, `${channel} must stay open`);
+    }
   });
 });
 

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { pathToFileURL } from 'node:url';
 import { join, resolve, sep } from 'node:path';
-import { isAllowedNavigation, redactUrl } from '../src/urlPolicy';
+import { isAllowedNavigation, isBundledRendererPage, redactUrl } from '../src/urlPolicy';
 
 // A plausible packaged renderer dir, resolved and separator-suffixed exactly as
 // main.ts builds RENDERER_DIR.
@@ -94,6 +94,97 @@ describe('isAllowedNavigation — bundled renderer files', () => {
     assert.equal(isAllowedNavigation(sibling, BACKEND, unsuffixed), false);
     const inside = pathToFileURL(RENDERER_DIR + 'index.html').href;
     assert.ok(isAllowedNavigation(inside, BACKEND, unsuffixed));
+  });
+});
+
+/**
+ * The wizard and the library app share one window and one preload, so before
+ * this the `setup:*` channels stayed reachable from library-served JavaScript
+ * after setup finished - and `setup:commit` rewrites the server config,
+ * repoints the library and restarts the backend (#1177 item 62). The sending
+ * frame's document is the only thing that separates them.
+ */
+describe('isBundledRendererPage — the setup screen, and only it', () => {
+  const isSetup = (target: string) =>
+    isBundledRendererPage(target, RENDERER_DIR, 'setup.html');
+
+  it('accepts the wizard page the shell itself loads', () => {
+    // The positive direction, and the one that matters most: over-blocking here
+    // breaks first-run setup outright, with no way past the wizard.
+    assert.ok(isSetup(pathToFileURL(RENDERER_DIR + 'setup.html').href));
+    // The dir handed in without its trailing separator must behave the same.
+    assert.ok(
+      isBundledRendererPage(
+        pathToFileURL(RENDERER_DIR + 'setup.html').href,
+        RENDERER_DIR.slice(0, -1),
+        'setup.html',
+      ),
+    );
+    // A query or hash is still the same document.
+    assert.ok(isSetup(pathToFileURL(RENDERER_DIR + 'setup.html').href + '?step=privacy'));
+  });
+
+  it('refuses the running library app, which is the actual attack', () => {
+    assert.equal(isSetup(BACKEND), false);
+    assert.equal(isSetup(BACKEND + 'pictures?page=2'), false);
+  });
+
+  it('refuses our other bundled pages', () => {
+    // Stricter than isAllowedNavigation on purpose: those may be navigated to,
+    // they may not answer for the wizard.
+    assert.equal(isSetup(pathToFileURL(RENDERER_DIR + 'index.html').href), false);
+    assert.equal(isSetup(pathToFileURL(RENDERER_DIR + 'permissions.html').href), false);
+  });
+
+  it('refuses traversal, a prefix-sharing sibling dir, and non-file schemes', () => {
+    assert.equal(isSetup(pathToFileURL(RENDERER_DIR + '../renderer-evil/setup.html').href), false);
+    assert.equal(isSetup(pathToFileURL(RENDERER_DIR + 'sub/setup.html').href), false);
+    assert.equal(
+      isSetup(pathToFileURL(resolve(RENDERER_DIR.slice(0, -1) + '-evil') + sep + 'setup.html').href),
+      false,
+    );
+    for (const bad of [
+      'file:///etc/setup.html',
+      'data:text/html,<b>setup.html</b>',
+      'blob:http://127.0.0.1:8723/setup.html',
+      'javascript:void 0',
+      'not a url',
+      '',
+    ]) {
+      assert.equal(isSetup(bad), false, `${bad} must not pass as the setup screen`);
+    }
+  });
+});
+
+describe('the setup:* handlers are gated on the sending frame', () => {
+  // __dirname is dist-test/test at run time; the sources are two levels up.
+  const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
+
+  for (const channel of ['setup:probe', 'setup:inspect', 'setup:pickFolder', 'setup:commit']) {
+    it(`${channel} refuses a sender that is not the wizard`, () => {
+      const start = main.indexOf(`'${channel}'`);
+      assert.ok(start >= 0, `${channel} handler not found`);
+      const body = main.slice(start, start + 900);
+      assert.match(
+        body,
+        new RegExp(`requireSetupRenderer\\(event, '${channel}'\\)`),
+        `${channel} must be gated before it does anything`,
+      );
+    });
+  }
+
+  it('the guard reads the sending frame and compares it to setup.html', () => {
+    assert.match(main, /event\.senderFrame\?\.url \?\? event\.sender\.getURL\(\)/);
+    assert.match(main, /isBundledRendererPage\(sender, RENDERER_DIR, 'setup\.html'\)/);
+  });
+
+  it('leaves the app-renderer startup:* channels open', () => {
+    // takePendingTelemetry / takePendingMapping / askQuestion are called BY the
+    // library app (useAppConfig.js, SideBar.vue). Gating them would break the
+    // upgrade privacy question and the folder-mapping handoff.
+    const startup = main.slice(main.indexOf("ipcMain.handle('startup:takePendingTelemetry'"));
+    const upToDesktop = startup.slice(0, startup.indexOf("ipcMain.handle('desktop:"));
+    assert.doesNotMatch(upToDesktop, /requireSetupRenderer/);
   });
 });
 

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -1504,6 +1504,11 @@ def _report_dependencies(
     for change in changes:
         note = f"replaces {change.installed}" if change.moves else "new"
         print(f"  {change.name:<{width}}  {change.version:<12}  {note}")
+        # Named, because it is the one line that changes what agreeing means:
+        # this package does not come from PyPI, so the name above says nothing
+        # about who wrote it. The URL is what actually gets installed.
+        if change.url:
+            print(f"  {'':<{width}}  from {change.url}")
 
     moved = [change for change in changes if change.moves]
     if not moved:

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -417,15 +417,6 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
             "PixlStash is using. This can stop PixlStash starting."
         ),
     )
-    install_parser.add_argument(
-        "--allow-sdist",
-        action="store_true",
-        help=(
-            "Allow dependencies published only as source. Working out what "
-            "they would install runs their build code first, before you are "
-            "shown anything."
-        ),
-    )
     install_parser.set_defaults(handler=_cmd_plugins_install)
 
     create_parser = commands.add_parser(
@@ -1590,17 +1581,8 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
                     "against each.",
                     file=sys.stderr,
                 )
-            if args.allow_sdist:
-                print(
-                    "\nwarning: --allow-sdist. Working out what these need "
-                    "runs build code from any source-only package among them, "
-                    "as you, before the list below exists.",
-                    file=sys.stderr,
-                )
             print(f"\nResolving {plan.requirements.name}...")
-            changes = plugin_install.resolve_requirements(
-                plan.requirements, allow_sdist=args.allow_sdist
-            )
+            changes = plugin_install.resolve_requirements(plan.requirements)
             if not _report_dependencies(changes, force=args.force_deps):
                 return EXIT_REFUSED
         elif plan.requirements:
@@ -1610,7 +1592,7 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             )
 
         if args.dry_run:
-            print("Dry run: nothing was written.")
+            print("Dry run: nothing was installed.")
             return EXIT_OK
         # Default yes only when the packages have just been listed one by one.
         question, default = ("Is this OK", True) if changes else ("Install it?", False)
@@ -1623,7 +1605,7 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             # The resolution that was shown and agreed to, not the file it came
             # from: re-reading the file would resolve it a second time and
             # could install something nobody was asked about.
-            plugin_install.install_requirements(changes, allow_sdist=args.allow_sdist)
+            plugin_install.install_requirements(changes)
 
     print(f"Installed {plan.name} to {plan.destination}")
     if plan.kind == plugin_install.CAPTIONING:

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -417,6 +417,15 @@ def _add_plugin_parsers(groups: argparse._SubParsersAction) -> None:
             "PixlStash is using. This can stop PixlStash starting."
         ),
     )
+    install_parser.add_argument(
+        "--allow-sdist",
+        action="store_true",
+        help=(
+            "Allow dependencies published only as source. Working out what "
+            "they would install runs their build code first, before you are "
+            "shown anything."
+        ),
+    )
     install_parser.set_defaults(handler=_cmd_plugins_install)
 
     create_parser = commands.add_parser(
@@ -1576,8 +1585,17 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
                     "source shown against each one.",
                     file=sys.stderr,
                 )
+            if args.allow_sdist:
+                print(
+                    "\nwarning: --allow-sdist. Working out what these need "
+                    "runs build code from any source-only package among them, "
+                    "as you, before the list below exists.",
+                    file=sys.stderr,
+                )
             print(f"\nResolving {plan.requirements.name}...")
-            changes = plugin_install.resolve_requirements(plan.requirements)
+            changes = plugin_install.resolve_requirements(
+                plan.requirements, allow_sdist=args.allow_sdist
+            )
             if not _report_dependencies(changes, force=args.force_deps):
                 return EXIT_REFUSED
         elif plan.requirements:
@@ -1600,7 +1618,7 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             # The resolution that was shown and agreed to, not the file it came
             # from: re-reading the file would resolve it a second time and
             # could install something nobody was asked about.
-            plugin_install.install_requirements(changes)
+            plugin_install.install_requirements(changes, allow_sdist=args.allow_sdist)
 
     print(f"Installed {plan.name} to {plan.destination}")
     if plan.kind == plugin_install.CAPTIONING:

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -1558,6 +1558,24 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             # Resolved before anything is copied. pip is asked what it would
             # do, and it is asked first, so a plugin whose dependencies cannot
             # be had leaves nothing behind to clean up.
+            # Named BEFORE the resolution, because these lines are the cause of
+            # anything surprising in the listing below: pip honours them, so a
+            # plainly-named requirement can resolve from the plugin author's
+            # own server rather than from PyPI.
+            options = plugin_install.index_options(plan.requirements)
+            if options:
+                print(
+                    f"\nwarning: {plan.requirements.name} changes where pip "
+                    "downloads from:",
+                    file=sys.stderr,
+                )
+                for option in options:
+                    print(f"  {option}", file=sys.stderr)
+                print(
+                    "  Packages below may not come from PyPI; check the "
+                    "source shown against each one.",
+                    file=sys.stderr,
+                )
             print(f"\nResolving {plan.requirements.name}...")
             changes = plugin_install.resolve_requirements(plan.requirements)
             if not _report_dependencies(changes, force=args.force_deps):

--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -1571,18 +1571,23 @@ def _cmd_plugins_install(args: argparse.Namespace) -> int:
             # anything surprising in the listing below: pip honours them, so a
             # plainly-named requirement can resolve from the plugin author's
             # own server rather than from PyPI.
-            options = plugin_install.index_options(plan.requirements)
+            options = plugin_install.pip_options(plan.requirements)
             if options:
+                # The lines are shown verbatim and described as what they are.
+                # Saying they "change where pip downloads from" would be a
+                # claim about each one, and the list is deliberately every
+                # option line rather than a curated download-source subset.
                 print(
-                    f"\nwarning: {plan.requirements.name} changes where pip "
-                    "downloads from:",
+                    f"\nwarning: {plan.requirements.name} passes options to pip:",
                     file=sys.stderr,
                 )
                 for option in options:
                     print(f"  {option}", file=sys.stderr)
                 print(
-                    "  Packages below may not come from PyPI; check the "
-                    "source shown against each one.",
+                    "  Options like --index-url and --find-links change where "
+                    "packages come from, so the ones below may not be the PyPI "
+                    "projects their names suggest; check the source shown "
+                    "against each.",
                     file=sys.stderr,
                 )
             if args.allow_sdist:

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -890,26 +890,47 @@ def resolve_requirements(
     entries include transitive dependencies -- which is the point, since a
     plugin asking for one package can pull in forty.
 
-    **A dry run is not a safe run, which is why this asks for wheels only.**
-    Resolving a source distribution makes pip BUILD its metadata, and building
-    executes the package's own ``setup.py`` -- as this user, before
+    **A dry run is not a safe run.**  Resolving a source distribution makes
+    pip BUILD its metadata, and building executes the package's own
+    ``setup.py`` -- as this user, before
     :func:`~pixlstash.cli._report_dependencies` has printed anything and before
     anyone has agreed to anything.  The consent this module exists to obtain
     would be collected after the code it is about had already run, which also
     guts :attr:`DependencyChange.url`: naming where an artefact came from is
-    worth little once that artefact has run.  ``--only-binary=:all:`` is
-    therefore passed by default, so nothing is built and nothing executes
-    before the listing.
+    worth little once that artefact has run.
+
+    **Two controls, because one is not enough.**  ``--only-binary=:all:`` stops
+    a requirement resolved BY NAME from picking an sdist -- and nothing more:
+    pip exempts direct references, VCS URLs, paths and editables from it, all
+    of which built and ran under it (reproduced, pip 24.0).  So
+    :func:`source_requirements` refuses those forms out of the file *before pip
+    is invoked*, which is the only point at which refusing still prevents
+    execution rather than reporting it.
 
     The trade is real and deliberate: a dependency published only as an sdist,
-    and any VCS or source-tree requirement, cannot be resolved this way at all.
-    *allow_sdist* is the way through, and the refusal below names it -- but it
-    is opt-in precisely because taking it means running the plugin author's
-    build code to find out what installing would do.
+    and any VCS, direct-URL or source-tree requirement, cannot be resolved this
+    way at all.  *allow_sdist* is the way through, and both refusals name it --
+    but it is opt-in precisely because taking it means running the plugin
+    author's build code to find out what installing would do.
 
     Nothing here decides whether the answer is acceptable; it says what would
     happen, and the caller shows it to the person who has to agree to it.
     """
+    if not allow_sdist:
+        # BEFORE pip runs: once it has read the file, a direct reference or a
+        # path has already been fetched and built, and refusing afterwards
+        # reports the execution rather than preventing it.
+        building = source_requirements(requirements)
+        if building:
+            raise PluginError(
+                f"{requirements.name} asks for "
+                + ", ".join(building)
+                + ". Working out what those would install means downloading "
+                "and building them first, which runs their code as you before "
+                "you are shown anything. Pass --allow-sdist if you accept "
+                "that. Nothing was installed."
+            )
+
     with TemporaryDirectory(prefix="pixlstash-deps-") as scratch:
         report = Path(scratch) / "report.json"
         result = subprocess.run(
@@ -990,6 +1011,131 @@ def read_requirements(requirements: Path) -> list[str]:
     ]
 
 
+#: A requirement pip can resolve by NAME against an index.  Anything a
+#: requirements file can say that does not match this - a direct reference
+#: (``name @ url``), a VCS URL, a local path, an editable - makes pip fetch and
+#: BUILD the thing to find out what it is, and building runs its code.  Written
+#: as "what is safe" rather than "what is dangerous" on purpose: a form nobody
+#: anticipated fails to match and is refused, instead of slipping through.
+_PLAIN_REQUIREMENT_RE = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9._-]*"  # project name
+    r"(?:\[[A-Za-z0-9,._\s-]+\])?"  # extras
+    r"(?:\s*[<>=!~][^;#]*)?"  # version specifier
+    r"(?:\s*;.*)?\Z"  # environment marker
+)
+
+#: ``-e``/``--editable``: an option line, so the plain-name test never sees it,
+#: and always a source tree.
+_EDITABLE_RE = re.compile(r"-(?:e|-editable)\b")
+
+
+def _without_inline_comment(line: str) -> str:
+    """Drop pip's ``  # ...`` inline comment, which is not part of the value."""
+    return re.split(r"\s+#", line, maxsplit=1)[0].strip()
+
+
+#: ``-r``/``-c`` include one requirements file from another.  pip reads the
+#: included file in full, so anything we check has to be checked there too.
+_INCLUDE_RE = re.compile(r"-(?:r|-requirement|c|-constraint)[=\s]+(.+)\Z")
+
+#: Includes nest, and a cycle or a very deep chain is not something a plugin
+#: has any reason to ship.  Beyond this the include is treated as unreadable.
+_MAX_INCLUDE_DEPTH = 5
+
+
+@dataclass
+class _Expanded:
+    """Every line pip will read from a requirements file, includes and all."""
+
+    #: The lines, in file order, with each include line kept in place so the
+    #: options warning still shows it.
+    lines: list[str] = field(default_factory=list)
+    #: Include lines we could NOT read ourselves.  Treated as build-triggering
+    #: by :func:`source_requirements`: pip will read them, and a file we cannot
+    #: see is a file we cannot vouch for.
+    unfollowable: list[str] = field(default_factory=list)
+
+
+def _expand_requirements(requirements: Path) -> _Expanded:
+    """Read *requirements* and every ``-r``/``-c`` file it pulls in.
+
+    SECURITY: without this, every check in this module reads one file while pip
+    reads several.  A plugin shipping ``-r deps/base.txt`` could put a direct
+    reference or an ``--index-url`` in that file and neither
+    :func:`source_requirements` nor :func:`pip_options` would see it -- verified
+    to run ``setup.py`` before this existed.
+
+    An include is followed only when it resolves inside the top requirements
+    file's own directory, is a real file, and is not too deeply nested.  A
+    plugin's requirements live with the plugin, so an include reaching outside
+    it is refused rather than read.
+    """
+    root = requirements.resolve().parent
+    found = _Expanded()
+    seen: set[Path] = set()
+    pending: list[tuple[Path, str | None, int]] = [(requirements.resolve(), None, 0)]
+    while pending:
+        path, via, depth = pending.pop(0)
+        if path in seen:
+            continue
+        seen.add(path)
+        try:
+            lines = read_requirements(path)
+        except (OSError, PluginError):
+            if via is not None:
+                found.unfollowable.append(via)
+            continue
+        for line in lines:
+            found.lines.append(line)
+            match = _INCLUDE_RE.match(line)
+            if match is None:
+                continue
+            target = (path.parent / match.group(1).strip().strip("\"'")).resolve()
+            if (
+                depth + 1 > _MAX_INCLUDE_DEPTH
+                or not _is_within(target, root)
+                or not target.is_file()
+            ):
+                found.unfollowable.append(line)
+                continue
+            pending.append((target, line, depth + 1))
+    return found
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """True when *path* is *root* or sits beneath it, both already resolved."""
+    return path == root or root in path.parents
+
+
+def source_requirements(requirements: Path) -> list[str]:
+    """Return the lines pip would have to fetch and BUILD in order to resolve.
+
+    SECURITY: this is the control ``--only-binary=:all:`` was mistakenly
+    believed to be.  pip applies ``--only-binary`` **only to requirements it
+    resolves by name through an index or ``--find-links``**; a direct
+    reference, a VCS URL, a local path and an editable are all exempt, and
+    every one of them runs the package's ``setup.py`` as this user during
+    ``--dry-run --report`` -- before the dependency listing exists and before
+    anyone agrees to anything (reproduced against pip 24.0 for all four).
+
+    So the refusal has to happen *before* pip is invoked at all, out of the
+    requirements file itself.  Includes are followed, because otherwise
+    ``-r deps/base.txt`` hides the very lines this refuses; an include that
+    cannot be followed is itself reported, since pip will read a file we could
+    not.
+    """
+    expanded = _expand_requirements(requirements)
+    risky: list[str] = list(expanded.unfollowable)
+    for line in expanded.lines:
+        if line.startswith("-"):
+            if _EDITABLE_RE.match(line):
+                risky.append(line)
+            continue
+        if not _PLAIN_REQUIREMENT_RE.fullmatch(_without_inline_comment(line)):
+            risky.append(line)
+    return risky
+
+
 def pip_options(requirements: Path) -> list[str]:
     """Return every option line in *requirements* -- each line starting ``-``.
 
@@ -1007,8 +1153,16 @@ def pip_options(requirements: Path) -> list[str]:
     no ordinary reason to carry any option line at all.  The caller shows them
     verbatim and lets the reader judge, rather than claiming per line what each
     one does.
+
+    Includes are followed (see :func:`_expand_requirements`), so an option
+    hidden one file down in ``-r deps/base.txt`` is listed rather than reported
+    as the innocuous-looking include line alone.
     """
-    return [line for line in read_requirements(requirements) if line.startswith("-")]
+    return [
+        line
+        for line in _expand_requirements(requirements).lines
+        if line.startswith("-")
+    ]
 
 
 def install_requirements(
@@ -1043,8 +1197,10 @@ def install_requirements(
             "pip",
             "install",
             "--no-deps",
-            # Matched to the resolve: without it a pin could still build from
-            # source here, which is the execution the resolve just refused.
+            # Matched to the resolve for the by-name case only. It does NOT
+            # constrain a direct-reference or VCS pin - pip exempts those - so
+            # what actually keeps those out is source_requirements() refusing
+            # them at resolve time, before a DependencyChange for one exists.
             *([] if allow_sdist else ["--only-binary=:all:"]),
             *pins,
         ],

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -879,14 +879,33 @@ class DependencyChange:
         return self.installed is not None and self.installed != self.version
 
 
-def resolve_requirements(requirements: Path) -> list[DependencyChange]:
+def resolve_requirements(
+    requirements: Path, *, allow_sdist: bool = False
+) -> list[DependencyChange]:
     """Return every package installing *requirements* would add or replace.
 
     Resolved by pip rather than by us: ``--dry-run --report`` runs the real
-    resolver, writes what it would do as JSON, and touches nothing.  The report
-    lists only what is not already satisfied, so an entry is by definition a
-    change, and the entries include transitive dependencies -- which is the
-    point, since a plugin asking for one package can pull in forty.
+    resolver and writes what it would do as JSON.  The report lists only what
+    is not already satisfied, so an entry is by definition a change, and the
+    entries include transitive dependencies -- which is the point, since a
+    plugin asking for one package can pull in forty.
+
+    **A dry run is not a safe run, which is why this asks for wheels only.**
+    Resolving a source distribution makes pip BUILD its metadata, and building
+    executes the package's own ``setup.py`` -- as this user, before
+    :func:`~pixlstash.cli._report_dependencies` has printed anything and before
+    anyone has agreed to anything.  The consent this module exists to obtain
+    would be collected after the code it is about had already run, which also
+    guts :attr:`DependencyChange.url`: naming where an artefact came from is
+    worth little once that artefact has run.  ``--only-binary=:all:`` is
+    therefore passed by default, so nothing is built and nothing executes
+    before the listing.
+
+    The trade is real and deliberate: a dependency published only as an sdist,
+    and any VCS or source-tree requirement, cannot be resolved this way at all.
+    *allow_sdist* is the way through, and the refusal below names it -- but it
+    is opt-in precisely because taking it means running the plugin author's
+    build code to find out what installing would do.
 
     Nothing here decides whether the answer is acceptable; it says what would
     happen, and the caller shows it to the person who has to agree to it.
@@ -903,6 +922,7 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
                 "--quiet",
                 "--report",
                 str(report),
+                *([] if allow_sdist else ["--only-binary=:all:"]),
                 "-r",
                 str(requirements),
             ],
@@ -912,11 +932,23 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout).strip().splitlines()
+            # Name the way through, or a plugin whose dependency is published
+            # only as an sdist is a dead end with no message saying why.
+            hint = (
+                ""
+                if allow_sdist
+                else (
+                    " If one of these is published only as a source "
+                    "distribution, --allow-sdist resolves it, at the cost of "
+                    "running that package's build code before you are asked."
+                )
+            )
             raise PluginError(
                 f"pip could not work out what {requirements.name} needs "
                 f"(exit {result.returncode})"
                 + (f": {detail[-1]}" if detail else "")
                 + ". Nothing was installed."
+                + hint
             )
         try:
             entries = json.loads(report.read_text(encoding="utf-8"))["install"]
@@ -976,7 +1008,9 @@ def index_options(requirements: Path) -> list[str]:
     return [line for line in read_requirements(requirements) if line.startswith("-")]
 
 
-def install_requirements(changes: list[DependencyChange]) -> None:
+def install_requirements(
+    changes: list[DependencyChange], *, allow_sdist: bool = False
+) -> None:
     """Install exactly the resolution *changes* describes, and nothing else.
 
     *changes* is what :func:`resolve_requirements` worked out and what the
@@ -1000,7 +1034,17 @@ def install_requirements(changes: list[DependencyChange]) -> None:
         return
     pins = [change.pin for change in changes]
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--no-deps", *pins],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            # Matched to the resolve: without it a pin could still build from
+            # source here, which is the execution the resolve just refused.
+            *([] if allow_sdist else ["--only-binary=:all:"]),
+            *pins,
+        ],
         check=False,
     )
     if result.returncode != 0:

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -814,8 +814,13 @@ class DependencyChange:
           download; it does not switch pip into hash-checking mode, so entries
           that have no hash (VCS, a local directory) still install alongside.
 
-        Falls back to ``name==version`` only when the report carried no
-        ``download_info`` at all.
+        Falls back to ``name==version`` whenever the entry carries no usable
+        ``download_info.url`` -- a missing ``download_info``, an empty one, or
+        one without a ``url``.  That fallback is the pre-#1177 behaviour and
+        therefore the vulnerable one, so it is deliberately the narrowest case:
+        pip records a ``url`` for every entry it resolves, and an entry without
+        one means the report did not say where the artefact came from, which
+        leaves the package name as the only thing left to install by.
         """
         info = self.download_info or {}
         url = info.get("url")

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -990,20 +990,23 @@ def read_requirements(requirements: Path) -> list[str]:
     ]
 
 
-def index_options(requirements: Path) -> list[str]:
-    """Return the option lines in *requirements*, which redirect where pip looks.
+def pip_options(requirements: Path) -> list[str]:
+    """Return every option line in *requirements* -- each line starting ``-``.
 
     SECURITY: a plugin's ``requirements.txt`` is written by the plugin author,
-    and pip honours option lines in it -- ``--index-url``,
-    ``--extra-index-url``, ``--find-links``, ``--no-index``, ``--trusted-host``
-    and their short forms.  Any of those makes an ordinary *named* requirement
-    resolve from somewhere other than PyPI, which is the cause of the
-    substitution :attr:`DependencyChange.url` reports the effect of.  The user
-    should see the cause before agreeing, so these are surfaced verbatim.
+    and pip honours option lines in it.  Some of them decide where packages
+    come from -- ``--index-url``, ``--extra-index-url``, ``--find-links``,
+    ``--no-index``, ``--trusted-host`` and their short forms -- and any of those
+    makes an ordinary *named* requirement resolve from somewhere other than
+    PyPI, which is the cause of the substitution
+    :attr:`DependencyChange.url` reports the effect of.
 
-    Every option line is returned rather than a curated subset: a plugin has no
-    ordinary reason to carry one at all, and an allowlist of "harmless" options
-    is a thing to get wrong in the direction of silence.
+    **Every option line is returned, not just those.**  The name says so
+    deliberately: a curated subset would be an allowlist of "harmless" options,
+    which is a thing to get wrong in the direction of silence, and a plugin has
+    no ordinary reason to carry any option line at all.  The caller shows them
+    verbatim and lets the reader judge, rather than claiming per line what each
+    one does.
     """
     return [line for line in read_requirements(requirements) if line.startswith("-")]
 

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -770,6 +770,27 @@ class DependencyChange:
     version: str
     #: The version already installed, or None when the package is new here.
     installed: str | None = None
+    #: The direct URL the requirement pinned, or None when it came from an
+    #: index.  Set only for pip's ``is_direct`` entries; see
+    #: :func:`install_requirements` for why it has to survive the round trip.
+    url: str | None = None
+
+    @property
+    def pin(self) -> str:
+        """The requirement to hand pip so it installs *this* distribution again.
+
+        SECURITY: a direct-URL requirement (``name @ https://.../x.whl``, a VCS
+        or a local path) names one artefact and deliberately does not name the
+        public index.  Reinstalling it as ``name==version`` would let whoever
+        owns that name on PyPI supply the code instead - the resolution the
+        user agreed to and the code that lands would be different packages
+        (CWE-494, dependency confusion / substitution).  The URL is therefore
+        replayed verbatim as a PEP 508 direct reference, which pins the
+        artefact rather than the name.  Indexed packages keep ``==``.
+        """
+        return (
+            f"{self.name} @ {self.url}" if self.url else f"{self.name}=={self.version}"
+        )
 
     @property
     def moves(self) -> bool:
@@ -836,7 +857,14 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
             installed = metadata_version(name)
         except PackageNotFoundError:
             installed = None
-        changes.append(DependencyChange(name, entry["metadata"]["version"], installed))
+        # `is_direct` is pip's own answer to "did the requirement name a URL
+        # rather than a name?", and `download_info.url` is the URL it actually
+        # resolved. Both have to be carried to the install step or the pin
+        # there silently becomes a PyPI lookup - see DependencyChange.pin.
+        url = entry["download_info"]["url"] if entry.get("is_direct") else None
+        changes.append(
+            DependencyChange(name, entry["metadata"]["version"], installed, url)
+        )
     return sorted(changes, key=lambda change: change.name.lower())
 
 
@@ -861,10 +889,14 @@ def install_requirements(changes: list[DependencyChange]) -> None:
     ``--no-deps`` for the same reason. The resolved list already holds every
     transitive dependency pip found, so letting it resolve again could only add
     something nobody was shown.
+
+    Each change contributes :attr:`DependencyChange.pin`, which keeps a
+    direct-URL requirement pinned to its URL instead of re-resolving the name
+    against PyPI.
     """
     if not changes:
         return
-    pins = [f"{change.name}=={change.version}" for change in changes]
+    pins = [change.pin for change in changes]
     result = subprocess.run(
         [sys.executable, "-m", "pip", "install", "--no-deps", *pins],
         check=False,

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -770,27 +770,78 @@ class DependencyChange:
     version: str
     #: The version already installed, or None when the package is new here.
     installed: str | None = None
-    #: The direct URL the requirement pinned, or None when it came from an
-    #: index.  Set only for pip's ``is_direct`` entries; see
-    #: :func:`install_requirements` for why it has to survive the round trip.
-    url: str | None = None
+    #: pip's ``download_info`` for this entry -- the artefact it actually
+    #: resolved.  None only when the report did not carry one.
+    download_info: dict | None = None
+    #: pip's ``is_direct``: True when the *requirement* named a URL rather than
+    #: a name.  Display only; the pin uses ``download_info`` either way.
+    direct: bool = False
+
+    @property
+    def url(self) -> str | None:
+        """The URL a directly-pinned requirement named, for the listing.
+
+        Only for ``is_direct`` entries: an ordinary indexed package also has a
+        URL, but naming ``files.pythonhosted.org`` on every line would be noise
+        that trains people to skip the one line that matters.
+        """
+        return (self.download_info or {}).get("url") if self.direct else None
 
     @property
     def pin(self) -> str:
-        """The requirement to hand pip so it installs *this* distribution again.
+        """The requirement to hand pip so it installs *this* artefact again.
 
-        SECURITY: a direct-URL requirement (``name @ https://.../x.whl``, a VCS
-        or a local path) names one artefact and deliberately does not name the
-        public index.  Reinstalling it as ``name==version`` would let whoever
-        owns that name on PyPI supply the code instead - the resolution the
-        user agreed to and the code that lands would be different packages
-        (CWE-494, dependency confusion / substitution).  The URL is therefore
-        replayed verbatim as a PEP 508 direct reference, which pins the
-        artefact rather than the name.  Indexed packages keep ``==``.
+        SECURITY: ``name==version`` names a *project on the default index*, and
+        that is not what was resolved.  The resolution the user agreed to can
+        come from a URL the plugin pinned, from a ``--find-links`` directory or
+        an ``--index-url`` line inside the plugin's own ``requirements.txt``, or
+        from a VCS at one commit.  Replaying it by name hands the install to
+        whoever owns that name on PyPI instead -- the code shown and the code
+        that lands are different packages (CWE-494, dependency confusion /
+        substitution).
+
+        So every entry is pinned to the artefact, not the name, reconstructed
+        from ``download_info`` the way pip's own
+        ``direct_url_as_pep440_direct_reference`` does it:
+
+        * a VCS entry becomes ``<vcs>+<url>@<commit_id>``, because ``url``
+          alone drops both the ``git+`` prefix and the commit -- replaying that
+          installs the repository's *working tree* rather than the revision
+          that was resolved;
+        * anything else becomes ``name @ url``, carrying the ``sha256`` pip
+          recorded as a link fragment so the artefact cannot change between the
+          dry run and the install.  A fragment hash makes pip verify the
+          download; it does not switch pip into hash-checking mode, so entries
+          that have no hash (VCS, a local directory) still install alongside.
+
+        Falls back to ``name==version`` only when the report carried no
+        ``download_info`` at all.
         """
-        return (
-            f"{self.name} @ {self.url}" if self.url else f"{self.name}=={self.version}"
-        )
+        info = self.download_info or {}
+        url = info.get("url")
+        if not url:
+            return f"{self.name}=={self.version}"
+
+        fragments = []
+        vcs = info.get("vcs_info")
+        if vcs:
+            # Not a PEP 508 `name @ git+...` reference: pip 24 rejects that
+            # spelling outright for a `git+file://` URL ("Invalid requirement
+            # ... It looks like a path"), while the plain VCS form is accepted
+            # for every scheme.
+            requirement = f"{vcs['vcs']}+{url}@{vcs['commit_id']}"
+        else:
+            archive = info.get("archive_info") or {}
+            sha256 = (archive.get("hashes") or {}).get("sha256")
+            if sha256:
+                fragments.append(f"sha256={sha256}")
+            elif archive.get("hash"):
+                # Older reports carry a single "<name>=<value>" string instead.
+                fragments.append(archive["hash"])
+            requirement = f"{self.name} @ {url}"
+        if info.get("subdirectory"):
+            fragments.append(f"subdirectory={info['subdirectory']}")
+        return requirement + ("#" + "&".join(fragments) if fragments else "")
 
     @property
     def moves(self) -> bool:
@@ -857,13 +908,18 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
             installed = metadata_version(name)
         except PackageNotFoundError:
             installed = None
-        # `is_direct` is pip's own answer to "did the requirement name a URL
-        # rather than a name?", and `download_info.url` is the URL it actually
-        # resolved. Both have to be carried to the install step or the pin
-        # there silently becomes a PyPI lookup - see DependencyChange.pin.
-        url = entry["download_info"]["url"] if entry.get("is_direct") else None
+        # `download_info` is what pip actually resolved, for every entry and
+        # not only the ones whose requirement named a URL. It has to reach the
+        # install step or the pin there silently becomes a lookup of the name
+        # on the default index - see DependencyChange.pin.
         changes.append(
-            DependencyChange(name, entry["metadata"]["version"], installed, url)
+            DependencyChange(
+                name,
+                entry["metadata"]["version"],
+                installed,
+                entry.get("download_info"),
+                bool(entry.get("is_direct")),
+            )
         )
     return sorted(changes, key=lambda change: change.name.lower())
 
@@ -890,9 +946,12 @@ def install_requirements(changes: list[DependencyChange]) -> None:
     transitive dependency pip found, so letting it resolve again could only add
     something nobody was shown.
 
-    Each change contributes :attr:`DependencyChange.pin`, which keeps a
-    direct-URL requirement pinned to its URL instead of re-resolving the name
-    against PyPI.
+    Each change contributes :attr:`DependencyChange.pin`, which pins the
+    artefact pip resolved rather than re-resolving the name against the default
+    index.  ``--no-index`` is deliberately NOT passed: an entry's pin already
+    names its own URL, so there is nothing left for an index to answer, and
+    passing it would break the fallback pin for a report without
+    ``download_info``.
     """
     if not changes:
         return

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -879,9 +879,7 @@ class DependencyChange:
         return self.installed is not None and self.installed != self.version
 
 
-def resolve_requirements(
-    requirements: Path, *, allow_sdist: bool = False
-) -> list[DependencyChange]:
+def resolve_requirements(requirements: Path) -> list[DependencyChange]:
     """Return every package installing *requirements* would add or replace.
 
     Resolved by pip rather than by us: ``--dry-run --report`` runs the real
@@ -890,47 +888,19 @@ def resolve_requirements(
     entries include transitive dependencies -- which is the point, since a
     plugin asking for one package can pull in forty.
 
-    **A dry run is not a safe run.**  Resolving a source distribution makes
-    pip BUILD its metadata, and building executes the package's own
-    ``setup.py`` -- as this user, before
-    :func:`~pixlstash.cli._report_dependencies` has printed anything and before
-    anyone has agreed to anything.  The consent this module exists to obtain
-    would be collected after the code it is about had already run, which also
-    guts :attr:`DependencyChange.url`: naming where an artefact came from is
-    worth little once that artefact has run.
-
-    **Two controls, because one is not enough.**  ``--only-binary=:all:`` stops
-    a requirement resolved BY NAME from picking an sdist -- and nothing more:
-    pip exempts direct references, VCS URLs, paths and editables from it, all
-    of which built and ran under it (reproduced, pip 24.0).  So
-    :func:`source_requirements` refuses those forms out of the file *before pip
-    is invoked*, which is the only point at which refusing still prevents
-    execution rather than reporting it.
-
-    The trade is real and deliberate: a dependency published only as an sdist,
-    and any VCS, direct-URL or source-tree requirement, cannot be resolved this
-    way at all.  *allow_sdist* is the way through, and both refusals name it --
-    but it is opt-in precisely because taking it means running the plugin
-    author's build code to find out what installing would do.
+    **Resolving is not free of side effects, and deliberately not guarded.**
+    Resolving a source distribution makes pip build its metadata, which runs
+    that package's ``setup.py`` as this user before anything is printed.  That
+    is not defended against here, because a plugin is arbitrary Python running
+    in this process the moment it loads: an author who wants to execute code
+    puts it in the plugin, not in a dependency's build hook.  Constraining the
+    dependencies of unsandboxed code buys nothing and costs the ability to
+    install an ordinary source-only package.  Only the owner can install a
+    plugin, and choosing one is theirs to do.
 
     Nothing here decides whether the answer is acceptable; it says what would
     happen, and the caller shows it to the person who has to agree to it.
     """
-    if not allow_sdist:
-        # BEFORE pip runs: once it has read the file, a direct reference or a
-        # path has already been fetched and built, and refusing afterwards
-        # reports the execution rather than preventing it.
-        building = source_requirements(requirements)
-        if building:
-            raise PluginError(
-                f"{requirements.name} asks for "
-                + ", ".join(building)
-                + ". Working out what those would install means downloading "
-                "and building them first, which runs their code as you before "
-                "you are shown anything. Pass --allow-sdist if you accept "
-                "that. Nothing was installed."
-            )
-
     with TemporaryDirectory(prefix="pixlstash-deps-") as scratch:
         report = Path(scratch) / "report.json"
         result = subprocess.run(
@@ -943,7 +913,6 @@ def resolve_requirements(
                 "--quiet",
                 "--report",
                 str(report),
-                *([] if allow_sdist else ["--only-binary=:all:"]),
                 "-r",
                 str(requirements),
             ],
@@ -953,23 +922,11 @@ def resolve_requirements(
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout).strip().splitlines()
-            # Name the way through, or a plugin whose dependency is published
-            # only as an sdist is a dead end with no message saying why.
-            hint = (
-                ""
-                if allow_sdist
-                else (
-                    " If one of these is published only as a source "
-                    "distribution, --allow-sdist resolves it, at the cost of "
-                    "running that package's build code before you are asked."
-                )
-            )
             raise PluginError(
                 f"pip could not work out what {requirements.name} needs "
                 f"(exit {result.returncode})"
                 + (f": {detail[-1]}" if detail else "")
                 + ". Nothing was installed."
-                + hint
             )
         try:
             entries = json.loads(report.read_text(encoding="utf-8"))["install"]
@@ -1011,131 +968,6 @@ def read_requirements(requirements: Path) -> list[str]:
     ]
 
 
-#: A requirement pip can resolve by NAME against an index.  Anything a
-#: requirements file can say that does not match this - a direct reference
-#: (``name @ url``), a VCS URL, a local path, an editable - makes pip fetch and
-#: BUILD the thing to find out what it is, and building runs its code.  Written
-#: as "what is safe" rather than "what is dangerous" on purpose: a form nobody
-#: anticipated fails to match and is refused, instead of slipping through.
-_PLAIN_REQUIREMENT_RE = re.compile(
-    r"[A-Za-z0-9][A-Za-z0-9._-]*"  # project name
-    r"(?:\[[A-Za-z0-9,._\s-]+\])?"  # extras
-    r"(?:\s*[<>=!~][^;#]*)?"  # version specifier
-    r"(?:\s*;.*)?\Z"  # environment marker
-)
-
-#: ``-e``/``--editable``: an option line, so the plain-name test never sees it,
-#: and always a source tree.
-_EDITABLE_RE = re.compile(r"-(?:e|-editable)\b")
-
-
-def _without_inline_comment(line: str) -> str:
-    """Drop pip's ``  # ...`` inline comment, which is not part of the value."""
-    return re.split(r"\s+#", line, maxsplit=1)[0].strip()
-
-
-#: ``-r``/``-c`` include one requirements file from another.  pip reads the
-#: included file in full, so anything we check has to be checked there too.
-_INCLUDE_RE = re.compile(r"-(?:r|-requirement|c|-constraint)[=\s]+(.+)\Z")
-
-#: Includes nest, and a cycle or a very deep chain is not something a plugin
-#: has any reason to ship.  Beyond this the include is treated as unreadable.
-_MAX_INCLUDE_DEPTH = 5
-
-
-@dataclass
-class _Expanded:
-    """Every line pip will read from a requirements file, includes and all."""
-
-    #: The lines, in file order, with each include line kept in place so the
-    #: options warning still shows it.
-    lines: list[str] = field(default_factory=list)
-    #: Include lines we could NOT read ourselves.  Treated as build-triggering
-    #: by :func:`source_requirements`: pip will read them, and a file we cannot
-    #: see is a file we cannot vouch for.
-    unfollowable: list[str] = field(default_factory=list)
-
-
-def _expand_requirements(requirements: Path) -> _Expanded:
-    """Read *requirements* and every ``-r``/``-c`` file it pulls in.
-
-    SECURITY: without this, every check in this module reads one file while pip
-    reads several.  A plugin shipping ``-r deps/base.txt`` could put a direct
-    reference or an ``--index-url`` in that file and neither
-    :func:`source_requirements` nor :func:`pip_options` would see it -- verified
-    to run ``setup.py`` before this existed.
-
-    An include is followed only when it resolves inside the top requirements
-    file's own directory, is a real file, and is not too deeply nested.  A
-    plugin's requirements live with the plugin, so an include reaching outside
-    it is refused rather than read.
-    """
-    root = requirements.resolve().parent
-    found = _Expanded()
-    seen: set[Path] = set()
-    pending: list[tuple[Path, str | None, int]] = [(requirements.resolve(), None, 0)]
-    while pending:
-        path, via, depth = pending.pop(0)
-        if path in seen:
-            continue
-        seen.add(path)
-        try:
-            lines = read_requirements(path)
-        except (OSError, PluginError):
-            if via is not None:
-                found.unfollowable.append(via)
-            continue
-        for line in lines:
-            found.lines.append(line)
-            match = _INCLUDE_RE.match(line)
-            if match is None:
-                continue
-            target = (path.parent / match.group(1).strip().strip("\"'")).resolve()
-            if (
-                depth + 1 > _MAX_INCLUDE_DEPTH
-                or not _is_within(target, root)
-                or not target.is_file()
-            ):
-                found.unfollowable.append(line)
-                continue
-            pending.append((target, line, depth + 1))
-    return found
-
-
-def _is_within(path: Path, root: Path) -> bool:
-    """True when *path* is *root* or sits beneath it, both already resolved."""
-    return path == root or root in path.parents
-
-
-def source_requirements(requirements: Path) -> list[str]:
-    """Return the lines pip would have to fetch and BUILD in order to resolve.
-
-    SECURITY: this is the control ``--only-binary=:all:`` was mistakenly
-    believed to be.  pip applies ``--only-binary`` **only to requirements it
-    resolves by name through an index or ``--find-links``**; a direct
-    reference, a VCS URL, a local path and an editable are all exempt, and
-    every one of them runs the package's ``setup.py`` as this user during
-    ``--dry-run --report`` -- before the dependency listing exists and before
-    anyone agrees to anything (reproduced against pip 24.0 for all four).
-
-    So the refusal has to happen *before* pip is invoked at all, out of the
-    requirements file itself.  Includes are followed, because otherwise
-    ``-r deps/base.txt`` hides the very lines this refuses; an include that
-    cannot be followed is itself reported, since pip will read a file we could
-    not.
-    """
-    expanded = _expand_requirements(requirements)
-    risky: list[str] = list(expanded.unfollowable)
-    for line in expanded.lines:
-        if line.startswith("-"):
-            if _EDITABLE_RE.match(line):
-                risky.append(line)
-            continue
-        if not _PLAIN_REQUIREMENT_RE.fullmatch(_without_inline_comment(line)):
-            risky.append(line)
-    return risky
-
-
 def pip_options(requirements: Path) -> list[str]:
     """Return every option line in *requirements* -- each line starting ``-``.
 
@@ -1154,20 +986,17 @@ def pip_options(requirements: Path) -> list[str]:
     verbatim and lets the reader judge, rather than claiming per line what each
     one does.
 
-    Includes are followed (see :func:`_expand_requirements`), so an option
-    hidden one file down in ``-r deps/base.txt`` is listed rather than reported
-    as the innocuous-looking include line alone.
+    Only **this file** is read.  ``-r``/``-c`` pull in further files that pip
+    also honours, and an option set in one of those is not listed here -- the
+    include line itself is, which is the visible trace of it.  This is
+    information for the reader rather than a gate, so it is described honestly
+    rather than made exhaustive: following includes is a containment problem of
+    its own and would not change what installs.
     """
-    return [
-        line
-        for line in _expand_requirements(requirements).lines
-        if line.startswith("-")
-    ]
+    return [line for line in read_requirements(requirements) if line.startswith("-")]
 
 
-def install_requirements(
-    changes: list[DependencyChange], *, allow_sdist: bool = False
-) -> None:
+def install_requirements(changes: list[DependencyChange]) -> None:
     """Install exactly the resolution *changes* describes, and nothing else.
 
     *changes* is what :func:`resolve_requirements` worked out and what the
@@ -1197,11 +1026,6 @@ def install_requirements(
             "pip",
             "install",
             "--no-deps",
-            # Matched to the resolve for the by-name case only. It does NOT
-            # constrain a direct-reference or VCS pin - pip exempts those - so
-            # what actually keeps those out is source_requirements() refusing
-            # them at resolve time, before a DependencyChange for one exists.
-            *([] if allow_sdist else ["--only-binary=:all:"]),
             *pins,
         ],
         check=False,

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -34,6 +34,7 @@ from importlib.metadata import version as metadata_version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Iterator
+from urllib.parse import urlparse
 
 import requests
 from platformdirs import user_data_dir
@@ -78,6 +79,11 @@ _REF_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]*\Z")
 
 PLUGINS_REPO = "Pikselkroken/PixlStash-plugins"
 DEFAULT_REF = "main"
+
+#: Hosts that mean "this came from the ordinary Python package index".  An
+#: artefact resolved from anywhere else is named in the dependency listing; see
+#: :attr:`DependencyChange.url`.
+_INDEX_HOSTS = frozenset({"files.pythonhosted.org", "pypi.org"})
 
 
 class PluginError(Exception):
@@ -779,13 +785,27 @@ class DependencyChange:
 
     @property
     def url(self) -> str | None:
-        """The URL a directly-pinned requirement named, for the listing.
+        """Where this artefact really comes from, when that is not the index.
 
-        Only for ``is_direct`` entries: an ordinary indexed package also has a
-        URL, but naming ``files.pythonhosted.org`` on every line would be noise
-        that trains people to skip the one line that matters.
+        SECURITY: keyed on the resolved URL's host, NOT on ``is_direct``.  A
+        plugin's own ``requirements.txt`` may carry ``--index-url``,
+        ``--extra-index-url`` or ``--find-links``, and an ordinary *named*
+        requirement resolved through one of those is reported by pip with
+        ``is_direct == False`` -- so keying on ``direct`` printed nothing and
+        the listing read as "the PyPI project called requests" while
+        :attr:`pin` faithfully installed a wheel from the plugin author's own
+        server.  Pinning the artefact without naming it made the substitution
+        *reliable* rather than preventing it: the user consents to a name and
+        receives something else.
+
+        An entry served from PyPI's own file host is not named, because a URL
+        on every line is noise that trains people to skip the one line that
+        matters.  Anything else is named, including ``file://``.
         """
-        return (self.download_info or {}).get("url") if self.direct else None
+        url = (self.download_info or {}).get("url")
+        if not url:
+            return None
+        return None if (urlparse(url).hostname or "") in _INDEX_HOSTS else url
 
     @property
     def pin(self) -> str:
@@ -936,6 +956,24 @@ def read_requirements(requirements: Path) -> list[str]:
         for line in read_source(requirements).splitlines()
         if line.strip() and not line.strip().startswith("#")
     ]
+
+
+def index_options(requirements: Path) -> list[str]:
+    """Return the option lines in *requirements*, which redirect where pip looks.
+
+    SECURITY: a plugin's ``requirements.txt`` is written by the plugin author,
+    and pip honours option lines in it -- ``--index-url``,
+    ``--extra-index-url``, ``--find-links``, ``--no-index``, ``--trusted-host``
+    and their short forms.  Any of those makes an ordinary *named* requirement
+    resolve from somewhere other than PyPI, which is the cause of the
+    substitution :attr:`DependencyChange.url` reports the effect of.  The user
+    should see the cause before agreeing, so these are surfaced verbatim.
+
+    Every option line is returned rather than a curated subset: a plugin has no
+    ordinary reason to carry one at all, and an allowlist of "harmless" options
+    is a thing to get wrong in the direction of silence.
+    """
+    return [line for line in read_requirements(requirements) if line.startswith("-")]
 
 
 def install_requirements(changes: list[DependencyChange]) -> None:

--- a/pixlstash/routes/config.py
+++ b/pixlstash/routes/config.py
@@ -18,6 +18,7 @@ from pixlstash.db_models.tag import (
     DEFAULT_SMART_SCORE_PENALIZED_TAG_WEIGHT,
 )
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
 from pixlstash.services import (
     config_service,
     library_settings_service,
@@ -928,7 +929,22 @@ def create_router(server) -> APIRouter:
                 status_code=403,
                 detail="Not available for token-authenticated requests.",
             )
-        folders = config_service.get_import_folder_paths(server.vault)
+        # A listing, not a safety check, so the refusal is about honesty rather
+        # than containment: reporting `[]` when the read failed tells the owner
+        # they have no watch folders, which is how someone adds a duplicate of
+        # one they already have or concludes their folders were lost. Say so
+        # instead, and say it as a refusal rather than as an unhandled 500.
+        try:
+            folders = config_service.get_import_folder_paths(server.vault)
+        except LibraryRootsUnavailable as exc:
+            logger.warning("Could not list the watch folders: %s", exc)
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "PixlStash could not read your watched folders just now. "
+                    "Try again in a moment."
+                ),
+            ) from exc
         return {
             "status": "success",
             "watch_folders": folders,

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -200,9 +200,33 @@ def register_routes(router, server):
         # so it is not deduplicated, and a folder carrying
         # `delete_after_import` then os.remove()s the file it has just
         # imported - so the export destroys its own output.
+        # Local import: pixlstash.vault pulls in every task and the inference
+        # stack, and this module only needs the exception's name.
+        from pixlstash.vault import ReferenceFolderRootsUnavailable
+
         vault = request.state.library_lease.vault
         library_roots = [getattr(vault, "image_root", None)]
-        library_roots.extend(vault.reference_folder_roots())
+        try:
+            library_roots.extend(vault.reference_folder_roots())
+        except ReferenceFolderRootsUnavailable as exc:
+            # The roots are a *blocklist* here, so an unknown set must refuse.
+            # Treating it as empty would let the destination land inside a
+            # reference folder, which is precisely what this check exists to
+            # stop (#1177 item 59).
+            logger.warning(
+                "Refusing the folder export: the reference folders could not "
+                "be read, so the destination cannot be shown to be outside "
+                "them: %s",
+                exc,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "PixlStash could not check your reference folders just "
+                    "now, so it cannot confirm this destination is outside "
+                    "your library. Try again in a moment."
+                ),
+            ) from exc
         library_roots.extend(get_import_folder_paths(vault))
         for root in library_roots:
             if root and path_is_within(resolved_destination, root):

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.config_service import get_import_folder_paths
-from pixlstash.utils.path_utils import path_is_within
+from pixlstash.utils.path_utils import LibraryRootsUnavailable, path_is_within
 from pixlstash.utils.reference_folder_validator import validate_reference_folder_path
 
 
@@ -200,34 +200,32 @@ def register_routes(router, server):
         # so it is not deduplicated, and a folder carrying
         # `delete_after_import` then os.remove()s the file it has just
         # imported - so the export destroys its own output.
-        # Local import: pixlstash.vault pulls in every task and the inference
-        # stack, and this module only needs the exception's name.
-        from pixlstash.vault import ReferenceFolderRootsUnavailable
-
         vault = request.state.library_lease.vault
         library_roots = [getattr(vault, "image_root", None)]
+        # Both lists are a *blocklist* here, so a list that cannot be read must
+        # refuse. Treating either as empty turns the check off silently and
+        # lets the destination land in the very folder it exists to keep the
+        # export out of (#1177 item 59 and its import-folder sibling).
         try:
             library_roots.extend(vault.reference_folder_roots())
-        except ReferenceFolderRootsUnavailable as exc:
-            # The roots are a *blocklist* here, so an unknown set must refuse.
-            # Treating it as empty would let the destination land inside a
-            # reference folder, which is precisely what this check exists to
-            # stop (#1177 item 59).
+            library_roots.extend(get_import_folder_paths(vault))
+        except LibraryRootsUnavailable as exc:
             logger.warning(
-                "Refusing the folder export: the reference folders could not "
-                "be read, so the destination cannot be shown to be outside "
-                "them: %s",
+                "Refusing the folder export to %s: a library root list could "
+                "not be read, so the destination cannot be shown to be "
+                "outside the library: %s",
+                resolved_destination,
                 exc,
             )
             raise HTTPException(
                 status_code=503,
                 detail=(
-                    "PixlStash could not check your reference folders just "
-                    "now, so it cannot confirm this destination is outside "
-                    "your library. Try again in a moment."
+                    "PixlStash could not check your reference folders and "
+                    "watched folders just now, so it cannot confirm this "
+                    "destination is outside your library. Try again in a "
+                    "moment."
                 ),
             ) from exc
-        library_roots.extend(get_import_folder_paths(vault))
         for root in library_roots:
             if root and path_is_within(resolved_destination, root):
                 raise HTTPException(

--- a/pixlstash/services/config_service.py
+++ b/pixlstash/services/config_service.py
@@ -13,6 +13,7 @@ from sqlmodel import select
 
 from pixlstash.db_models import ImportFolder
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
 
 if TYPE_CHECKING:
     from pixlstash.vault import Vault
@@ -41,8 +42,21 @@ def get_import_folder_paths(vault: "Vault") -> list[str]:
     Args:
         vault: Application vault, used for DB task dispatch.
 
+    **A read failure raises; it is never an empty list.** The folder-export
+    destination check reads this as a blocklist, and a watch folder is the
+    worst member of it: the watcher imports whatever appears there, and a
+    folder carrying ``delete_after_import`` then removes the file it has just
+    imported, so an export into one destroys its own output. An empty list is
+    indistinguishable from "no watch folders are configured", so returning it
+    on error turned that check off silently. See
+    :class:`~pixlstash.utils.path_utils.LibraryRootsUnavailable`.
+
     Returns:
-        List of import folder path strings, in ID order.
+        List of import folder path strings, in ID order; empty only when no
+        import folder is configured.
+
+    Raises:
+        LibraryRootsUnavailable: The import folder list could not be read.
     """
     try:
         db_folders = vault.db.run_immediate_read_task(
@@ -50,14 +64,21 @@ def get_import_folder_paths(vault: "Vault") -> list[str]:
                 select(ImportFolder).order_by(ImportFolder.id)
             ).all()
         )
-        return [
-            folder.folder
-            for folder in (db_folders or [])
-            if getattr(folder, "folder", None)
-        ]
     except Exception as exc:
-        logger.debug("Failed to read import folders from DB: %s", exc)
-        return []
+        logger.warning(
+            "Could not read the import folders; refusing to answer rather "
+            "than reporting none, because an empty answer reads as 'nothing "
+            "to protect' to the export destination check: %s",
+            exc,
+        )
+        raise LibraryRootsUnavailable(
+            f"Could not read the configured import folders: {exc}"
+        ) from exc
+    return [
+        folder.folder
+        for folder in (db_folders or [])
+        if getattr(folder, "folder", None)
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/pixlstash/services/scrapheap_service.py
+++ b/pixlstash/services/scrapheap_service.py
@@ -106,7 +106,7 @@ from pixlstash.db_models import Character, DeletedFileLog, Picture, ReferenceFol
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.utils.image_processing.image_utils import ImageUtils
-from pixlstash.utils.path_utils import path_is_within
+from pixlstash.utils.path_utils import LibraryRootsUnavailable, path_is_within
 from pixlstash.utils.service.scope_table import scope_id_subquery
 
 logger = get_logger(__name__)
@@ -1515,13 +1515,9 @@ def remove_picture_files_and_reconcile_ledger(
     ``owned_path_shas`` comes from the :func:`purge_rows_in_session` call that
     wrote those rows, and bounds the correction to them.
     """
-    # Local import: pixlstash.vault imports this module, so the exception can
-    # only be named from inside a function.
-    from pixlstash.vault import ReferenceFolderRootsUnavailable
-
     try:
         reference_roots = vault.reference_folder_roots()
-    except ReferenceFolderRootsUnavailable as exc:
+    except LibraryRootsUnavailable as exc:
         # Empty is the safe answer *here*, and only here: the roots are an
         # allowlist of places this unattended os.remove may follow a stored
         # path to, so not knowing them means only image_root is honoured and

--- a/pixlstash/services/scrapheap_service.py
+++ b/pixlstash/services/scrapheap_service.py
@@ -1515,9 +1515,30 @@ def remove_picture_files_and_reconcile_ledger(
     ``owned_path_shas`` comes from the :func:`purge_rows_in_session` call that
     wrote those rows, and bounds the correction to them.
     """
-    unconfirmed = remove_picture_files(
-        vault.image_root, targets, vault.reference_folder_roots()
-    )
+    # Local import: pixlstash.vault imports this module, so the exception can
+    # only be named from inside a function.
+    from pixlstash.vault import ReferenceFolderRootsUnavailable
+
+    try:
+        reference_roots = vault.reference_folder_roots()
+    except ReferenceFolderRootsUnavailable as exc:
+        # Empty is the safe answer *here*, and only here: the roots are an
+        # allowlist of places this unattended os.remove may follow a stored
+        # path to, so not knowing them means only image_root is honoured and
+        # every other target is reported unconfirmed and kept. Letting the
+        # error propagate would be worse than useless - the rows are already
+        # purged by the time this runs, so an escape leaves the ledger
+        # asserting deletions that never happened (see the docstring above).
+        logger.warning(
+            "Purge could not read the reference folders of %s; only %s will be "
+            "deleted from and files elsewhere are kept and reported "
+            "unconfirmed: %s",
+            vault.image_root,
+            vault.image_root,
+            exc,
+        )
+        reference_roots = ()
+    unconfirmed = remove_picture_files(vault.image_root, targets, reference_roots)
     if unconfirmed:
         vault.db.run_task(
             mark_files_kept_in_session,

--- a/pixlstash/services/views_service.py
+++ b/pixlstash/services/views_service.py
@@ -334,7 +334,21 @@ def check_views_root(root: str, vault, other_library_roots: Iterable[str] = ()) 
                 "rather than above it."
             )
 
-    for reference_root in getattr(vault, "reference_folder_roots", lambda: ())():
+    # Local import: pixlstash.vault pulls in every task and the inference
+    # stack, and this module only needs the exception's name.
+    from pixlstash.vault import ReferenceFolderRootsUnavailable
+
+    try:
+        reference_roots = getattr(vault, "reference_folder_roots", lambda: ())()
+    except ReferenceFolderRootsUnavailable as exc:
+        # A blocklist that cannot be read refuses; treating it as empty would
+        # publish links into a reference folder (#1177 item 59).
+        raise ViewsError(
+            "PixlStash could not read your reference folders just now, so it "
+            "cannot confirm this folder is outside them. Try again in a moment."
+        ) from exc
+
+    for reference_root in reference_roots:
         if path_is_within(root, reference_root):
             raise ViewsError(
                 "That folder is inside a reference folder, so the next scan "

--- a/pixlstash/services/views_service.py
+++ b/pixlstash/services/views_service.py
@@ -51,7 +51,11 @@ from pixlstash.db_models.picture_set import PictureSet, PictureSetMember
 from pixlstash.db_models.project import Project
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.image_utils import ImageUtils
-from pixlstash.utils.path_utils import path_is_within, resolve_path_within
+from pixlstash.utils.path_utils import (
+    LibraryRootsUnavailable,
+    path_is_within,
+    resolve_path_within,
+)
 from pixlstash.utils.reference_folder_validator import (
     validate_reference_folder_path,
 )
@@ -334,13 +338,9 @@ def check_views_root(root: str, vault, other_library_roots: Iterable[str] = ()) 
                 "rather than above it."
             )
 
-    # Local import: pixlstash.vault pulls in every task and the inference
-    # stack, and this module only needs the exception's name.
-    from pixlstash.vault import ReferenceFolderRootsUnavailable
-
     try:
         reference_roots = getattr(vault, "reference_folder_roots", lambda: ())()
-    except ReferenceFolderRootsUnavailable as exc:
+    except LibraryRootsUnavailable as exc:
         # A blocklist that cannot be read refuses; treating it as empty would
         # publish links into a reference folder (#1177 item 59).
         raise ViewsError(

--- a/pixlstash/utils/path_utils.py
+++ b/pixlstash/utils/path_utils.py
@@ -3,6 +3,27 @@
 import os
 
 
+class LibraryRootsUnavailable(RuntimeError):
+    """A list of the library's own roots could not be read.
+
+    Raised by the helpers that answer "which directories belong to this
+    library" - :meth:`pixlstash.vault.Vault.reference_folder_roots` and
+    :func:`pixlstash.services.config_service.get_import_folder_paths` - instead
+    of returning an empty collection, because "there are none" and "we do not
+    know" are the same value with opposite safety (#1177 items 59, and the
+    import-folder sibling found in its review).
+
+    Each list is read as an **allowlist** in one place and a **blocklist** in
+    another. The scrapheap purge asks which roots its unattended ``os.remove``
+    may follow a stored path into, where empty means "only ``image_root``" and
+    is safe. The folder-export destination check and ``views_service`` ask
+    which roots nothing may be written into, where empty means "nothing to
+    avoid" and permits exactly what the check exists to refuse. No single value
+    is safe in both directions, so the failure is made distinguishable and the
+    caller picks the direction.
+    """
+
+
 def resolve_path_within(base_dir: str, *segments: str) -> str:
     """Resolve a path and confirm it remains strictly within *base_dir*.
 

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -63,20 +63,10 @@ from pixlstash.services.scrapheap_service import DEFAULT_RETENTION_DAYS
 from pixlstash.services.snapshot_service import SnapshotService
 from pixlstash.services.restore import RestoreService
 from pixlstash.trusted_sqlite import TrustedSQLiteLocation
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
 
 
 logger = get_logger(__name__)
-
-
-class ReferenceFolderRootsUnavailable(RuntimeError):
-    """The configured reference folders could not be read.
-
-    Raised by :meth:`Vault.reference_folder_roots` instead of returning an
-    empty tuple, because "no reference folders" and "we do not know" are the
-    same value with opposite safety: an allowlist caller may treat the unknown
-    as empty and refuse, a blocklist caller must not, and only the caller knows
-    which it is.
-    """
 
 
 class Vault:
@@ -540,7 +530,7 @@ class Vault:
             is configured.
 
         Raises:
-            ReferenceFolderRootsUnavailable: The folder list could not be read.
+            LibraryRootsUnavailable: The folder list could not be read.
         """
         from pixlstash.db_models.reference_folder import ReferenceFolder
 
@@ -561,7 +551,7 @@ class Vault:
                 self.image_root,
                 exc,
             )
-            raise ReferenceFolderRootsUnavailable(
+            raise LibraryRootsUnavailable(
                 f"Could not read the reference folders of {self.image_root}: {exc}"
             ) from exc
 

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -68,6 +68,17 @@ from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 logger = get_logger(__name__)
 
 
+class ReferenceFolderRootsUnavailable(RuntimeError):
+    """The configured reference folders could not be read.
+
+    Raised by :meth:`Vault.reference_folder_roots` instead of returning an
+    empty tuple, because "no reference folders" and "we do not know" are the
+    same value with opposite safety: an allowlist caller may treat the unknown
+    as empty and refuse, a blocklist caller must not, and only the caller knows
+    which it is.
+    """
+
+
 class Vault:
     AGGRESSIVE_UNLOAD_INTERVAL = 180
 
@@ -511,10 +522,25 @@ class Vault:
         under the mapped form in Docker deployments, while the
         ``reference_folder`` row keeps the host form.
 
+        **A read failure raises; it is never an empty answer.** The two things
+        this list is used for want opposite behaviour from the same value:
+        :func:`~pixlstash.services.scrapheap_service.remove_picture_files`
+        treats it as an *allowlist* of places a purge may delete from, where
+        empty is safe, while the folder-export destination check and
+        ``views_service`` treat it as a *blocklist* of places nothing may be
+        written to, where empty silently permits what it exists to refuse
+        (#1177 item 59). Returning ``()`` on error therefore fails closed for
+        one caller and open for the other. Only the caller knows which
+        direction is safe, so the error is made distinguishable from "no
+        reference folders are configured" and the allowlist caller is the one
+        that catches it.
+
         Returns:
-            The root directories, empty when the folder list cannot be read
-            (logged) so a caller containing a destructive operation refuses
-            rather than guesses.
+            The root directories; an empty tuple only when no reference folder
+            is configured.
+
+        Raises:
+            ReferenceFolderRootsUnavailable: The folder list could not be read.
         """
         from pixlstash.db_models.reference_folder import ReferenceFolder
 
@@ -529,12 +555,15 @@ class Vault:
             folders = self.db.run_immediate_read_task(fetch)
         except Exception as exc:
             logger.warning(
-                "Could not read the reference folders of %s; treating the set "
-                "as empty, so paths outside the image root will be refused: %s",
+                "Could not read the reference folders of %s; refusing to "
+                "answer rather than reporting none, because an empty answer "
+                "reads as 'nothing to protect' to some callers: %s",
                 self.image_root,
                 exc,
             )
-            return ()
+            raise ReferenceFolderRootsUnavailable(
+                f"Could not read the reference folders of {self.image_root}: {exc}"
+            ) from exc
 
         roots: list[str] = []
         for folder in folders:

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -394,6 +394,54 @@ def test_pictures_export_folder_rejects_a_destination_inside_the_library():
         gc.collect()
 
 
+def test_pictures_export_folder_refuses_when_the_reference_folders_are_unreadable():
+    """#1177 item 59: an unknown blocklist must refuse, not permit.
+
+    The roots the check above compares against were previously reported as an
+    empty tuple when the folder table could not be read, which is exactly what
+    "no reference folders are configured" looks like - so a read failure turned
+    the destination check off silently, and an export into a reference folder
+    was accepted.
+    """
+    from unittest import mock
+
+    temp_dir, client, server = _setup()
+    try:
+        _upload_picture(client)
+        destination = os.path.join(temp_dir.name, "unreadable-refs-destination")
+        os.makedirs(destination, exist_ok=True)
+
+        # Broken at the DB read, not at the vault method, so this exercises the
+        # whole chain: replacing the raise with `return ()` again turns this
+        # test green-to-red rather than leaving it passing on a stubbed vault.
+        def _explode(_task, *args, **kwargs):
+            raise RuntimeError("test-induced reference folder read failure")
+
+        with mock.patch.object(server.vault.db, "run_immediate_read_task", _explode):
+            resp = client.post(
+                "/pictures/export/folder", params={"destination": destination}
+            )
+        assert resp.status_code == 503, resp.text
+        assert "reference folders" in resp.json().get("detail", "")
+        assert not os.listdir(destination), "nothing may be written on a refusal"
+
+        # The positive control: the same destination is accepted once the
+        # folder table reads normally again.
+        with mock.patch(
+            "pixlstash.utils.service.export_utils.open_in_file_manager",
+            return_value=True,
+        ):
+            accepted = client.post(
+                "/pictures/export/folder", params={"destination": destination}
+            )
+            assert accepted.status_code == 200, accepted.text
+            _wait_for_export(client, accepted.json()["task_id"])
+    finally:
+        server.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_pictures_export_folder_rejects_a_destination_in_a_watched_folder():
     """An import folder is the same refusal as a reference folder, and worse.
 

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -442,6 +442,54 @@ def test_pictures_export_folder_refuses_when_the_reference_folders_are_unreadabl
         gc.collect()
 
 
+def test_pictures_export_folder_refuses_when_the_watch_folders_are_unreadable():
+    """The import-folder half of item 59, found in its adversarial review.
+
+    `get_import_folder_paths` logged at DEBUG and returned `[]`, which is what
+    "no watch folders are configured" looks like - so a read failure turned off
+    the worst refusal in this route. A watch folder imports whatever appears in
+    it, and one carrying `delete_after_import` then removes the file it has
+    just imported, so an export into one destroys its own output.
+    """
+    from unittest import mock
+
+    from pixlstash.utils.path_utils import LibraryRootsUnavailable
+
+    temp_dir, client, server = _setup()
+    try:
+        _upload_picture(client)
+        destination = os.path.join(temp_dir.name, "unreadable-watch-destination")
+        os.makedirs(destination, exist_ok=True)
+
+        # Only the import-folder read fails, so this cannot pass on the
+        # reference-folder refusal that lands one line above it.
+        def _explode(_vault):
+            raise LibraryRootsUnavailable("test-induced import folder read failure")
+
+        with mock.patch(
+            "pixlstash.routes.pictures._export.get_import_folder_paths", _explode
+        ):
+            resp = client.post(
+                "/pictures/export/folder", params={"destination": destination}
+            )
+        assert resp.status_code == 503, resp.text
+        assert not os.listdir(destination), "nothing may be written on a refusal"
+
+        with mock.patch(
+            "pixlstash.utils.service.export_utils.open_in_file_manager",
+            return_value=True,
+        ):
+            accepted = client.post(
+                "/pictures/export/folder", params={"destination": destination}
+            )
+            assert accepted.status_code == 200, accepted.text
+            _wait_for_export(client, accepted.json()["task_id"])
+    finally:
+        server.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_pictures_export_folder_rejects_a_destination_in_a_watched_folder():
     """An import folder is the same refusal as a reference folder, and worse.
 

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -31,7 +31,11 @@ from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolde
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.server import Server
 from pixlstash.services.operation_log_service import apply_orientation
-from pixlstash.services.scrapheap_service import remove_picture_files
+from pixlstash.services.scrapheap_service import (
+    remove_picture_files,
+    remove_picture_files_and_reconcile_ledger,
+)
+from pixlstash.vault import ReferenceFolderRootsUnavailable
 from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
 from pixlstash.utils.image_processing.orientation import read_orientation
 from pixlstash.utils.path_utils import path_is_within
@@ -355,6 +359,54 @@ def test_vault_supplies_the_reference_roots_the_purge_needs(server, tmp_path):
     os.makedirs(ref_root)
     _add_reference_folder(server, ref_root)
     assert ref_root in server.vault.reference_folder_roots()
+
+
+def test_an_unreadable_reference_folder_table_raises_rather_than_reporting_none(
+    server, monkeypatch
+):
+    """#1177 item 59. ``()`` means "none are configured" and nothing else.
+
+    The same list is an allowlist for the purge (empty is safe) and a blocklist
+    for the export destination and views roots (empty permits). One value
+    cannot be safe in both directions, so a read failure is made distinguishable
+    and each caller decides.
+    """
+
+    def _explode(_task, *args, **kwargs):
+        raise RuntimeError("test-induced reference folder read failure")
+
+    monkeypatch.setattr(server.vault.db, "run_immediate_read_task", _explode)
+    with pytest.raises(ReferenceFolderRootsUnavailable):
+        server.vault.reference_folder_roots()
+
+
+def test_a_purge_whose_reference_roots_are_unreadable_deletes_only_in_root(
+    server, tmp_path, monkeypatch
+):
+    """The allowlist direction, both ways at once.
+
+    Not knowing the roots must not widen what the unattended ``os.remove`` may
+    follow a stored path to (the negative), and must not stop it clearing the
+    image root either, or a failed read strands every file (the over-blocking
+    regression).
+    """
+    image_root = server.vault.image_root
+    doomed = os.path.join(image_root, "purge-in-root.png")
+    _write_png(doomed)
+    spared = str(tmp_path / "unreadable-refs" / "ref.png")
+    _write_png(spared)
+
+    def _explode():
+        raise ReferenceFolderRootsUnavailable("test-induced read failure")
+
+    monkeypatch.setattr(server.vault, "reference_folder_roots", _explode)
+    remove_picture_files_and_reconcile_ledger(
+        server.vault,
+        [(1, "purge-in-root.png", False), (2, spared, True)],
+        set(),
+    )
+    assert not os.path.exists(doomed), "an in-root file must still be deleted"
+    assert os.path.exists(spared), "an unprovable root must not be deleted from"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -35,7 +35,7 @@ from pixlstash.services.scrapheap_service import (
     remove_picture_files,
     remove_picture_files_and_reconcile_ledger,
 )
-from pixlstash.vault import ReferenceFolderRootsUnavailable
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
 from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
 from pixlstash.utils.image_processing.orientation import read_orientation
 from pixlstash.utils.path_utils import path_is_within
@@ -376,7 +376,7 @@ def test_an_unreadable_reference_folder_table_raises_rather_than_reporting_none(
         raise RuntimeError("test-induced reference folder read failure")
 
     monkeypatch.setattr(server.vault.db, "run_immediate_read_task", _explode)
-    with pytest.raises(ReferenceFolderRootsUnavailable):
+    with pytest.raises(LibraryRootsUnavailable):
         server.vault.reference_folder_roots()
 
 
@@ -397,7 +397,7 @@ def test_a_purge_whose_reference_roots_are_unreadable_deletes_only_in_root(
     _write_png(spared)
 
     def _explode():
-        raise ReferenceFolderRootsUnavailable("test-induced read failure")
+        raise LibraryRootsUnavailable("test-induced read failure")
 
     monkeypatch.setattr(server.vault, "reference_folder_roots", _explode)
     remove_picture_files_and_reconcile_ledger(

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1793,11 +1793,26 @@ def test_a_subdirectory_survives_the_round_trip(pip_report, tmp_path):
     assert change.pin.endswith(f"#sha256={_SHA}&subdirectory=packages/moondream")
 
 
-def test_a_report_without_download_info_falls_back_to_name_and_version(
-    pip_report, tmp_path
+def test_a_dependency_with_no_download_info_at_all_pins_name_and_version():
+    """The absent-key case, asserted directly: `_entry` cannot express it."""
+    assert plugin_install.DependencyChange("flask", "3.1.3").pin == "flask==3.1.3"
+
+
+@pytest.mark.parametrize(
+    "download_info", [{}, {"archive_info": {"hashes": {"sha256": _SHA}}}]
+)
+def test_an_entry_without_a_usable_url_falls_back_to_name_and_version(
+    pip_report, tmp_path, download_info
 ):
-    """The one case that cannot be pinned to an artefact still installs."""
-    pip_report(("flask", "3.1.3", {}, False), installed={})
+    """The one case that cannot be pinned to an artefact still installs.
+
+    Every spelling of "the report did not say where this came from" takes the
+    fallback, not only a missing `download_info`: an empty object, and one
+    carrying a hash but no url, reach it too. This branch is the pre-#1177
+    behaviour and therefore the vulnerable one, so this pins exactly how narrow
+    it is.
+    """
+    pip_report(("flask", "3.1.3", download_info, False), installed={})
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("flask\n", encoding="utf-8")
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -785,7 +785,11 @@ def test_requirements_are_never_installed_implicitly(
     tmp_path, plugin_root, monkeypatch, capsys
 ):
     calls = []
-    monkeypatch.setattr(plugin_install, "install_requirements", calls.append)
+    monkeypatch.setattr(
+        plugin_install,
+        "install_requirements",
+        lambda changes, **_kwargs: calls.append(changes),
+    )
     folder = tmp_path / "pkg"
     _write(folder / "__init__.py", CAPTIONER)
     _write(folder / "requirements.txt", "definitely-not-a-real-package==1.0\n")
@@ -804,7 +808,11 @@ def test_with_deps_says_what_it_will_install(
     the time, and it is the resolved set that lands in the environment.
     """
     calls = []
-    monkeypatch.setattr(plugin_install, "install_requirements", calls.append)
+    monkeypatch.setattr(
+        plugin_install,
+        "install_requirements",
+        lambda changes, **_kwargs: calls.append(changes),
+    )
     pip_report(("something", "1.0"), ("a-dependency-of-it", "2.4"), installed={})
     folder = tmp_path / "pkg"
     _write(folder / "__init__.py", CAPTIONER)
@@ -1659,6 +1667,71 @@ def test_transitive_packages_are_reported_too(pip_report, tmp_path):
     assert [c.name for c in changes] == ["blinker", "Flask", "Werkzeug"]
 
 
+def test_resolving_refuses_to_build_a_source_distribution(pip_report, tmp_path):
+    """#1201 F3: a dry run is not a safe run.
+
+    Resolving an sdist makes pip build its metadata, which executes the
+    package's own `setup.py` as this user - before anything is printed and
+    before anyone agrees to anything. Reproduced against real pip: a marker
+    file written by `setup.py` existed after a plain `--dry-run --report`.
+    `--only-binary=:all:` is what stops the build, so it must be on the command
+    by default, and off only when the caller opted in.
+    """
+    calls = pip_report(("flask", "3.1.3"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    plugin_install.resolve_requirements(requirements)
+    assert "--only-binary=:all:" in calls[0]
+
+
+def test_allow_sdist_is_the_only_way_to_build_at_resolve_time(pip_report, tmp_path):
+    """The opt-in, and the over-blocking escape hatch it exists to be."""
+    calls = pip_report(("flask", "3.1.3"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    assert "--only-binary=:all:" not in calls[0]
+
+
+def test_a_refusal_names_the_flag_that_gets_past_it(monkeypatch, tmp_path):
+    """A sdist-only dependency must not be a dead end with no way forward."""
+    monkeypatch.setattr(
+        plugin_install.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command, 1, stdout="", stderr="ERROR: No matching distribution found\n"
+        ),
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("sdist-only-package\n", encoding="utf-8")
+
+    with pytest.raises(PluginError, match="--allow-sdist"):
+        plugin_install.resolve_requirements(requirements)
+    # ...and it does not nag about the flag when the flag is already on.
+    with pytest.raises(PluginError) as caught:
+        plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    assert "--allow-sdist" not in str(caught.value)
+
+
+def test_installing_matches_the_resolve_on_building_from_source(monkeypatch):
+    """A pin must not build what the resolve refused to build."""
+    commands: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(plugin_install.subprocess, "run", fake_run)
+    change = plugin_install.DependencyChange("something", "1.0")
+    plugin_install.install_requirements([change])
+    plugin_install.install_requirements([change], allow_sdist=True)
+
+    assert "--only-binary=:all:" in commands[0]
+    assert "--only-binary=:all:" not in commands[1]
+
+
 def test_resolving_asks_pip_not_to_install_anything(pip_report, tmp_path):
     """It runs before the plugin is copied, so it must change nothing."""
     calls = pip_report(("flask", "3.1.3"), installed={})
@@ -1926,7 +1999,9 @@ def test_force_deps_installs_anyway_and_says_so(
     pip_report(("pillow", "11.0.0"), installed={"pillow": "12.3.0"})
     installed: list[Path] = []
     monkeypatch.setattr(
-        plugin_install, "install_requirements", lambda path: installed.append(path)
+        plugin_install,
+        "install_requirements",
+        lambda path, **_kwargs: installed.append(path),
     )
 
     exit_code = cli.main(
@@ -1945,7 +2020,9 @@ def test_a_plugin_whose_dependencies_are_all_present_says_so(
     (source / "dep_filter.py").write_text(IMAGE_PLUGIN, encoding="utf-8")
     (source / "requirements.txt").write_text("pillow\n", encoding="utf-8")
     pip_report(installed={"pillow": "12.3.0"})
-    monkeypatch.setattr(plugin_install, "install_requirements", lambda path: None)
+    monkeypatch.setattr(
+        plugin_install, "install_requirements", lambda path, **_kwargs: None
+    )
 
     assert cli.main(["plugins", "install", str(source), "--with-deps", "--yes"]) == 0
     assert "Everything it needs is already installed." in capsys.readouterr().out

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+import tarfile
 import zipfile
 from pathlib import Path
 
@@ -1612,9 +1613,15 @@ def pip_report(monkeypatch, tmp_path):
         calls: list[list[str]] = []
 
         def fake_run(command, **kwargs):
+            # Both pip calls land here, not only the resolve: a test that runs
+            # `plugins install --with-deps` all the way through reaches
+            # install_requirements too, and that command carries no --report.
             calls.append(command)
-            index = command.index("--report")
-            Path(command[index + 1]).write_text(_report(*packages), encoding="utf-8")
+            if "--report" in command:
+                index = command.index("--report")
+                Path(command[index + 1]).write_text(
+                    _report(*packages), encoding="utf-8"
+                )
             return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
         def fake_version(name: str) -> str:
@@ -1666,6 +1673,148 @@ def test_transitive_packages_are_reported_too(pip_report, tmp_path):
 
     changes = plugin_install.resolve_requirements(requirements)
     assert [c.name for c in changes] == ["blinker", "Flask", "Werkzeug"]
+
+
+# The tests below run REAL pip. The stubbed-argv tests further down assert that
+# `--only-binary=:all:` is on the command; they cannot see that pip applies it
+# only to requirements resolved BY NAME, which is how a fix that covered one
+# form out of five passed a green suite. Anything claiming "no code runs before
+# consent" has to be proved by code that would have run.
+
+
+def _marker_sdist(tmp_path, marker):
+    """An sdist whose setup.py writes *marker* when pip builds it."""
+    src = tmp_path / "src" / "evilpkg-1.0"
+    src.mkdir(parents=True)
+    (src / "setup.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n"
+        "from setuptools import setup\n"
+        "setup(name='evilpkg', version='1.0', py_modules=['evilpkg'])\n",
+        encoding="utf-8",
+    )
+    (src / "evilpkg.py").write_text("", encoding="utf-8")
+    tarball = tmp_path / "evilpkg-1.0.tar.gz"
+    with tarfile.open(tarball, "w:gz") as archive:
+        archive.add(src, arcname="evilpkg-1.0")
+    return src, tarball
+
+
+@pytest.mark.parametrize("form", ["direct-url", "path", "editable", "include"])
+def test_no_plugin_code_runs_before_the_listing(tmp_path, form):
+    """The behaviour, against real pip: nothing is built before consent.
+
+    `--only-binary=:all:` covers only the by-name case; pip exempts direct
+    references, VCS URLs, paths and editables, and each of those ran setup.py
+    during `--dry-run --report` before this refused them up front. The
+    `include` case is the same attack hidden one file down in `-r`.
+    """
+    marker = tmp_path / "EXECUTED"
+    src, tarball = _marker_sdist(tmp_path, marker)
+    requirements = tmp_path / "requirements.txt"
+    if form == "direct-url":
+        requirements.write_text(f"evilpkg @ file://{tarball}\n", encoding="utf-8")
+    elif form == "path":
+        requirements.write_text(f"{src}\n", encoding="utf-8")
+    elif form == "editable":
+        requirements.write_text(f"-e {src}\n", encoding="utf-8")
+    else:
+        deps = tmp_path / "deps"
+        deps.mkdir()
+        (deps / "base.txt").write_text(
+            f"evilpkg @ file://{tarball}\n", encoding="utf-8"
+        )
+        requirements.write_text("-r deps/base.txt\n", encoding="utf-8")
+
+    with pytest.raises(PluginError, match="--allow-sdist"):
+        plugin_install.resolve_requirements(requirements)
+    assert not marker.exists(), f"{form}: plugin code ran before anyone was asked"
+
+
+def test_a_plain_wheel_requirement_still_resolves(tmp_path):
+    """The over-blocking control, also against real pip.
+
+    Refusing everything would satisfy the test above and destroy the feature.
+    A wheel served from a local directory is the ordinary case and must pass
+    with no marker anywhere near it.
+    """
+    links = tmp_path / "wheels"
+    links.mkdir()
+    dist = "zzplain-1.0.dist-info"
+    with zipfile.ZipFile(links / "zzplain-1.0-py3-none-any.whl", "w") as wheel:
+        wheel.writestr(
+            f"{dist}/METADATA", "Metadata-Version: 2.1\nName: zzplain\nVersion: 1.0\n"
+        )
+        wheel.writestr(
+            f"{dist}/WHEEL",
+            "Wheel-Version: 1.0\nGenerator: x\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        )
+        wheel.writestr(f"{dist}/RECORD", "")
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        f"--no-index\n--find-links {links}\nzzplain\n", encoding="utf-8"
+    )
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.name == "zzplain"
+    assert change.url is not None, "a non-PyPI source must still be named"
+
+
+def test_allow_sdist_lets_the_build_happen_and_says_so(tmp_path):
+    """The opt-in really does opt in - otherwise the escape hatch is a lie."""
+    marker = tmp_path / "EXECUTED"
+    _src, tarball = _marker_sdist(tmp_path, marker)
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"evilpkg @ file://{tarball}\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    assert change.name == "evilpkg"
+    assert marker.exists(), "allow_sdist is documented as running build code"
+
+
+def test_a_legitimate_include_chain_is_not_refused(tmp_path):
+    """Over-blocking control for the include-following: `-r` is ordinary."""
+    (tmp_path / "deps").mkdir()
+    (tmp_path / "deps" / "base.txt").write_text("pillow==11.0.0\n", encoding="utf-8")
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("-r deps/base.txt\nflask\n", encoding="utf-8")
+
+    assert plugin_install.source_requirements(requirements) == []
+
+
+def test_an_include_reaching_outside_the_plugin_is_refused(tmp_path):
+    """pip would read it; we cannot, so we do not vouch for the file."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("flask\n", encoding="utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    requirements = plugin / "requirements.txt"
+    requirements.write_text(f"-r {outside}\n", encoding="utf-8")
+
+    assert plugin_install.source_requirements(requirements) == [f"-r {outside}"]
+
+
+def test_an_include_cycle_terminates(tmp_path):
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("-r b.txt\nflask\n", encoding="utf-8")
+    second.write_text("-r a.txt\npillow\n", encoding="utf-8")
+
+    assert plugin_install.source_requirements(first) == []
+
+
+def test_options_hidden_in_an_include_are_still_listed(tmp_path):
+    """`-r deps/base.txt` alone reads as housekeeping; the option is the point."""
+    (tmp_path / "deps").mkdir()
+    (tmp_path / "deps" / "base.txt").write_text(
+        "--index-url https://packages.example.invalid/simple\nflask\n", encoding="utf-8"
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("-r deps/base.txt\n", encoding="utf-8")
+
+    assert plugin_install.pip_options(requirements) == [
+        "-r deps/base.txt",
+        "--index-url https://packages.example.invalid/simple",
+    ]
 
 
 def test_resolving_refuses_to_build_a_source_distribution(pip_report, tmp_path):
@@ -1799,7 +1948,10 @@ def test_a_direct_url_requirement_is_installed_from_that_url(
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    (change,) = plugin_install.resolve_requirements(requirements)
+    # allow_sdist: a direct-URL requirement now needs the opt-in to resolve at
+    # all, because pip must fetch and build it to say what it is. This asserts
+    # the pin AFTER that consent, which is the only way the pin is reached.
+    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
     assert change.url == _DIRECT_URL
 
     command = _installed_command(change, monkeypatch)
@@ -1856,7 +2008,7 @@ def test_a_vcs_requirement_is_pinned_to_the_resolved_commit(pip_report, tmp_path
         encoding="utf-8",
     )
 
-    (change,) = plugin_install.resolve_requirements(requirements)
+    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
     assert change.pin == f"git+{vcs['url']}@{'b' * 40}"
 
 
@@ -1867,7 +2019,7 @@ def test_a_subdirectory_survives_the_round_trip(pip_report, tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    (change,) = plugin_install.resolve_requirements(requirements)
+    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
     assert change.pin.endswith(f"#sha256={_SHA}&subdirectory=packages/moondream")
 
 
@@ -1896,6 +2048,74 @@ def test_an_entry_without_a_usable_url_falls_back_to_name_and_version(
 
     (change,) = plugin_install.resolve_requirements(requirements)
     assert change.pin == "flask==3.1.3"
+
+
+def test_the_cli_prints_the_option_warning_before_resolving(
+    tmp_path, plugin_root, pip_report, capsys
+):
+    """The consent text is only a control if something asserts it reaches screen.
+
+    `plugin_install.pip_options` had its own test while the CLI wiring had
+    none, so replacing the call with `options = []` left the whole suite green.
+    """
+    pip_report(("flask", "3.1.3"), installed={})
+    folder = tmp_path / "pkg"
+    _write(folder / "__init__.py", CAPTIONER)
+    _write(folder / "requirements.txt", "--find-links /srv/plugin-wheels\nflask\n")
+
+    assert _install(folder, "--with-deps") == cli.EXIT_OK
+    err = capsys.readouterr().err
+    assert "passes options to pip" in err
+    assert "--find-links /srv/plugin-wheels" in err
+    assert "--index-url" in err, "the reason to care must be named"
+
+
+def test_the_cli_stays_quiet_for_an_ordinary_requirements_file(
+    tmp_path, plugin_root, pip_report, capsys
+):
+    """Over-warning is its own failure: a warning on every install is noise."""
+    pip_report(("flask", "3.1.3"), installed={})
+    folder = tmp_path / "pkg"
+    _write(folder / "__init__.py", CAPTIONER)
+    _write(folder / "requirements.txt", "flask\n")
+
+    assert _install(folder, "--with-deps") == cli.EXIT_OK
+    assert "passes options to pip" not in capsys.readouterr().err
+
+
+def test_the_cli_warns_that_allow_sdist_runs_build_code(
+    tmp_path, plugin_root, pip_report, capsys
+):
+    """The flag's whole cost is that code runs; saying so is the point of it."""
+    pip_report(("flask", "3.1.3"), installed={})
+    folder = tmp_path / "pkg"
+    _write(folder / "__init__.py", CAPTIONER)
+    _write(folder / "requirements.txt", "flask\n")
+
+    assert _install(folder, "--with-deps", "--allow-sdist") == cli.EXIT_OK
+    err = capsys.readouterr().err
+    assert "--allow-sdist" in err
+    assert "runs build code" in err
+
+
+def test_a_dry_run_never_reaches_pip_for_a_building_requirement(
+    tmp_path, plugin_root, capsys
+):
+    """`--dry-run` promises nothing happened, so nothing may have happened.
+
+    The resolve runs before the dry-run check, so before the refusal existed
+    `plugins install <hostile> --with-deps --dry-run` executed the author's
+    build code and then printed "nothing was written".
+    """
+    marker = tmp_path / "EXECUTED"
+    _src, tarball = _marker_sdist(tmp_path, marker)
+    folder = tmp_path / "pkg"
+    _write(folder / "__init__.py", CAPTIONER)
+    _write(folder / "requirements.txt", f"evilpkg @ file://{tarball}\n")
+
+    assert _install(folder, "--with-deps", "--dry-run") == cli.EXIT_REFUSED
+    assert not marker.exists(), "a dry run must not run the plugin author's code"
+    assert "--allow-sdist" in capsys.readouterr().err
 
 
 def test_the_listing_names_a_find_links_source_the_user_never_asked_for(
@@ -1965,7 +2185,7 @@ def test_the_listing_names_the_url_a_direct_requirement_comes_from(
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    changes = plugin_install.resolve_requirements(requirements)
+    changes = plugin_install.resolve_requirements(requirements, allow_sdist=True)
     assert cli._report_dependencies(changes, force=False)
     out = capsys.readouterr().out
     assert _DIRECT_URL in out

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -18,7 +18,6 @@ import os
 import re
 import subprocess
 import sys
-import tarfile
 import zipfile
 from pathlib import Path
 
@@ -1675,213 +1674,6 @@ def test_transitive_packages_are_reported_too(pip_report, tmp_path):
     assert [c.name for c in changes] == ["blinker", "Flask", "Werkzeug"]
 
 
-# The tests below run REAL pip. The stubbed-argv tests further down assert that
-# `--only-binary=:all:` is on the command; they cannot see that pip applies it
-# only to requirements resolved BY NAME, which is how a fix that covered one
-# form out of five passed a green suite. Anything claiming "no code runs before
-# consent" has to be proved by code that would have run.
-
-
-def _marker_sdist(tmp_path, marker):
-    """An sdist whose setup.py writes *marker* when pip builds it."""
-    src = tmp_path / "src" / "evilpkg-1.0"
-    src.mkdir(parents=True)
-    (src / "setup.py").write_text(
-        f"from pathlib import Path\nPath({str(marker)!r}).write_text('ran')\n"
-        "from setuptools import setup\n"
-        "setup(name='evilpkg', version='1.0', py_modules=['evilpkg'])\n",
-        encoding="utf-8",
-    )
-    (src / "evilpkg.py").write_text("", encoding="utf-8")
-    tarball = tmp_path / "evilpkg-1.0.tar.gz"
-    with tarfile.open(tarball, "w:gz") as archive:
-        archive.add(src, arcname="evilpkg-1.0")
-    return src, tarball
-
-
-@pytest.mark.parametrize("form", ["direct-url", "path", "editable", "include"])
-def test_no_plugin_code_runs_before_the_listing(tmp_path, form):
-    """The behaviour, against real pip: nothing is built before consent.
-
-    `--only-binary=:all:` covers only the by-name case; pip exempts direct
-    references, VCS URLs, paths and editables, and each of those ran setup.py
-    during `--dry-run --report` before this refused them up front. The
-    `include` case is the same attack hidden one file down in `-r`.
-    """
-    marker = tmp_path / "EXECUTED"
-    src, tarball = _marker_sdist(tmp_path, marker)
-    requirements = tmp_path / "requirements.txt"
-    if form == "direct-url":
-        requirements.write_text(f"evilpkg @ file://{tarball}\n", encoding="utf-8")
-    elif form == "path":
-        requirements.write_text(f"{src}\n", encoding="utf-8")
-    elif form == "editable":
-        requirements.write_text(f"-e {src}\n", encoding="utf-8")
-    else:
-        deps = tmp_path / "deps"
-        deps.mkdir()
-        (deps / "base.txt").write_text(
-            f"evilpkg @ file://{tarball}\n", encoding="utf-8"
-        )
-        requirements.write_text("-r deps/base.txt\n", encoding="utf-8")
-
-    with pytest.raises(PluginError, match="--allow-sdist"):
-        plugin_install.resolve_requirements(requirements)
-    assert not marker.exists(), f"{form}: plugin code ran before anyone was asked"
-
-
-def test_a_plain_wheel_requirement_still_resolves(tmp_path):
-    """The over-blocking control, also against real pip.
-
-    Refusing everything would satisfy the test above and destroy the feature.
-    A wheel served from a local directory is the ordinary case and must pass
-    with no marker anywhere near it.
-    """
-    links = tmp_path / "wheels"
-    links.mkdir()
-    dist = "zzplain-1.0.dist-info"
-    with zipfile.ZipFile(links / "zzplain-1.0-py3-none-any.whl", "w") as wheel:
-        wheel.writestr(
-            f"{dist}/METADATA", "Metadata-Version: 2.1\nName: zzplain\nVersion: 1.0\n"
-        )
-        wheel.writestr(
-            f"{dist}/WHEEL",
-            "Wheel-Version: 1.0\nGenerator: x\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-        )
-        wheel.writestr(f"{dist}/RECORD", "")
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text(
-        f"--no-index\n--find-links {links}\nzzplain\n", encoding="utf-8"
-    )
-
-    (change,) = plugin_install.resolve_requirements(requirements)
-    assert change.name == "zzplain"
-    assert change.url is not None, "a non-PyPI source must still be named"
-
-
-def test_allow_sdist_lets_the_build_happen_and_says_so(tmp_path):
-    """The opt-in really does opt in - otherwise the escape hatch is a lie."""
-    marker = tmp_path / "EXECUTED"
-    _src, tarball = _marker_sdist(tmp_path, marker)
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text(f"evilpkg @ file://{tarball}\n", encoding="utf-8")
-
-    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
-    assert change.name == "evilpkg"
-    assert marker.exists(), "allow_sdist is documented as running build code"
-
-
-def test_a_legitimate_include_chain_is_not_refused(tmp_path):
-    """Over-blocking control for the include-following: `-r` is ordinary."""
-    (tmp_path / "deps").mkdir()
-    (tmp_path / "deps" / "base.txt").write_text("pillow==11.0.0\n", encoding="utf-8")
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text("-r deps/base.txt\nflask\n", encoding="utf-8")
-
-    assert plugin_install.source_requirements(requirements) == []
-
-
-def test_an_include_reaching_outside_the_plugin_is_refused(tmp_path):
-    """pip would read it; we cannot, so we do not vouch for the file."""
-    outside = tmp_path / "outside.txt"
-    outside.write_text("flask\n", encoding="utf-8")
-    plugin = tmp_path / "plugin"
-    plugin.mkdir()
-    requirements = plugin / "requirements.txt"
-    requirements.write_text(f"-r {outside}\n", encoding="utf-8")
-
-    assert plugin_install.source_requirements(requirements) == [f"-r {outside}"]
-
-
-def test_an_include_cycle_terminates(tmp_path):
-    first = tmp_path / "a.txt"
-    second = tmp_path / "b.txt"
-    first.write_text("-r b.txt\nflask\n", encoding="utf-8")
-    second.write_text("-r a.txt\npillow\n", encoding="utf-8")
-
-    assert plugin_install.source_requirements(first) == []
-
-
-def test_options_hidden_in_an_include_are_still_listed(tmp_path):
-    """`-r deps/base.txt` alone reads as housekeeping; the option is the point."""
-    (tmp_path / "deps").mkdir()
-    (tmp_path / "deps" / "base.txt").write_text(
-        "--index-url https://packages.example.invalid/simple\nflask\n", encoding="utf-8"
-    )
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text("-r deps/base.txt\n", encoding="utf-8")
-
-    assert plugin_install.pip_options(requirements) == [
-        "-r deps/base.txt",
-        "--index-url https://packages.example.invalid/simple",
-    ]
-
-
-def test_resolving_refuses_to_build_a_source_distribution(pip_report, tmp_path):
-    """#1201 F3: a dry run is not a safe run.
-
-    Resolving an sdist makes pip build its metadata, which executes the
-    package's own `setup.py` as this user - before anything is printed and
-    before anyone agrees to anything. Reproduced against real pip: a marker
-    file written by `setup.py` existed after a plain `--dry-run --report`.
-    `--only-binary=:all:` is what stops the build, so it must be on the command
-    by default, and off only when the caller opted in.
-    """
-    calls = pip_report(("flask", "3.1.3"), installed={})
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text("flask\n", encoding="utf-8")
-
-    plugin_install.resolve_requirements(requirements)
-    assert "--only-binary=:all:" in calls[0]
-
-
-def test_allow_sdist_is_the_only_way_to_build_at_resolve_time(pip_report, tmp_path):
-    """The opt-in, and the over-blocking escape hatch it exists to be."""
-    calls = pip_report(("flask", "3.1.3"), installed={})
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text("flask\n", encoding="utf-8")
-
-    plugin_install.resolve_requirements(requirements, allow_sdist=True)
-    assert "--only-binary=:all:" not in calls[0]
-
-
-def test_a_refusal_names_the_flag_that_gets_past_it(monkeypatch, tmp_path):
-    """A sdist-only dependency must not be a dead end with no way forward."""
-    monkeypatch.setattr(
-        plugin_install.subprocess,
-        "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(
-            command, 1, stdout="", stderr="ERROR: No matching distribution found\n"
-        ),
-    )
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text("sdist-only-package\n", encoding="utf-8")
-
-    with pytest.raises(PluginError, match="--allow-sdist"):
-        plugin_install.resolve_requirements(requirements)
-    # ...and it does not nag about the flag when the flag is already on.
-    with pytest.raises(PluginError) as caught:
-        plugin_install.resolve_requirements(requirements, allow_sdist=True)
-    assert "--allow-sdist" not in str(caught.value)
-
-
-def test_installing_matches_the_resolve_on_building_from_source(monkeypatch):
-    """A pin must not build what the resolve refused to build."""
-    commands: list[list[str]] = []
-
-    def fake_run(command, **_kwargs):
-        commands.append(command)
-        return subprocess.CompletedProcess(command, 0)
-
-    monkeypatch.setattr(plugin_install.subprocess, "run", fake_run)
-    change = plugin_install.DependencyChange("something", "1.0")
-    plugin_install.install_requirements([change])
-    plugin_install.install_requirements([change], allow_sdist=True)
-
-    assert "--only-binary=:all:" in commands[0]
-    assert "--only-binary=:all:" not in commands[1]
-
-
 def test_resolving_asks_pip_not_to_install_anything(pip_report, tmp_path):
     """It runs before the plugin is copied, so it must change nothing."""
     calls = pip_report(("flask", "3.1.3"), installed={})
@@ -1948,10 +1740,7 @@ def test_a_direct_url_requirement_is_installed_from_that_url(
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    # allow_sdist: a direct-URL requirement now needs the opt-in to resolve at
-    # all, because pip must fetch and build it to say what it is. This asserts
-    # the pin AFTER that consent, which is the only way the pin is reached.
-    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    (change,) = plugin_install.resolve_requirements(requirements)
     assert change.url == _DIRECT_URL
 
     command = _installed_command(change, monkeypatch)
@@ -2008,7 +1797,7 @@ def test_a_vcs_requirement_is_pinned_to_the_resolved_commit(pip_report, tmp_path
         encoding="utf-8",
     )
 
-    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    (change,) = plugin_install.resolve_requirements(requirements)
     assert change.pin == f"git+{vcs['url']}@{'b' * 40}"
 
 
@@ -2019,7 +1808,7 @@ def test_a_subdirectory_survives_the_round_trip(pip_report, tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    (change,) = plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    (change,) = plugin_install.resolve_requirements(requirements)
     assert change.pin.endswith(f"#sha256={_SHA}&subdirectory=packages/moondream")
 
 
@@ -2081,41 +1870,6 @@ def test_the_cli_stays_quiet_for_an_ordinary_requirements_file(
 
     assert _install(folder, "--with-deps") == cli.EXIT_OK
     assert "passes options to pip" not in capsys.readouterr().err
-
-
-def test_the_cli_warns_that_allow_sdist_runs_build_code(
-    tmp_path, plugin_root, pip_report, capsys
-):
-    """The flag's whole cost is that code runs; saying so is the point of it."""
-    pip_report(("flask", "3.1.3"), installed={})
-    folder = tmp_path / "pkg"
-    _write(folder / "__init__.py", CAPTIONER)
-    _write(folder / "requirements.txt", "flask\n")
-
-    assert _install(folder, "--with-deps", "--allow-sdist") == cli.EXIT_OK
-    err = capsys.readouterr().err
-    assert "--allow-sdist" in err
-    assert "runs build code" in err
-
-
-def test_a_dry_run_never_reaches_pip_for_a_building_requirement(
-    tmp_path, plugin_root, capsys
-):
-    """`--dry-run` promises nothing happened, so nothing may have happened.
-
-    The resolve runs before the dry-run check, so before the refusal existed
-    `plugins install <hostile> --with-deps --dry-run` executed the author's
-    build code and then printed "nothing was written".
-    """
-    marker = tmp_path / "EXECUTED"
-    _src, tarball = _marker_sdist(tmp_path, marker)
-    folder = tmp_path / "pkg"
-    _write(folder / "__init__.py", CAPTIONER)
-    _write(folder / "requirements.txt", f"evilpkg @ file://{tarball}\n")
-
-    assert _install(folder, "--with-deps", "--dry-run") == cli.EXIT_REFUSED
-    assert not marker.exists(), "a dry run must not run the plugin author's code"
-    assert "--allow-sdist" in capsys.readouterr().err
 
 
 def test_the_listing_names_a_find_links_source_the_user_never_asked_for(
@@ -2185,7 +1939,7 @@ def test_the_listing_names_the_url_a_direct_requirement_comes_from(
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
-    changes = plugin_install.resolve_requirements(requirements, allow_sdist=True)
+    changes = plugin_install.resolve_requirements(requirements)
     assert cli._report_dependencies(changes, force=False)
     out = capsys.readouterr().out
     assert _DIRECT_URL in out

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1560,28 +1560,39 @@ def test_the_hub_is_read_off_the_command_line_in_both_spellings(monkeypatch):
 # `install` list holds only what is *not* already satisfied.
 
 
-def _report(*packages: tuple[str, str]) -> str:
-    """Return a pip install report naming *packages* as (name, version).
+#: A stand-in sha256, the length pip records.
+_SHA = "a" * 64
 
-    A third element, when present, is the direct URL pip resolved the
-    requirement to, and produces the `is_direct` / `download_info` shape pip
-    writes for `name @ https://...`.
+
+def _entry(name: str, version: str, download_info=None, direct=False) -> dict:
+    """One `install` entry in the shape pip's --report writes."""
+    if download_info is None:
+        # What pip writes for a package resolved from the default index.
+        download_info = {
+            "url": f"https://files.pythonhosted.org/packages/{name}-{version}.whl",
+            "archive_info": {"hash": f"sha256={_SHA}", "hashes": {"sha256": _SHA}},
+        }
+    return {
+        "metadata": {"name": name, "version": version},
+        "is_direct": direct,
+        "download_info": download_info,
+    }
+
+
+def _report(*packages) -> str:
+    """Return a pip install report naming *packages*.
+
+    Each entry is `(name, version)`, or `(name, version, download_info,
+    is_direct)` to model a URL, a `--find-links` hit or a VCS checkout.
     """
-    entries = []
-    for package in packages:
-        name, version = package[0], package[1]
-        url = package[2] if len(package) > 2 else None
-        entry: dict = {"metadata": {"name": name, "version": version}}
-        if url:
-            entry["is_direct"] = True
-            entry["download_info"] = {"url": url}
-        else:
-            entry["is_direct"] = False
-            entry["download_info"] = {
-                "url": f"https://files.pythonhosted.org/packages/{name}-{version}.whl"
-            }
-        entries.append(entry)
-    return json.dumps({"install": entries})
+    return json.dumps(
+        {
+            "install": [
+                _entry(*package) if len(package) > 2 else _entry(package[0], package[1])
+                for package in packages
+            ]
+        }
+    )
 
 
 @pytest.fixture
@@ -1684,19 +1695,14 @@ def test_a_pip_that_cannot_resolve_is_a_refusal_not_a_crash(monkeypatch, tmp_pat
 # the code that lands are different packages (CWE-494).
 
 _DIRECT_URL = "https://example.invalid/wheels/moondream-1.0-py3-none-any.whl"
+_DIRECT_INFO = {
+    "url": _DIRECT_URL,
+    "archive_info": {"hash": f"sha256={_SHA}", "hashes": {"sha256": _SHA}},
+}
 
 
-def test_a_direct_url_requirement_is_installed_from_that_url(
-    pip_report, tmp_path, monkeypatch
-):
-    """The negative: `name==version` must never be the pin for a URL pin."""
-    pip_report(("moondream", "1.0", _DIRECT_URL), installed={})
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
-
-    (change,) = plugin_install.resolve_requirements(requirements)
-    assert change.url == _DIRECT_URL
-
+def _installed_command(change, monkeypatch) -> list[str]:
+    """Run install_requirements against a stubbed pip and return the argv."""
     commands: list[list[str]] = []
 
     def fake_run(command, **_kwargs):
@@ -1704,50 +1710,118 @@ def test_a_direct_url_requirement_is_installed_from_that_url(
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(plugin_install.subprocess, "run", fake_run)
-    plugin_install.install_requirements([change])
-
+    plugin_install.install_requirements(
+        change if isinstance(change, list) else [change]
+    )
     (command,) = commands
-    assert command[-1] == f"moondream @ {_DIRECT_URL}"
+    return command
+
+
+def test_a_direct_url_requirement_is_installed_from_that_url(
+    pip_report, tmp_path, monkeypatch
+):
+    """The negative: `name==version` must never be the pin for a URL pin."""
+    pip_report(("moondream", "1.0", _DIRECT_INFO, True), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.url == _DIRECT_URL
+
+    command = _installed_command(change, monkeypatch)
+    assert command[-1] == f"moondream @ {_DIRECT_URL}#sha256={_SHA}"
     assert "moondream==1.0" not in command
 
 
-def test_an_indexed_requirement_still_installs_by_name_and_version(
+def test_an_indexed_requirement_is_pinned_to_the_artefact_pip_resolved(
     pip_report, tmp_path, monkeypatch
 ):
-    """The positive control: over-pinning ordinary packages is its own bug."""
-    pip_report(("flask", "3.1.3"), installed={})
+    """An index entry is a substitution vector too, and used to be missed.
+
+    A `--index-url`, `--extra-index-url` or `--find-links` line inside the
+    plugin's own requirements.txt resolves against *that* source, and pip marks
+    the result `is_direct: false` because the requirement named a name. Pinning
+    it `name==version` then re-resolves against the DEFAULT index, i.e. against
+    whoever owns that name on PyPI. The URL pip reported is the only thing that
+    names what was actually shown to the user.
+    """
+    find_links = {
+        "url": "file:///srv/wheels/zzprivate-1.0-py3-none-any.whl",
+        "archive_info": {"hashes": {"sha256": _SHA}},
+    }
+    pip_report(("zzprivate", "1.0", find_links, False), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("--find-links /srv/wheels\nzzprivate\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.pin == f"zzprivate @ {find_links['url']}#sha256={_SHA}"
+    # Display stays quiet: the requirement itself did not name a URL.
+    assert change.url is None
+    assert "zzprivate==1.0" not in _installed_command(change, monkeypatch)
+
+
+def test_a_vcs_requirement_is_pinned_to_the_resolved_commit(pip_report, tmp_path):
+    """`download_info.url` drops both the `git+` prefix and the commit.
+
+    Replaying the bare URL succeeds and installs the repository's *working
+    tree* instead of the revision that was resolved and shown - so it fails
+    silently, which is worse than failing loudly.
+    """
+    vcs = {
+        "url": "https://example.invalid/someone/moondream",
+        "vcs_info": {"vcs": "git", "commit_id": "b" * 40, "requested_revision": "main"},
+    }
+    pip_report(("moondream", "1.0", vcs, True), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "git+https://example.invalid/someone/moondream#egg=moondream\n",
+        encoding="utf-8",
+    )
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.pin == f"git+{vcs['url']}@{'b' * 40}"
+
+
+def test_a_subdirectory_survives_the_round_trip(pip_report, tmp_path):
+    """A monorepo requirement installs the wrong package without it."""
+    info = dict(_DIRECT_INFO, subdirectory="packages/moondream")
+    pip_report(("moondream", "1.0", info, True), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.pin.endswith(f"#sha256={_SHA}&subdirectory=packages/moondream")
+
+
+def test_a_report_without_download_info_falls_back_to_name_and_version(
+    pip_report, tmp_path
+):
+    """The one case that cannot be pinned to an artefact still installs."""
+    pip_report(("flask", "3.1.3", {}, False), installed={})
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("flask\n", encoding="utf-8")
 
     (change,) = plugin_install.resolve_requirements(requirements)
-    assert change.url is None
     assert change.pin == "flask==3.1.3"
-
-
-def test_a_transitive_dependency_of_a_direct_url_stays_indexed(pip_report, tmp_path):
-    """`is_direct` is per entry: only the requirement itself pinned a URL."""
-    pip_report(("moondream", "1.0", _DIRECT_URL), ("pillow", "11.0.0"), installed={})
-    requirements = tmp_path / "requirements.txt"
-    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
-
-    pins = {c.name: c.pin for c in plugin_install.resolve_requirements(requirements)}
-    assert pins == {
-        "moondream": f"moondream @ {_DIRECT_URL}",
-        "pillow": "pillow==11.0.0",
-    }
 
 
 def test_the_listing_names_the_url_a_direct_requirement_comes_from(
     pip_report, tmp_path, capsys
 ):
     """Consent has to describe the artefact, not just a name and a version."""
-    pip_report(("moondream", "1.0", _DIRECT_URL), installed={})
+    pip_report(
+        ("moondream", "1.0", _DIRECT_INFO, True), ("pillow", "11.0.0"), installed={}
+    )
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
 
     changes = plugin_install.resolve_requirements(requirements)
     assert cli._report_dependencies(changes, force=False)
-    assert _DIRECT_URL in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert _DIRECT_URL in out
+    # Over-reporting is its own regression: naming files.pythonhosted.org on
+    # every ordinary line trains people to skip the one line that matters.
+    assert "files.pythonhosted.org" not in out
 
 
 def test_install_refuses_dependencies_that_replace_a_package_in_use(

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1755,8 +1755,12 @@ def test_an_indexed_requirement_is_pinned_to_the_artefact_pip_resolved(
 
     (change,) = plugin_install.resolve_requirements(requirements)
     assert change.pin == f"zzprivate @ {find_links['url']}#sha256={_SHA}"
-    # Display stays quiet: the requirement itself did not name a URL.
-    assert change.url is None
+    # And it is NAMED. Pinning the artefact without saying where it came from
+    # only made the substitution reliable: the listing would have read as "the
+    # PyPI project called zzprivate" while installing the plugin author's own
+    # wheel. `is_direct` is false here, which is why keying the display on it
+    # printed nothing.
+    assert change.url == find_links["url"]
     assert "zzprivate==1.0" not in _installed_command(change, monkeypatch)
 
 
@@ -1818,6 +1822,56 @@ def test_an_entry_without_a_usable_url_falls_back_to_name_and_version(
 
     (change,) = plugin_install.resolve_requirements(requirements)
     assert change.pin == "flask==3.1.3"
+
+
+def test_the_listing_names_a_find_links_source_the_user_never_asked_for(
+    pip_report, tmp_path, capsys
+):
+    """The consent half of item 14, found by #1201's adversarial review.
+
+    A plugin's own requirements.txt can carry `--find-links` / `--index-url`,
+    and an ordinary NAMED requirement resolved through one is reported by pip
+    with `is_direct == False`. Keying the display on `is_direct` printed
+    nothing, so a package silently replacing an installed one read exactly like
+    the PyPI project of the same name - while the pin faithfully installed the
+    plugin author's artefact. Named on the resolved host instead.
+    """
+    hostile = {
+        "url": "file:///srv/plugin-wheels/requests-99.0.0-py3-none-any.whl",
+        "archive_info": {"hashes": {"sha256": _SHA}},
+    }
+    pip_report(("requests", "99.0.0", hostile, False), installed={"requests": "2.34.2"})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "--find-links /srv/plugin-wheels\nrequests\n", encoding="utf-8"
+    )
+
+    changes = plugin_install.resolve_requirements(requirements)
+    # It replaces an installed package, so consent is refused without
+    # --force-deps; the listing is printed either way and is what matters here.
+    cli._report_dependencies(changes, force=False)
+    out = capsys.readouterr().out
+    assert hostile["url"] in out, "a non-PyPI source must be named before consent"
+
+
+def test_the_listing_surfaces_index_options_from_the_plugins_requirements(tmp_path):
+    """The cause, not just the effect: the option lines are the attack."""
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        "# a comment\n"
+        "--extra-index-url https://packages.example.invalid/simple\n"
+        "--find-links /srv/plugin-wheels\n"
+        "requests\n",
+        encoding="utf-8",
+    )
+    assert plugin_install.index_options(requirements) == [
+        "--extra-index-url https://packages.example.invalid/simple",
+        "--find-links /srv/plugin-wheels",
+    ]
+    # An ordinary requirements.txt has none, so the warning stays off screen.
+    plain = tmp_path / "plain.txt"
+    plain.write_text("flask\npillow==11.0.0\n", encoding="utf-8")
+    assert plugin_install.index_options(plain) == []
 
 
 def test_the_listing_names_the_url_a_direct_requirement_comes_from(

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1593,14 +1593,15 @@ def _report(*packages) -> str:
     Each entry is `(name, version)`, or `(name, version, download_info,
     is_direct)` to model a URL, a `--find-links` hit or a VCS checkout.
     """
-    return json.dumps(
-        {
-            "install": [
-                _entry(*package) if len(package) > 2 else _entry(package[0], package[1])
-                for package in packages
-            ]
-        }
-    )
+    entries = []
+    for package in packages:
+        # (name, version) uses _entry's default indexed download_info;
+        # (name, version, download_info, is_direct) states it explicitly.
+        if len(package) > 2:
+            entries.append(_entry(*package))
+        else:
+            entries.append(_entry(package[0], package[1]))
+    return json.dumps({"install": entries})
 
 
 @pytest.fixture
@@ -1927,7 +1928,7 @@ def test_the_listing_names_a_find_links_source_the_user_never_asked_for(
     assert hostile["url"] in out, "a non-PyPI source must be named before consent"
 
 
-def test_the_listing_surfaces_index_options_from_the_plugins_requirements(tmp_path):
+def test_the_listing_surfaces_every_pip_option_from_the_requirements(tmp_path):
     """The cause, not just the effect: the option lines are the attack."""
     requirements = tmp_path / "requirements.txt"
     requirements.write_text(
@@ -1937,14 +1938,21 @@ def test_the_listing_surfaces_index_options_from_the_plugins_requirements(tmp_pa
         "requests\n",
         encoding="utf-8",
     )
-    assert plugin_install.index_options(requirements) == [
+    assert plugin_install.pip_options(requirements) == [
         "--extra-index-url https://packages.example.invalid/simple",
         "--find-links /srv/plugin-wheels",
     ]
     # An ordinary requirements.txt has none, so the warning stays off screen.
     plain = tmp_path / "plain.txt"
     plain.write_text("flask\npillow==11.0.0\n", encoding="utf-8")
-    assert plugin_install.index_options(plain) == []
+    assert plugin_install.pip_options(plain) == []
+
+    # Deliberately NOT narrowed to download-source flags: an option a curated
+    # allowlist judged harmless would be shown to nobody, and the reader is
+    # better served seeing every line a plugin asks pip to honour.
+    broad = tmp_path / "broad.txt"
+    broad.write_text("--only-binary=:all:\n--pre\nflask\n", encoding="utf-8")
+    assert plugin_install.pip_options(broad) == ["--only-binary=:all:", "--pre"]
 
 
 def test_the_listing_names_the_url_a_direct_requirement_comes_from(

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1561,22 +1561,34 @@ def test_the_hub_is_read_off_the_command_line_in_both_spellings(monkeypatch):
 
 
 def _report(*packages: tuple[str, str]) -> str:
-    """Return a pip install report naming *packages* as (name, version)."""
-    return json.dumps(
-        {
-            "install": [
-                {"metadata": {"name": name, "version": version}}
-                for name, version in packages
-            ]
-        }
-    )
+    """Return a pip install report naming *packages* as (name, version).
+
+    A third element, when present, is the direct URL pip resolved the
+    requirement to, and produces the `is_direct` / `download_info` shape pip
+    writes for `name @ https://...`.
+    """
+    entries = []
+    for package in packages:
+        name, version = package[0], package[1]
+        url = package[2] if len(package) > 2 else None
+        entry: dict = {"metadata": {"name": name, "version": version}}
+        if url:
+            entry["is_direct"] = True
+            entry["download_info"] = {"url": url}
+        else:
+            entry["is_direct"] = False
+            entry["download_info"] = {
+                "url": f"https://files.pythonhosted.org/packages/{name}-{version}.whl"
+            }
+        entries.append(entry)
+    return json.dumps({"install": entries})
 
 
 @pytest.fixture
 def pip_report(monkeypatch, tmp_path):
     """Serve a canned pip `--report`, and record what pip was asked."""
 
-    def serve(*packages: tuple[str, str], installed: dict[str, str] | None = None):
+    def serve(*packages: tuple[str, ...], installed: dict[str, str] | None = None):
         calls: list[list[str]] = []
 
         def fake_run(command, **kwargs):
@@ -1660,6 +1672,82 @@ def test_a_pip_that_cannot_resolve_is_a_refusal_not_a_crash(monkeypatch, tmp_pat
 
     with pytest.raises(PluginError, match="no matching distribution"):
         plugin_install.resolve_requirements(requirements)
+
+
+# ----------------------------------------------------------------------
+# Direct-URL requirements (item 14: substitution / dependency confusion)
+# ----------------------------------------------------------------------
+#
+# A requirement pinned to a URL names one artefact and deliberately does not
+# name the public index. Reinstalling it as `name==version` hands the install
+# to whoever owns that name on PyPI, so the resolution the user agreed to and
+# the code that lands are different packages (CWE-494).
+
+_DIRECT_URL = "https://example.invalid/wheels/moondream-1.0-py3-none-any.whl"
+
+
+def test_a_direct_url_requirement_is_installed_from_that_url(
+    pip_report, tmp_path, monkeypatch
+):
+    """The negative: `name==version` must never be the pin for a URL pin."""
+    pip_report(("moondream", "1.0", _DIRECT_URL), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.url == _DIRECT_URL
+
+    commands: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(plugin_install.subprocess, "run", fake_run)
+    plugin_install.install_requirements([change])
+
+    (command,) = commands
+    assert command[-1] == f"moondream @ {_DIRECT_URL}"
+    assert "moondream==1.0" not in command
+
+
+def test_an_indexed_requirement_still_installs_by_name_and_version(
+    pip_report, tmp_path, monkeypatch
+):
+    """The positive control: over-pinning ordinary packages is its own bug."""
+    pip_report(("flask", "3.1.3"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("flask\n", encoding="utf-8")
+
+    (change,) = plugin_install.resolve_requirements(requirements)
+    assert change.url is None
+    assert change.pin == "flask==3.1.3"
+
+
+def test_a_transitive_dependency_of_a_direct_url_stays_indexed(pip_report, tmp_path):
+    """`is_direct` is per entry: only the requirement itself pinned a URL."""
+    pip_report(("moondream", "1.0", _DIRECT_URL), ("pillow", "11.0.0"), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
+
+    pins = {c.name: c.pin for c in plugin_install.resolve_requirements(requirements)}
+    assert pins == {
+        "moondream": f"moondream @ {_DIRECT_URL}",
+        "pillow": "pillow==11.0.0",
+    }
+
+
+def test_the_listing_names_the_url_a_direct_requirement_comes_from(
+    pip_report, tmp_path, capsys
+):
+    """Consent has to describe the artefact, not just a name and a version."""
+    pip_report(("moondream", "1.0", _DIRECT_URL), installed={})
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(f"moondream @ {_DIRECT_URL}\n", encoding="utf-8")
+
+    changes = plugin_install.resolve_requirements(requirements)
+    assert cli._report_dependencies(changes, force=False)
+    assert _DIRECT_URL in capsys.readouterr().out
 
 
 def test_install_refuses_dependencies_that_replace_a_package_in_use(

--- a/tests/test_views_links.py
+++ b/tests/test_views_links.py
@@ -669,6 +669,40 @@ def test_a_views_root_containing_a_reference_folder_is_refused(tmp_path, library
         views_service.check_views_root(str(tmp_path / "outer"), vault)
 
 
+def test_a_views_root_is_refused_when_the_reference_folders_cannot_be_read(
+    tmp_path, library
+):
+    """#1177 item 59: "we do not know" must not be read as "there are none".
+
+    The roots are a blocklist here. Before the fix the vault answered a failed
+    read with ``()``, which is indistinguishable from "no reference folders are
+    configured", so every check below this line silently passed.
+    """
+    from pixlstash.vault import ReferenceFolderRootsUnavailable
+
+    image_root, _paths = library
+
+    class _UnreadableVault(_FakeVault):
+        def reference_folder_roots(self):
+            raise ReferenceFolderRootsUnavailable("test-induced read failure")
+
+    vault = _UnreadableVault(image_root)
+    with pytest.raises(views_service.ViewsError, match="could not read"):
+        views_service.check_views_root(str(tmp_path / "views"), vault)
+
+
+def test_a_views_root_outside_every_reference_folder_is_still_accepted(
+    tmp_path, library
+):
+    """Over-blocking control for the test above: a readable, empty set allows."""
+    image_root, _paths = library
+    reference = tmp_path / "reference"
+    reference.mkdir()
+    vault = _FakeVault(image_root, reference_roots=(str(reference),))
+
+    views_service.check_views_root(str(tmp_path / "beside" / "views"), vault)
+
+
 @pytest.mark.parametrize("marker", [".dropbox.cache", ".tmp.driveupload"])
 def test_a_cloud_sync_folder_is_refused_by_its_marker(tmp_path, library, marker):
     """A sync client uploads the file a link points at, duplicating the library."""

--- a/tests/test_views_links.py
+++ b/tests/test_views_links.py
@@ -39,6 +39,7 @@ from pixlstash.db_models.picture_set import PictureSet, PictureSetMember
 from pixlstash.db_models.project import Project
 from pixlstash.server import Server
 from pixlstash.services import views_service
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
 from pixlstash.tasks.reference_folder_scan_task import VIEWS_MARKER_NAME
 from tests.utils import upload_pictures_and_wait
 
@@ -678,13 +679,11 @@ def test_a_views_root_is_refused_when_the_reference_folders_cannot_be_read(
     read with ``()``, which is indistinguishable from "no reference folders are
     configured", so every check below this line silently passed.
     """
-    from pixlstash.vault import ReferenceFolderRootsUnavailable
-
     image_root, _paths = library
 
     class _UnreadableVault(_FakeVault):
         def reference_folder_roots(self):
-            raise ReferenceFolderRootsUnavailable("test-induced read failure")
+            raise LibraryRootsUnavailable("test-induced read failure")
 
     vault = _UnreadableVault(image_root)
     with pytest.raises(views_service.ViewsError, match="could not read"):

--- a/tests/test_watch_folder_worker.py
+++ b/tests/test_watch_folder_worker.py
@@ -562,3 +562,48 @@ def test_claim_if_settled_requires_a_wall_clock_quiet_window():
 
     # Claimed once. Later scans of the same bytes must not offer it again.
     assert finder._claim_if_settled(path, complete, 2 * settle + 60.0) is False
+
+
+def test_watch_folder_listing_refuses_rather_than_reporting_none():
+    """#1177 item 59's import-folder sibling, from the review of #1201.
+
+    `get_import_folder_paths` used to answer a failed read with `[]`, which is
+    exactly what "no watch folders are configured" looks like. In the export
+    route that turned a destination check off silently; here it is a plainer
+    lie - the owner is told they watch nothing, which is how someone re-adds a
+    folder they already have or concludes their folders were lost. It now
+    raises, and this route turns that into a 503 rather than an unhandled 500.
+    """
+    from unittest import mock
+
+    from pixlstash.utils.path_utils import LibraryRootsUnavailable
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with Server(f"{temp_dir}/server-config.json") as server:
+            with TestClient(server.api) as client:
+                response = client.post(
+                    f"{API_PREFIX}/login",
+                    json={"username": "testuser", "password": "testpassword"},
+                )
+                assert response.status_code == 200, response.text
+
+                # The positive control first, so a 503 below cannot be the
+                # route being broken outright: a readable table still lists.
+                ok = client.get(f"{API_PREFIX}/server-config/watch-folders")
+                assert ok.status_code == 200, ok.text
+                assert isinstance(ok.json()["watch_folders"], list)
+
+                def _explode(_vault):
+                    raise LibraryRootsUnavailable("test-induced read failure")
+
+                with mock.patch(
+                    "pixlstash.routes.config.config_service.get_import_folder_paths",
+                    _explode,
+                ):
+                    refused = client.get(f"{API_PREFIX}/server-config/watch-folders")
+                assert refused.status_code == 503, refused.text
+                assert "watched folders" in refused.json()["detail"]
+
+                # And it recovers: the refusal is about this read, not a latch.
+                again = client.get(f"{API_PREFIX}/server-config/watch-folders")
+                assert again.status_code == 200, again.text


### PR DESCRIPTION
Security items from the v1.11.1 backlog (#1177), kept in one lane so one
reviewer holds the whole threat picture. Items 14, 16, 56, 57, 59 and 62, plus
the findings from three review passes over them.

### 14 — a resolved requirement was re-installed by name

`resolve_requirements` asks pip what it would install and shows the answer;
`install_requirements` then pinned each entry as `name==version`, which names a
project on the *default index* rather than the artefact that was resolved. A
requirement the plugin pinned to a URL, to a VCS commit, or to its own
`--find-links` directory therefore landed as whatever owns that name on PyPI —
the code shown and the code installed could be different projects (CWE-494,
dependency confusion).

Every entry is now pinned to the artefact, rebuilt from pip's `download_info`
the way pip's own `direct_url_as_pep440_direct_reference` builds it: a VCS entry
becomes `<vcs>+<url>@<commit_id>`, anything else `name @ url` carrying the
recorded `sha256`. A fragment hash makes pip verify the download without
switching it into hash-checking mode, so entries that cannot have one still
install alongside.

**Consent had the same hole one layer up.** The listing named the source only
for pip's `is_direct` entries, but an ordinary *named* requirement resolved
through a plugin's own `--index-url` / `--find-links` is reported with
`is_direct == false` — so pinning the artefact without naming it made the
substitution *reliable* rather than preventing it. The source is now shown
whenever the resolved host is not the ordinary package index, and the option
lines that cause it are printed before resolution.

**Resolving still runs a source package's build code, deliberately.** Resolving
an sdist makes pip build its metadata, which runs that package's `setup.py`
before anything is printed. An earlier revision of this branch refused those
requirement forms; it was removed on the owner's ruling, and the reasoning is
recorded here because the absence is a decision rather than an oversight: a
plugin is arbitrary Python running in-process the moment it loads, so an author
who wants to execute code puts it in the plugin, not in a dependency's build
hook. Constraining the dependencies of unsandboxed code bought nothing and cost
the ability to install ordinary source-only, VCS and path requirements.

What remains is correctness and transparency rather than a gate: the pin
installs the artefact that was actually resolved, and the listing says where
each one came from.

### 59 — a fail-open library-root list

`Vault.reference_folder_roots()` returned `()` on a DB read error. The same list
is an **allowlist** for the scrapheap purge (empty means "only `image_root` may
be deleted from" — safe) and a **blocklist** for the folder-export destination
and the views root (empty means "nothing to avoid" — permits). No single value
is safe in both directions, and `()` is also exactly what "none are configured"
looks like.

Both helpers — `reference_folder_roots()` and `get_import_folder_paths()`, which
had the identical shape — now raise `LibraryRootsUnavailable`. The purge catches
it and keeps its empty-is-safe behaviour (letting it escape would be worse: the
rows are already purged, so the ledger would assert deletions that never
happened). The blocklist callers refuse: the export returns 503, the views root
raises `ViewsError`, and the watch-folder listing returns 503 rather than
reporting an empty list the owner would read as "you watch nothing".

### 56, 57, 62 — Electron IPC trust boundaries

- **56.** `backend:setLocation` reaches `moveDir`, which recursively deletes
  `<caller-chosen root>/<accel>`; `setup:commit` takes an arbitrary `imageRoot`
  and `installLocation`. Both are *meant* to take a folder the user chose, so
  the check is provenance, not an allowlist: `offerPath` records every path the
  main process hands out and `requireOfferedPath` refuses anything else. Kept
  per purpose, so a library folder cannot be replayed as the GPU install
  location. Path identity follows the platform — case-folded on Windows only,
  matching `normalizeBackendsRoot` — and the value returned is the one PixlStash
  offered, never the renderer's spelling of it.
- **57.** `server:setSettings` wrote `enabled` and `ssl` unchecked. Both are now
  type-checked and rejected rather than coerced; `port` is type-checked but
  deliberately left lenient on range, because the field emits `Number('')` while
  it is being typed and `writeServerSettings` already ignores anything outside
  1-65535.
- **62.** The wizard and the app are one window behind one preload, so every
  `setup:*` handler stayed reachable from app-served JavaScript after setup had
  finished. A `webContents` binding cannot separate them; the sending frame's
  document can. `startup:*` is deliberately left open — the running app owns
  those channels.
- Validating a payload's shape does not gate a capability: `server:*` is now
  restricted to the app's own origin, which is where the Settings dialog lives.

**The gating is complete rather than opt-in.** The tests enumerate handlers from
the source instead of naming them, so a new `setup:*` or `server:*` channel, or
a new handler reaching a path sink, that nobody gated turns them red — the same
"safe by omission is a machine fact" property the authz gate has on the Python
side.

### 16 — mode-bit guards downgraded from refuse to warn: accepted

Filed "for the CSO to acknowledge". The downgrade landed in #1152 and its
reasoning was in `trusted_sqlite.py`'s docstring, but the accepted-risk register
had no owner or revisit date for it. **Accepted, not reverted**, and recorded as
W20 in `docs/backend_architecture.md` §13 with the risk, the blast radius, the
compensating controls, an owner and a revisit date. Refusing on mode alone took
the product down twice on evidence that is a proxy rather than an observation.
It reverts to a refusal when multi-user work starts.

The record also corrects three claims that had gone stale: the Electron
permission-repair dialog is dead code since #1152 removed the marker that armed
it, so only a terminal is actually offered the `chmod`; an unresolvable group
warns rather than refusing; and deletion of `vault.db`/`-wal` on a non-sticky
world-writable directory belongs in the blast radius.

### Tests

Both directions for each item, in files already gated in `ci.yml`, plus
`electron/test/pathIpcValidation.test.ts` and additions to
`electron/test/urlPolicy.test.ts`. Each guard was mutation-checked: removing it,
or widening it the obvious wrong way, turns specific tests red.

