### PR TITLE
v1.11.1 frontend backlog: lost updates, a lost prompt, a lost subfolder, and two keyboard traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   no PixlStash record and asks whether to include them. Enter keeps them, so a
   restore puts back exactly what was there; `--skip-orphans` leaves them out
   without asking, and `--yes` includes them.
+- Clicking a subfolder in the sidebar now puts it in the address bar, so
+  reloading or sharing that link comes back to the subfolder rather than the
+  whole folder.
+- Keyboard fixes: the folder-mapping wizard's folder list is one Tab stop with
+  the arrow keys moving inside it, instead of one stop per folder, and a
+  library switch that fails puts focus back on a control that is still there.
 
 # [1.11.0] [Security:High]
 

--- a/changelog.d/frontend-1177-batch.md
+++ b/changelog.d/frontend-1177-batch.md
@@ -1,0 +1,10 @@
+- Clicking a subfolder in the sidebar now puts it in the address bar, so
+  reloading or sharing that link comes back to the subfolder rather than the
+  whole folder.
+- Fixed: the privacy question could stop being asked altogether if an
+  unfinished "add a folder" was left behind by a library you no longer have.
+  Nothing was ever sent — the setting stays off until you answer it — but the
+  question itself never appeared again.
+- Keyboard fixes: the folder-mapping wizard's folder list is one Tab stop with
+  the arrow keys moving inside it, instead of one stop per folder, and a
+  library switch that fails puts focus back on a control that is still there.

--- a/changelog.d/frontend-1177-batch.md
+++ b/changelog.d/frontend-1177-batch.md
@@ -1,10 +1,8 @@
 - Clicking a subfolder in the sidebar now puts it in the address bar, so
   reloading or sharing that link comes back to the subfolder rather than the
   whole folder.
-- Fixed: the privacy question could stop being asked altogether if an
-  unfinished "add a folder" was left behind by a library you no longer have.
-  Nothing was ever sent — the setting stays off until you answer it — but the
-  question itself never appeared again.
+- Fixed: an unfinished "add a folder" left behind by a library you no longer
+  have could stop the privacy question from being asked.
 - Keyboard fixes: the folder-mapping wizard's folder list is one Tab stop with
   the arrow keys moving inside it, instead of one stop per folder, and a
   library switch that fails puts focus back on a control that is still there.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -308,7 +308,15 @@ watching only the key meant every subfolder click created a history entry
 deduplicates, so there was none) whose Back moved the address bar and nothing
 else. The watcher's "already in sync" test therefore compares the folder *and*
 the path, or a click would re-fetch both listings and re-emit the payload it
-had just set. `parseFolderPath`
+had just set — **through `_urlPath`, not `_samePath`**, because
+`routeSubfolderUnder` re-spells the path into the folder's own separators and
+`parseFolderPath` keeps the URL's, so the two are in different spaces. Compared
+in the wrong one they never match, the sidebar stops recognising its own work,
+and the re-emit pushes a URL that differs from the one that arrived — the
+inert-Back bug again, in a loop. `SideBarFolderRouteRestore.test.js` pins the
+whole class with one property, "a route arriving twice is inert",
+parameterised over the separator-changing inputs; the POSIX-only version of it
+was green while the Windows case looped. `parseFolderPath`
 resolves it to the same `{pathPrefix, label}` payload the sidebar emits, and so
 to the listing API's existing `file_path_prefix` param — there is no new backend
 filter behind it. Read on every grid route rather than only on `/`, the same

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -300,10 +300,15 @@ param is for. **It also carries the sidebar's subfolder selection.**
 reads it back once the folder listing is in, selecting the subfolder rather
 than the folder root. The id still owns `referenceFolderId`, so
 `reference_folder_id` stays in the grid query — the query only says which
-folder *inside* it is open. The route is re-read when `activeFolderKey`
-changes, so a reload, a deep link and a Back out of another view all restore
-the subfolder; Back between two subfolders of the same folder does not, since
-that never changes the key. `parseFolderPath`
+folder *inside* it is open. **The sidebar watcher watches `?path=` alongside
+`activeFolderKey`, and has to.** Two sibling subfolders of one folder push
+routes that differ only in the query, so the key alone cannot tell them apart;
+watching only the key meant every subfolder click created a history entry
+(`/ref-folder/5` used to be pushed identically each time, which vue-router
+deduplicates, so there was none) whose Back moved the address bar and nothing
+else. The watcher's "already in sync" test therefore compares the folder *and*
+the path, or a click would re-fetch both listings and re-emit the payload it
+had just set. `parseFolderPath`
 resolves it to the same `{pathPrefix, label}` payload the sidebar emits, and so
 to the listing API's existing `file_path_prefix` param — there is no new backend
 filter behind it. Read on every grid route rather than only on `/`, the same

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -290,15 +290,20 @@ It is split in two so the URL contract is testable on its own:
 **`?path=<absolute folder>` is the folder facet for folders that have no id.** A
 reference folder and an import folder each have a route (`/ref-folder/:id`,
 `/import-folder/:id`) and the sidebar owns their payload — which is why those
-two routes do not clear `selectedFolderFilter`, and why `?path=` is ignored on
-them (`applyView` guards on `folderKey`). The folder an "About your library"
-finding points at (§9.3) has no id of any kind, which is what this param is
-for. **The sidebar's subfolder selection is still not in the URL:**
+two routes do not clear `selectedFolderFilter`, and why `applyView` refuses to
+apply `?path=` on them (it guards on `folderKey`). The folder an "About your
+library" finding points at (§9.3) has no id of any kind, which is what this
+param is for. **It also carries the sidebar's subfolder selection.**
 `FolderTreeNode.vue` requires `rfId`, so a subfolder click takes
-`pushRouteForCurrentSelection`'s ref-folder branch and the path is dropped as
-before — closing that means teaching the sidebar's `activeFolderKey` watcher to
-restore a subfolder rather than the folder root, which is a change to the
-folder tree. `parseFolderPath`
+`pushRouteForCurrentSelection`'s ref-folder branch; the branch now pushes the
+`pathPrefix` as `?path=` alongside the id, and `SideBar.routeSubfolderUnder`
+reads it back once the folder listing is in, selecting the subfolder rather
+than the folder root. The id still owns `referenceFolderId`, so
+`reference_folder_id` stays in the grid query — the query only says which
+folder *inside* it is open. The route is re-read when `activeFolderKey`
+changes, so a reload, a deep link and a Back out of another view all restore
+the subfolder; Back between two subfolders of the same folder does not, since
+that never changes the key. `parseFolderPath`
 resolves it to the same `{pathPrefix, label}` payload the sidebar emits, and so
 to the listing API's existing `file_path_prefix` param — there is no new backend
 filter behind it. Read on every grid route rather than only on `/`, the same

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -1906,10 +1906,12 @@ A reference folder and an import folder each have a route of their own
 no id of any kind, so it travels as **`?path=<absolute folder>`** on any grid
 route (`useViewStore.parseFolderPath`), resolving to the same `{pathPrefix}`
 payload the sidebar emits and therefore to the listing API's existing
-`file_path_prefix` query param. It is ignored on a folder route, where the
-sidebar owns the payload. (It does **not** yet put the sidebar's own subfolder
-selection in the URL: `FolderTreeNode.vue` requires an `rfId`, so a subfolder
-click still takes the ref-folder branch.)
+`file_path_prefix` query param. On a folder route the sidebar owns the payload,
+so the route never applies it directly — but it does ride along there, because
+it is also how the sidebar's own subfolder selection stays in the URL: a
+subfolder click carries an `rfId` and so takes the ref-folder branch, which
+pushes `/ref-folder/:id?path=<abs folder>`, and the sidebar restores the
+subfolder from the query once the folder listing is in.
 
 **`?face=with_face|without_face`** is the face facet, additive like
 `?stack_state=` — an absent or unrecognised value leaves

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -143,14 +143,22 @@ const telemetryConsentIsUpgrade = ref(false);
 // Initial setup comes first: the telemetry question waits until the library
 // has been counted and any folder-mapping wizard (a pending mapping, or the
 // first-run offer to import the pictures already in the folder) is closed.
+//
+// It waits on the wizard being OPEN, never on `mappingStore.pending`. That
+// entry is localStorage-backed and unbounded: a `local_import` saved against a
+// library that was since detached, or a legacy `reference` entry, is one the
+// sidebar's auto-open deliberately refuses - so gating on it suppressed the
+// question for the life of the install. It fails closed
+// (`telemetry_send_install_id` defaults false), so the cost was a prompt the
+// owner never saw rather than a choice made for them. `librarySettled` is what
+// carries the ordering now; see `onLibraryLoaded`.
 const librarySettled = ref(false);
 const mappingStore = useFolderMappingStore();
 const telemetryConsentVisible = computed(
   () =>
     telemetryConsentOpen.value &&
     librarySettled.value &&
-    !mappingStore.wizardOpen &&
-    !mappingStore.pending,
+    !mappingStore.wizardOpen,
 );
 const telemetryInstallIsNew = ref(false);
 const photosDialogOpen = ref(false);
@@ -372,7 +380,17 @@ function offerLoosePictures() {
 
 /** The first count is in; an empty library gets its import offer first. */
 async function onLibraryLoaded({ empty }) {
+  // The sidebar's pending-mapping auto-open watches the libraries listing, so
+  // `mappingStore.wizardOpen` only answers honestly once that listing is in
+  // and the watcher it feeds has flushed. Settling before either is what let
+  // the telemetry question open under a wizard that was on its way up.
+  // Owner-only, like the mount-time read: a share session would 403, and it
+  // has no wizard to wait for either.
+  if (!isReadOnly.value && !librariesStore.hasLoadedSuccessfully) {
+    await librariesStore.refresh();
+  }
   if (empty) await offerLoosePictures();
+  await nextTick();
   librarySettled.value = true;
 }
 

--- a/frontend/src/AppTelemetryConsentGate.test.js
+++ b/frontend/src/AppTelemetryConsentGate.test.js
@@ -1,0 +1,197 @@
+// When the privacy question is allowed on screen.
+//
+// It waits for two things: the library's first count (so the question does not
+// land over a still-loading grid) and the folder-mapping wizard being closed
+// (so two modals do not stack on a first run). It used to wait on a third -
+// `useFolderMappingStore.pending` - and that one has no end. The entry is
+// localStorage-backed, and the sidebar's auto-open deliberately refuses two
+// whole classes of it: a `local_import` saved against a library that is no
+// longer the active one, and a legacy `reference` entry. For those, no wizard
+// ever opens, `pending` never clears, and the question was suppressed for the
+// life of the install.
+//
+// It fails CLOSED - `telemetry_send_install_id` defaults false - so what was
+// lost was the prompt, not the choice. Still a bug: the owner is never asked.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const nav = vi.hoisted(() => ({ route: null }));
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual("vue");
+  const { vi: vitest } = await import("vitest");
+  nav.route = reactive({ path: "/", name: "all-pictures", params: {}, query: {} });
+  return {
+    useRoute: () => nav.route,
+    useRouter: () => ({
+      push: vitest.fn().mockResolvedValue(undefined),
+      replace: vitest.fn().mockResolvedValue(undefined),
+      currentRoute: { value: nav.route },
+    }),
+  };
+});
+
+vi.mock("vuetify", () => ({
+  useTheme: () => ({ global: { name: { value: "dark" } } }),
+}));
+
+vi.mock("./utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return {
+    API_BASE_URL: "/api/v1",
+    appendShareToken: (url) => url,
+    isReadOnly: ref(false),
+    sessionContext: ref(null),
+    onSessionReset: () => () => {},
+    toBackendWebSocketUrl: () => "",
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    activateShareToken: vi.fn(),
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: ref(true),
+    login: vi.fn(),
+    logout: vi.fn(),
+    apiClient: {
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+  };
+});
+
+// The owner of this library has never answered the question, which is what
+// makes `useAppConfig` call back and open the dialog in the first place.
+vi.mock("./api/config", () => ({
+  getUserConfig: vi.fn(async () => ({
+    data: {
+      sort: "date",
+      thumbnail: 256,
+      check_for_updates: null,
+      telemetry_send_install_id: false,
+      telemetry_consent_prompted: false,
+    },
+  })),
+  patchUserConfig: vi.fn(async () => ({ data: {} })),
+}));
+
+vi.mock("./api/telemetry", () => ({
+  getInstallId: vi.fn(async () => ({ is_new_install: true })),
+}));
+
+import App from "./App.vue";
+import TelemetryConsentDialog from "./components/dialogs/TelemetryConsentDialog.vue";
+import ImageGrid from "./components/views/ImageGrid.vue";
+import { useFolderMappingStore } from "./stores/useFolderMappingStore";
+
+const STORAGE_KEY = "pixlstash.pendingFolderMapping";
+
+// The one child App.vue calls INTO rather than only renders. A bare stub has
+// no `refreshSidebar`, and the mount-time call would reject unhandled.
+const SideBarStub = {
+  name: "SideBar",
+  template: "<div />",
+  methods: {
+    refreshSidebar() {},
+    async offerLoosePictures() {},
+    openSettingsDialog() {},
+    openReferenceFolderEditor() {},
+    startLocalImport() {},
+  },
+};
+
+/** Mount App with every child stubbed; only App.vue's own logic runs. */
+async function mountApp() {
+  const wrapper = mount(App, {
+    shallow: true,
+    global: {
+      stubs: { SideBar: SideBarStub },
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+/** Answer the grid's first count, the way ImageGrid does. */
+async function libraryLoaded(wrapper, { empty = false } = {}) {
+  wrapper.findComponent(ImageGrid).vm.$emit("library-loaded", { empty });
+  await flushPromises();
+  await flushPromises();
+}
+
+const consentOpen = (wrapper) =>
+  wrapper.findComponent(TelemetryConsentDialog).props("open");
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setActivePinia(createPinia());
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ json: async () => ({}) })),
+  );
+  vi.stubGlobal("WebSocket", class {
+    static OPEN = 1;
+    constructor() {
+      this.readyState = 1;
+    }
+    send() {}
+    close() {}
+  });
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("the privacy question", () => {
+  it("opens once the library has been counted", async () => {
+    const wrapper = await mountApp();
+    expect(consentOpen(wrapper)).toBe(false);
+
+    await libraryLoaded(wrapper);
+
+    expect(consentOpen(wrapper)).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("still opens with a pending folder mapping nothing will ever act on", async () => {
+    // A `local_import` entry for a library that is not the active one: the
+    // sidebar's auto-open refuses it by design, so no wizard is coming and
+    // nothing will ever clear the entry.
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        taskId: "task-7",
+        path: "/home/me/Pictures/detached",
+        label: "detached",
+        mode: "local_import",
+      }),
+    );
+    const wrapper = await mountApp();
+    await libraryLoaded(wrapper);
+
+    expect(useFolderMappingStore().pending).not.toBeNull();
+    expect(consentOpen(wrapper)).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("waits while the folder-mapping wizard is actually on screen", async () => {
+    const wrapper = await mountApp();
+    const mapping = useFolderMappingStore();
+    mapping.openWizard(null);
+    await libraryLoaded(wrapper);
+
+    expect(consentOpen(wrapper)).toBe(false);
+
+    mapping.closeWizard();
+    await flushPromises();
+    expect(consentOpen(wrapper)).toBe(true);
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/folders/FolderMappingPreviewStep.vue
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.vue
@@ -304,11 +304,11 @@ onUnmounted(() => {
           {{ entityCount === 1 ? "is" : "are" }} created or matched
         </div>
         <div class="preview-step__fact">
-          <span class="preview-step__fact-mark"> - </span>
+          <span class="preview-step__fact-mark">—</span>
           no file is copied, moved or renamed
         </div>
         <div class="preview-step__fact">
-          <span class="preview-step__fact-mark"> - </span>
+          <span class="preview-step__fact-mark">—</span>
           {{ lastFact }}
         </div>
       </div>

--- a/frontend/src/components/folders/FolderMappingTreeStep.test.js
+++ b/frontend/src/components/folders/FolderMappingTreeStep.test.js
@@ -201,3 +201,52 @@ describe("the scrollbar offset", () => {
     expect(wrapper.find(".map-tree").attributes("style")).toContain("--sb: 10px");
   });
 });
+
+// A level here is one `role="tree"`, and the WAI-ARIA tree pattern gives a tree
+// ONE tab stop: Tab reaches the tree, the arrow keys (already implemented in
+// `onRowKeydown`) move inside it. Every row carried `tabindex="0"` and every
+// row's kind button was tabbable on top of that, so a level of 400 folders put
+// 800 presses between the filter box and `Continue`.
+describe("the tab sequence", () => {
+  const tabbable = (w, depth) =>
+    rows(w, depth).filter((r) => r.attributes("tabindex") === "0");
+
+  it("gives each level exactly one tab stop, on its first row", () => {
+    wrapper = mountStep();
+    for (const depth of [1, 2, 3]) {
+      const stops = tabbable(wrapper, depth);
+      expect(stops).toHaveLength(1);
+      expect(stops[0].element).toBe(rows(wrapper, depth)[0].element);
+    }
+  });
+
+  it("keeps the per-row kind dropdowns out of the tab sequence", () => {
+    wrapper = mountStep();
+    const kdds = levelEl(wrapper, 2).findAll(
+      ".map-tree__kdd:not(.map-tree__kdd--band)",
+    );
+    expect(kdds.length).toBeGreaterThan(1);
+    for (const kdd of kdds) expect(kdd.attributes("tabindex")).toBe("-1");
+  });
+
+  it("moves the level's one stop to whichever row was last focused", async () => {
+    wrapper = mountStep();
+    await rows(wrapper, 2)[3].trigger("focusin");
+
+    const stops = tabbable(wrapper, 2);
+    expect(stops).toHaveLength(1);
+    expect(stops[0].element).toBe(rows(wrapper, 2)[3].element);
+    // Levels are independent trees, so the others keep their own one stop.
+    expect(tabbable(wrapper, 3)).toHaveLength(1);
+  });
+
+  it("puts the stop back on a drawn row when a filter hides the last one", async () => {
+    wrapper = mountStep();
+    await rows(wrapper, 2)[3].trigger("focusin");
+    await levelEl(wrapper, 2).find(".map-tree__filter").setValue("eta");
+
+    const stops = tabbable(wrapper, 2);
+    expect(stops).toHaveLength(1);
+    expect(stops[0].element).toBe(rows(wrapper, 2)[0].element);
+  });
+});

--- a/frontend/src/components/folders/FolderMappingTreeStep.vue
+++ b/frontend/src/components/folders/FolderMappingTreeStep.vue
@@ -44,6 +44,15 @@ const overrides = reactive(new Map());
 const filterText = reactive(new Map()); // depth -> string
 const collapsed = reactive(new Set()); // depth
 
+// Roving tabindex, depth -> folder.id: which row of each level's tree Tab
+// reaches. The WAI-ARIA tree pattern gives a tree ONE tab stop and moves inside
+// it with the arrow keys, which `onRowKeydown` already implements; without this
+// every row - and every row's kind button - sat in the tab sequence, so a level
+// of 400 folders was 800 presses between the filter box and `Continue`.
+// Unset means "the first row that is drawn", so a freshly rendered or filtered
+// level is always reachable.
+const focusedRowId = reactive(new Map());
+
 // Selection: one level at a time. `anchorId` is the Shift+click range start.
 const selectedIds = reactive(new Set());
 const selectedDepth = ref(null);
@@ -85,6 +94,13 @@ function selectionCount(level) {
 
 function isSelected(folder) {
   return selectedIds.has(folder.id);
+}
+
+/** Whether this row is its level's single tab stop. `index` comes from the
+ *  `v-for`, so the fallback costs nothing per row. */
+function isTabStop(level, folder, index) {
+  const remembered = focusedRowId.get(level.depth);
+  return remembered == null ? index === 0 : remembered === folder.id;
 }
 
 /** Distinct resolved kinds across a level's rows, in strip order. */
@@ -238,6 +254,9 @@ function onRowKeydown(level, folder, event) {
 
 function setFilter(level, value) {
   filterText.set(level.depth, value);
+  // The remembered tab stop may have just been filtered out of the level. Fall
+  // back to "the first row drawn" rather than leaving the tree unreachable.
+  focusedRowId.delete(level.depth);
 }
 
 function toggleCollapsed(level) {
@@ -393,17 +412,18 @@ onUnmounted(() => window.removeEventListener("resize", measureSb));
           :aria-label="`Level ${level.depth}`"
         >
           <div
-            v-for="folder in visibleFolders(level)"
+            v-for="(folder, rowIndex) in visibleFolders(level)"
             :key="folder.id"
             class="map-tree__row"
             :class="{ 'map-tree__row--sel': isSelected(folder) }"
             role="treeitem"
-            tabindex="0"
+            :tabindex="isTabStop(level, folder, rowIndex) ? 0 : -1"
             :aria-selected="isSelected(folder)"
             :aria-label="`${folder.name}, ${folder.picture_count.toLocaleString()} pictures`"
             aria-keyshortcuts="1 2 3 4 0"
             @click="onRowClick(level, folder, $event)"
             @keydown="onRowKeydown(level, folder, $event)"
+            @focusin="focusedRowId.set(level.depth, folder.id)"
           >
             <v-icon class="map-tree__lead" size="15">mdi-folder-outline</v-icon>
             <span class="map-tree__name">{{ folder.name }}</span>
@@ -413,6 +433,7 @@ onUnmounted(() => window.removeEventListener("resize", measureSb));
                 <button
                   type="button"
                   class="map-tree__kdd"
+                  tabindex="-1"
                   :class="{
                     'map-tree__kdd--none': !resolvedKind(folder),
                     'map-tree__kdd--folder': resolvedKind(folder) === JUST_A_FOLDER_KIND.value,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -649,7 +649,7 @@ async function _offerLoosePictures() {
   // doing it there: the wizard opens on its questions instead of on a second
   // progress bar over an empty grid.
   const parked = await takeParkedFolderRead();
-  if (parked?.result && parked.path === path) {
+  if (parked?.result && _samePath(parked.path, path)) {
     autoOpenedPendingMapping = true;
     openFolderMappingWizard({
       path,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -511,6 +511,32 @@ function _samePath(a, b) {
   return norm(a) !== "" && norm(a) === norm(b);
 }
 
+/**
+ * The `?path=` on the current folder route, when it names a folder INSIDE
+ * `root` rather than `root` itself.
+ *
+ * A subfolder click pushes `/ref-folder/:id?path=<abs path>`, and this is what
+ * reads it back so a reload or a shared link lands on the subfolder the URL
+ * names instead of the folder root. `null` means "the route names the folder
+ * itself", which is the ordinary case and the pre-existing behaviour.
+ *
+ * Both separators, because the path comes from the server and may be a Windows
+ * path while the browser showing it is not.
+ *
+ * @param {string} root the reference folder's own path
+ * @returns {{pathPrefix: string, label: string}|null}
+ */
+function routeSubfolderUnder(root) {
+  const filter = viewStore.view?.folderFilter;
+  if (!filter?.pathPrefix || !root) return null;
+  if (_samePath(filter.pathPrefix, root)) return null;
+  const prefix = String(root).replace(/[\\/]+$/, "");
+  const inside =
+    filter.pathPrefix.startsWith(`${prefix}/`) ||
+    filter.pathPrefix.startsWith(`${prefix}\\`);
+  return inside ? filter : null;
+}
+
 // The pending mapping this library can act on. A `local_import` entry names
 // the library root it was saved for; shown or auto-opened against any OTHER
 // library it would offer to "set up" a library that is already set up - which
@@ -3932,10 +3958,16 @@ watch(
       const id = parseInt(newKey.slice(3), 10);
       const folder = referenceFolders.value.find((f) => f.id === id);
       if (folder) {
-        handleFolderNodeSelect(newKey, {
+        // A subfolder in the URL wins over the folder root: the route is only
+        // re-read when `activeFolderKey` itself changes, so this restores the
+        // subfolder on a reload, a deep link or a Back out of another view -
+        // not on Back between two subfolders of the SAME folder, which never
+        // changes the key.
+        const sub = routeSubfolderUnder(folder.folder);
+        handleFolderNodeSelect(sub ? `path-${sub.pathPrefix}` : newKey, {
           referenceFolderId: folder.id,
-          pathPrefix: folder.folder,
-          label: folder.label || folder.folder,
+          pathPrefix: sub ? sub.pathPrefix : folder.folder,
+          label: sub ? sub.label : folder.label || folder.folder,
         });
       }
     } else if (newKey.startsWith("if-")) {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -509,9 +509,57 @@ const referenceFolderEditorFolder = ref(null); // null = create, object = edit
 const mappingStore = useFolderMappingStore();
 const librariesStore = useLibrariesStore();
 
+// ── Folder keys: five spellings, and which comparisons may cross them ────────
+//
+// Three separate rounds of review found bugs here, all of the same shape: two
+// of these compared with `===` as though they were one thing. They are not, and
+// none of them is redundant - they carry different information. The map:
+//
+//   1. Row key      `selectedFolderKey`: `rf-<id>` | `if-<id>` | `path-<path>`.
+//      Identifies a ROW, which is why a subfolder needs its own path in it.
+//      Written only by `handleFolderNodeSelect`.
+//   2. Route key    `viewStore.activeFolderKey`: `rf-<id>` | `if-<id>`.
+//      Identifies a FOLDER. Never `path-`: a route has no row.
+//   3. Route path   `?path=`. A URL - any separator spelling, and editable.
+//   4. Grid filter  `selectedFolderFilter.pathPrefix`, which reaches the
+//      listing as `file_path_prefix`: a literal LIKE against the stored
+//      `file_path`, so it MUST be in the server's spelling.
+//   5. Tree path    `entry.path` from the browse listing. Server spelling.
+//
+// Exactly three crossings are legitimate, and each has one owner:
+//   1 -> 2         `selectedFolderRouteKey`
+//   2 + 3 -> 1,4   `routeSubfolderUnder`  (the only place a URL path is
+//                  allowed to become a server path)
+//   5 -> 1,4       direct; both are already the server's spelling.
+//
+// Anything else that compares two of these with `===`, or coerces an id
+// without `_folderId`, is the next bug. Add the crossing to the list above or
+// route it through an owner; do not inline a fourth one.
+
+/**
+ * A reference-folder id, or null. The ONE rule for reading one.
+ *
+ * `Number(null)` is `0` and `Number.isFinite(0)` is true, so coercing before
+ * testing turns "no folder selected" into "folder zero" - which then reads as
+ * a real selection everywhere downstream. `Number("")` is `0` too, so a
+ * malformed `rf-` key would do the same. Both are rejected before coercion.
+ */
+function _folderId(value) {
+  if (value == null || value === "") return null;
+  const id = Number(value);
+  return Number.isFinite(id) ? id : null;
+}
+
 /** A path made comparable: trailing separators dropped. */
 function _normPath(p) {
   return String(p || "").replace(/[\\/]+$/, "");
+}
+
+/** Which separator a path is spelled with. A POSIX path always contains `/`,
+ *  including one whose folder is legally NAMED `a\b`; a Windows path never
+ *  does. Testing for `/` rather than for `\` is what keeps that name working. */
+function _pathSeparator(p) {
+  return String(p || "").includes("/") ? "/" : "\\";
 }
 
 function _samePath(a, b) {
@@ -542,12 +590,21 @@ function _urlPath(p) {
  * names instead of the folder root. `null` means "the route names the folder
  * itself", which is the ordinary case and the pre-existing behaviour.
  *
- * Compared through `_normPath`, so the two sides may disagree about separators
+ * Matched through `_urlPath`, so the two sides may disagree about separators
  * and still match. They come from the same server and normally agree, but the
  * `?path=` half is a URL: it survives being shared, edited and pasted, and a
- * `/` where the folder listing said `\` would otherwise silently drop the
- * reader back to the folder root. The value handed back keeps its original
- * spelling - only the comparison is normalised.
+ * `/` where the folder listing said `\` would otherwise drop the reader back
+ * to the folder root.
+ *
+ * **The path handed back is re-spelled in `root`'s own separator, not the
+ * URL's.** It becomes `selectedFolderFilter.pathPrefix` and travels to the
+ * listing API as `file_path_prefix`, which is a literal `LIKE` against the
+ * stored `file_path` (`utils/query/predicate_filter.py`) - it does not
+ * normalise anything. So on a Windows library a slash-spelled link would
+ * select the right row and return an EMPTY grid, and the tree row's own key
+ * (built from the browse listing's spelling) would not match the highlight
+ * either. Rebuilding the tail off the root fixes both, and is a no-op on a
+ * POSIX library, where the two spellings already agree.
  *
  * @param {string} root the reference folder's own path
  * @returns {{pathPrefix: string, label: string}|null}
@@ -557,8 +614,13 @@ function routeSubfolderUnder(root) {
   if (!filter?.pathPrefix || !root) return null;
   const here = _urlPath(filter.pathPrefix);
   const base = _urlPath(root);
-  if (!base || here === base) return null;
-  return here.startsWith(`${base}/`) ? filter : null;
+  if (!base || here === base || !here.startsWith(`${base}/`)) return null;
+  const sep = _pathSeparator(_normPath(root));
+  const tail = here.slice(base.length + 1).split("/").join(sep);
+  return {
+    pathPrefix: `${_normPath(root)}${sep}${tail}`,
+    label: tail.split(sep).pop() || filter.label,
+  };
 }
 
 // The pending mapping this library can act on. A `local_import` entry names
@@ -928,8 +990,8 @@ const registeredImportFolderPaths = computed(() =>
 );
 
 const selectedReferenceFolderForHeader = computed(() => {
-  const id = Number(selectedFolderReferenceId.value);
-  if (!Number.isFinite(id)) return null;
+  const id = _folderId(selectedFolderReferenceId.value);
+  if (id == null) return null;
   return (
     referenceFolders.value.find((folder) => Number(folder.id) === id) || null
   );
@@ -953,8 +1015,8 @@ const selectedFolderScanning = computed(() => {
     );
     return Boolean(importFolder && importFolder.last_checked == null);
   }
-  const id = Number(selectedFolderReferenceId.value);
-  if (!Number.isFinite(id)) return false;
+  const id = _folderId(selectedFolderReferenceId.value);
+  if (id == null) return false;
   const rf = referenceFolders.value.find((f) => f.id === id);
   return Boolean(rf && rf.status === "active" && rf.last_scanned == null);
 });
@@ -1133,8 +1195,8 @@ function referenceFolderCanDisclose(rf) {
  * sibling", nor recognise its own selection on the way out.
  */
 const selectedFolderRouteKey = computed(() => {
-  const id = Number(selectedFolderReferenceId.value);
-  if (Number.isFinite(id)) return `rf-${id}`;
+  const id = _folderId(selectedFolderReferenceId.value);
+  if (id != null) return `rf-${id}`;
   return selectedFolderKey.value?.startsWith("if-")
     ? selectedFolderKey.value
     : null;
@@ -1142,12 +1204,11 @@ const selectedFolderRouteKey = computed(() => {
 
 function handleFolderNodeSelect(key, payload) {
   selectedFolderKey.value = key;
-  const payloadId = Number(payload?.referenceFolderId);
-  if (Number.isFinite(payloadId)) {
+  const payloadId = _folderId(payload?.referenceFolderId);
+  if (payloadId != null) {
     selectedFolderReferenceId.value = payloadId;
   } else if (key?.startsWith("rf-")) {
-    const parsed = parseInt(key.slice(3), 10);
-    selectedFolderReferenceId.value = Number.isFinite(parsed) ? parsed : null;
+    selectedFolderReferenceId.value = _folderId(key.slice(3));
   } else {
     selectedFolderReferenceId.value = null;
   }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -627,18 +627,22 @@ function routeSubfolderUnder(root) {
   if (!filter?.pathPrefix || !root) return null;
   const raw = _normPath(filter.pathPrefix);
   const rootPath = _normPath(root);
-  // `_urlPath` only swaps `\` for `/` one-for-one, so these keep `raw`'s
-  // offsets and the tail can be sliced back out of the ORIGINAL spelling.
-  const here = _urlPath(raw);
-  const base = _urlPath(rootPath);
-  if (!base || here === base || !here.startsWith(`${base}/`)) return null;
   const sep = _pathSeparator(rootPath);
+  // Folding `\` into `/` is for a WINDOWS root only, where both characters
+  // separate and a URL may legitimately spell either. A POSIX root is compared
+  // raw, because there `\` is an ordinary character in a folder's name and
+  // folding would make `?path=/x/a/b/2024` - a different folder, or none -
+  // read as a subfolder of `/x/a\b` and then be rewritten into it.
+  const windows = sep === "\\";
+  // `_urlPath` swaps one character for one character, so both stay aligned
+  // with `raw` and the tail can be sliced back out of the ORIGINAL spelling.
+  const here = windows ? _urlPath(raw) : raw;
+  const base = windows ? _urlPath(rootPath) : rootPath;
+  if (!base || here === base || !here.startsWith(`${base}/`)) return null;
   const rawTail = raw.slice(base.length + 1);
-  // On Windows both characters separate, so the tail is re-spelled. On POSIX
-  // only `/` does and a `\` is part of a folder's NAME - re-spelling there
-  // would corrupt the very name `_urlPath` exists to protect, so the tail is
-  // taken verbatim and the whole function is genuinely a no-op.
-  const tail = sep === "/" ? rawTail : rawTail.split(/[\\/]/).join(sep);
+  // Re-spelt only on Windows, for the same reason: on POSIX the tail's own
+  // backslashes are part of a name, so this is genuinely a no-op there.
+  const tail = windows ? rawTail.split(/[\\/]/).join(sep) : rawTail;
   return {
     pathPrefix: `${rootPath}${sep}${tail}`,
     label: tail.split(sep).pop() || filter.label,
@@ -4104,6 +4108,13 @@ watch(
     // `_urlPath`, NOT `_samePath`: this compares the sidebar's path, which
     // `routeSubfolderUnder` has re-spelled into the folder's separators,
     // against `?path=`, which `parseFolderPath` keeps verbatim from the URL.
+    //
+    // This one folds unconditionally, where `routeSubfolderUnder` folds only
+    // for a Windows root, and the asymmetry is deliberate. That function
+    // decides whether a URL belongs to a folder AT ALL, so a false match
+    // selects the wrong folder. This one only asks "did I just do this?", so a
+    // false match can at worst skip re-restoring something already restored -
+    // while a false MISS is the loop. Cheap direction, expensive direction.
     // With `_samePath` the two could never match once the re-spelling changed
     // anything, so the sidebar could not recognise its own work: it re-emitted,
     // the emit pushed the re-spelled path as a NEW url, and Back returned to

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -526,15 +526,28 @@ const librariesStore = useLibrariesStore();
 //      `file_path`, so it MUST be in the server's spelling.
 //   5. Tree path    `entry.path` from the browse listing. Server spelling.
 //
-// Exactly three crossings are legitimate, and each has one owner:
+// Four crossings are legitimate, and each has one owner:
 //   1 -> 2         `selectedFolderRouteKey`
 //   2 + 3 -> 1,4   `routeSubfolderUnder`  (the only place a URL path is
 //                  allowed to become a server path)
+//   4 vs 3         the watcher's "already in sync" test, through `_urlPath`.
+//                  This is the one an earlier pass missed: `routeSubfolderUnder`
+//                  RE-SPELLS the path, so the sidebar's copy and the `?path=`
+//                  that produced it are in different spaces and `_samePath`
+//                  could never match them.
 //   5 -> 1,4       direct; both are already the server's spelling.
 //
-// Anything else that compares two of these with `===`, or coerces an id
-// without `_folderId`, is the next bug. Add the crossing to the list above or
-// route it through an owner; do not inline a fourth one.
+// **The guardrail, not this comment, is the mechanism.** This list was written
+// with three crossings and a claim that anything else was a bug; a fourth was
+// found the same day, and the id rule it stated was already violated five
+// times in this file. So: `SideBarFolderRouteRestore.test.js` asserts a route
+// arriving twice is inert, parameterised over the separator-changing inputs -
+// that is what fails when a new crossing is compared in the wrong space. Treat
+// the list above as a map to read before editing, and add to it when you add a
+// crossing; it is documentation, and the test is the enforcement.
+//
+// Ids: read every one through `_folderId`. That IS enforced, in the sense that
+// there is now no other coercion in this file to copy from.
 
 /**
  * A reference-folder id, or null. The ONE rule for reading one.
@@ -612,13 +625,22 @@ function _urlPath(p) {
 function routeSubfolderUnder(root) {
   const filter = viewStore.view?.folderFilter;
   if (!filter?.pathPrefix || !root) return null;
-  const here = _urlPath(filter.pathPrefix);
-  const base = _urlPath(root);
+  const raw = _normPath(filter.pathPrefix);
+  const rootPath = _normPath(root);
+  // `_urlPath` only swaps `\` for `/` one-for-one, so these keep `raw`'s
+  // offsets and the tail can be sliced back out of the ORIGINAL spelling.
+  const here = _urlPath(raw);
+  const base = _urlPath(rootPath);
   if (!base || here === base || !here.startsWith(`${base}/`)) return null;
-  const sep = _pathSeparator(_normPath(root));
-  const tail = here.slice(base.length + 1).split("/").join(sep);
+  const sep = _pathSeparator(rootPath);
+  const rawTail = raw.slice(base.length + 1);
+  // On Windows both characters separate, so the tail is re-spelled. On POSIX
+  // only `/` does and a `\` is part of a folder's NAME - re-spelling there
+  // would corrupt the very name `_urlPath` exists to protect, so the tail is
+  // taken verbatim and the whole function is genuinely a no-op.
+  const tail = sep === "/" ? rawTail : rawTail.split(/[\\/]/).join(sep);
   return {
-    pathPrefix: `${_normPath(root)}${sep}${tail}`,
+    pathPrefix: `${rootPath}${sep}${tail}`,
     label: tail.split(sep).pop() || filter.label,
   };
 }
@@ -728,14 +750,21 @@ watch(
 // through on a fresh desktop library.
 let loosePicturesOffer = null;
 function offerLoosePictures() {
-  // `pendingForThisLibrary`, never the raw `mappingStore.pending`. That entry
-  // is localStorage-backed and unbounded, and the auto-open above deliberately
-  // refuses two whole classes of it (a `reference` entry; a `local_import`
-  // saved against a library that is no longer the active one). Gating on the
-  // raw flag meant an empty library whose owner held one of those got no
-  // wizard AND no offer, for the life of the install - the same failure the
-  // telemetry question had, in a second place.
-  if (isReadOnly.value || pendingForThisLibrary.value) return Promise.resolve();
+  // Suppressed only by an entry that will ACTUALLY bring a wizard up, which is
+  // the auto-open's own condition above: a `local_import` for this library.
+  // `mappingStore.pending` is localStorage-backed and unbounded, and
+  // `pendingForThisLibrary` is not the answer either - it returns a
+  // `reference` entry unchanged, and the auto-open refuses those. Gating on
+  // either meant an empty library whose owner held a stale entry got no wizard
+  // AND no offer, for the life of the install; there was no way into the
+  // library at all. This has to stay the same test as the auto-open, so state
+  // it the same way.
+  if (
+    isReadOnly.value ||
+    pendingForThisLibrary.value?.mode === "local_import"
+  ) {
+    return Promise.resolve();
+  }
   loosePicturesOffer ??= _offerLoosePictures();
   return loosePicturesOffer;
 }
@@ -947,8 +976,8 @@ async function importFolderSaved() {
   }
 
   if (!selectedFolderKey.value?.startsWith("if-")) return;
-  const selectedId = Number(selectedFolderKey.value.slice(3));
-  if (!Number.isFinite(selectedId)) return;
+  const selectedId = _folderId(selectedFolderKey.value.slice(3));
+  if (selectedId == null) return;
   const selectedImportFolder = importFolders.value.find(
     (entry) => Number(entry.id) === selectedId,
   );
@@ -999,8 +1028,8 @@ const selectedReferenceFolderForHeader = computed(() => {
 
 const selectedImportFolderForHeader = computed(() => {
   if (!selectedFolderKey.value?.startsWith("if-")) return null;
-  const id = Number(selectedFolderKey.value.slice(3));
-  if (!Number.isFinite(id)) return null;
+  const id = _folderId(selectedFolderKey.value.slice(3));
+  if (id == null) return null;
   return importFolders.value.find((entry) => Number(entry.id) === id) || null;
 });
 
@@ -1008,8 +1037,8 @@ const selectedImportFolderForHeader = computed(() => {
 // for the first time (active but never completed a pass).
 const selectedFolderScanning = computed(() => {
   if (selectedFolderKey.value?.startsWith("if-")) {
-    const id = Number(selectedFolderKey.value.slice(3));
-    if (!Number.isFinite(id)) return false;
+    const id = _folderId(selectedFolderKey.value.slice(3));
+    if (id == null) return false;
     const importFolder = importFolders.value.find(
       (entry) => Number(entry.id) === id,
     );
@@ -1029,12 +1058,12 @@ const collapsedProjectBtnTitle = computed(() => {
   if (sidebarPrimaryTab.value === "folders") {
     if (!selectedFolderKey.value) return "Folders";
     if (selectedFolderKey.value.startsWith("rf-")) {
-      const id = Number(selectedFolderKey.value.slice(3));
+      const id = _folderId(selectedFolderKey.value.slice(3));
       const rf = referenceFolders.value.find((f) => f.id === id);
       return rf ? rf.label || rf.folder : "Folder";
     }
     if (selectedFolderKey.value.startsWith("if-")) {
-      const id = Number(selectedFolderKey.value.slice(3));
+      const id = _folderId(selectedFolderKey.value.slice(3));
       const imf = importFolders.value.find((f) => Number(f.id) === id);
       return imf ? imf.label || imf.folder : "Folder";
     }
@@ -4071,10 +4100,22 @@ watch(
     // Already showing exactly what the route names, folder AND subfolder. A
     // click gets here right after setting both, so without this every one of
     // them would re-fetch the listings and re-emit the payload it just sent.
+    //
+    // `_urlPath`, NOT `_samePath`: this compares the sidebar's path, which
+    // `routeSubfolderUnder` has re-spelled into the folder's separators,
+    // against `?path=`, which `parseFolderPath` keeps verbatim from the URL.
+    // With `_samePath` the two could never match once the re-spelling changed
+    // anything, so the sidebar could not recognise its own work: it re-emitted,
+    // the emit pushed the re-spelled path as a NEW url, and Back returned to
+    // the original spelling and started the round again. A shared Windows link
+    // could not be navigated away from.
     const showingSubfolder = selectedFolderKey.value?.startsWith("path-");
+    const routePath = _urlPath(newPath);
     if (
       selectedFolderRouteKey.value === newKey &&
-      (newPath ? _samePath(selectedFolderPath.value, newPath) : !showingSubfolder)
+      (newPath
+        ? routePath !== "" && _urlPath(selectedFolderPath.value) === routePath
+        : !showingSubfolder)
     ) {
       return;
     }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -506,9 +506,17 @@ const referenceFolderEditorFolder = ref(null); // null = create, object = edit
 const mappingStore = useFolderMappingStore();
 const librariesStore = useLibrariesStore();
 
+/** A path made comparable: trailing separators dropped, `\` folded to `/`.
+ *  Only ever for comparing - the original spelling is what goes on to the
+ *  server, and normalising that would be a different (and wrong) change. */
+function _normPath(p) {
+  return String(p || "")
+    .replace(/[\\/]+$/, "")
+    .replace(/\\/g, "/");
+}
+
 function _samePath(a, b) {
-  const norm = (p) => String(p || "").replace(/[\\/]+$/, "");
-  return norm(a) !== "" && norm(a) === norm(b);
+  return _normPath(a) !== "" && _normPath(a) === _normPath(b);
 }
 
 /**
@@ -520,8 +528,12 @@ function _samePath(a, b) {
  * names instead of the folder root. `null` means "the route names the folder
  * itself", which is the ordinary case and the pre-existing behaviour.
  *
- * Both separators, because the path comes from the server and may be a Windows
- * path while the browser showing it is not.
+ * Compared through `_normPath`, so the two sides may disagree about separators
+ * and still match. They come from the same server and normally agree, but the
+ * `?path=` half is a URL: it survives being shared, edited and pasted, and a
+ * `/` where the folder listing said `\` would otherwise silently drop the
+ * reader back to the folder root. The value handed back keeps its original
+ * spelling - only the comparison is normalised.
  *
  * @param {string} root the reference folder's own path
  * @returns {{pathPrefix: string, label: string}|null}
@@ -530,11 +542,9 @@ function routeSubfolderUnder(root) {
   const filter = viewStore.view?.folderFilter;
   if (!filter?.pathPrefix || !root) return null;
   if (_samePath(filter.pathPrefix, root)) return null;
-  const prefix = String(root).replace(/[\\/]+$/, "");
-  const inside =
-    filter.pathPrefix.startsWith(`${prefix}/`) ||
-    filter.pathPrefix.startsWith(`${prefix}\\`);
-  return inside ? filter : null;
+  return _normPath(filter.pathPrefix).startsWith(`${_normPath(root)}/`)
+    ? filter
+    : null;
 }
 
 // The pending mapping this library can act on. A `local_import` entry names

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -493,6 +493,9 @@ const referenceFoldersImageRoot = ref(null);
 const folderBrowseCache = ref({}); // keyed by path → { entries, loading, image_count }
 const selectedFolderKey = ref(null); // 'rf-{id}' | 'path-{path}' | 'if-{id}' | null
 const selectedFolderReferenceId = ref(null); // numeric reference-folder id or null
+/** The absolute folder path the selection is filtering on, or null. The row key
+    above cannot carry it: a folder ROOT row's key is `rf-{id}`. */
+const selectedFolderPath = ref(null);
 const dragOverReferenceTargetKey = ref(null);
 
 // Reference folder editor state
@@ -506,17 +509,28 @@ const referenceFolderEditorFolder = ref(null); // null = create, object = edit
 const mappingStore = useFolderMappingStore();
 const librariesStore = useLibrariesStore();
 
-/** A path made comparable: trailing separators dropped, `\` folded to `/`.
- *  Only ever for comparing - the original spelling is what goes on to the
- *  server, and normalising that would be a different (and wrong) change. */
+/** A path made comparable: trailing separators dropped. */
 function _normPath(p) {
-  return String(p || "")
-    .replace(/[\\/]+$/, "")
-    .replace(/\\/g, "/");
+  return String(p || "").replace(/[\\/]+$/, "");
 }
 
 function _samePath(a, b) {
   return _normPath(a) !== "" && _normPath(a) === _normPath(b);
+}
+
+/**
+ * The same, and `\` folded to `/` as well.
+ *
+ * ONLY for comparing a path against one that arrived in a URL, where the two
+ * halves can genuinely disagree about separators. Deliberately not folded into
+ * `_samePath`: a POSIX folder may legally be named `a\b`, and making every
+ * caller treat that as `a/b` would let the parked-read and pending-mapping
+ * matches fire on the wrong folder - a wrong action, which is worse than the
+ * missed one this guards against. Comparison only; the original spelling is
+ * what goes on to the server.
+ */
+function _urlPath(p) {
+  return _normPath(p).replace(/\\/g, "/");
 }
 
 /**
@@ -541,10 +555,10 @@ function _samePath(a, b) {
 function routeSubfolderUnder(root) {
   const filter = viewStore.view?.folderFilter;
   if (!filter?.pathPrefix || !root) return null;
-  if (_samePath(filter.pathPrefix, root)) return null;
-  return _normPath(filter.pathPrefix).startsWith(`${_normPath(root)}/`)
-    ? filter
-    : null;
+  const here = _urlPath(filter.pathPrefix);
+  const base = _urlPath(root);
+  if (!base || here === base) return null;
+  return here.startsWith(`${base}/`) ? filter : null;
 }
 
 // The pending mapping this library can act on. A `local_import` entry names
@@ -652,7 +666,14 @@ watch(
 // through on a fresh desktop library.
 let loosePicturesOffer = null;
 function offerLoosePictures() {
-  if (isReadOnly.value || mappingStore.pending) return Promise.resolve();
+  // `pendingForThisLibrary`, never the raw `mappingStore.pending`. That entry
+  // is localStorage-backed and unbounded, and the auto-open above deliberately
+  // refuses two whole classes of it (a `reference` entry; a `local_import`
+  // saved against a library that is no longer the active one). Gating on the
+  // raw flag meant an empty library whose owner held one of those got no
+  // wizard AND no offer, for the life of the install - the same failure the
+  // telemetry question had, in a second place.
+  if (isReadOnly.value || pendingForThisLibrary.value) return Promise.resolve();
   loosePicturesOffer ??= _offerLoosePictures();
   return loosePicturesOffer;
 }
@@ -1101,26 +1122,23 @@ function referenceFolderCanDisclose(rf) {
 }
 
 /**
- * Whether the sidebar's current folder selection sits under the folder the
- * route key `key` names.
+ * The sidebar's current selection, said the way a ROUTE says it.
  *
- * The two are NOT always the same string. A subfolder row's key is
- * `path-<absolute path>` (`FolderTreeNode.vue`) while the route only ever says
- * `rf-<id>` / `if-<id>`, so an equality test read "not mine" for every
- * subfolder and left the highlight - and `selectedFolderReferenceId`, which
- * the scanning light reads - stuck on a folder the app had navigated away
- * from. `selectedFolderReferenceId` is the folder a `path-` selection belongs
- * to, which is what makes the two comparable.
- *
- * @param {string} key an `activeFolderKey` value
- * @returns {boolean}
+ * The sidebar's own key identifies a row, so a subfolder's is
+ * `path-<absolute path>` (`FolderTreeNode.vue`); the route only ever names the
+ * folder the row sits in. These two are what let the watcher below compare the
+ * two spellings without either of them having to change: this is the folder,
+ * `selectedFolderPath` is which folder inside it. An equality test on the row
+ * key alone could neither tell "already showing this" from "showing its
+ * sibling", nor recognise its own selection on the way out.
  */
-function _selectionBelongsToFolderKey(key) {
-  if (!key || !selectedFolderKey.value) return false;
-  if (selectedFolderKey.value === key) return true;
-  if (!selectedFolderKey.value.startsWith("path-")) return false;
-  return key === `rf-${selectedFolderReferenceId.value}`;
-}
+const selectedFolderRouteKey = computed(() => {
+  const id = Number(selectedFolderReferenceId.value);
+  if (Number.isFinite(id)) return `rf-${id}`;
+  return selectedFolderKey.value?.startsWith("if-")
+    ? selectedFolderKey.value
+    : null;
+});
 
 function handleFolderNodeSelect(key, payload) {
   selectedFolderKey.value = key;
@@ -1133,6 +1151,7 @@ function handleFolderNodeSelect(key, payload) {
   } else {
     selectedFolderReferenceId.value = null;
   }
+  selectedFolderPath.value = payload?.pathPrefix ?? null;
   emit("select-folder", payload);
   // Emit immediately on selection so ImageGrid updates before next poll tick.
   sidebarStore.folderScanning = selectedFolderScanning.value;
@@ -3966,35 +3985,55 @@ watch(
 // When App.vue navigates to /ref-folder/:id or /import-folder/:id it passes
 // the matching key via the activeFolderKey prop so we can switch to the
 // folders tab and emit the correct filter payload.
+//
+// `?path=` is watched alongside the key, and it has to be: a subfolder click
+// pushes a route that differs from its sibling's ONLY in the query, so the key
+// alone cannot see the difference. Watching just the key made every one of
+// those a history entry whose Back went nowhere - the address bar moved and the
+// grid did not - which is worse than the previous behaviour, where the pushes
+// were identical and vue-router created no Back target at all.
 watch(
-  () => viewStore.activeFolderKey,
-  async (newKey, oldKey) => {
+  () => [
+    viewStore.activeFolderKey,
+    viewStore.view?.folderFilter?.pathPrefix ?? null,
+  ],
+  async ([newKey, newPath], [oldKey] = []) => {
     if (!newKey) {
       // Route left a folder view - clear the sidebar's folder highlight.
-      if (oldKey && _selectionBelongsToFolderKey(oldKey)) {
+      if (oldKey && selectedFolderRouteKey.value === oldKey) {
         selectedFolderKey.value = null;
         selectedFolderReferenceId.value = null;
+        selectedFolderPath.value = null;
       }
       return;
     }
-    if (selectedFolderKey.value === newKey) return; // already in sync
+    // Already showing exactly what the route names, folder AND subfolder. A
+    // click gets here right after setting both, so without this every one of
+    // them would re-fetch the listings and re-emit the payload it just sent.
+    const showingSubfolder = selectedFolderKey.value?.startsWith("path-");
+    if (
+      selectedFolderRouteKey.value === newKey &&
+      (newPath ? _samePath(selectedFolderPath.value, newPath) : !showingSubfolder)
+    ) {
+      return;
+    }
 
     sidebarPrimaryTab.value = "folders";
     await fetchReferenceFolders();
     await fetchImportFolders();
 
-    // Guard: user may have navigated away while fetches were in flight.
+    // Guard: user may have navigated away - or to a sibling subfolder, which
+    // moves only the query - while the fetches were in flight.
     if (viewStore.activeFolderKey !== newKey) return;
+    if ((viewStore.view?.folderFilter?.pathPrefix ?? null) !== newPath) return;
 
     if (newKey.startsWith("rf-")) {
       const id = parseInt(newKey.slice(3), 10);
       const folder = referenceFolders.value.find((f) => f.id === id);
       if (folder) {
-        // A subfolder in the URL wins over the folder root: the route is only
-        // re-read when `activeFolderKey` itself changes, so this restores the
-        // subfolder on a reload, a deep link or a Back out of another view -
-        // not on Back between two subfolders of the SAME folder, which never
-        // changes the key.
+        // A subfolder in the URL wins over the folder root, on every way in:
+        // a reload, a deep link, Back out of another view, and Back between
+        // two subfolders of this same folder.
         const sub = routeSubfolderUnder(folder.folder);
         handleFolderNodeSelect(sub ? `path-${sub.pathPrefix}` : newKey, {
           referenceFolderId: folder.id,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -1090,6 +1090,28 @@ function referenceFolderCanDisclose(rf) {
   return (cached.entries?.length ?? 0) > 0;
 }
 
+/**
+ * Whether the sidebar's current folder selection sits under the folder the
+ * route key `key` names.
+ *
+ * The two are NOT always the same string. A subfolder row's key is
+ * `path-<absolute path>` (`FolderTreeNode.vue`) while the route only ever says
+ * `rf-<id>` / `if-<id>`, so an equality test read "not mine" for every
+ * subfolder and left the highlight - and `selectedFolderReferenceId`, which
+ * the scanning light reads - stuck on a folder the app had navigated away
+ * from. `selectedFolderReferenceId` is the folder a `path-` selection belongs
+ * to, which is what makes the two comparable.
+ *
+ * @param {string} key an `activeFolderKey` value
+ * @returns {boolean}
+ */
+function _selectionBelongsToFolderKey(key) {
+  if (!key || !selectedFolderKey.value) return false;
+  if (selectedFolderKey.value === key) return true;
+  if (!selectedFolderKey.value.startsWith("path-")) return false;
+  return key === `rf-${selectedFolderReferenceId.value}`;
+}
+
 function handleFolderNodeSelect(key, payload) {
   selectedFolderKey.value = key;
   const payloadId = Number(payload?.referenceFolderId);
@@ -3939,7 +3961,7 @@ watch(
   async (newKey, oldKey) => {
     if (!newKey) {
       // Route left a folder view - clear the sidebar's folder highlight.
-      if (oldKey && selectedFolderKey.value === oldKey) {
+      if (oldKey && _selectionBelongsToFolderKey(oldKey)) {
         selectedFolderKey.value = null;
         selectedFolderReferenceId.value = null;
       }

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -310,6 +310,75 @@ describe("the loose-pictures offer for an empty library", () => {
     wrapper.unmount();
   });
 
+  it("still offers when a pending entry belongs to some other library", async () => {
+    // The offer used to be gated on the raw `mappingStore.pending`, the same
+    // unbounded localStorage flag the telemetry question was gated on. The
+    // auto-open above deliberately refuses a `local_import` saved against a
+    // library that is no longer the active one, so on an empty library the
+    // owner got no wizard AND no offer - for the life of the install, since
+    // nothing clears the entry. The guard beside it already read
+    // `pendingForThisLibrary`; now this one does too.
+    const path = "/home/me/Pictures";
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        taskId: "task-3",
+        path: "/home/me/Pictures/detached",
+        label: "detached",
+        mode: "local_import",
+      }),
+    );
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({ data: { picture_count: 12 } })
+        : Promise.resolve(respond(url)),
+    );
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    expect(useFolderMappingStore().wizardOpen).toBe(true);
+    expect(useFolderMappingStore().wizardResume).toEqual({
+      path,
+      mode: "local_import",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("stays quiet when the pending entry is this library's own", async () => {
+    // The control: an entry the auto-open WILL act on must still suppress the
+    // offer, or the owner gets the wizard twice.
+    const path = "/home/me/Pictures";
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ taskId: "task-4", path, label: "Pictures", mode: "local_import" }),
+    );
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      return Promise.resolve(respond(url));
+    });
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    expect(inspect).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
   it("resumes it when the parked path only differs by a trailing separator", async () => {
     // The parked path comes from the Electron shell's folder dialog and the
     // library path from the registry, so the two agree about the folder and

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -350,6 +350,44 @@ describe("the loose-pictures offer for an empty library", () => {
     wrapper.unmount();
   });
 
+  it("still offers when the pending entry is a legacy reference read", async () => {
+    // The second of the two classes the auto-open refuses, and the one a
+    // previous fix here claimed to cover and did not: `pendingForThisLibrary`
+    // returns a `reference` entry UNCHANGED, so gating on its truthiness still
+    // refused the offer. An empty library plus a stale `reference` entry meant
+    // no wizard and no offer - no way into the library at all, permanently.
+    const path = "/home/me/Pictures";
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        taskId: "task-9",
+        path: "/home/me/Pictures/External",
+        label: "External",
+        mode: "reference",
+      }),
+    );
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({ data: { picture_count: 12 } })
+        : Promise.resolve(respond(url)),
+    );
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    expect(useFolderMappingStore().wizardOpen).toBe(true);
+    expect(useFolderMappingStore().wizardResume).toEqual({
+      path,
+      mode: "local_import",
+    });
+
+    wrapper.unmount();
+  });
+
   it("stays quiet when the pending entry is this library's own", async () => {
     // The control: an entry the auto-open WILL act on must still suppress the
     // offer, or the owner gets the wizard twice.

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -310,6 +310,44 @@ describe("the loose-pictures offer for an empty library", () => {
     wrapper.unmount();
   });
 
+  it("resumes it when the parked path only differs by a trailing separator", async () => {
+    // The parked path comes from the Electron shell's folder dialog and the
+    // library path from the registry, so the two agree about the folder and
+    // not always about how it is spelled. `===` threw the completed read away
+    // and started a second one over an empty grid; `_samePath` - the helper
+    // the pending-entry match beside it already uses - does not.
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    const readResult = { levels: [{ depth: 1, folders: [] }] };
+    window.pixlstashDesktop = {
+      takePendingMapping: async () => ({ path: `${path}/`, result: readResult }),
+    };
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      return Promise.resolve(respond(url));
+    });
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    expect(useFolderMappingStore().wizardResume).toEqual({
+      path,
+      result: readResult,
+      mode: "local_import",
+    });
+    expect(inspect).not.toHaveBeenCalled();
+
+    delete window.pixlstashDesktop;
+    wrapper.unmount();
+  });
+
   it("ignores a parked read of some other folder", async () => {
     const path = "/home/me/Pictures";
     activeLibraryAt(path);

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -78,6 +78,9 @@ const ROOT = "/home/me/library/refs";
 const SUB = "/home/me/library/refs/2024/summer";
 // A second folder, spelled the way a Windows server's listing spells it.
 const WIN_ROOT = "D:\\library\\refs";
+// A third: POSIX, but with a backslash inside a folder NAME. Legal on POSIX,
+// and the reason `_urlPath` is not folded into `_samePath`.
+const ODD_ROOT = "/home/me/refs/a\\b";
 
 // `status: active` with no `last_scanned` is what makes `selectedFolderScanning`
 // true while this folder is selected, which is how a test sees the sidebar's
@@ -94,6 +97,7 @@ const FOLDER = {
 };
 
 const WIN_FOLDER = { id: 6, folder: WIN_ROOT, label: "Win refs", active: true };
+const ODD_FOLDER = { id: 7, folder: ODD_ROOT, label: "Odd refs", active: true };
 
 const IMPORT_FOLDER = { id: 9, folder: "/home/me/inbox", label: "Inbox" };
 
@@ -102,7 +106,7 @@ function respond(url) {
     return { data: { folders: [IMPORT_FOLDER] } };
   }
   if (String(url).includes("/reference-folders")) {
-    return { data: { folders: [FOLDER, WIN_FOLDER], in_docker: true } };
+    return { data: { folders: [FOLDER, WIN_FOLDER, ODD_FOLDER], in_docker: true } };
   }
   return { data: [] };
 }
@@ -278,25 +282,66 @@ describe("restoring /ref-folder/:id", () => {
     wrapper.unmount();
   });
 
-  it("does not re-fetch the listings for a route it is already showing", async () => {
-    // The other side of watching the query: a click sets the selection and
-    // THEN pushes, so the watcher sees its own work arrive. Without the
-    // in-sync test that is two listing round trips and a duplicate
-    // `select-folder` on every single subfolder click.
-    const wrapper = await mountSidebar();
-    routeToFolder(SUB);
-    await flushPromises();
-    const emittedOnce = wrapper.emitted("select-folder").length;
-    const fetchedOnce = apiGet.mock.calls.length;
+  // THE GUARDRAIL for this whole region. A route arriving twice must be inert
+  // the second time.
+  //
+  // That one property catches the entire bug class the key-space map describes,
+  // because every one of these spellings ends up compared against another one
+  // here: if any crossing compares two spaces with the wrong comparator, the
+  // sidebar stops recognising its own work, re-emits, and the emit pushes a
+  // route that differs from the one that arrived - a new history entry whose
+  // Back returns to the first spelling and starts the round again. That is not
+  // a redundant fetch, it is a folder view you cannot leave.
+  //
+  // **Parameterised over the separator-changing inputs on purpose.** The POSIX
+  // case alone passed happily while the Windows case looped, because on POSIX
+  // `routeSubfolderUnder` re-spells nothing and the two spaces coincide. A
+  // guardrail that only tries the input where the spaces agree cannot see a
+  // spaces-disagree bug.
+  describe("a route arriving twice is inert", () => {
+    const cases = [
+      // [name, folderKey, the ?path= as it arrives in the URL]
+      ["a POSIX path, spelled as the server spells it", "rf-5", SUB],
+      ["the folder root", "rf-5", ROOT],
+      [
+        "a Windows folder reached by a slash-spelled link",
+        "rf-6",
+        `${WIN_ROOT.replace(/\\/g, "/")}/2024/summer`,
+      ],
+      [
+        "a Windows folder reached by its own spelling",
+        "rf-6",
+        `${WIN_ROOT}\\2024\\summer`,
+      ],
+      [
+        "a POSIX folder whose own name contains a backslash",
+        "rf-7",
+        `${ODD_ROOT}/2024`,
+      ],
+      [
+        "a POSIX SUBfolder whose name contains a backslash",
+        "rf-7",
+        `${ODD_ROOT}/c\\d`,
+      ],
+    ];
 
-    // Exactly what the sidebar just applied, arriving again.
-    routeToFolder(SUB);
-    await flushPromises();
+    it.each(cases)("%s", async (_name, folderKey, path) => {
+      const wrapper = await mountSidebar();
+      routeToFolder(path, folderKey);
+      await flushPromises();
+      const emittedOnce = wrapper.emitted("select-folder")?.length ?? 0;
+      const fetchedOnce = apiGet.mock.calls.length;
+      expect(emittedOnce).toBeGreaterThan(0);
 
-    expect(wrapper.emitted("select-folder").length).toBe(emittedOnce);
-    expect(apiGet.mock.calls.length).toBe(fetchedOnce);
+      // Exactly what the sidebar just applied, arriving again.
+      routeToFolder(path, folderKey);
+      await flushPromises();
 
-    wrapper.unmount();
+      expect(wrapper.emitted("select-folder").length).toBe(emittedOnce);
+      expect(apiGet.mock.calls.length).toBe(fetchedOnce);
+
+      wrapper.unmount();
+    });
   });
 
   // `selectedFolderRouteKey` is the one crossing from the sidebar's row-key
@@ -327,6 +372,26 @@ describe("restoring /ref-folder/:id", () => {
     await flushPromises();
 
     expect(sidebarStore.folderScanning).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("keeps a backslash that is part of a POSIX folder's name", async () => {
+    // The mirror of the Windows case. There `/` in the URL means "separator";
+    // here it does not, and a `\` is a legal character in a POSIX folder name.
+    // Re-spelling the tail on POSIX would rewrite `c\d` to `c/d`, hand the
+    // listing a `file_path_prefix` for a folder that does not exist, and come
+    // back with an empty grid - the same failure the re-spelling exists to
+    // prevent, caused by the fix for it.
+    const wrapper = await mountSidebar();
+    routeToFolder(`${ODD_ROOT}/c\\d`, "rf-7");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 7,
+      pathPrefix: `${ODD_ROOT}/c\\d`,
+      label: "c\\d",
+    });
 
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -229,6 +229,71 @@ describe("restoring /ref-folder/:id", () => {
     wrapper.unmount();
   });
 
+  // The push half of item 43 gives each subfolder click a distinct URL, which
+  // means vue-router now creates a Back target where it used to deduplicate
+  // the identical `/ref-folder/5` and create none. Watching only
+  // `activeFolderKey` left every one of those inert - `rf-5` either side, so
+  // nothing re-read the query and the grid stayed on the newer subfolder while
+  // the address bar went back. A Back button that moves the URL and nothing
+  // else is worse than the gesture having had nowhere to go.
+  it("follows Back from one subfolder to its sibling", async () => {
+    const other = `${ROOT}/2023/winter`;
+    const wrapper = await mountSidebar();
+    routeToFolder(SUB);
+    await flushPromises();
+    expect(lastFolderPayload(wrapper).pathPrefix).toBe(SUB);
+
+    routeToFolder(other); // Back: same folderKey, different ?path=
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: other,
+      label: "winter",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("follows Back from a subfolder to the folder root", async () => {
+    const wrapper = await mountSidebar();
+    routeToFolder(SUB);
+    await flushPromises();
+    expect(lastFolderPayload(wrapper).pathPrefix).toBe(SUB);
+
+    routeToFolder(ROOT); // Back again, to the root click's own URL
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "Refs",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("does not re-fetch the listings for a route it is already showing", async () => {
+    // The other side of watching the query: a click sets the selection and
+    // THEN pushes, so the watcher sees its own work arrive. Without the
+    // in-sync test that is two listing round trips and a duplicate
+    // `select-folder` on every single subfolder click.
+    const wrapper = await mountSidebar();
+    routeToFolder(SUB);
+    await flushPromises();
+    const emittedOnce = wrapper.emitted("select-folder").length;
+    const fetchedOnce = apiGet.mock.calls.length;
+
+    // Exactly what the sidebar just applied, arriving again.
+    routeToFolder(SUB);
+    await flushPromises();
+
+    expect(wrapper.emitted("select-folder").length).toBe(emittedOnce);
+    expect(apiGet.mock.calls.length).toBe(fetchedOnce);
+
+    wrapper.unmount();
+  });
+
   it("matches a subfolder whose separators disagree with the folder's", async () => {
     // The folder listing and the `?path=` come from the same server and
     // normally agree, but the query half is a URL: it gets shared, edited and

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -376,6 +376,26 @@ describe("restoring /ref-folder/:id", () => {
     wrapper.unmount();
   });
 
+  it("does not read a slash-spelled URL as inside a POSIX folder named a\\b", async () => {
+    // The other direction of the same rule. Folding `\` to `/` on a POSIX root
+    // makes `/home/me/refs/a/b/2024` and `/home/me/refs/a\b/2024` the same
+    // string, so a URL naming a DIFFERENT folder was accepted as a subfolder
+    // and then rewritten into this one - the grid would show the wrong folder
+    // or nothing. Folding is for Windows roots, where both characters really
+    // do separate; here it must fall back to the folder root.
+    const wrapper = await mountSidebar();
+    routeToFolder("/home/me/refs/a/b/2024", "rf-7");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 7,
+      pathPrefix: ODD_ROOT,
+      label: "Odd refs",
+    });
+
+    wrapper.unmount();
+  });
+
   it("keeps a backslash that is part of a POSIX folder's name", async () => {
     // The mirror of the Windows case. There `/` in the URL means "separator";
     // here it does not, and a `\` is a legal character in a POSIX folder name.

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -76,6 +76,8 @@ import { useSidebarStore } from "../../stores/useSidebarStore";
 
 const ROOT = "/home/me/library/refs";
 const SUB = "/home/me/library/refs/2024/summer";
+// A second folder, spelled the way a Windows server's listing spells it.
+const WIN_ROOT = "D:\\library\\refs";
 
 // `status: active` with no `last_scanned` is what makes `selectedFolderScanning`
 // true while this folder is selected, which is how a test sees the sidebar's
@@ -91,9 +93,11 @@ const FOLDER = {
   last_scanned: null,
 };
 
+const WIN_FOLDER = { id: 6, folder: WIN_ROOT, label: "Win refs", active: true };
+
 function respond(url) {
   if (String(url).includes("/reference-folders")) {
-    return { data: { folders: [FOLDER], in_docker: true } };
+    return { data: { folders: [FOLDER, WIN_FOLDER], in_docker: true } };
   }
   return { data: [] };
 }
@@ -118,11 +122,13 @@ function lastFolderPayload(wrapper) {
   return emitted ? emitted[emitted.length - 1][0] : null;
 }
 
-/** Put the app on `/ref-folder/5`, with or without a `?path=`. */
-function routeToFolder(path) {
+/** Put the app on `/ref-folder/<id>`, with or without a `?path=`. */
+function routeToFolder(path, folderKey = "rf-5") {
   useViewStore().view = {
-    folderKey: "rf-5",
-    folderFilter: path ? { pathPrefix: path, label: path.split("/").pop() } : null,
+    folderKey,
+    folderFilter: path
+      ? { pathPrefix: path, label: path.split(/[/\\]/).pop() }
+      : null,
   };
 }
 
@@ -219,6 +225,27 @@ describe("restoring /ref-folder/:id", () => {
     await flushPromises();
 
     expect(sidebarStore.folderScanning).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("matches a subfolder whose separators disagree with the folder's", async () => {
+    // The folder listing and the `?path=` come from the same server and
+    // normally agree, but the query half is a URL: it gets shared, edited and
+    // pasted. A `/` where the listing said `\` used to read as "not inside
+    // this folder" and drop the reader back to the folder root.
+    const slashed = `${WIN_ROOT.replace(/\\/g, "/")}/2024/summer`;
+    const wrapper = await mountSidebar();
+    routeToFolder(slashed, "rf-6");
+    await flushPromises();
+
+    // The payload keeps the URL's own spelling - only the comparison that got
+    // it here was normalised.
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 6,
+      pathPrefix: slashed,
+      label: "summer",
+    });
 
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -1,0 +1,190 @@
+// The other half of the folder URL round trip (`useAppNavigationFolders.test.js`
+// is the first): what the sidebar does when the route arrives.
+//
+// `/ref-folder/:id` is restored by the `activeFolderKey` watcher, which
+// rebuilt the payload from the folder listing alone and therefore always
+// selected the folder ROOT. Since a subfolder click now keeps its `?path=`,
+// that watcher would have thrown it away on the very next reload - the URL
+// would say the subfolder and the grid would show the whole folder.
+//
+// The id keeps owning `referenceFolderId`, so the grid query still carries
+// `reference_folder_id`; only `pathPrefix` and the highlight key come from the
+// query.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const apiGet = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    onSessionReset: () => () => {},
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeRef(false),
+    sessionContext: makeRef(null),
+    login: vi.fn(),
+    logout: vi.fn(),
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    toBackendWebSocketUrl: () => "",
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", async () => {
+  const { vuetifyComponentStubs } = await import("../../testing/vuetifyStubs");
+  return vuetifyComponentStubs();
+});
+
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual("vue");
+  const { vi: vitest } = await import("vitest");
+  const route = reactive({
+    query: {},
+    params: {},
+    path: "/",
+    name: "all-pictures",
+  });
+  return {
+    useRoute: () => route,
+    useRouter: () => ({
+      push: vitest.fn(),
+      replace: vitest.fn(),
+      currentRoute: { value: route },
+    }),
+  };
+});
+
+import SideBar from "./SideBar.vue";
+import { useViewStore } from "../../stores/useViewStore";
+
+const ROOT = "/home/me/library/refs";
+const SUB = "/home/me/library/refs/2024/summer";
+
+const FOLDER = { id: 5, folder: ROOT, label: "Refs", active: true };
+
+function respond(url) {
+  if (String(url).includes("/reference-folders")) {
+    return { data: { folders: [FOLDER], in_docker: true } };
+  }
+  return { data: [] };
+}
+
+async function mountSidebar() {
+  const wrapper = mount(SideBar, {
+    shallow: true,
+    props: { backendUrl: "/api/v1" },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  for (let i = 0; i < 5; i += 1) await flushPromises();
+  return wrapper;
+}
+
+/** The payload the sidebar last handed the grid via `select-folder`. */
+function lastFolderPayload(wrapper) {
+  const emitted = wrapper.emitted("select-folder");
+  return emitted ? emitted[emitted.length - 1][0] : null;
+}
+
+/** Put the app on `/ref-folder/5`, with or without a `?path=`. */
+function routeToFolder(path) {
+  useViewStore().view = {
+    folderKey: "rf-5",
+    folderFilter: path ? { pathPrefix: path, label: path.split("/").pop() } : null,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setActivePinia(createPinia());
+  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("restoring /ref-folder/:id", () => {
+  it("selects the subfolder the query names, keeping the folder's id", async () => {
+    const wrapper = await mountSidebar();
+    routeToFolder(SUB);
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: SUB,
+      label: "summer",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("selects the folder root when the route names no path", async () => {
+    const wrapper = await mountSidebar();
+    routeToFolder(null);
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "Refs",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("selects the folder root when the query only restates it", async () => {
+    // The root row's own click carries `pathPrefix: folder.folder`, so the URL
+    // it pushes repeats the root. That must stay the folder itself - label and
+    // highlight key included - not a subfolder that happens to be the root.
+    const wrapper = await mountSidebar();
+    routeToFolder(`${ROOT}/`);
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "Refs",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("ignores a path that is not inside this folder", async () => {
+    // A `?path=` left over from an "About your library" destination names a
+    // folder with no id at all. Applying it under this folder's id would build
+    // a grid query for a pair that does not exist.
+    const wrapper = await mountSidebar();
+    routeToFolder("/home/me/somewhere-else");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "Refs",
+    });
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -95,7 +95,12 @@ const FOLDER = {
 
 const WIN_FOLDER = { id: 6, folder: WIN_ROOT, label: "Win refs", active: true };
 
+const IMPORT_FOLDER = { id: 9, folder: "/home/me/inbox", label: "Inbox" };
+
 function respond(url) {
+  if (String(url).includes("/import-folders")) {
+    return { data: { folders: [IMPORT_FOLDER] } };
+  }
   if (String(url).includes("/reference-folders")) {
     return { data: { folders: [FOLDER, WIN_FOLDER], in_docker: true } };
   }
@@ -294,6 +299,38 @@ describe("restoring /ref-folder/:id", () => {
     wrapper.unmount();
   });
 
+  // `selectedFolderRouteKey` is the one crossing from the sidebar's row-key
+  // space into the route's. It reads `selectedFolderReferenceId`, which is
+  // `null` when no reference folder is selected - and `Number(null)` is `0`,
+  // which `Number.isFinite` accepts. So it used to answer `rf-0` for "nothing
+  // selected", which made the teardown believe a phantom folder was showing,
+  // and made the `if-` branch unreachable in exactly the case it exists for.
+  it("clears an import-folder selection when the route leaves it", async () => {
+    // An import folder is selected with `selectedFolderReferenceId` left null,
+    // and `Number(null)` is `0`, which `Number.isFinite` accepts - so the
+    // crossing into the route's key space answered `rf-0` for a selection that
+    // is really `if-9`. The teardown then compared `rf-0` against the `if-9`
+    // it was leaving, found no match, and left the import folder highlighted
+    // (and its scanning light on) after the app had navigated away.
+    const wrapper = await mountSidebar();
+    const sidebarStore = useSidebarStore();
+    useViewStore().view = { folderKey: "if-9", folderFilter: null };
+    await flushPromises();
+    expect(lastFolderPayload(wrapper)).toEqual({
+      importSourceFolder: IMPORT_FOLDER.folder,
+      importFolderId: 9,
+      label: "Inbox",
+    });
+    expect(sidebarStore.folderScanning).toBe(true);
+
+    useViewStore().view = null;
+    await flushPromises();
+
+    expect(sidebarStore.folderScanning).toBe(false);
+
+    wrapper.unmount();
+  });
+
   it("matches a subfolder whose separators disagree with the folder's", async () => {
     // The folder listing and the `?path=` come from the same server and
     // normally agree, but the query half is a URL: it gets shared, edited and
@@ -304,11 +341,15 @@ describe("restoring /ref-folder/:id", () => {
     routeToFolder(slashed, "rf-6");
     await flushPromises();
 
-    // The payload keeps the URL's own spelling - only the comparison that got
-    // it here was normalised.
+    // And the payload comes back in the FOLDER's spelling, not the URL's.
+    // `file_path_prefix` is a literal LIKE against the stored `file_path`
+    // (`utils/query/predicate_filter.py`), so a slash-spelled prefix against a
+    // Windows library matches nothing and the grid comes back empty - and the
+    // tree row's own key, built from the browse listing, would not match the
+    // highlight either.
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 6,
-      pathPrefix: slashed,
+      pathPrefix: `${WIN_ROOT}\\2024\\summer`,
       label: "summer",
     });
 

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -72,11 +72,24 @@ vi.mock("vue-router", async () => {
 
 import SideBar from "./SideBar.vue";
 import { useViewStore } from "../../stores/useViewStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 
 const ROOT = "/home/me/library/refs";
 const SUB = "/home/me/library/refs/2024/summer";
 
-const FOLDER = { id: 5, folder: ROOT, label: "Refs", active: true };
+// `status: active` with no `last_scanned` is what makes `selectedFolderScanning`
+// true while this folder is selected, which is how a test sees the sidebar's
+// selection without reaching into the component: it reaches
+// `sidebarStore.folderScanning`, and it is driven by `selectedFolderReferenceId`
+// - the half of the selection the teardown below has to clear.
+const FOLDER = {
+  id: 5,
+  folder: ROOT,
+  label: "Refs",
+  active: true,
+  status: "active",
+  last_scanned: null,
+};
 
 function respond(url) {
   if (String(url).includes("/reference-folders")) {
@@ -167,6 +180,45 @@ describe("restoring /ref-folder/:id", () => {
       pathPrefix: ROOT,
       label: "Refs",
     });
+
+    wrapper.unmount();
+  });
+
+  // The teardown at the top of the same watcher compares the sidebar's own
+  // selection key against the route key it is leaving. Those two stopped being
+  // the same string once a subfolder could be selected: the sidebar holds
+  // `path-<abs path>` and the route only ever said `rf-5`, so the equality test
+  // read "not mine" and left the highlight - and the scanning light behind
+  // `selectedFolderReferenceId` - stuck on a folder the app had navigated away
+  // from. Found by review on this branch; it applies to a hand-clicked
+  // subfolder as much as to a restored one, which is why the guard compares on
+  // the folder the selection belongs to rather than on the key.
+  it("clears the selection when the route leaves a restored subfolder", async () => {
+    const wrapper = await mountSidebar();
+    const sidebarStore = useSidebarStore();
+    routeToFolder(SUB);
+    await flushPromises();
+    expect(sidebarStore.folderScanning).toBe(true);
+
+    useViewStore().view = null; // the route left every folder view
+    await flushPromises();
+
+    expect(sidebarStore.folderScanning).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("still clears the selection when the route leaves a folder root", async () => {
+    const wrapper = await mountSidebar();
+    const sidebarStore = useSidebarStore();
+    routeToFolder(null);
+    await flushPromises();
+    expect(sidebarStore.folderScanning).toBe(true);
+
+    useViewStore().view = null;
+    await flushPromises();
+
+    expect(sidebarStore.folderScanning).toBe(false);
 
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/StatsSidebar.vue
+++ b/frontend/src/components/panels/StatsSidebar.vue
@@ -1280,7 +1280,7 @@ defineExpose({ focusTasksTab });
                 {{
                   stats.total > 0
                     ? Math.round((stats.tagged / stats.total) * 100) + "%"
-                    : " - "
+                    : "—"
                 }}
               </text>
             </svg>

--- a/frontend/src/components/reviews/ReviewArchivedReceipt.vue
+++ b/frontend/src/components/reviews/ReviewArchivedReceipt.vue
@@ -49,7 +49,7 @@ const store = useReviewSessionsStore();
 const receipt = computed(() => store.receiptFor(props.review.id));
 
 function formatWhen(iso) {
-  if (!iso) return " - ";
+  if (!iso) return "—";
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return String(iso);
   return d.toLocaleDateString(undefined, {

--- a/frontend/src/components/settings/AccountSection.vue
+++ b/frontend/src/components/settings/AccountSection.vue
@@ -195,9 +195,9 @@ async function clearWatermark() {
 }
 
 function formatTokenTimestamp(value) {
-  if (!value) return " - ";
+  if (!value) return "—";
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return " - ";
+  if (Number.isNaN(date.getTime())) return "—";
   // Date-only keeps the table columns compact (a full locale datetime is far
   // too wide for the dense token table).
   return date.toLocaleDateString();

--- a/frontend/src/components/settings/LibrariesSection.test.js
+++ b/frontend/src/components/settings/LibrariesSection.test.js
@@ -459,6 +459,26 @@ describe("switching", () => {
     warn.mockRestore();
   });
 
+  it("says nothing when no focus target was offered in the first place", async () => {
+    // `begin` is also called with no trigger at all - the folder-mapping
+    // wizard's own switch does exactly that - and those are not failures to
+    // report. Without the guard this warns on an ordinary overlay dismissal,
+    // which is a console line on a working flow.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const switchStore = useLibrarySwitchStore();
+
+    await switchStore.begin(
+      { uuid: "uuid-b", name: "Client work" },
+      { uuid: "uuid-a", name: "Family Photos" },
+      null,
+    );
+    const restored = await switchStore.stayOnCurrent();
+
+    expect(restored).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("does not POST until the share-link warning has been accepted", async () => {
     let resolveConfirm;
     confirmMock.mockReturnValue(

--- a/frontend/src/components/settings/LibrariesSection.test.js
+++ b/frontend/src/components/settings/LibrariesSection.test.js
@@ -384,6 +384,81 @@ describe("switching", () => {
     wrapper.unmount();
   });
 
+  // The other door into the same switch. `Open this library` is a menu item,
+  // and clicking it closes the menu that owns it, so the element the click
+  // arrived on is gone by the time a failed switch tries to give focus back -
+  // `.focus()` on it is a silent no-op and the keyboard lands on <body>.
+  //
+  // Vuetify's menu is stubbed inline here, so the item is NOT removed by the
+  // stub: the test removes it by hand, which is what makes it fail against the
+  // unfixed code instead of passing on a node that never went anywhere.
+  it("restores focus to the ⋯ button when the switch came from the row menu", async () => {
+    setActiveLibrary.mockRejectedValue({
+      response: { data: { detail: "Could not open it." } },
+    });
+    const wrapper = mount(LibrariesSection, {
+      props: { open: true },
+      attachTo: document.body,
+      global: {
+        plugins: [pinia],
+        stubs: {
+          VIcon: true,
+          VProgressCircular: true,
+          LibraryLayoutDialog: true,
+          AppButton: {
+            props: ["disabled", "loading"],
+            template:
+              '<button :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+          },
+        },
+      },
+    });
+    await settle(wrapper);
+    const row = rowFor(wrapper, "Client work");
+    const more = row.find(".library-row__more");
+    const item = menuItem(wrapper, "Client work", "Open this library");
+
+    await item.trigger("click");
+    await settle(wrapper);
+    // What the real menu does on close, and what the bug depended on.
+    item.element.remove();
+
+    const switchStore = useLibrarySwitchStore();
+    expect(switchStore.phase).toBe("failed");
+    await switchStore.stayOnCurrent();
+
+    expect(document.activeElement).toBe(more.element);
+    expect(document.activeElement).not.toBe(document.body);
+    wrapper.unmount();
+  });
+
+  it("says so rather than pretending when there is nothing left to focus", async () => {
+    // The belt behind the fix above: a trigger that has left the document
+    // cannot take focus, and a silent `.focus?.()` on it reads as a successful
+    // restore. Any future caller that hands over a doomed element gets a
+    // warning naming the loss instead of a keyboard user on <body>.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const switchStore = useLibrarySwitchStore();
+    const orphan = document.createElement("button");
+    document.body.appendChild(orphan);
+
+    await switchStore.begin(
+      { uuid: "uuid-b", name: "Client work" },
+      { uuid: "uuid-a", name: "Family Photos" },
+      orphan,
+    );
+    orphan.remove();
+
+    const restored = await switchStore.stayOnCurrent();
+
+    expect(restored).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Could not return focus"),
+      expect.objectContaining({ stillInDocument: false }),
+    );
+    warn.mockRestore();
+  });
+
   it("does not POST until the share-link warning has been accepted", async () => {
     let resolveConfirm;
     confirmMock.mockReturnValue(

--- a/frontend/src/components/settings/LibrariesSection.vue
+++ b/frontend/src/components/settings/LibrariesSection.vue
@@ -81,6 +81,9 @@ let copyResetTimer = 0;
 const commandsOpen = ref(false);
 const expandedPaths = ref(new Set());
 const openMenuUuid = ref("");
+/** uuid -> the row's ⋯ button. Plain object, not a ref: nothing renders off it,
+    it only supplies a focus target that outlives the menu it opens. */
+const moreButtons = {};
 /** The library being renamed, or null. Held rather than looked up by uuid so a
     refresh mid-edit cannot swap the dialog's subject under the typing. */
 const renaming = ref(null);
@@ -160,7 +163,15 @@ async function switchTo(library, event) {
   // DOM Event.currentTarget is cleared as soon as synchronous dispatch ends.
   // Save the invoking control before the confirmation awaits so failure can
   // restore focus to the exact Switch button.
-  const trigger = event?.currentTarget ?? null;
+  const invoker = event?.currentTarget ?? null;
+  // `Open this library` lives in the ⋯ menu, and the click closes that menu -
+  // so by the time a failed switch tries to give focus back, the item it came
+  // from is no longer in the document and `.focus()` is a silent no-op that
+  // drops the keyboard on <body>. The ⋯ button that opened the menu is where
+  // focus belongs anyway, and it outlives the menu.
+  const trigger = invoker?.classList?.contains("library-menu__item")
+    ? (moreButtons[library.uuid] ?? null)
+    : invoker;
   const shareCount = Number(activeLibrary.value?.active_share_links ?? 0);
   const ok = await confirm({
     title: `Switch to ${library.name}?`,
@@ -390,6 +401,7 @@ onUnmounted(() => window.clearTimeout(copyResetTimer));
               <template #activator="{ props: menuProps }">
                 <button
                   v-bind="menuProps"
+                  :ref="(el) => (moreButtons[library.uuid] = el)"
                   type="button"
                   class="library-row__more"
                   :disabled="busyUuid === library.uuid"

--- a/frontend/src/components/settings/SettingsValuePlaceholders.test.js
+++ b/frontend/src/components/settings/SettingsValuePlaceholders.test.js
@@ -118,11 +118,13 @@ describe("a Settings readout with no value", () => {
   });
 });
 
-// The sweep flattened eight of these, not the three found first. Rather than
-// mount five more components for one glyph each, this reads the sources: the
-// point is that no value placeholder is spelled `" - "` anywhere, and a source
-// read says that about files no test happens to mount. Verified against
-// c760dd05, which is where each of these lost its em dash.
+// The sweep flattened TEN of these, across seven files. Each count in this
+// file has been wrong once already: it was three, then eight, and the eight
+// missed `FolderMappingPreviewStep.vue` because that one is markup (`> - <`)
+// rather than a string literal, and the first version of this regex only
+// looked between double quotes. Rather than mount seven components for one
+// glyph each, this reads the sources. Verified against c760dd05, which is
+// where every one of them lost its em dash.
 describe("no value placeholder was left flattened by the em-dash sweep", () => {
   const SWEPT = [
     "components/settings/AccountSection.vue",
@@ -131,13 +133,15 @@ describe("no value placeholder was left flattened by the em-dash sweep", () => {
     "components/widgets/RestoreConfirmDialog.vue",
     "components/panels/StatsSidebar.vue",
     "components/reviews/ReviewArchivedReceipt.vue",
+    "components/folders/FolderMappingPreviewStep.vue",
   ];
 
   it.each(SWEPT)("%s spells its empty value as an em dash", (relative) => {
     const source = readFileSync(join(process.cwd(), "src", relative), "utf8");
-    // `" - "` as a whole string literal is only ever a placeholder; prose
-    // hyphens live inside longer sentences and are not matched by this.
-    expect(source).not.toMatch(/"\s-\s"/);
+    // A lone hyphen standing on its own between quotes or tags is only ever a
+    // placeholder; a prose hyphen has words either side of it and is not
+    // matched. Both delimiters, or the markup form walks straight past.
+    expect(source).not.toMatch(/["'>]\s-\s["'<]/);
     expect(source).toContain(EM_DASH);
   });
 });

--- a/frontend/src/components/settings/SettingsValuePlaceholders.test.js
+++ b/frontend/src/components/settings/SettingsValuePlaceholders.test.js
@@ -1,0 +1,117 @@
+// The glyph a Settings readout shows when it has no value to show.
+//
+// It is an em dash, and it is a value, not prose: it sits in a table cell or a
+// key/value pair where a date or a port number would be, and it has to read as
+// "nothing here" rather than as a stray hyphen with spaces around it. The
+// repo-wide em-dash-to-hyphen sweep that ran over the prose (commit c760dd05)
+// took these three with it, turning `"—"` into `" - "` in a token table's date
+// columns and the ComfyUI port readout.
+//
+// Pinned here rather than left to review, because the next sweep will look
+// exactly as harmless as the last one did.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return { isReadOnly: ref(false) };
+});
+
+vi.mock("../../api/config", () => ({
+  getUserConfig: vi.fn(async () => ({ data: {} })),
+  patchUserConfig: vi.fn(async () => ({ data: {} })),
+}));
+
+vi.mock("../../api/comfyui", () => ({
+  listWorkflows: vi.fn(async () => []),
+  deleteWorkflow: vi.fn(),
+  importWorkflow: vi.fn(),
+}));
+
+vi.mock("../../api/users", () => ({
+  getAuthState: vi.fn(async () => ({ auth_required: true, username: "owner" })),
+  changePassword: vi.fn(),
+  listTokens: vi.fn(async () => [
+    {
+      id: 1,
+      label: "example-token",
+      scope: "READ",
+      resource_type: null,
+      created_at: null,
+      last_used_at: null,
+      expires_at: null,
+    },
+  ]),
+  createToken: vi.fn(),
+  patchToken: vi.fn(),
+  deleteToken: vi.fn(),
+  uploadWatermark: vi.fn(),
+  deleteWatermark: vi.fn(),
+}));
+
+vi.mock("../../api/pictureSets", () => ({ listPictureSets: vi.fn(async () => []) }));
+vi.mock("../../api/projects", () => ({ listProjects: vi.fn(async () => []) }));
+vi.mock("../../api/characters", () => ({ listCharacters: vi.fn(async () => []) }));
+vi.mock("../../utils/clipboard", () => ({ copyText: vi.fn() }));
+
+vi.mock("vuetify/components", () => ({
+  VSwitch: { name: "v-switch", template: "<div><slot /></div>" },
+}));
+
+import AccountSection from "./AccountSection.vue";
+import WorkflowsSection from "./WorkflowsSection.vue";
+
+const EM_DASH = "—";
+
+const stubs = {
+  VIcon: true,
+  "v-icon": true,
+  AppDialog: true,
+  AppSelect: true,
+  AppInput: true,
+  AppButton: {
+    props: ["disabled", "loading"],
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+  },
+};
+
+async function settle(wrapper) {
+  for (let i = 0; i < 4; i += 1) await nextTick();
+  return wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("a Settings readout with no value", () => {
+  it("shows an em dash for a token that has never been used", async () => {
+    const wrapper = await settle(
+      mount(AccountSection, { props: { open: true }, global: { stubs } }),
+    );
+
+    const cells = wrapper.findAll(".account-token-sub").map((c) => c.text());
+    expect(cells.length).toBeGreaterThanOrEqual(2);
+    // Created and last-used, both absent on this row.
+    expect(cells[0]).toBe(EM_DASH);
+    expect(cells[1]).toBe(EM_DASH);
+    for (const cell of cells) expect(cell).not.toBe("-");
+
+    wrapper.unmount();
+  });
+
+  it("shows an em dash for the ComfyUI port when none is configured", async () => {
+    const wrapper = await settle(
+      mount(WorkflowsSection, { props: { open: true }, global: { stubs } }),
+    );
+
+    const values = wrapper.findAll(".wf-host-value").map((v) => v.text());
+    expect(values).toContain("Not configured");
+    expect(values).toContain(EM_DASH);
+    expect(values).not.toContain("-");
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/settings/SettingsValuePlaceholders.test.js
+++ b/frontend/src/components/settings/SettingsValuePlaceholders.test.js
@@ -13,6 +13,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 vi.mock("../../utils/apiClient", async () => {
   const { ref } = await import("vue");
@@ -113,5 +115,29 @@ describe("a Settings readout with no value", () => {
     expect(values).not.toContain("-");
 
     wrapper.unmount();
+  });
+});
+
+// The sweep flattened eight of these, not the three found first. Rather than
+// mount five more components for one glyph each, this reads the sources: the
+// point is that no value placeholder is spelled `" - "` anywhere, and a source
+// read says that about files no test happens to mount. Verified against
+// c760dd05, which is where each of these lost its em dash.
+describe("no value placeholder was left flattened by the em-dash sweep", () => {
+  const SWEPT = [
+    "components/settings/AccountSection.vue",
+    "components/settings/WorkflowsSection.vue",
+    "components/settings/SnapshotsSection.vue",
+    "components/widgets/RestoreConfirmDialog.vue",
+    "components/panels/StatsSidebar.vue",
+    "components/reviews/ReviewArchivedReceipt.vue",
+  ];
+
+  it.each(SWEPT)("%s spells its empty value as an em dash", (relative) => {
+    const source = readFileSync(join(process.cwd(), "src", relative), "utf8");
+    // `" - "` as a whole string literal is only ever a placeholder; prose
+    // hyphens live inside longer sentences and are not matched by this.
+    expect(source).not.toMatch(/"\s-\s"/);
+    expect(source).toContain(EM_DASH);
   });
 });

--- a/frontend/src/components/settings/SnapshotsSection.vue
+++ b/frontend/src/components/settings/SnapshotsSection.vue
@@ -299,7 +299,7 @@ function handleRestore(cp) {
             title="Double-click to rename"
             @dblclick="!activeJob && startEditing(cp)"
           >
-            {{ cp.label || " - " }}
+            {{ cp.label || "—" }}
           </span>
         </div>
 

--- a/frontend/src/components/settings/WorkflowsSection.vue
+++ b/frontend/src/components/settings/WorkflowsSection.vue
@@ -684,7 +684,7 @@ watch(
           </div>
           <div class="wf-host-pair">
             <span class="wf-host-key">Port</span>
-            <span class="wf-host-value">{{ comfyuiPort || " - " }}</span>
+            <span class="wf-host-value">{{ comfyuiPort || "—" }}</span>
           </div>
         </div>
         <AppButton

--- a/frontend/src/components/widgets/RestoreConfirmDialog.vue
+++ b/frontend/src/components/widgets/RestoreConfirmDialog.vue
@@ -322,7 +322,7 @@ const canRestore = computed(
               {{ cp.kind }}
             </v-chip>
             <span class="restore-picker-label">
-              {{ cp.label || " - " }}
+              {{ cp.label || "—" }}
             </span>
             <span
               class="restore-picker-date"
@@ -369,7 +369,7 @@ const canRestore = computed(
               {{ preview.snapshot?.kind }}
             </v-chip>
             <span class="restore-preview-cp-label">
-              {{ preview.snapshot?.label || " - " }}
+              {{ preview.snapshot?.label || "—" }}
             </span>
             <span
               class="restore-preview-cp-date"

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -258,10 +258,19 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
 
     if (sel.selectedFolderFilter) {
       const f = sel.selectedFolderFilter;
+      // `?path=` rides along on the folder routes too. A sidebar subfolder
+      // click carries `rfId` (`FolderTreeNode.vue` requires it), so it takes
+      // the ref-folder branch, and without the query the URL named the folder
+      // ROOT: a reload or a shared link landed one level up from what was on
+      // screen. The id still owns the payload - `useViewStore.applyView`
+      // refuses to overwrite it from `?path=` on a folder route, and the
+      // sidebar restores the subfolder from the query instead.
+      const folderQuery = f.pathPrefix ? { path: f.pathPrefix } : {};
       if (f.referenceFolderId != null) {
         pushAppRoute({
           name: "ref-folder",
           params: { id: String(f.referenceFolderId) },
+          query: folderQuery,
         });
         return;
       }
@@ -269,21 +278,14 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
         pushAppRoute({
           name: "import-folder",
           params: { id: String(f.importFolderId) },
+          query: folderQuery,
         });
         return;
       }
       // A folder payload with no id of any kind - what an "About your
       // library" finding points at. It travels as `?path=` rather than being
       // dropped, and `useViewStore.parseFolderPath` reads it back.
-      //
-      // NOT the sidebar's subfolder case: `FolderTreeNode.vue` requires
-      // `rfId`, so a subfolder click takes the ref-folder branch above and its
-      // path is still lost from the URL. Fixing that is a change to the folder
-      // tree's route restoration, not to this branch.
-      pushAppRoute({
-        name: "all-pictures",
-        query: f.pathPrefix ? { path: f.pathPrefix } : {},
-      });
+      pushAppRoute({ name: "all-pictures", query: folderQuery });
       return;
     }
 

--- a/frontend/src/composables/useAppNavigationFolders.test.js
+++ b/frontend/src/composables/useAppNavigationFolders.test.js
@@ -1,0 +1,140 @@
+// A folder click and what the URL says afterwards.
+//
+// The sidebar's folder tree emits `{referenceFolderId, pathPrefix, label}` for
+// EVERY node - `FolderTreeNode.vue` requires the `rfId` - so a subfolder click
+// and its folder's root click differ only in `pathPrefix`. The route builder
+// keyed off the id alone, so both pushed `/ref-folder/5` and the subfolder
+// vanished from the URL: a reload or a shared link landed one level up, on the
+// whole folder, showing pictures the person had just navigated away from.
+//
+// The id still owns the payload (`useViewStore.applyView` refuses to overwrite
+// a folder route's filter from `?path=`, or `reference_folder_id` would drop
+// out of the grid query); `?path=` only says which folder INSIDE it is open.
+// The sidebar half of the round trip is `SideBarFolderRouteRestore.test.js`.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { defineComponent, h } from "vue";
+import { mount } from "@vue/test-utils";
+
+const nav = vi.hoisted(() => ({ route: null, push: null, replace: null }));
+vi.mock("vue-router", async () => {
+  const { reactive } = await vi.importActual("vue");
+  const { vi: vitest } = await import("vitest");
+  nav.route = reactive({
+    path: "/",
+    name: "all-pictures",
+    params: {},
+    query: {},
+  });
+  nav.push = vitest.fn();
+  nav.replace = vitest.fn();
+  return {
+    useRoute: () => nav.route,
+    useRouter: () => ({
+      push: nav.push,
+      replace: nav.replace,
+      currentRoute: { value: nav.route },
+    }),
+  };
+});
+
+import { useAppNavigation } from "./useAppNavigation";
+
+function mountNav() {
+  let api = null;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useAppNavigation();
+        return () => h("div");
+      },
+    }),
+  );
+  return { wrapper, api };
+}
+
+const ROOT = "/home/me/library/refs";
+const SUB = "/home/me/library/refs/2024/summer";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  nav.route.name = "all-pictures";
+  nav.route.path = "/";
+  nav.route.query = {};
+  nav.push.mockReset().mockReturnValue(Promise.resolve());
+  nav.replace.mockReset().mockReturnValue(Promise.resolve());
+});
+
+describe("a reference-folder click", () => {
+  it("keeps the subfolder in the URL", () => {
+    const { wrapper, api } = mountNav();
+
+    api.handleSelectFolder({
+      referenceFolderId: 5,
+      pathPrefix: SUB,
+      label: "summer",
+    });
+
+    expect(nav.push).toHaveBeenCalledWith({
+      name: "ref-folder",
+      params: { id: "5" },
+      query: { path: SUB },
+    });
+
+    wrapper.unmount();
+  });
+
+  it("names the folder root when that is what was clicked", () => {
+    const { wrapper, api } = mountNav();
+
+    api.handleSelectFolder({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "refs",
+    });
+
+    expect(nav.push).toHaveBeenCalledWith({
+      name: "ref-folder",
+      params: { id: "5" },
+      query: { path: ROOT },
+    });
+
+    wrapper.unmount();
+  });
+
+  it("pushes no query when the payload carries no path at all", () => {
+    // The project menu's folder rows build the payload from the listing, and
+    // an import folder's has no `pathPrefix`. An empty query, not `path=`.
+    const { wrapper, api } = mountNav();
+
+    api.handleSelectFolder({
+      importSourceFolder: "/home/me/inbox",
+      importFolderId: 7,
+      label: "inbox",
+    });
+
+    expect(nav.push).toHaveBeenCalledWith({
+      name: "import-folder",
+      params: { id: "7" },
+      query: {},
+    });
+
+    wrapper.unmount();
+  });
+
+  it("still sends an id-less folder payload to all-pictures with its path", () => {
+    // "About your library" points at folders that are not registered as either
+    // kind. Unchanged by the above.
+    const { wrapper, api } = mountNav();
+
+    api.handleSelectFolder({ pathPrefix: SUB, label: "summer" });
+
+    expect(nav.push).toHaveBeenCalledWith({
+      name: "all-pictures",
+      query: { path: SUB },
+    });
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -585,24 +585,40 @@ export function useUpdatesSocket({
   // A Set, so a long pass costs one insert per id rather than a rebuild of
   // everything held so far on every eight-picture batch.
   const heldSortChangedIds = new Set();
+
+  /** Queue the pill's ids on the store, minus anything the import pill owns. */
+  function publishSortChangedIds(ids) {
+    const pending = new Set(wsStore.pendingExternalImportIds);
+    const fresh = ids.filter((id) => !pending.has(id));
+    if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
+  }
+
+  /** Hand whatever is held to the store. Bypasses the hold test on purpose:
+   *  the two callers below release BECAUSE the reason to hold has gone (the
+   *  pass ended) or is about to stop being observable (this composable is
+   *  being torn down), and re-testing `taggingActive` would re-hold them into
+   *  a Set nothing will read again. */
+  function releaseHeldSortChangedIds() {
+    if (!heldSortChangedIds.size) return;
+    const ids = Array.from(heldSortChangedIds);
+    heldSortChangedIds.clear();
+    publishSortChangedIds(ids);
+  }
+
   function onFlagSortChanged(ids) {
     if (!Array.isArray(ids) || !ids.length) return;
     if (tasksStore.taggingActive) {
       for (const id of ids) heldSortChangedIds.add(id);
       return;
     }
-    const pending = new Set(wsStore.pendingExternalImportIds);
-    const fresh = ids.filter((id) => !pending.has(id));
-    if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
+    publishSortChangedIds(ids);
   }
 
   watch(
     () => tasksStore.taggingActive,
     (active) => {
-      if (active || !heldSortChangedIds.size) return;
-      const ids = Array.from(heldSortChangedIds);
-      heldSortChangedIds.clear();
-      onFlagSortChanged(ids);
+      if (active) return;
+      releaseHeldSortChangedIds();
     },
   );
 
@@ -632,6 +648,12 @@ export function useUpdatesSocket({
   );
 
   onUnmounted(() => {
+    // The held ids are the one piece of state here the store does not already
+    // hold: a tag pass still running when this composable goes away would
+    // otherwise take the whole batch with it and the next view would never be
+    // told it had changed. The store outlives an App.vue remount, so hand them
+    // over rather than dropping them.
+    releaseHeldSortChangedIds();
     disconnectUpdatesSocket();
     gridWsScheduler.cancel();
     if (externalMovesPendingTimer) {

--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -651,8 +651,14 @@ export function useUpdatesSocket({
     // The held ids are the one piece of state here the store does not already
     // hold: a tag pass still running when this composable goes away would
     // otherwise take the whole batch with it and the next view would never be
-    // told it had changed. The store outlives an App.vue remount, so hand them
-    // over rather than dropping them.
+    // told it had changed. Hand them over rather than dropping them.
+    //
+    // The one production unmount is the session ending (`Root.vue` swaps App
+    // out when `isAuthenticated` goes false) - route changes reuse this
+    // instance. `logout()` notifies its reset BEFORE flipping that flag, so
+    // this hand-over lands AFTER the reset; `useWsStore` subscribes to the
+    // same reset and clears both pills, which is what keeps the outgoing
+    // session's picture ids from being offered to the next login in this tab.
     releaseHeldSortChangedIds();
     disconnectUpdatesSocket();
     gridWsScheduler.cancel();

--- a/frontend/src/composables/useUpdatesSocket.test.js
+++ b/frontend/src/composables/useUpdatesSocket.test.js
@@ -60,7 +60,9 @@ import { useNoticeStore } from "../stores/useNoticeStore";
 import { useWsStore } from "../stores/useWsStore";
 import { useTasksStore } from "../stores/useTasksStore";
 import { useGridStore } from "../stores/useGridStore";
-import { API_BASE_URL } from "../utils/apiClient";
+// The real ones: the apiClient mock below spreads `importOriginal`, so a test
+// can drive an actual session transition rather than a stand-in for one.
+import { API_BASE_URL, notifySessionReset } from "../utils/apiClient";
 
 describe("updates socket close lifecycle", () => {
   it("reloads a non-initiating client after a library switch", () => {
@@ -515,6 +517,40 @@ describe("the view-changed pill while the tagger runs", () => {
 
     expect(tasksStore.taggingActive).toBe(true);
     expect([...wsStore.sortChangedExternalIds].sort()).toEqual([11, 12]);
+  });
+
+  // The hand-over above lands on the way DOWN, and the only production unmount
+  // is the session ending: `logout()` notifies its reset and then flips
+  // `isAuthenticated`, so the ids arrive in the store *after* the reset has
+  // already run. A picture id means nothing outside the session that made it -
+  // a different library reuses the same numbers - so what stops the next login
+  // in this tab being offered the previous session's pictures is the store
+  // clearing on the reset that login itself fires.
+  it("does not carry held ids into the next session in this tab", async () => {
+    const { api, wsStore, tasksStore } = mountApi();
+    tasksStore.workerSnapshots = { TagTask: { active: true, total: 800 } };
+    await host.vm.$nextTick();
+    api.onFlagSortChanged([31, 32]);
+
+    notifySessionReset("logout"); // logout notifies BEFORE the unmount
+    host.unmount();
+    host = null;
+    expect([...wsStore.sortChangedExternalIds].sort()).toEqual([31, 32]);
+
+    notifySessionReset("login"); // ...and the next login notifies again
+
+    expect(wsStore.sortChangedExternalIds).toEqual([]);
+  });
+
+  it("does not carry the import pill into the next session either", () => {
+    // The half that predates the hand-over: an ordinary import pill queued
+    // before a logout survived it the same way.
+    const { wsStore } = mountApi();
+    wsStore.addPendingExternalImportIds([41, 42]);
+
+    notifySessionReset("login");
+
+    expect(wsStore.pendingExternalImportIds).toEqual([]);
   });
 
   it("does not raise a pill on unmount when nothing was held", () => {

--- a/frontend/src/composables/useUpdatesSocket.test.js
+++ b/frontend/src/composables/useUpdatesSocket.test.js
@@ -490,4 +490,37 @@ describe("the view-changed pill while the tagger runs", () => {
     await host.vm.$nextTick();
     expect(wsStore.sortChangedExternalIds).toEqual([]);
   });
+
+  // The hold is a plain Set inside the composable, so it dies with the
+  // composable. A pass over a large library runs for minutes; anything that
+  // takes App.vue down inside that window - a re-login, a full-restore
+  // transition - used to take the whole batch with it, and the view that came
+  // back was never told it had changed. The store outlives the composable, so
+  // teardown hands them over instead of dropping them.
+  //
+  // `taggingActive` is deliberately still true at unmount: that is the whole
+  // scenario, and a flush that re-tested it would put the ids straight back
+  // into a Set nothing will ever read again.
+  it("hands held ids to the store when the app unmounts mid-pass", async () => {
+    const { api, wsStore, tasksStore } = mountApi();
+    tasksStore.workerSnapshots = { TagTask: { active: true, total: 800 } };
+    await host.vm.$nextTick();
+    expect(tasksStore.taggingActive).toBe(true);
+
+    api.onFlagSortChanged([11, 12]);
+    expect(wsStore.sortChangedExternalIds).toEqual([]);
+
+    host.unmount();
+    host = null;
+
+    expect(tasksStore.taggingActive).toBe(true);
+    expect([...wsStore.sortChangedExternalIds].sort()).toEqual([11, 12]);
+  });
+
+  it("does not raise a pill on unmount when nothing was held", () => {
+    const { wsStore } = mountApi();
+    host.unmount();
+    host = null;
+    expect(wsStore.sortChangedExternalIds).toEqual([]);
+  });
 });

--- a/frontend/src/stores/useLibrariesStore.js
+++ b/frontend/src/stores/useLibrariesStore.js
@@ -72,8 +72,10 @@ export const useLibrariesStore = defineStore("libraries", () => {
     hasLoadedSuccessfully.value = false;
   }
 
-  // Logout / login / share-token entry / library switch all funnel through the
-  // one chokepoint in apiClient, so there is no second mechanism to keep in sync.
+  // Logout, login and share-token entry all funnel through the one chokepoint
+  // in apiClient, so there is no second mechanism to keep in sync. A library
+  // switch is NOT one of them - it ends in `reloadPage()`, which discards this
+  // store along with the whole document, so it needs no reset and gets none.
   const unsubscribe = onSessionReset(reset);
   onScopeDispose(() => unsubscribe());
 

--- a/frontend/src/stores/useLibrariesStore.js
+++ b/frontend/src/stores/useLibrariesStore.js
@@ -142,7 +142,21 @@ export const useLibrarySwitchStore = defineStore("library-switch", () => {
     error.value = "";
     triggerElement.value = null;
     await nextTick();
-    returnTarget?.focus?.();
+    // `.focus()` on a node that has left the document throws nothing and does
+    // nothing: focus stays on <body> and a keyboard user loses their place
+    // with no sign anything failed. Callers are responsible for handing over a
+    // control that outlives the switch (LibrariesSection passes the row's ⋯
+    // button rather than the menu item inside it, which its own click
+    // destroys); this only refuses to pretend when they have not.
+    if (returnTarget?.isConnected) {
+      returnTarget.focus?.();
+      if (document.activeElement === returnTarget) return true;
+    }
+    console.warn("Could not return focus after a cancelled library switch", {
+      hadTrigger: Boolean(returnTarget),
+      stillInDocument: Boolean(returnTarget?.isConnected),
+    });
+    return false;
   }
 
   return {

--- a/frontend/src/stores/useLibrariesStore.js
+++ b/frontend/src/stores/useLibrariesStore.js
@@ -152,10 +152,15 @@ export const useLibrarySwitchStore = defineStore("library-switch", () => {
       returnTarget.focus?.();
       if (document.activeElement === returnTarget) return true;
     }
-    console.warn("Could not return focus after a cancelled library switch", {
-      hadTrigger: Boolean(returnTarget),
-      stillInDocument: Boolean(returnTarget?.isConnected),
-    });
+    // Only a trigger that was offered and could not be honoured is worth
+    // saying anything about. `begin` is also called with no trigger at all
+    // (the folder-mapping wizard's own switch), and warning on those would
+    // put a line in the console on an ordinary dismissal.
+    if (returnTarget) {
+      console.warn("Could not return focus after a cancelled library switch", {
+        stillInDocument: returnTarget.isConnected,
+      });
+    }
     return false;
   }
 

--- a/frontend/src/stores/useViewStore.js
+++ b/frontend/src/stores/useViewStore.js
@@ -119,12 +119,12 @@ function parseStackState(raw) {
  * `/character/UNASSIGNED?path=…` - the unassigned pictures in one folder - is
  * exactly what a finding opens.
  *
- * **It does NOT yet fix the sidebar's subfolder selection.** A subfolder click
+ * It carries the sidebar's subfolder selection too. A subfolder click also
  * carries `referenceFolderId` (`FolderTreeNode.vue` requires it), so
- * `pushRouteForCurrentSelection` takes its ref-folder branch and the subfolder
- * path is still dropped from the URL. Closing that means teaching the
- * sidebar's `activeFolderKey` watcher to restore a subfolder rather than the
- * folder root, which is a change to the folder tree and not to this param.
+ * `pushRouteForCurrentSelection` takes its ref-folder branch - the id owns the
+ * payload and this param says which folder *inside* it is showing. `applyView`
+ * therefore refuses to apply the bare `{pathPrefix, label}` on a folder route;
+ * `SideBar.routeSubfolderUnder` reads it once the folder has loaded.
  *
  * @param {string|string[]|undefined} raw `route.query.path`
  * @returns {{pathPrefix: string, label: string}|null}
@@ -358,8 +358,9 @@ function applyView(view, selectionStore, projectStore, filterStore) {
     // Without the `folderKey` guard, `/ref-folder/5?path=/sub` would overwrite
     // the sidebar's `{referenceFolderId, pathPrefix, label}` with a bare
     // `{pathPrefix, label}` and drop `reference_folder_id` from the grid
-    // query. Nothing pushes that combination today; the guard is here so
-    // nothing can start to.
+    // query. A sidebar subfolder click pushes exactly that combination, so
+    // this guard is load-bearing: `SideBar.routeSubfolderUnder` applies the
+    // path WITH the folder's id once the folder listing is in.
     const current = selectionStore.selectedFolderFilter;
     if (current?.pathPrefix !== view.folderFilter.pathPrefix) {
       selectionStore.selectedFolderFilter = view.folderFilter;

--- a/frontend/src/stores/useWsStore.js
+++ b/frontend/src/stores/useWsStore.js
@@ -1,6 +1,6 @@
-import { computed, ref } from "vue";
+import { computed, onScopeDispose, ref } from "vue";
 import { defineStore } from "pinia";
-import { setRequestClientId } from "../utils/apiClient";
+import { onSessionReset, setRequestClientId } from "../utils/apiClient";
 
 const CLIENT_ID_STORAGE_KEY = "pixlstash:clientId";
 
@@ -97,6 +97,19 @@ export const useWsStore = defineStore("ws", () => {
   function clearSortChangedExternalIds() {
     sortChangedExternalIds.value = [];
   }
+
+  // Both pills are picture ids, and a picture id means nothing outside the
+  // session that produced it - a different library reuses the same numbers.
+  // Logout notifies BEFORE it flips `isAuthenticated`, so anything the app
+  // writes here on its way down (`useUpdatesSocket` hands over the ids a tag
+  // pass was holding) lands after the reset and would be offered to whoever
+  // logs in next, in the same tab, as "pictures that changed". Same reasoning
+  // as `useLibrariesStore.reset`: one chokepoint, no second mechanism.
+  const unsubscribeSessionReset = onSessionReset(() => {
+    clearPendingExternalImportIds();
+    clearSortChangedExternalIds();
+  });
+  onScopeDispose(unsubscribeSessionReset);
 
   return {
     wsTagUpdate,

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -312,6 +312,14 @@ apiClient.interceptors.request.use((config) => {
 async function login(username, password) {
   try {
     const response = await apiClient.post('/login', {username, password});
+    // Reset BEFORE the flag, and the order is load-bearing. Flipping
+    // `isAuthenticated` is what mounts App.vue, and a store cleared after that
+    // would be cleared out from under the new session's first writes. It is
+    // also what makes the reset the sweep for anything the OUTGOING session
+    // wrote on its way down: `logout` notifies before its own flag flip, so
+    // App.vue's teardown runs after that reset, and only this one catches what
+    // the teardown left behind (see `useWsStore`'s pill ids). Pinned by
+    // `apiClientSessionResetOrder.test.js`.
     notifySessionReset('login');
     isAuthenticated.value = true;  // Update authentication state
     if (typeof window !== 'undefined' && 'credentials' in navigator &&

--- a/frontend/src/utils/apiClientSessionResetOrder.test.js
+++ b/frontend/src/utils/apiClientSessionResetOrder.test.js
@@ -20,7 +20,12 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
-const post = vi.fn();
+// Hoisted with the `vi.mock` factory that closes over it: `vi.mock` is lifted
+// above the module body, so a plain `const post` here would still be in its
+// temporal dead zone if the factory ran first. Same shape as
+// `useUpdatesSocket.test.js`, and the reason that file does it too.
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+
 vi.mock("axios", () => {
   const instance = {
     post: (...args) => post(...args),

--- a/frontend/src/utils/apiClientSessionResetOrder.test.js
+++ b/frontend/src/utils/apiClientSessionResetOrder.test.js
@@ -1,0 +1,93 @@
+// The order of the two lines that end and begin a session.
+//
+// `login()` and `logout()` each do two things: notify the session reset, and
+// flip `isAuthenticated`. Both notify FIRST, and several unrelated pieces of
+// correctness rest on that without saying so - which is exactly why it is
+// pinned here rather than left to a comment.
+//
+// The flag is what mounts and unmounts App.vue (`Root.vue`), so:
+//
+//   * logout notifying first means App.vue's teardown runs AFTER the reset, so
+//     anything the teardown hands to a store (`useUpdatesSocket` releases the
+//     ids a tag pass was holding into `useWsStore`) lands in a store that has
+//     already been cleared;
+//   * login notifying first is therefore the sweep that catches it, before the
+//     new session's App.vue exists to read it.
+//
+// Swap either pair and the "view changed" pill offers the previous session's
+// picture ids to whoever logs in next in the same tab - silently, because
+// picture ids from another library are still perfectly valid numbers.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const post = vi.fn();
+vi.mock("axios", () => {
+  const instance = {
+    post: (...args) => post(...args),
+    get: vi.fn(),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+  return { default: { create: () => instance } };
+});
+
+import {
+  isAuthenticated,
+  login,
+  logout,
+  onSessionReset,
+} from "./apiClient";
+
+/** Record what `isAuthenticated` was at the moment each reset fired.
+ *  Handlers are called with NO arguments (`notifySessionReset` passes the
+ *  reason only to its own log line), so the flag is the whole observation. */
+function recordFlagAtReset() {
+  const seen = [];
+  const stop = onSessionReset(() => seen.push(isAuthenticated.value));
+  return { seen, stop };
+}
+
+let stopListening;
+
+beforeEach(() => {
+  post.mockReset().mockResolvedValue({ data: {} });
+  isAuthenticated.value = false;
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  stopListening?.();
+  vi.restoreAllMocks();
+});
+
+describe("a session transition notifies before it flips the flag", () => {
+  it("login resets while the app is still torn down", async () => {
+    const { seen, stop } = recordFlagAtReset();
+    stopListening = stop;
+
+    await login("me", "example-password");
+
+    expect(seen).toHaveLength(1);
+    // The point: false, not true. A subscriber clearing here runs before the
+    // incoming session's App.vue is mounted to write anything.
+    expect(seen[0]).toBe(false);
+    expect(isAuthenticated.value).toBe(true);
+  });
+
+  it("logout resets while the app is still mounted", async () => {
+    isAuthenticated.value = true;
+    const { seen, stop } = recordFlagAtReset();
+    stopListening = stop;
+
+    await logout();
+
+    expect(seen).toHaveLength(1);
+    // True, not false: App.vue is still up, so its `onUnmounted` has NOT run
+    // yet and will write after this. That is why login has to sweep too.
+    expect(seen[0]).toBe(true);
+    expect(isAuthenticated.value).toBe(false);
+  });
+});


### PR DESCRIPTION
Frontend lane of the v1.11.1 backlog (#1177). Seven findings, one commit each.
Items 33, 34 and 44 from the same section are deliberately out of scope: they
are flow and discoverability decisions rather than code.

### 30 — held "view changed" ids died with the composable
`useUpdatesSocket` holds ids while a tag pass runs so the pill is raised once at
the end instead of every eight-picture batch. The hold is a plain `Set` inside
the composable, so anything that unmounted App.vue mid-pass (a re-login, a
full-restore transition) took the batch with it and the next view was never told
it had changed. Teardown now hands them to the store, which outlives the
composable. The release deliberately bypasses the `taggingActive` test, since
both callers release *because* the reason to hold has gone or is about to stop
being observable.

### 31 — a stale pending folder mapping suppressed the privacy question forever
The question waited on `useFolderMappingStore.pending`, which is
localStorage-backed and unbounded. The sidebar's auto-open refuses two whole
classes of entry by design — a `local_import` saved against a library that is no
longer active, and a legacy `reference` entry — so for those no wizard ever
opens, nothing clears the entry, and the question never appeared again for the
life of the install. It fails closed (`telemetry_send_install_id` defaults
false), so what was lost is the prompt, not the choice.

The gate now waits on the wizard actually being open. The ordering that
`pending` was standing in for moves to `librarySettled`: `onLibraryLoaded` waits
for the libraries listing (which the sidebar's auto-open watches) and one tick,
so `wizardOpen` answers honestly by the time the question is allowed. The
listing read is owner-only, matching the mount-time one.

### 32 — the parked desktop read was matched with `===`
`_samePath` sits four lines above and is what the sibling pending-entry match
already uses. A trailing separator threw away a completed folder read and
started a second one over an empty grid.

### 43 — `?path=` was dropped for a sidebar subfolder click
`FolderTreeNode.vue` requires an `rfId`, so a subfolder click takes the
ref-folder branch, which pushed the id alone. The URL named the folder root: a
reload or a shared link landed one level up from what was on screen.

The branch now pushes `pathPrefix` as `?path=` alongside the id, and
`SideBar.routeSubfolderUnder` reads it back once the folder listing is in. The
id still owns `referenceFolderId`, so `reference_folder_id` stays in the grid
query — the query only says which folder *inside* it is open, and `applyView`'s
existing `folderKey` guard (which now has a real caller) keeps the route from
overwriting the sidebar's payload with a bare one. Restored on reload, deep link
and Back out of another view; not on Back between two subfolders of the same
folder, which never changes `activeFolderKey`. Both architecture docs updated.

### 45 — focus restore targeted a detached node
`Open this library` is a menu item, and clicking it closes the menu that owns
it, so a failed switch called `.focus()` on an element that had left the
document — a silent no-op that drops the keyboard on `<body>`. The menu path now
hands over the row's `⋯` button, which opened the menu and outlives it. The
store additionally refuses to report a restore it did not achieve, and says so
rather than failing silently.

### 46 — every mapping row was a tab stop
Each level is one `role="tree"`, and the WAI-ARIA tree pattern gives a tree one
tab stop with the arrow keys moving inside it — which `onRowKeydown` already
implemented. Roving tabindex on the rows, and the per-row kind dropdown out of
the tab sequence (Enter on the focused row already opens it, and the row
advertises `aria-keyshortcuts`). A level of 400 folders was 800 presses between
the filter box and `Continue`. The tab stop follows focus and falls back to the
first drawn row, so filtering can never leave a tree unreachable.

### 47 — the em-dash sweep flattened three value placeholders
`"—"` in a token table's date columns and the ComfyUI port readout is a value
meaning "nothing here", not prose; commit c760dd05 turned all three into `" - "`.
Restored, and pinned by a test so the next sweep cannot repeat it.

---

Every fix has a test demonstrated red against the unfixed code first. Items 30
and 45 are lifecycle bugs a naive test passes either way, so those two exercise
the real teardown: 30 asserts after `host.unmount()` with the pass still
running, and 45 removes the menu item from the document (the stubbed menu does
not) before restoring focus.

No new dependency. No new styling — all seven are behavioural.
Frontend suite: 222 files, 3912 tests, green. `eslint` clean.
