### PR TITLE
Finish CI action pinning: guardrail test, Dependabot, and a formatting fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2783,3 +2783,88 @@ def test_the_changelog_opens_on_a_released_version_heading():
         "CHANGELOG.md does not open on a version heading: "
         f"{first.splitlines()[0] if first else '(empty)'}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Guardrail: every third-party Action reference is pinned to a full commit SHA
+# ---------------------------------------------------------------------------
+
+_ACTION_REF_RE = re.compile(r'uses:\s*["\']?([^"\'\s#]+)')
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _floating_action_refs(paths: list[Path]) -> list[str]:
+    """Return ``"<path>:<lineno>: <line>"`` for every un-pinned ``uses:``.
+
+    A local composite action (``./.github/actions/...``) and a Docker-image
+    reference (``docker://...``) name no upstream tag to float, so both are
+    skipped. Everything else naming a third-party action must pin ``@<ref>``
+    to a full 40-character commit SHA - a moving tag like ``@v4`` or
+    ``@main`` can be repointed by whoever controls that repository.
+    """
+    offenders: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            match = _ACTION_REF_RE.search(line)
+            if not match:
+                continue
+            ref = match.group(1)
+            if ref.startswith("./") or ref.startswith("docker://"):
+                continue
+            if "@" not in ref:
+                offenders.append(f"{path}:{lineno}: {line.strip()}")
+                continue
+            sha = ref.rsplit("@", 1)[1]
+            if not _FULL_SHA_RE.fullmatch(sha):
+                offenders.append(f"{path}:{lineno}: {line.strip()}")
+    return offenders
+
+
+def test_every_action_reference_is_pinned_to_a_sha():
+    """A floating tag on a workflow action is a supply-chain hole (#1177 item 60).
+
+    #1192 pinned ``ci.yml`` and ``docker-build.yml``; this closes the sweep
+    over every remaining workflow and composite action so a *new* floating
+    tag fails the build instead of quietly shipping.
+    """
+    workflow_files = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    action_files = sorted((REPO_ROOT / ".github" / "actions").glob("*/action.yml"))
+    assert workflow_files, "no workflow files found - the scan target moved"
+
+    offenders = _floating_action_refs([*workflow_files, *action_files])
+    assert not offenders, (
+        "these Action references are not pinned to a full commit SHA:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nFix: pin to the commit SHA the tag currently resolves to, with "
+        "the human-readable version in a trailing comment, e.g. "
+        "`uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0`."
+    )
+
+
+def test_action_pin_guardrail_has_teeth(tmp_path):
+    """Both directions, or the guardrail can pass by being broken."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    actions = tmp_path / ".github" / "actions" / "example"
+    actions.mkdir(parents=True)
+
+    bad = workflows / "bad.yml"
+    bad.write_text(
+        "steps:\n  - uses: actions/checkout@v4\n  - uses: actions/checkout@main\n"
+    )
+    good = workflows / "good.yml"
+    good.write_text(
+        "steps:\n"
+        "  - uses: ./.github/actions/setup-backend\n"
+        "  - uses: docker://alpine:3\n"
+        "  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0\n"
+    )
+    action = actions / "action.yml"
+    action.write_text("runs:\n  steps:\n    - uses: actions/cache@v5\n")
+
+    offenders = _floating_action_refs([bad, good, action])
+    caught = {str(o).split(":", 1)[0] for o in offenders}
+    assert caught == {str(bad), str(action)}, (
+        f"the guardrail reported the wrong set of files: {offenders}"
+    )

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2789,8 +2789,34 @@ def test_the_changelog_opens_on_a_released_version_heading():
 # Guardrail: every third-party Action reference is pinned to a full commit SHA
 # ---------------------------------------------------------------------------
 
-_ACTION_REF_RE = re.compile(r'uses:\s*["\']?([^"\'\s#]+)')
-_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+# Anchored to the start of the line (leading whitespace and an optional list
+# dash only): PR #1203 review noted an unanchored ``search`` would also match
+# "uses:" appearing inside a string or comment elsewhere on the line, and flag
+# or silently pass whatever floating ref happened to follow it. Hex is
+# case-insensitive - Git SHAs are usually printed lowercase but are valid
+# either way, and a genuinely pinned uppercase SHA is not a floating tag.
+_ACTION_REF_RE = re.compile(r'\s*(?:-\s*)?uses:\s*["\']?([^"\'\s#]+)')
+_FULL_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def _action_scan_targets(root: Path) -> tuple[list[Path], list[Path]]:
+    """Every workflow and composite-action file GitHub will read ``uses:`` from.
+
+    Returns ``(workflow_files, action_files)``. A workflow may be named
+    ``*.yml`` or ``*.yaml`` - GitHub accepts both - and a composite action can
+    live at any depth under ``.github/actions/``, not only the one level down
+    the original ``*/action.yml`` glob assumed (PR #1203 review, thread 2).
+    """
+    workflows = root / ".github" / "workflows"
+    actions = root / ".github" / "actions"
+    workflow_files = sorted(
+        p for pattern in ("*.yml", "*.yaml") for p in workflows.glob(pattern)
+    )
+    action_files = sorted(
+        p for pattern in ("action.yml", "action.yaml") for p in actions.rglob(pattern)
+    )
+    return workflow_files, action_files
 
 
 def _floating_action_refs(paths: list[Path]) -> list[str]:
@@ -2812,7 +2838,7 @@ def _floating_action_refs(paths: list[Path]) -> list[str]:
     for path in paths:
         text = path.read_text(encoding="utf-8")
         for lineno, line in enumerate(text.splitlines(), start=1):
-            match = _ACTION_REF_RE.search(line)
+            match = _ACTION_REF_RE.match(line)
             if not match:
                 continue
             ref = match.group(1)
@@ -2834,8 +2860,7 @@ def test_every_action_reference_is_pinned_to_a_sha():
     over every remaining workflow and composite action so a *new* floating
     tag fails the build instead of quietly shipping.
     """
-    workflow_files = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
-    action_files = sorted((REPO_ROOT / ".github" / "actions").glob("*/action.yml"))
+    workflow_files, action_files = _action_scan_targets(REPO_ROOT)
     assert workflow_files, "no workflow files found - the scan target moved"
 
     offenders = _floating_action_refs([*workflow_files, *action_files])
@@ -2849,33 +2874,53 @@ def test_every_action_reference_is_pinned_to_a_sha():
 
 
 def test_action_pin_guardrail_has_teeth(tmp_path):
-    """Both directions, or the guardrail can pass by being broken."""
+    """Both directions, or the guardrail can pass by being broken.
+
+    Also covers PR #1203's review of this guardrail: a ``.yaml`` workflow and
+    a composite action nested two directories deep (thread 2's discovery
+    gap), an uppercase-hex SHA and a ``uses:`` mention that is not the step
+    key itself (thread 1's false positive and false negative). Routed through
+    ``_action_scan_targets`` rather than a hand-built file list, so a future
+    change that narrows the glob back to ``*.yml`` / one-level actions is
+    caught here too.
+    """
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
-    actions = tmp_path / ".github" / "actions" / "example"
-    actions.mkdir(parents=True)
+    shallow_action_dir = tmp_path / ".github" / "actions" / "example"
+    shallow_action_dir.mkdir(parents=True)
+    nested_action_dir = tmp_path / ".github" / "actions" / "group" / "nested"
+    nested_action_dir.mkdir(parents=True)
 
     bad = workflows / "bad.yml"
     bad.write_text(
         "steps:\n  - uses: actions/checkout@v4\n  - uses: actions/checkout@main\n"
     )
+    bad_yaml = workflows / "bad.yaml"
+    bad_yaml.write_text("steps:\n  - uses: actions/setup-node@v4\n")
     good = workflows / "good.yml"
     good.write_text(
         "steps:\n"
         "  - uses: ./.github/actions/setup-backend\n"
         "  - uses: docker://alpine:3\n"
         "  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0\n"
+        # Uppercase hex is still a genuine pin.
+        "  - uses: actions/setup-python@ECE7CB06CAEFA5FFF74198D8649806C4678C61A1 # v6.3.0\n"
+        # "uses:" here names a step, not a mapping key - must not be read as one.
+        '  - name: "mentions uses: actions/checkout@v4 in prose"\n'
     )
-    action = actions / "action.yml"
+    action = shallow_action_dir / "action.yml"
     action.write_text("runs:\n  steps:\n    - uses: actions/cache@v5\n")
+    nested_action = nested_action_dir / "action.yaml"
+    nested_action.write_text("runs:\n  steps:\n    - uses: actions/cache@v4\n")
 
-    offenders = _floating_action_refs([bad, good, action])
+    workflow_files, action_files = _action_scan_targets(tmp_path)
+    offenders = _floating_action_refs([*workflow_files, *action_files])
     # Not a plain split(":", 1): a Windows path starts "C:\...", so the first
     # colon in the string belongs to the drive letter, not the path/line
     # separator. Anchor on the "<path>:<lineno>: " shape instead - greedy
     # ``.*`` eats the drive-letter colon too before backtracking to the real
     # split point.
     caught = {re.match(r"^(.*):\d+: ", o).group(1) for o in offenders}
-    assert caught == {str(bad), str(action)}, (
+    assert caught == {str(bad), str(bad_yaml), str(action), str(nested_action)}, (
         f"the guardrail reported the wrong set of files: {offenders}"
     )

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2870,7 +2870,12 @@ def test_action_pin_guardrail_has_teeth(tmp_path):
     action.write_text("runs:\n  steps:\n    - uses: actions/cache@v5\n")
 
     offenders = _floating_action_refs([bad, good, action])
-    caught = {str(o).split(":", 1)[0] for o in offenders}
+    # Not a plain split(":", 1): a Windows path starts "C:\...", so the first
+    # colon in the string belongs to the drive letter, not the path/line
+    # separator. Anchor on the "<path>:<lineno>: " shape instead - greedy
+    # ``.*`` eats the drive-letter colon too before backtracking to the real
+    # split point.
+    caught = {re.match(r"^(.*):\d+: ", o).group(1) for o in offenders}
     assert caught == {str(bad), str(action)}, (
         f"the guardrail reported the wrong set of files: {offenders}"
     )

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -2801,6 +2801,12 @@ def _floating_action_refs(paths: list[Path]) -> list[str]:
     skipped. Everything else naming a third-party action must pin ``@<ref>``
     to a full 40-character commit SHA - a moving tag like ``@v4`` or
     ``@main`` can be repointed by whoever controls that repository.
+
+    Ceiling: this proves the ref has the *shape* of a commit SHA, not that it
+    is genuinely the commit the trailing comment claims - confirming that
+    needs a live call to the action's own repository, which a unit test
+    should not make. Spot-check the claim by hand (or in review) whenever a
+    pin changes.
     """
     offenders: list[str] = []
     for path in paths:

--- a/tests/test_index_install_type.py
+++ b/tests/test_index_install_type.py
@@ -41,7 +41,9 @@ def _write_index(tmp_path):
 def test_placeholder_is_replaced_with_every_declared_bucket(
     tmp_path, monkeypatch, install_type
 ):
-    monkeypatch.setattr(Server, "detect_install_type", staticmethod(lambda: install_type))
+    monkeypatch.setattr(
+        Server, "detect_install_type", staticmethod(lambda: install_type)
+    )
     body = Server._index_html_response(_Stub(str(_write_index(tmp_path)))).body.decode()
 
     assert f'content="{install_type}"' in body


### PR DESCRIPTION
## Summary

Closes out issue #1177 items 60 and 61, the follow-ups PR #1192's security review deliberately kept out of scope.

- **Item 60**: swept every workflow file and composite action for floating Action tags. Every reference was already pinned to a full commit SHA (finished by earlier hardening commits plus #1192), so there was nothing left to pin. Added `test_every_action_reference_is_pinned_to_a_sha` (+ a teeth test) to `tests/test_architecture_guardrails.py` so a *new* floating tag fails the build, and a minimal `.github/dependabot.yml` for the `github-actions` ecosystem to keep the pins current.
- **Item 61**: `ruff format` on `tests/test_index_install_type.py`, isolated to its own commit since it's unrelated drift on `develop`.

A `chief-security-officer` review of this diff passed with no blockers before push; its two non-blocking hardening suggestions (a comment noting the SHA-check only verifies shape, not provenance; a weekly rather than monthly Dependabot interval) are folded into the final commit.

## Test plan
- [x] `ruff format --check` / `ruff check` clean on all changed files
- [x] `pytest tests/test_architecture_guardrails.py` — 44 passed
- [x] Guardrail demonstrated red-then-green: temporarily floated a tag in a real workflow file, confirmed the new test failed, reverted, confirmed it passed again