### PR TITLE
Layout rename: claim the folder that is really there, and only this entity's

### DIFF
--- a/changelog.d/1202.md
+++ b/changelog.d/1202.md
@@ -1,0 +1,8 @@
+- Fixed: on macOS and Windows, renaming a project, person or set in a library
+  with a folder layout could lose every picture filed under that folder. The
+  folder on disk was renamed, but PixlStash went on looking for those pictures
+  under the old name and within the hour forgot them, along with their tags,
+  score, people and sets. The picture files themselves were never touched.
+- Renaming a project, person or set to a different capitalisation of the same
+  name now renames its folder, instead of quietly leaving it under the old
+  spelling.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -6508,10 +6508,28 @@ collide the same way. `_name_is_ambiguous` declines those. The cost is that
 those folders drop out of the layout's language; the alternative costs the owner
 moved files, and this design errs the other way every time.
 
+Two entities of the same name are told apart by **primary key**, not by name.
+`rename_entity_folders` takes the id of the entity being renamed and
+`_name_is_ambiguous` skips only that row: excluding every row still holding the
+old name would exclude the *other* Mira as well, so renaming one would read as
+unambiguous and rename the other's folder.
+
+**The directory is found by scanning, not by joining the path.** `_entry_matching`
+resolves the real on-disk entry with the same fold `is_true` compares under, so
+the name is read as it is actually spelled. Joining `parent/<layout name>` and
+asking `os.path.isdir` is what a case-insensitive filesystem answers yes to for a
+directory really called `summer`; the rename would then move that directory while
+every row underneath still carried the real spelling, `_repoint_under` would match
+none of them, and the purge sweep would delete those pictures. The same match
+decides whether the destination is taken, so a rename that only changes case is
+made rather than refused, and a sibling spelled differently blocks it even where
+`os.path.exists` cannot see it.
+
 The renames and the `file_path` rewrites that describe them commit **together**,
 inside `rename_entity_folders` itself, and the directories are renamed back if
 that commit fails. A half-applied rename would leave every picture under the
-folder naming a path that does not exist, which is the purge sweep's input.
+folder naming a path that does not exist, which is the purge sweep's input. That
+is why every caller renames **before** its own `session.commit()`, not after.
 
 ### What Phase 6 sees once a layout is on
 

--- a/pixlstash/database.py
+++ b/pixlstash/database.py
@@ -323,7 +323,17 @@ def _before_flush_layout_tracker(session, flush_context, instances) -> None:
             if obj.picture_id is not None:
                 dirty_pids.add(obj.picture_id)
         elif isinstance(obj, Face) and obj.picture_id is not None:
-            if _attribute_changed(obj, "character_id"):
+            # A row on its way out has no attribute history, so the narrowing
+            # below reads False for it and deleting the face that carried the
+            # only person naming the folder would never stamp its picture. Ask
+            # what the face CARRIED instead. New and dirty rows keep the
+            # narrowing, so face *detection* does not stamp the library.
+            changed = (
+                obj.character_id is not None
+                if obj in session.deleted
+                else _attribute_changed(obj, "character_id")
+            )
+            if changed:
                 dirty_pids.add(obj.picture_id)
         elif isinstance(obj, Picture) and obj.id is not None:
             # Deliberately NOT session.new: a picture that has just been created

--- a/pixlstash/routes/characters.py
+++ b/pixlstash/routes/characters.py
@@ -1056,24 +1056,32 @@ def create_router(server) -> APIRouter:
                                 pic.text_embedding = None
                                 session.add(pic)
 
+                    if name_changing:
+                        # **Renaming a person renames their FOLDER; it moves no
+                        # files** (v1.11 §4). Required rather than tidy: the
+                        # layout reads folder names against the library's
+                        # current vocabulary, so a folder left under the old
+                        # name names nobody and its pictures fall out of the
+                        # rule for good.
+                        #
+                        # BEFORE the commit, as its docstring requires: the
+                        # renames and the ``file_path`` rewrites describing them
+                        # have to land together, or a failed commit leaves every
+                        # picture under a renamed folder naming a path that no
+                        # longer exists. It commits for itself when it renamed
+                        # anything; the commit below is the fallback for when it
+                        # did not. A name change always sets ``updated``, so
+                        # this block is never skipped by sitting inside it.
+                        rename_entity_folders(
+                            session,
+                            Facet.PERSON,
+                            previous_name,
+                            character.name,
+                            entity_id=id,
+                            image_root=server.vault.image_root,
+                        )
                     session.commit()
                     session.refresh(character)
-                if name_changing:
-                    # **Renaming a person renames their FOLDER; it moves no
-                    # files** (v1.11 §4). Required rather than tidy: the layout
-                    # reads folder names against the library's current
-                    # vocabulary, so a folder left under the old name names
-                    # nobody and its pictures fall out of the rule for good.
-                    # Commits for itself, and rolls the directories back if
-                    # it cannot: the renames and the ``file_path`` rewrites
-                    # describing them have to land together.
-                    rename_entity_folders(
-                        session,
-                        Facet.PERSON,
-                        previous_name,
-                        character.name,
-                        image_root=server.vault.image_root,
-                    )
                 # Serialize while the session is open; the row may be detached
                 # (and its attributes expired) by the time the handler returns.
                 payload = character.model_dump(exclude_unset=False)

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -1649,22 +1649,27 @@ def create_router(server) -> APIRouter:
                     if m is not None
                 ]
 
-            session.commit()
             if name_changing:
                 # **Renaming a set renames its FOLDER; it moves no files**
                 # (v1.11 §4). Required, not cosmetic: a folder still carrying
                 # the old name names nothing the library knows, so the layout
                 # can no longer read it and its pictures fall out of the rule.
-                # Commits for itself, and rolls the directories back if it
-                # cannot: the renames and the ``file_path`` rewrites describing
-                # them have to land together.
+                #
+                # BEFORE the commit, as its docstring requires: the renames and
+                # the ``file_path`` rewrites describing them have to land
+                # together, or a failed commit leaves every picture under a
+                # renamed folder naming a path that no longer exists. It commits
+                # for itself when it renamed anything; the commit below is the
+                # fallback for when it did not.
                 rename_entity_folders(
                     session,
                     Facet.SET,
                     previous_name,
                     picture_set.name,
+                    entity_id=id,
                     image_root=server.vault.image_root,
                 )
+            session.commit()
             return (
                 True,
                 project_id_changed or pictures_changed,

--- a/pixlstash/routes/projects.py
+++ b/pixlstash/routes/projects.py
@@ -533,6 +533,30 @@ def create_router(server) -> APIRouter:
                 project.extra_metadata = payload.extra_metadata
             session.add(project)
             try:
+                if normalized_name is not None and previous_name != normalized_name:
+                    # **Renaming a project renames its FOLDER; it moves no
+                    # files** (v1.11 §4). It is also not cosmetic: the layout
+                    # reads folder names against the library's *current*
+                    # vocabulary, so a folder left under the old name would name
+                    # nothing PixlStash knows and its pictures would drop out of
+                    # the layout for good.
+                    #
+                    # BEFORE the commit, as its docstring requires: the renames
+                    # and the ``file_path`` rewrites describing them have to
+                    # land together, or a failed commit leaves every picture
+                    # under a renamed folder naming a path that no longer
+                    # exists. It commits for itself when it renamed anything and
+                    # rolls the directories back if it cannot - and being inside
+                    # this ``try`` is what still turns a name-uniqueness race
+                    # into a 409 once the directories are back.
+                    rename_entity_folders(
+                        session,
+                        Facet.PROJECT,
+                        previous_name,
+                        normalized_name,
+                        entity_id=pid,
+                        image_root=server.vault.image_root,
+                    )
                 session.commit()
             except IntegrityError:
                 session.rollback()
@@ -541,22 +565,6 @@ def create_router(server) -> APIRouter:
                     detail="Project name already exists",
                 )
             session.refresh(project)
-            if normalized_name is not None and previous_name != normalized_name:
-                # **Renaming a project renames its FOLDER; it moves no files**
-                # (v1.11 §4). It is also not cosmetic: the layout reads folder
-                # names against the library's *current* vocabulary, so a folder
-                # left under the old name would name nothing PixlStash knows
-                # and its pictures would drop out of the layout for good.
-                # Commits for itself, and rolls the directories back if it
-                # cannot: the renames and the ``file_path`` rewrites describing
-                # them have to land together.
-                rename_entity_folders(
-                    session,
-                    Facet.PROJECT,
-                    previous_name,
-                    normalized_name,
-                    image_root=server.vault.image_root,
-                )
             return project
 
         return server.vault.db.run_task(

--- a/pixlstash/services/layout_move_service.py
+++ b/pixlstash/services/layout_move_service.py
@@ -1283,7 +1283,10 @@ def rename_entity_folders(
                     # ``os.path.exists``: an entry that IS the source (a rename
                     # that only changes case) is not a collision, and a sibling
                     # spelled differently is one even where ``exists`` says no.
-                    taken = _entry_matching(parent, new_folder)
+                    # Asked exact-first, because here the exactly-spelled entry
+                    # is the collision even when the source also matches the key
+                    # - see :func:`_entry_matching`.
+                    taken = _entry_matching(parent, new_folder, prefer_exact=True)
                     if taken is not None and taken != source:
                         logger.warning(
                             "Layout rename: %s already exists, so %s keeps its "
@@ -1376,7 +1379,9 @@ def _entity_names(session: Session, facet: Facet) -> list:
     ]
 
 
-def _entry_matching(parent: str, folder: str) -> Optional[str]:
+def _entry_matching(
+    parent: str, folder: str, *, prefer_exact: bool = False
+) -> Optional[str]:
     """The real on-disk path in *parent* that the layout reads as *folder*.
 
     ``os.path.isdir(os.path.join(parent, folder))`` is not enough, and the
@@ -1389,29 +1394,44 @@ def _entry_matching(parent: str, folder: str) -> Optional[str]:
     ``MissingFilePurgeFinder`` purges within the hour along with its metadata.
 
     So resolve the entry the way the truth check compares, and hand back the
-    name as it is actually written. Directories rank above files and the exact
-    spelling breaks the tie; see the loop.
+    name as it is actually written.
+
+    **The two questions this answers rank the candidates the opposite way, and
+    that is the whole reason for the flag.** Looking for the entity's own folder
+    (``prefer_exact=False``) a *directory* wins, because a stray file sharing an
+    entity's match key must not stand in for the folder and make the rename
+    silently not happen. Asking whether the destination is taken
+    (``prefer_exact=True``) the *exact spelling* wins, because the question is
+    "is something already sitting where I am about to write" - and a file named
+    exactly like the destination is a collision even when the source directory
+    also matches the key. Ranking that one directory-first hands back the source
+    itself, which reads as "not taken" and sends a case-only rename into an
+    ``os.rename`` that cannot succeed. Within each question the other property
+    breaks the tie, so a case-sensitive filesystem holding both ``Summer`` and
+    ``summer`` still renames the one that was asked for.
+
+    Args:
+        parent: The directory to look in.
+        folder: The folder name as the layout writes it.
+        prefer_exact: Rank an exactly-spelled entry above a directory. Use it
+            for the destination, not for the source.
+
+    Returns:
+        The path of the best-matching entry, or ``None`` if nothing matches.
     """
     key = _match_key(folder)
     best = None
-    best_rank = -1
+    best_rank = None
     try:
         with os.scandir(parent) as entries:
             for entry in entries:
                 if _match_key(entry.name) != key:
                     continue
-                # A directory outranks a file, and the exact spelling breaks the
-                # tie. Directory first because a stray file sharing an entity's
-                # match key must not stand in for the entity's real folder and
-                # make the rename silently not happen; exact second so a
-                # case-sensitive filesystem holding both ``Summer`` and
-                # ``summer`` renames the one that was asked for. A file still
-                # comes back when nothing better does, because for the
-                # destination it is a collision like any other.
-                rank = (2 if entry.is_dir() else 0) + (entry.name == folder)
-                if rank > best_rank:
+                exact, is_dir = entry.name == folder, entry.is_dir()
+                rank = (exact, is_dir) if prefer_exact else (is_dir, exact)
+                if best_rank is None or rank > best_rank:
                     best, best_rank = entry.path, rank
-                if best_rank == 3:
+                if best_rank == (True, True):
                     break
     except OSError as exc:
         logger.warning("Layout rename: cannot list %s (%s)", parent, exc)

--- a/pixlstash/services/layout_move_service.py
+++ b/pixlstash/services/layout_move_service.py
@@ -62,6 +62,10 @@ from pixlstash.utils.path_utils import path_is_within, resolve_path_within
 from pixlstash.utils.library_layout import (
     DEFAULT_LAYOUT,
     Facet,
+    # The component-level fold, deliberately not ``folder_match_key``: an
+    # on-disk name is already a folder name, and running ``folder_name`` over it
+    # again would read the real directory ``A:B`` as the entity ``A_B``.
+    _match_key,
     folder_match_key,
     format_layout,
     match_destination,
@@ -1180,6 +1184,7 @@ def rename_entity_folders(
     old_name: str,
     new_name: str,
     *,
+    entity_id: Optional[int],
     image_root: Optional[str],
 ) -> int:
     """Rename the folders named after an entity. **Moves no files.**
@@ -1212,6 +1217,11 @@ def rename_entity_folders(
     language and costs nobody a moved file - the direction this whole design
     errs in.
 
+    Args:
+        entity_id: The primary key of the entity being renamed, so its own row
+            can be told apart from a genuine second entity of the same name.
+            Two people really can be called Mira.
+
     **The caller must not commit before this returns**, and this commits for
     them: the directory renames and the ``file_path`` rewrites that describe
     them have to land together, or a failed commit leaves every picture under a
@@ -1231,7 +1241,9 @@ def rename_entity_folders(
     renamed: list = []
     try:
         for root in roots.values():
-            if _name_is_ambiguous(session, facet, old_name, root.layout):
+            if _name_is_ambiguous(
+                session, facet, old_name, root.layout, entity_id=entity_id
+            ):
                 logger.warning(
                     "Layout rename: %r names more than one thing this layout "
                     "could put at the same depth, so its folders under %s are "
@@ -1245,16 +1257,23 @@ def rename_entity_folders(
                 if facet not in segment:
                     continue
                 for parent in _directories_at_depth(root.path, depth):
-                    source = os.path.join(parent, old_folder)
-                    destination = os.path.join(parent, new_folder)
-                    if not os.path.isdir(source):
+                    # The directory as it is REALLY spelled, not as the layout
+                    # spells it - see :func:`_entry_matching`.
+                    source = _entry_matching(parent, old_folder)
+                    if source is None or not os.path.isdir(source):
                         continue
-                    if os.path.exists(destination):
+                    destination = os.path.join(parent, new_folder)
+                    # "Is the destination taken" is the same match question, not
+                    # ``os.path.exists``: an entry that IS the source (a rename
+                    # that only changes case) is not a collision, and a sibling
+                    # spelled differently is one even where ``exists`` says no.
+                    taken = _entry_matching(parent, new_folder)
+                    if taken is not None and taken != source:
                         logger.warning(
                             "Layout rename: %s already exists, so %s keeps its "
                             "old name. Its pictures read as off-layout until "
                             "one of the two folders is renamed by hand.",
-                            destination,
+                            taken,
                             source,
                         )
                         continue
@@ -1291,7 +1310,12 @@ def rename_entity_folders(
 
 
 def _name_is_ambiguous(
-    session: Session, facet: Facet, name: str, layout: Layout
+    session: Session,
+    facet: Facet,
+    name: str,
+    layout: Layout,
+    *,
+    entity_id: Optional[int],
 ) -> bool:
     """Whether another entity would write the same folder name at the same depth.
 
@@ -1306,21 +1330,22 @@ def _name_is_ambiguous(
     }
     key = folder_match_key(name)
     for other in wanted:
-        for candidate in _entity_names(session, other):
+        for candidate_id, candidate in _entity_names(session, other):
             if folder_match_key(candidate) != key:
                 continue
-            if other is facet and candidate == name:
-                # The entity being renamed no longer carries this name (the
-                # caller wrote the new one first), so a row still holding it is
-                # a genuine second entity. A row that IS this one - an
-                # unflushed session, a caller that renames after - is not.
+            if other is facet and candidate_id == entity_id:
+                # The row that IS the entity being renamed, told apart by
+                # primary key rather than by name. By name it could not be:
+                # two people really can be called Mira, and skipping every row
+                # holding the name would skip the second one too - so renaming
+                # one Mira would rename the other Mira's folder.
                 continue
             return True
     return False
 
 
 def _entity_names(session: Session, facet: Facet) -> list:
-    """Every name in the library for one facet."""
+    """Every ``(id, name)`` in the library for one facet."""
     model = {
         Facet.PROJECT: Project,
         Facet.SET: PictureSet,
@@ -1328,7 +1353,42 @@ def _entity_names(session: Session, facet: Facet) -> list:
     }.get(facet)
     if model is None:
         return []
-    return [name for name in session.exec(select(model.name)).all() if name]
+    return [
+        (entity_id, name)
+        for entity_id, name in session.exec(select(model.id, model.name)).all()
+        if name
+    ]
+
+
+def _entry_matching(parent: str, folder: str) -> Optional[str]:
+    """The real on-disk path in *parent* that the layout reads as *folder*.
+
+    ``os.path.isdir(os.path.join(parent, folder))`` is not enough, and the
+    difference destroys pictures. On a case-insensitive filesystem it answers
+    yes for a directory really spelled ``summer`` when the layout spells it
+    ``Summer`` - ``is_true`` attributes it, so the rename is right to claim it -
+    and ``os.rename`` then renames that real directory. But the rows underneath
+    carry the real spelling, so :func:`_repoint_under` matches none of them and
+    every one of those pictures is left naming a path with no file at it, which
+    ``MissingFilePurgeFinder`` purges within the hour along with its metadata.
+
+    So resolve the entry the way the truth check compares, and hand back the
+    name as it is actually written. The exact spelling wins where it exists, so
+    a case-sensitive filesystem holding both ``Summer`` and ``summer`` renames
+    the one that was asked for.
+    """
+    key = _match_key(folder)
+    match = None
+    try:
+        with os.scandir(parent) as entries:
+            for entry in entries:
+                if entry.name == folder:
+                    return entry.path
+                if match is None and _match_key(entry.name) == key:
+                    match = entry.path
+    except OSError as exc:
+        logger.warning("Layout rename: cannot list %s (%s)", parent, exc)
+    return match
 
 
 def _directories_at_depth(root: str, depth: int) -> list:

--- a/pixlstash/services/layout_move_service.py
+++ b/pixlstash/services/layout_move_service.py
@@ -1184,7 +1184,7 @@ def rename_entity_folders(
     old_name: str,
     new_name: str,
     *,
-    entity_id: Optional[int],
+    entity_id: int,
     image_root: Optional[str],
 ) -> int:
     """Rename the folders named after an entity. **Moves no files.**
@@ -1222,6 +1222,15 @@ def rename_entity_folders(
             can be told apart from a genuine second entity of the same name.
             Two people really can be called Mira.
 
+    Raises:
+        ValueError: If ``entity_id`` is ``None``. Without it there is no way to
+            tell this entity's own row from a second entity of the same name,
+            and the function would silently fall back to the name comparison
+            this replaced - which either renames the other entity's folder or
+            refuses a rename that was fine, depending on flush state. A caller
+            that cannot name the row it is renaming has a bug, and a loud one is
+            worth more than a rename that quietly goes to the wrong folder.
+
     **The caller must not commit before this returns**, and this commits for
     them: the directory renames and the ``file_path`` rewrites that describe
     them have to land together, or a failed commit leaves every picture under a
@@ -1232,6 +1241,13 @@ def rename_entity_folders(
     Returns:
         How many directories were renamed.
     """
+    if entity_id is None:
+        raise ValueError(
+            "rename_entity_folders needs the entity_id of the entity being "
+            f"renamed ({facet}, {old_name!r} -> {new_name!r}); without it its "
+            "own row cannot be told apart from a second entity of the same name"
+        )
+
     old_folder = folder_name(old_name)
     new_folder = folder_name(new_name)
     if old_folder == new_folder:
@@ -1373,22 +1389,33 @@ def _entry_matching(parent: str, folder: str) -> Optional[str]:
     ``MissingFilePurgeFinder`` purges within the hour along with its metadata.
 
     So resolve the entry the way the truth check compares, and hand back the
-    name as it is actually written. The exact spelling wins where it exists, so
-    a case-sensitive filesystem holding both ``Summer`` and ``summer`` renames
-    the one that was asked for.
+    name as it is actually written. Directories rank above files and the exact
+    spelling breaks the tie; see the loop.
     """
     key = _match_key(folder)
-    match = None
+    best = None
+    best_rank = -1
     try:
         with os.scandir(parent) as entries:
             for entry in entries:
-                if entry.name == folder:
-                    return entry.path
-                if match is None and _match_key(entry.name) == key:
-                    match = entry.path
+                if _match_key(entry.name) != key:
+                    continue
+                # A directory outranks a file, and the exact spelling breaks the
+                # tie. Directory first because a stray file sharing an entity's
+                # match key must not stand in for the entity's real folder and
+                # make the rename silently not happen; exact second so a
+                # case-sensitive filesystem holding both ``Summer`` and
+                # ``summer`` renames the one that was asked for. A file still
+                # comes back when nothing better does, because for the
+                # destination it is a collision like any other.
+                rank = (2 if entry.is_dir() else 0) + (entry.name == folder)
+                if rank > best_rank:
+                    best, best_rank = entry.path, rank
+                if best_rank == 3:
+                    break
     except OSError as exc:
         logger.warning("Layout rename: cannot list %s (%s)", parent, exc)
-    return match
+    return best
 
 
 def _directories_at_depth(root: str, depth: int) -> list:

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -852,6 +852,7 @@ def test_renaming_a_project_renames_the_folder_and_moves_no_files(library):
         Facet.PROJECT,
         "2024 Shoots",
         "2024 Shoots (archive)",
+        entity_id=library["project_id"],
         image_root=root,
     )
     session.commit()
@@ -873,7 +874,12 @@ def test_renaming_a_project_renames_the_folder_and_moves_no_files(library):
 def test_a_rename_is_journalled_so_the_scan_does_not_read_it_as_intent(library):
     session, root = library["session"], library["root"]
     engine.rename_entity_folders(
-        session, Facet.PROJECT, "2024 Shoots", "Renamed", image_root=root
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "Renamed",
+        entity_id=library["project_id"],
+        image_root=root,
     )
     session.commit()
     rows = session.exec(select(PictureMove)).all()
@@ -893,6 +899,187 @@ def test_a_taken_destination_is_declined_not_overwritten(library):
     assert skipped == [(library["picture_id"], "destination_taken")]
     with open(os.path.join(blocker, "0412.png"), "rb") as handle:
         assert handle.read() == b"somebody else's file"
+
+
+def _spell_the_project_folder(library, on_disk: str) -> None:
+    """Respell the project's directory and its rows without renaming the entity.
+
+    Standing in for a case-insensitive filesystem, where the directory really
+    written is ``2024 shoots`` while the layout spells the project ``2024
+    Shoots`` and ``is_true`` attributes it anyway. Simulated rather than
+    observed so the tests below are just as sharp on a case-SENSITIVE runner,
+    which is what CI is: there the buggy code skipped the folder outright, and
+    on a case-insensitive one it renamed the folder and repointed nothing.
+    """
+    session, root = library["session"], library["root"]
+    os.rename(os.path.join(root, "2024 Shoots"), os.path.join(root, on_disk))
+    picture = session.get(Picture, library["picture_id"])
+    picture.file_path = picture.file_path.replace("2024 Shoots/", f"{on_disk}/", 1)
+    session.add(picture)
+    session.commit()
+
+
+def test_a_folder_spelled_differently_is_renamed_under_its_real_name(library):
+    """The severe one: the rename must claim the directory that is really there.
+
+    Matching on the joined path finds a directory whose real spelling differs
+    on a case-insensitive filesystem, renames THAT, and then repoints nothing -
+    because the rows underneath carry the real spelling. Every picture under the
+    folder is left naming a path with no file at it, which the purge sweep
+    deletes within the hour along with its metadata.
+    """
+    session, root = library["session"], library["root"]
+    _spell_the_project_folder(library, "2024 shoots")
+
+    project = session.get(Project, library["project_id"])
+    project.name = "2025 Shoots"
+    session.add(project)
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "2025 Shoots",
+        entity_id=library["project_id"],
+        image_root=root,
+    )
+
+    assert renamed == 1
+    assert os.path.isfile(
+        os.path.join(root, "2025 Shoots", "Mira", "2026-08", "0412.png")
+    )
+    # The row is the point. A rename that moved the directory and left this
+    # naming the old one is the data-loss case.
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2025 Shoots/Mira/2026-08/0412.png"
+    )
+
+
+def test_a_rename_that_only_changes_case_is_made_not_refused(library):
+    """``2024 shoots`` -> ``2024 SHOOTS`` is the entity's own folder, not a rival."""
+    session, root = library["session"], library["root"]
+    _spell_the_project_folder(library, "2024 shoots")
+
+    project = session.get(Project, library["project_id"])
+    project.name = "2024 SHOOTS"
+    session.add(project)
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "2024 SHOOTS",
+        entity_id=library["project_id"],
+        image_root=root,
+    )
+
+    assert renamed == 1
+    assert os.path.isfile(
+        os.path.join(root, "2024 SHOOTS", "Mira", "2026-08", "0412.png")
+    )
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2024 SHOOTS/Mira/2026-08/0412.png"
+    )
+
+
+def test_a_sibling_spelled_differently_still_blocks_the_rename(library):
+    """The other direction: a folder that is not this entity's is not claimed.
+
+    ``os.path.exists`` cannot see it on a case-sensitive filesystem, so the
+    rename would put two folders the layout reads as one name side by side.
+    """
+    session, root = library["session"], library["root"]
+    rival = os.path.join(root, "2025 shoots")
+    os.makedirs(rival)
+
+    project = session.get(Project, library["project_id"])
+    project.name = "2025 Shoots"
+    session.add(project)
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "2025 Shoots",
+        entity_id=library["project_id"],
+        image_root=root,
+    )
+
+    assert renamed == 0
+    assert os.path.isdir(rival)
+    assert os.path.isfile(
+        os.path.join(root, "2024 Shoots", "Mira", "2026-08", "0412.png")
+    )
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2024 Shoots/Mira/2026-08/0412.png"
+    )
+
+
+def test_renaming_one_of_two_people_of_the_same_name_touches_no_folder(library):
+    """Two people really can be called Mira, and only one of them was renamed.
+
+    The self-exclusion has to be by primary key. Excluding every row still
+    holding the old name excludes the OTHER Mira too, so the name reads as
+    unambiguous and her folder is renamed out from under her.
+    """
+    session, root = library["session"], library["root"]
+    person = session.get(Character, library["person_id"])
+    session.add(Character(name="Mira"))
+    session.commit()
+
+    person.name = "Mira K"
+    session.add(person)
+    # Deliberately NOT committed: the caller must not commit before the rename.
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PERSON,
+        "Mira",
+        "Mira K",
+        entity_id=person.id,
+        image_root=root,
+    )
+
+    assert renamed == 0
+    assert os.path.isfile(
+        os.path.join(root, "2024 Shoots", "Mira", "2026-08", "0412.png")
+    )
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2024 Shoots/Mira/2026-08/0412.png"
+    )
+
+
+def test_a_rename_driven_before_the_callers_commit_lands_whole(library):
+    """How the routes call it: the name change is pending, and this commits it.
+
+    The directory rename and the ``file_path`` rewrites that describe it have to
+    land in ONE commit with the name that caused them - a commit that lands only
+    two of the three leaves the pictures naming paths that do not exist. The
+    ``rollback`` is the assertion: anything still uncommitted dies there.
+    """
+    session, root = library["session"], library["root"]
+    project = session.get(Project, library["project_id"])
+    project.name = "2024 Shoots (archive)"
+    session.add(project)
+
+    assert (
+        engine.rename_entity_folders(
+            session,
+            Facet.PROJECT,
+            "2024 Shoots",
+            "2024 Shoots (archive)",
+            entity_id=library["project_id"],
+            image_root=root,
+        )
+        == 1
+    )
+    session.rollback()
+
+    assert session.get(Project, library["project_id"]).name == "2024 Shoots (archive)"
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2024 Shoots (archive)/Mira/2026-08/0412.png"
+    )
 
 
 def test_a_symlinked_source_is_refused(library, tmp_path):
@@ -1139,6 +1326,45 @@ def test_a_person_landing_on_a_picture_stamps_it(stamped):
     assert _due(session, stamped["picture_id"]) is not None
 
 
+def test_taking_a_person_off_a_picture_stamps_it(stamped):
+    """The face that named the folder is gone, so the folder may have stopped
+    being true - and a deleted row has no attribute history to say so.
+
+    Reached from the untag route and from the face-model refresh, both of which
+    delete the row rather than null it. Without this the picture is never
+    revisited and its folder keeps a name nobody on it answers to.
+    """
+    session = stamped["session"]
+    face = session.exec(
+        select(Face).where(Face.picture_id == stamped["picture_id"])
+    ).first()
+    assert face.character_id is not None
+    session.delete(face)
+    session.commit()
+    assert _due(session, stamped["picture_id"]) is not None
+
+
+def test_removing_a_face_that_named_nobody_stamps_nothing(stamped):
+    """The narrowing has to survive: face DETECTION must not wake the engine.
+
+    Detection writes and rewrites unassigned faces constantly. Stamping on every
+    deleted face rather than on what it carried would put the whole library
+    through the layout check for work that changed no assignment.
+    """
+    session = stamped["session"]
+    face = Face(picture_id=stamped["picture_id"], character_id=None, face_index=7)
+    session.add(face)
+    session.commit()
+    picture = session.get(Picture, stamped["picture_id"])
+    picture.layout_check_due_at = None
+    session.add(picture)
+    session.commit()
+
+    session.delete(face)
+    session.commit()
+    assert _due(session, stamped["picture_id"]) is None
+
+
 def test_the_task_finds_only_what_is_due(stamped):
     from pixlstash.tasks.layout_move_task import LayoutMoveTask
 
@@ -1256,7 +1482,12 @@ def test_renaming_a_person_leaves_a_same_named_sets_folder_alone(library):
     session.add(person)
     session.commit()
     renamed = engine.rename_entity_folders(
-        session, Facet.PERSON, "Summer", "Summer B", image_root=root
+        session,
+        Facet.PERSON,
+        "Summer",
+        "Summer B",
+        entity_id=person.id,
+        image_root=root,
     )
 
     assert renamed == 0

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -1124,6 +1124,58 @@ def test_a_file_at_the_destination_still_blocks_the_rename(library):
         assert handle.read() == b"the owner's own file"
 
 
+def test_a_file_spelled_exactly_like_the_destination_is_a_collision(caplog, library):
+    """The destination question ranks the opposite way round from the source one.
+
+    Looking for the entity's folder a directory must win. Asking whether the
+    destination is taken the exact spelling must win: otherwise the source
+    directory itself comes back as the best key match, reads as "not taken", and
+    the rename goes ahead into an ``os.rename`` that cannot succeed - the folder
+    keeps its old name and its pictures go off-layout, reported as a failed
+    syscall rather than as the collision it is.
+
+    Built from the ligature for the same reason as the test above: on the
+    Windows runners a directory and a file whose names differ only in case
+    cannot both exist.
+    """
+    session, root = library["session"], library["root"]
+    real = "ﬁeld Notes"
+    destination = "Field Notes"
+    assert engine._match_key(real) == engine._match_key(destination)
+
+    _spell_the_project_folder(library, real)
+    try:
+        with open(os.path.join(root, destination), "wb") as handle:
+            handle.write(b"the owner's own file")
+    except OSError as exc:  # pragma: no cover - not seen on Linux or Windows
+        pytest.skip(f"this filesystem stores the two names as one entry: {exc}")
+
+    project = session.get(Project, library["project_id"])
+    project.name = destination
+    session.add(project)
+    with caplog.at_level("WARNING", logger=engine.logger.name):
+        renamed = engine.rename_entity_folders(
+            session,
+            Facet.PROJECT,
+            real,
+            destination,
+            entity_id=library["project_id"],
+            image_root=root,
+        )
+
+    assert renamed == 0
+    # The refusal has to be the DELIBERATE one. Reaching os.rename and having it
+    # fail leaves the same folder on disk, so the count alone cannot tell a
+    # handled collision from a syscall we should never have attempted.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("already exists" in message for message in messages), messages
+    assert not any("could not rename" in message for message in messages), messages
+
+    assert os.path.isdir(os.path.join(root, real))
+    with open(os.path.join(root, destination), "rb") as handle:
+        assert handle.read() == b"the owner's own file"
+
+
 def test_renaming_one_of_two_people_of_the_same_name_touches_no_folder(library):
     """Two people really can be called Mira, and only one of them was renamed.
 

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -1037,43 +1037,60 @@ def test_a_rename_that_cannot_name_its_own_entity_is_refused_loudly(library):
 
 
 def test_a_file_sharing_the_folders_name_does_not_hide_the_folder(library):
-    """A directory outranks a file, whichever of them is spelled exactly right.
+    """A directory outranks a file, even one spelled exactly as the layout does.
 
     Taking the first entry that matches lets an unrelated file stand in for the
     entity's real folder: the rename then finds a non-directory, skips it, and
     silently does not happen - the folder stays under a name the library no
     longer knows and its pictures drop out of the layout.
+
+    The two names collide through the LIGATURE rather than through case. That
+    is not decoration: ``_match_key`` folds ``ﬁ`` to ``fi``, an expansion no
+    filesystem's case-insensitive comparison performs, because those tables map
+    one character to one character and cannot produce two. So the collision the
+    matcher sees is real on every platform while the two entries stay separate
+    on every platform - including the Windows runners, where two names
+    differing only in case cannot both exist and creating the second would
+    error the module out before a single assertion ran.
     """
     session, root = library["session"], library["root"]
-    _spell_the_project_folder(library, "2024 shoots")
-    # Spelled exactly as the layout writes it, so the old "exact name wins"
-    # short-circuit returned THIS deterministically, whatever order the
-    # directory happens to be listed in.
-    with open(os.path.join(root, "2024 Shoots"), "wb") as handle:
-        handle.write(b"not a folder")
+    real = "Field Notes"
+    written = "ﬁeld Notes"
+    assert engine._match_key(real) == engine._match_key(written)
+    assert real != written
+
+    _spell_the_project_folder(library, real)
+    # Spelled exactly as the layout writes the entity's name, so the old "exact
+    # name wins" short-circuit returned THIS deterministically, whatever order
+    # the directory happens to be listed in.
+    try:
+        with open(os.path.join(root, written), "wb") as handle:
+            handle.write(b"not a folder")
+    except OSError as exc:  # pragma: no cover - not seen on Linux or Windows
+        pytest.skip(f"this filesystem stores the two names as one entry: {exc}")
 
     project = session.get(Project, library["project_id"])
-    project.name = "2025 Shoots"
+    project.name = "Field Trip"
     session.add(project)
     renamed = engine.rename_entity_folders(
         session,
         Facet.PROJECT,
-        "2024 Shoots",
-        "2025 Shoots",
+        written,
+        "Field Trip",
         entity_id=library["project_id"],
         image_root=root,
     )
 
     assert renamed == 1
     assert os.path.isfile(
-        os.path.join(root, "2025 Shoots", "Mira", "2026-08", "0412.png")
+        os.path.join(root, "Field Trip", "Mira", "2026-08", "0412.png")
     )
     assert (
         session.get(Picture, library["picture_id"]).file_path
-        == "2025 Shoots/Mira/2026-08/0412.png"
+        == "Field Trip/Mira/2026-08/0412.png"
     )
     # The owner's file is not ours to touch.
-    assert os.path.isfile(os.path.join(root, "2024 Shoots"))
+    assert os.path.isfile(os.path.join(root, written))
 
 
 def test_a_file_at_the_destination_still_blocks_the_rename(library):

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -1015,6 +1015,98 @@ def test_a_sibling_spelled_differently_still_blocks_the_rename(library):
     )
 
 
+def test_a_rename_that_cannot_name_its_own_entity_is_refused_loudly(library):
+    """No id, no rename. The exclusion is by primary key or it is nothing.
+
+    Without an id the only thing left to tell this entity's row from a second
+    entity of the same name is the name itself - which is the comparison that
+    renamed the wrong person's folder. A caller that cannot say which row it is
+    renaming has a bug, and it must not degrade quietly back into that.
+    """
+    session, root = library["session"], library["root"]
+    with pytest.raises(ValueError, match="entity_id"):
+        engine.rename_entity_folders(
+            session,
+            Facet.PROJECT,
+            "2024 Shoots",
+            "2025 Shoots",
+            entity_id=None,
+            image_root=root,
+        )
+    assert os.path.isdir(os.path.join(root, "2024 Shoots"))
+
+
+def test_a_file_sharing_the_folders_name_does_not_hide_the_folder(library):
+    """A directory outranks a file, whichever of them is spelled exactly right.
+
+    Taking the first entry that matches lets an unrelated file stand in for the
+    entity's real folder: the rename then finds a non-directory, skips it, and
+    silently does not happen - the folder stays under a name the library no
+    longer knows and its pictures drop out of the layout.
+    """
+    session, root = library["session"], library["root"]
+    _spell_the_project_folder(library, "2024 shoots")
+    # Spelled exactly as the layout writes it, so the old "exact name wins"
+    # short-circuit returned THIS deterministically, whatever order the
+    # directory happens to be listed in.
+    with open(os.path.join(root, "2024 Shoots"), "wb") as handle:
+        handle.write(b"not a folder")
+
+    project = session.get(Project, library["project_id"])
+    project.name = "2025 Shoots"
+    session.add(project)
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "2025 Shoots",
+        entity_id=library["project_id"],
+        image_root=root,
+    )
+
+    assert renamed == 1
+    assert os.path.isfile(
+        os.path.join(root, "2025 Shoots", "Mira", "2026-08", "0412.png")
+    )
+    assert (
+        session.get(Picture, library["picture_id"]).file_path
+        == "2025 Shoots/Mira/2026-08/0412.png"
+    )
+    # The owner's file is not ours to touch.
+    assert os.path.isfile(os.path.join(root, "2024 Shoots"))
+
+
+def test_a_file_at_the_destination_still_blocks_the_rename(library):
+    """The control on the ranking above: preferring directories must not stop a
+    FILE from being a collision.
+
+    ``os.rename`` onto an existing file is not a rename this may make, and the
+    destination question is "is anything already called that", not "is a folder".
+    """
+    session, root = library["session"], library["root"]
+    with open(os.path.join(root, "2025 shoots"), "wb") as handle:
+        handle.write(b"the owner's own file")
+
+    project = session.get(Project, library["project_id"])
+    project.name = "2025 Shoots"
+    session.add(project)
+    renamed = engine.rename_entity_folders(
+        session,
+        Facet.PROJECT,
+        "2024 Shoots",
+        "2025 Shoots",
+        entity_id=library["project_id"],
+        image_root=root,
+    )
+
+    assert renamed == 0
+    assert os.path.isfile(
+        os.path.join(root, "2024 Shoots", "Mira", "2026-08", "0412.png")
+    )
+    with open(os.path.join(root, "2025 shoots"), "rb") as handle:
+        assert handle.read() == b"the owner's own file"
+
+
 def test_renaming_one_of_two_people_of_the_same_name_touches_no_folder(library):
     """Two people really can be called Mira, and only one of them was renamed.
 


### PR DESCRIPTION
Issue #1177, lane 1A. Four defects in the layout rename path and its trigger. No
new abstraction: one helper, one keyword argument, one reordering per caller.

### 1. A rename could move the wrong directory and repoint none of its rows

`rename_entity_folders` located the folder with
`os.path.isdir(os.path.join(parent, old_folder))`. On a case-insensitive
filesystem that answers yes for a directory really spelled `summer` when the
layout spells the entity `Summer` — and `is_true` attributes it, so the rename is
right to want it. But `os.rename` then moved the *real* directory while
`_repoint_under` filtered on `source.startswith(old_dir + os.sep)` built from the
layout spelling, matched nothing, and rewrote **zero** rows. Every picture under
that folder was left naming a path with no file at it, which
`MissingFilePurgeFinder` deletes within the hour along with its metadata.

`_entry_matching` now scans the parent and compares with the same component-level
fold `is_true` uses, so the rename and the repoint both work against the real
path. The same match decides whether the destination is taken, which makes two
further corrections:

- a rename that only changes case (`Summer` → `SUMMER`) is no longer silently
  refused as "destination already exists" — the entry it sees is its own;
- a sibling spelled differently (`2025 shoots` next to a rename to
  `2025 Shoots`) now blocks the rename even where `os.path.exists` cannot see it.

Deliberately `_match_key` and not `folder_match_key`: an on-disk name is already
a folder name, and running `folder_name` over it again would read the real
directory `A:B` as the entity `A_B`.

### 2. Renaming one Mira renamed the other Mira's folder

`_name_is_ambiguous` skipped the renamed entity's own row by comparing **names**,
so a genuine second entity of the same name was skipped too — the name then read
as unambiguous and the rename claimed the other entity's folder. `entity_id` is
now a required keyword argument and the skip is on the primary key.

### 3. Every caller committed before the rename

All three routes committed the new name and then called `rename_entity_folders`,
which its docstring forbids: the directory renames and the `file_path` rewrites
that describe them have to land in one commit with the name that caused them.
Each call moved above its `session.commit()`; the function still commits only
when it renamed something, so the caller's commit remains the fallback. In
`projects.py` the call sits inside the existing `try`/`except IntegrityError`, so
a name-uniqueness race still returns 409 after the directories are rolled back.

### 4. Removing a face never armed the layout check

`_before_flush_layout_tracker` narrowed on attribute history, and a row in
`session.deleted` has none — so deleting the face that carried the only person
naming a folder never stamped the picture as due. A deleted `Face` is now judged
on what it *carried*; new and dirty rows keep the narrowing, so face detection
still does not stamp the library.

The second half of that finding is withdrawn rather than fixed: deleting a
character already works, because `delete_character` nulls `face.character_id`
through the ORM first and `Face.character_id` carries no `ondelete` cascade.

### Out of scope

The `render`/`_walk` depth mismatch is left alone — #1199 makes every layout
segment render a folder and removes it. This branch deliberately does not touch
`utils/library_layout.py` at all.

### Tests

Seven added to the already-gated `tests/test_library_layout.py`, on its existing
`library` and `stamped` fixtures. Each of the five regression tests was confirmed
red against the unfixed code. The case-insensitivity ones simulate the mismatch
(directory created under one spelling, rename driven with the other) so they are
just as sharp on the case-sensitive Linux runners.
