### PR TITLE
Tagging and face-extraction lane for v1.11.1: items 22, 23, 24, 25

### DIFF
--- a/changelog.d/1205.md
+++ b/changelog.d/1205.md
@@ -1,4 +1,5 @@
 - Fixed: a video PixlStash could not make sense of would stop it finding faces
   in the rest of your library, retrying the same pictures instead of moving on.
-- Fixed: a few unreadable pictures could stop tagging altogether, leaving
+- Fixed: a few pictures PixlStash could not open - a damaged file, or one on a
+  drive that had been unplugged - could stop tagging altogether, leaving
   everything imported afterwards untagged.

--- a/changelog.d/1205.md
+++ b/changelog.d/1205.md
@@ -1,0 +1,4 @@
+- Fixed: a video PixlStash could not make sense of would stop it finding faces
+  in the rest of your library, retrying the same pictures instead of moving on.
+- Fixed: a few unreadable pictures could stop tagging altogether, leaving
+  everything imported afterwards untagged.

--- a/pixlstash/inference/vram_budget.py
+++ b/pixlstash/inference/vram_budget.py
@@ -29,6 +29,15 @@ ORT_ARENA_SHARE = {
     "insightface_session": None,
 }
 
+#: WD14's memory model in MiB: the loaded ONNX session, and one 448 px image's
+#: activations on top of it. **Both** the batch cap and that session's
+#: ``gpu_mem_limit`` are derived from these two numbers, which is the point of
+#: their being here rather than inline at the batch-sizing call. A batch sized
+#: from one model and an arena capped from another is an allocation the sizer
+#: sanctioned and the runtime refuses - a hard ORT failure, not a slow run.
+WD14_BASE_MB = 900
+WD14_PER_ITEM_MB = 220
+
 
 class VramBudget:
     """Stateful VRAM budget for GPU-memory-aware batch sizing.
@@ -114,7 +123,9 @@ class VramBudget:
             self._max_vram_usage_mb / 1024.0,
         )
 
-    def ort_cuda_provider_options(self, share: float | None) -> dict[str, object]:
+    def ort_cuda_provider_options(
+        self, share: float | None, min_limit_mb: int = 0
+    ) -> dict[str, object]:
         """CUDAExecutionProvider options for one ONNX Runtime session.
 
         ORT's default arena doubles on every growth (``kNextPowerOfTwo``) and
@@ -126,10 +137,23 @@ class VramBudget:
         and is left unset when there is none: a cap nobody configured is an
         OOM nobody asked for.
 
+        *share* is a split of the budget between sessions and knows nothing
+        about what the session will be asked to run. ``min_limit_mb`` is the
+        other half of the same question - :meth:`batch_footprint_mb` for the
+        model this session holds - and raises the cap to it when the share
+        alone would sit below what the batch sizer has already allowed. The
+        budget itself stays the ceiling. Without this the two disagree: at the
+        shipped 2 GB default, WD14's 40 % share is 819 MiB while its own model
+        base is 900 MiB, so the session was capped below its own weights.
+
         Args:
             share: Fraction of the configured budget, from
                 :data:`ORT_ARENA_SHARE`; ``None`` for a session that must never
                 be capped (only the cudnn search setting applies).
+            min_limit_mb: Floor for the cap, in MiB - what one full batch of
+                this session's model actually occupies. Ignored when there is
+                no budget (nothing is capped) or when the share already
+                exceeds it.
 
         Returns:
             Options dict for ``provider_options`` / a ``providers`` tuple.
@@ -141,8 +165,29 @@ class VramBudget:
             return options
         options["arena_extend_strategy"] = "kSameAsRequested"
         if self._max_vram_usage_mb is not None:
-            options["gpu_mem_limit"] = int(self._max_vram_usage_mb * share) * 1024**2
+            limit_mb = max(int(self._max_vram_usage_mb * share), int(min_limit_mb))
+            limit_mb = min(limit_mb, self._max_vram_usage_mb)
+            options["gpu_mem_limit"] = limit_mb * 1024**2
         return options
+
+    def batch_footprint_mb(self, base_mb: int, per_item_mb: int) -> int:
+        """MiB one full batch of this model occupies at the size this budget allows.
+
+        The counterpart to :meth:`limited_batch_cap`: what that cap costs. An
+        ORT session whose ``gpu_mem_limit`` is below this refuses an allocation
+        the batch sizer already sanctioned.
+
+        Args:
+            base_mb: Fixed model footprint in MiB (loaded once).
+            per_item_mb: Incremental VRAM per image/item in MiB.
+
+        Returns:
+            Footprint in MiB, or ``0`` when no budget is set - there is no cap
+            to reconcile against, so there is nothing to floor.
+        """
+        if self._max_vram_usage_mb is None:
+            return 0
+        return base_mb + per_item_mb * self.limited_batch_cap(base_mb, per_item_mb)
 
     def limited_batch_cap(self, base_mb: int, per_item_mb: int) -> int:
         """Return the maximum batch size that fits within the configured budget.

--- a/pixlstash/inference/vram_budget.py
+++ b/pixlstash/inference/vram_budget.py
@@ -29,14 +29,34 @@ ORT_ARENA_SHARE = {
     "insightface_session": None,
 }
 
-#: WD14's memory model in MiB: the loaded ONNX session, and one 448 px image's
-#: activations on top of it. **Both** the batch cap and that session's
-#: ``gpu_mem_limit`` are derived from these two numbers, which is the point of
-#: their being here rather than inline at the batch-sizing call. A batch sized
-#: from one model and an arena capped from another is an allocation the sizer
-#: sanctioned and the runtime refuses - a hard ORT failure, not a slow run.
+#: WD14's **process** VRAM in MiB: everything the tagger costs the card once
+#: loaded, including the ~400 MiB CUDA context, plus one 448 px image on top.
+#: This is the scheduler's admission model - what ``limited_batch_cap`` sizes a
+#: batch against and what ``estimated_vram_mb`` reports - and it is the figure
+#: measured after load (~904 MiB against 377 MiB of weights on disk).
 WD14_BASE_MB = 900
 WD14_PER_ITEM_MB = 220
+
+#: The same session's **ORT arena** in MiB, which is a different quantity: ORT's
+#: ``gpu_mem_limit`` governs only the CUDA EP's own allocator, not the context
+#: and not anything torch holds. Bisected on an RTX 5090 against the real
+#: ``wd-convnext-tagger-v3`` (ORT 1.28, CUDA EP) as ``385 + 111·n``, which
+#: predicts every observed outcome: loads at 409 MiB, batch 1 needs 496, batch
+#: 3 needs 718 and does run under the 819 MiB that a 2 GB budget's 40 % share
+#: gives it. Carries ~10 % over the fit, because one card's bisect is not every
+#: driver's allocator.
+#:
+#: Conflating the two is what made the first version of this wrong: the process
+#: figure is roughly twice the arena figure, so using it as the arena floor
+#: overshot every budget and left ``ORT_ARENA_SHARE["wd14"]`` applying nowhere.
+WD14_ARENA_BASE_MB = 425
+WD14_ARENA_PER_ITEM_MB = 122
+
+#: Most images WD14 is ever asked to do at once, whatever the budget allows -
+#: the tagging workflow's own concurrency ceiling. The arena floor is sized for
+#: the batch that will actually run, so a large budget does not float the floor
+#: past a share that already covers it.
+MAX_CONCURRENT_GPU_IMAGES = 64
 
 
 class VramBudget:
@@ -138,22 +158,22 @@ class VramBudget:
         OOM nobody asked for.
 
         *share* is a split of the budget between sessions and knows nothing
-        about what the session will be asked to run. ``min_limit_mb`` is the
-        other half of the same question - :meth:`batch_footprint_mb` for the
-        model this session holds - and raises the cap to it when the share
-        alone would sit below what the batch sizer has already allowed. The
-        budget itself stays the ceiling. Without this the two disagree: at the
-        shipped 2 GB default, WD14's 40 % share is 819 MiB while its own model
-        base is 900 MiB, so the session was capped below its own weights.
+        about what the session will be asked to run, so on a small budget it
+        can land under what a single batch needs: WD14's 40 % of a 1 GB budget
+        is 409 MiB, which loads the model and cannot run batch 1 (496 MiB).
+        ``min_limit_mb`` - :meth:`wd14_arena_limit_mb` for that session - is
+        the other half of the question and raises the cap where the share
+        genuinely falls short. It is a floor, never a target: where the share
+        already covers the batch it wins and the configured split stands, and
+        the budget is the ceiling in either case.
 
         Args:
             share: Fraction of the configured budget, from
                 :data:`ORT_ARENA_SHARE`; ``None`` for a session that must never
                 be capped (only the cudnn search setting applies).
-            min_limit_mb: Floor for the cap, in MiB - what one full batch of
-                this session's model actually occupies. Ignored when there is
-                no budget (nothing is capped) or when the share already
-                exceeds it.
+            min_limit_mb: Floor for the cap, in MiB - what this session's own
+                arena needs for the batch it will be given. Ignored when there
+                is no budget (nothing is capped) or when the share is larger.
 
         Returns:
             Options dict for ``provider_options`` / a ``providers`` tuple.
@@ -170,24 +190,33 @@ class VramBudget:
             options["gpu_mem_limit"] = limit_mb * 1024**2
         return options
 
-    def batch_footprint_mb(self, base_mb: int, per_item_mb: int) -> int:
-        """MiB one full batch of this model occupies at the size this budget allows.
+    def wd14_arena_limit_mb(self) -> int:
+        """MiB WD14's ORT arena needs for the batch this budget will hand it.
 
-        The counterpart to :meth:`limited_batch_cap`: what that cap costs. An
-        ORT session whose ``gpu_mem_limit`` is below this refuses an allocation
-        the batch sizer already sanctioned.
+        Two models, deliberately: the batch is sized against the **process**
+        pair (:data:`WD14_BASE_MB` / :data:`WD14_PER_ITEM_MB`), because that is
+        what the scheduler admits work against and what
+        ``limited_batch_cap`` is calibrated for; the resulting batch is then
+        costed against the **arena** pair, because ``gpu_mem_limit`` governs
+        only the CUDA EP's allocator. Sizing with one and capping with the
+        other is the whole point - and using the process pair for both is what
+        made this overshoot.
 
-        Args:
-            base_mb: Fixed model footprint in MiB (loaded once).
-            per_item_mb: Incremental VRAM per image/item in MiB.
+        The batch is clamped to :data:`MAX_CONCURRENT_GPU_IMAGES`, the most
+        the workflow ever runs at once, so a large budget does not inflate the
+        floor past a share that already covers the real batch.
 
         Returns:
-            Footprint in MiB, or ``0`` when no budget is set - there is no cap
-            to reconcile against, so there is nothing to floor.
+            Floor in MiB, or ``0`` when no budget is set - nothing is capped,
+            so there is nothing to reconcile against.
         """
         if self._max_vram_usage_mb is None:
             return 0
-        return base_mb + per_item_mb * self.limited_batch_cap(base_mb, per_item_mb)
+        batch = min(
+            MAX_CONCURRENT_GPU_IMAGES,
+            self.limited_batch_cap(WD14_BASE_MB, WD14_PER_ITEM_MB),
+        )
+        return WD14_ARENA_BASE_MB + WD14_ARENA_PER_ITEM_MB * batch
 
     def limited_batch_cap(self, base_mb: int, per_item_mb: int) -> int:
         """Return the maximum batch size that fits within the configured budget.

--- a/pixlstash/inference/workflows/tagging.py
+++ b/pixlstash/inference/workflows/tagging.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from pixlstash.inference.vram_budget import WD14_BASE_MB, WD14_PER_ITEM_MB
+from pixlstash.inference.vram_budget import (
+    MAX_CONCURRENT_GPU_IMAGES,
+    WD14_BASE_MB,
+    WD14_PER_ITEM_MB,
+)
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.service.caption_utils import merge_video_frame_tags
@@ -16,7 +20,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _VIDEO_EXTS = frozenset({".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"})
-_MAX_CONCURRENT_GPU = 64
 _MAX_CONCURRENT_CPU = 8
 
 
@@ -587,7 +590,7 @@ class TaggingWorkflow:
     def _max_concurrent_images(self) -> int:
         """Maximum image concurrency determined by device type."""
         if self._engine.device == "cuda":
-            return _MAX_CONCURRENT_GPU
+            return MAX_CONCURRENT_GPU_IMAGES
         return _MAX_CONCURRENT_CPU
 
     def _vram_limited_batch_cap(self, base_mb: int, per_item_mb: int) -> int:

--- a/pixlstash/inference/workflows/tagging.py
+++ b/pixlstash/inference/workflows/tagging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from pixlstash.inference.vram_budget import WD14_BASE_MB, WD14_PER_ITEM_MB
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.utils.service.caption_utils import merge_video_frame_tags
@@ -601,7 +602,9 @@ class TaggingWorkflow:
         if self._engine.device == "cuda":
             wd14_batch = min(
                 wd14_batch,
-                self._vram_limited_batch_cap(base_mb=900, per_item_mb=220),
+                self._vram_limited_batch_cap(
+                    base_mb=WD14_BASE_MB, per_item_mb=WD14_PER_ITEM_MB
+                ),
             )
         return max(1, int(wd14_batch))
 
@@ -623,7 +626,9 @@ class TaggingWorkflow:
             if self._use_wd14:
                 max_concurrent = min(
                     max_concurrent,
-                    self._vram_limited_batch_cap(base_mb=900, per_item_mb=220),
+                    self._vram_limited_batch_cap(
+                        base_mb=WD14_BASE_MB, per_item_mb=WD14_PER_ITEM_MB
+                    ),
                 )
             if self._use_pixlstash_tagger:
                 max_concurrent = min(
@@ -661,7 +666,7 @@ class TaggingWorkflow:
         candidates = [1200]
         if self._use_wd14:
             wd14_batch = min(self.effective_wd14_batch_size(), image_count)
-            candidates.append(900 + 220 * wd14_batch)
+            candidates.append(WD14_BASE_MB + WD14_PER_ITEM_MB * wd14_batch)
         if self._use_pixlstash_tagger:
             custom_batch = min(
                 self.effective_pixlstash_tagger_batch_size(), image_count
@@ -677,7 +682,7 @@ class TaggingWorkflow:
                 self.effective_wd14_batch_size(),
                 max(1, int(image_count or 1)),
             )
-            candidates.append(220 * wd14_batch)
+            candidates.append(WD14_PER_ITEM_MB * wd14_batch)
         if self._use_pixlstash_tagger:
             custom_batch = min(
                 self.effective_pixlstash_tagger_batch_size(),

--- a/pixlstash/tagger_plugins/wd14.py
+++ b/pixlstash/tagger_plugins/wd14.py
@@ -15,12 +15,7 @@ import onnxruntime as ort
 import torch
 from tqdm import tqdm
 
-from pixlstash.inference.vram_budget import (
-    ORT_ARENA_SHARE,
-    VramBudget,
-    WD14_BASE_MB,
-    WD14_PER_ITEM_MB,
-)
+from pixlstash.inference.vram_budget import ORT_ARENA_SHARE, VramBudget
 from pixlstash.pixl_logging import get_logger
 from pixlstash.tagger_plugins.base import TagResult, TaggerPlugin
 from pixlstash.utils.service.caption_utils import naturalize_tags, sanitise_tag
@@ -283,15 +278,13 @@ class WD14Service:
                     provider_options=[{"device_type": "GPU", "precision": "FP32"}],
                 )
             else:
-                # The arena has to hold the batch `effective_wd14_batch_size`
-                # will hand it, which is sized from the same two figures; the
-                # bare share does not know about that batch and at a small
-                # budget lands under WD14's own model base.
+                # The share alone is too small below ~1.25 GB of budget - it
+                # loads the model and cannot run a single image - so it is
+                # floored by what this session's arena actually needs. Above
+                # that the share stands.
                 cuda_options = self._vram_budget.ort_cuda_provider_options(
                     ORT_ARENA_SHARE["wd14"],
-                    min_limit_mb=self._vram_budget.batch_footprint_mb(
-                        WD14_BASE_MB, WD14_PER_ITEM_MB
-                    ),
+                    min_limit_mb=self._vram_budget.wd14_arena_limit_mb(),
                 )
                 logger.debug("WD14 CUDA provider options: %s", cuda_options)
                 self._ort_sess = ort.InferenceSession(

--- a/pixlstash/tagger_plugins/wd14.py
+++ b/pixlstash/tagger_plugins/wd14.py
@@ -15,7 +15,12 @@ import onnxruntime as ort
 import torch
 from tqdm import tqdm
 
-from pixlstash.inference.vram_budget import ORT_ARENA_SHARE, VramBudget
+from pixlstash.inference.vram_budget import (
+    ORT_ARENA_SHARE,
+    VramBudget,
+    WD14_BASE_MB,
+    WD14_PER_ITEM_MB,
+)
 from pixlstash.pixl_logging import get_logger
 from pixlstash.tagger_plugins.base import TagResult, TaggerPlugin
 from pixlstash.utils.service.caption_utils import naturalize_tags, sanitise_tag
@@ -278,8 +283,15 @@ class WD14Service:
                     provider_options=[{"device_type": "GPU", "precision": "FP32"}],
                 )
             else:
+                # The arena has to hold the batch `effective_wd14_batch_size`
+                # will hand it, which is sized from the same two figures; the
+                # bare share does not know about that batch and at a small
+                # budget lands under WD14's own model base.
                 cuda_options = self._vram_budget.ort_cuda_provider_options(
-                    ORT_ARENA_SHARE["wd14"]
+                    ORT_ARENA_SHARE["wd14"],
+                    min_limit_mb=self._vram_budget.batch_footprint_mb(
+                        WD14_BASE_MB, WD14_PER_ITEM_MB
+                    ),
                 )
                 logger.debug("WD14 CUDA provider options: %s", cuda_options)
                 self._ort_sess = ort.InferenceSession(

--- a/pixlstash/tagger_plugins/wd14.py
+++ b/pixlstash/tagger_plugins/wd14.py
@@ -278,10 +278,17 @@ class WD14Service:
                     provider_options=[{"device_type": "GPU", "precision": "FP32"}],
                 )
             else:
-                # The share alone is too small below ~1.25 GB of budget - it
-                # loads the model and cannot run a single image - so it is
-                # floored by what this session's arena actually needs. Above
-                # that the share stands.
+                # The share alone is a hard allocation failure below ~1.25 GB
+                # of budget: it loads the model and cannot run a single image.
+                # So it is floored by what this session's arena actually
+                # needs. The floor is the measured need plus ~10 %, and the
+                # share only clears that at the 2 GB default and again above
+                # ~24 GB - across 3-16 GB the share sits within a few per cent
+                # of the true need (at 8 GB, 3276 MiB against 3160) and the
+                # floor takes over to keep a margin. WD14 is therefore capped
+                # a little above 40 % of budget in that range: a ceiling, not
+                # a reservation, and an arena only grows to what a run asks
+                # for.
                 cuda_options = self._vram_budget.ort_cuda_provider_options(
                     ORT_ARENA_SHARE["wd14"],
                     min_limit_mb=self._vram_budget.wd14_arena_limit_mb(),

--- a/pixlstash/tasks/face_extraction_task.py
+++ b/pixlstash/tasks/face_extraction_task.py
@@ -685,7 +685,7 @@ class FaceExtractionTask(BaseTask):
         # (batched - all crops from all images in one ONNX call) up front.
         # This replaces N×(detector + recogniser + landmark + genderage) calls
         # with N detector calls + 1 recogniser call.
-        runner = BatchedFaceRunner(self._insightface_app)
+        #
         # Build the set of resolved paths for the current chunk only.  The
         # preloaded dict contains ALL task images; without this filter, every
         # chunk would run run_batch() on the full task and get_feat() on all
@@ -834,7 +834,15 @@ class FaceExtractionTask(BaseTask):
                     first_bboxes = []
                     if frames:
                         _infer_start = time.time()
-                        per_frame_faces = runner.run_batch([f for _, f in frames])
+                        # Same entry point as the still path: a frame below
+                        # _MIN_DETECTION_DIM is skipped rather than crashing
+                        # RetinaFace's internal cv2.resize, and a VRAM OOM is
+                        # re-raised instead of being written as "no faces".
+                        # A clip is exactly as able to be tiny, or to arrive
+                        # while the card is full, as a still is.
+                        per_frame_faces = FaceExtractionTask.detect_faces_in_images(
+                            self._insightface_app, [f for _, f in frames]
+                        )
                         inference_s += time.time() - _infer_start
                     else:
                         per_frame_faces = []

--- a/pixlstash/tasks/missing_tag_finder.py
+++ b/pixlstash/tasks/missing_tag_finder.py
@@ -63,9 +63,23 @@ class MissingTagFinder(BaseTaskFinder):
         # Fetch enough candidates that _filter_and_claim can always fill one
         # additional task even when all max_inflight slots are already in-flight.
         max_inflight = max(1, self.max_inflight_tasks())
+        # Exclude undecodable pictures at the query, as the face, thumbnail and
+        # embedding finders already do. `_filter_and_claim` drops them anyway,
+        # but only after they have taken up room in the candidate window - and
+        # an undecodable picture keeps its pending-tag sentinel for ever
+        # (TagTask marks it unprocessable and writes nothing, so nothing
+        # clears the sentinel). They therefore accumulate permanently, and
+        # this window is ordered by `Picture.id`: once as few as
+        # `batch_limit * (max_inflight + 1)` of them sit below the pictures
+        # that still need tagging, every sweep reads the same corrupt rows,
+        # claims none of them and returns None - which the planner reads as
+        # "no work" and answers with a growing backoff. That is tagging
+        # starving library-wide on a handful of bad files, the same shape
+        # `MissingFaceExtractionFinder` documents on its own query.
+        suppressed_ids = self._db.unprocessable_images.active_suppressed_ids()
         pictures = self._db.run_immediate_read_task(
             lambda session: self._fetch_missing_tags(
-                session, batch_limit * (max_inflight + 1)
+                session, batch_limit * (max_inflight + 1), suppressed_ids
             )
         )
         if not pictures:
@@ -95,7 +109,7 @@ class MissingTagFinder(BaseTaskFinder):
         )
 
     @staticmethod
-    def _fetch_missing_tags(session: Session, limit: int):
+    def _fetch_missing_tags(session: Session, limit: int, suppressed_ids=None):
         pending = select(Tag.picture_id).where(
             Tag.tag >= TAG_PENDING_SENTINEL, Tag.tag < _SENTINEL_RANGE_END
         )
@@ -106,6 +120,13 @@ class MissingTagFinder(BaseTaskFinder):
         # quality crop in TagTask only *prefers* a face (it centre-crops
         # without one), but cropping on the face is the shipped behaviour, so
         # the picture waits for it.
+        #
+        # The wait is bounded because `MissingFaceExtractionFinder` selects on
+        # the exact complement, `~Picture.faces.any()`: a picture with no row
+        # is by definition still face-stage work, so a cancelled or failed
+        # batch is re-offered rather than stranded. The one predicate the two
+        # finders did not share was the suppressed set, which is why it is
+        # applied above.
         faces_known = Picture.faces.any()
         # A picture frozen by a locked set keeps its confirmed tags: never re-queue
         # it for tagging (the write-side skip in TagTask is the belt; this is the
@@ -120,10 +141,13 @@ class MissingTagFinder(BaseTaskFinder):
         # selected again on the very next sweep - an unbounded inference loop.
         # One definition on both sides is what closes it.
         locked_member = ~Picture.id.in_(locked_picture_id_subquery())
+        stmt = select(Picture).where(
+            Picture.id.in_(pending), faces_known, locked_member
+        )
+        if suppressed_ids:
+            stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))
         return session.exec(
-            select(Picture)
-            .where(Picture.id.in_(pending), faces_known, locked_member)
-            .options(
+            stmt.options(
                 selectinload(Picture.tags),
             )
             .order_by(Picture.id)

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -319,6 +319,12 @@ class TagTask(BaseTask):
                 if img is None:
                     if undecodable:
                         self._mark_unprocessable(pic, file_path)
+                    else:
+                        # Not undecodable, so either the machine failed
+                        # (retry it, mark nothing) or the file's whole
+                        # location is gone - the one case neither the
+                        # registry nor the missing-file purge would take.
+                        self._hold_unreachable(pic, file_path)
                     return None
                 preloaded_images[file_path] = img
             w, h = img.size
@@ -355,76 +361,38 @@ class TagTask(BaseTask):
             )
             return None
 
-    @staticmethod
-    def _clear_sentinels(session: Session, picture_ids: list) -> list:
-        """Delete only the pending-tag sentinel rows of *picture_ids*.
+    def _hold_unreachable(self, pic, file_path) -> None:
+        """Hold *pic* out of the finders while its file's location is gone.
 
-        Only the sentinel: a retag request carries the picture's existing tags
-        alongside it, and writing an empty tag set through ``_add_tags_bulk``
-        would delete those too. A picture the tagger never reached must lose
-        its place in the queue, not its labels.
+        The counterpart to :meth:`_mark_unprocessable`, and deliberately NOT a
+        sentinel deletion. Everything `_is_transient_load_error` classes as
+        "the machine failed, not the file" is un-suppressed, so retiring an
+        unresolved picture would also retire the whole batch behind one
+        stalled DataLoader (`wd14.tag_images` returns ``{}`` for all of them)
+        or one swallowed ONNX error - and a deleted sentinel never comes back,
+        because only import and an explicit retag write one.
+
+        Suppression is reversible where deletion is not: the registry entry
+        lifts by itself when the directory returns, so a remounted drive hands
+        the picture back to every stage with its pending tag work intact.
+        `MissingFilePurgeTask` will not clean up after us either - it
+        explicitly skips a picture whose location is unreachable, because
+        purging would write ``file_removed=True`` and block a later restore.
         """
-        if not picture_ids:
-            return []
-        frozen = locked_picture_ids(session, picture_ids)
-        cleared = [pid for pid in picture_ids if pid not in frozen]
-        if not cleared:
-            return []
-        session.exec(
-            delete(Tag).where(
-                Tag.picture_id.in_(cleared),
-                Tag.tag.like(
-                    TAG_SENTINEL_LIKE_PATTERN, escape=TAG_SENTINEL_ESCAPE_CHAR
-                ),
-            )
-        )
-        session.commit()
-        return cleared
-
-    def _retire_unresolved(self, batch: list, resolved_ids: set) -> None:
-        """Give every picture in the batch a terminal outcome, as faces do.
-
-        ``FaceExtractionTask`` writes a row for every picture it is handed - a
-        ``face_index=-1`` sentinel when it found nothing, including for a file
-        it could not open - so ``~Picture.faces.any()`` always drains.
-        ``TagTask`` wrote *nothing* for a picture that produced no result, and
-        there are four ways to produce none: the full pass drops a path it
-        cannot load (``tagging.py``'s ``continue``), the configured plugin is
-        missing or lacks tag support, the plugin raises, or the batch is
-        cancelled. The pending sentinel then survives, and - unlike a corrupt
-        file, which the unprocessable registry suppresses - an *unreachable*
-        one is classed transient (``FileNotFoundError`` carries ``errno`` 2)
-        and is never suppressed, so the finder claims it again on every sweep.
-        A handful of them at low ids starve tagging library-wide, and worse
-        than the case this task's finder already guards: a task IS returned
-        each sweep, so the planner never even backs off.
-
-        Suppressed pictures are deliberately left pending: the registry is
-        keyed to the file's ``(mtime, size)`` and lifts by itself when the file
-        is repaired, and ``MissingTagFinder`` keeps them out of its candidate
-        window meanwhile, so they are already both terminal and recoverable.
-        """
-        unresolved = [
-            pic.id
-            for pic in batch
-            if getattr(pic, "id", None) is not None and pic.id not in resolved_ids
-        ]
-        if not unresolved:
-            return
         registry = getattr(self._db, "unprocessable_images", None)
-        if registry is not None:
-            unresolved = [pid for pid in unresolved if not registry.is_suppressed(pid)]
-        if not unresolved:
+        if registry is None:
+            logger.warning(
+                "TagTask: picture %s (%s) is unreachable and there is no "
+                "registry to hold it; it will be re-selected every sweep.",
+                getattr(pic, "id", None),
+                str(file_path),
+            )
             return
-        logger.warning(
-            "TagTask %s: %d picture(s) produced no tag result and are not "
-            "suppressed (ids %s); clearing their pending-tag sentinel so they "
-            "stop being re-queued. Their existing tags are kept.",
-            self.id,
-            len(unresolved),
-            unresolved[:20],
+        registry.mark_unreachable(
+            getattr(pic, "id", None),
+            str(file_path),
+            reason="tag source location is not mounted",
         )
-        self._db.run_task(self._clear_sentinels, unresolved, priority=DBPriority.LOW)
 
     def _mark_unprocessable(self, pic, file_path) -> None:
         """Record *pic* as undecodable so the finders stop re-selecting it (#585).
@@ -836,10 +804,15 @@ class TagTask(BaseTask):
                 # provenance that never existed. Only merge when the two
                 # passes are the same model; the crop's *tags* are unversioned
                 # and still apply either way.
-                use_pixlstash_tagger = (
-                    active_workflow.is_pixlstash_tagger_enabled
-                    and full_pass == "pixlstash_tagger"
-                )
+                #
+                # `full_pass` alone, NOT `is_pixlstash_tagger_enabled`: that
+                # property reads the *configured* plugin and ignores the
+                # override, so a retag stamped `__tag:pixlstash_tagger` while
+                # WD14 is configured would be treated as cross-model and lose
+                # its crop confidences even though both passes are the same
+                # model. The crop pass is always the built-in tagger, so the
+                # full pass's identity is the whole question.
+                crop_is_full_pass_model = full_pass == "pixlstash_tagger"
                 inference_start = time.perf_counter()
                 tag_results = active_workflow.tag_images(
                     image_paths,
@@ -907,7 +880,7 @@ class TagTask(BaseTask):
                         quality_results = active_workflow.tag_quality_crops(
                             quality_items,
                             out_raw_scores=crop_raw_scores
-                            if use_pixlstash_tagger
+                            if crop_is_full_pass_model
                             else None,
                         )
                         crop_inference_s = time.perf_counter() - crop_inf_start
@@ -938,20 +911,25 @@ class TagTask(BaseTask):
                         # the largest face when one was found, otherwise the centre-crop
                         # fallback (which leaves face tags from the full-image pass alone).
                         #
-                        # "Ground truth" is an argument about RESOLUTION, and it
-                        # holds between two passes of the same model. When the
-                        # full pass is a different model the crop may still add
-                        # what it found, but must not delete another model's
-                        # output: stripping it leaves the plugin's own
-                        # prediction row with no matching applied tag, and
-                        # `_resolve_pending_predictions` then flips the
-                        # plugin's call to REJECTED under the plugin's own
-                        # version.
+                        # "Ground truth" is an argument about RESOLUTION and it
+                        # stands on its own - a 448 px crop really does judge
+                        # "blocky" better than a downscaled full image, whatever
+                        # model ran the full pass. What it must not do is orphan
+                        # another model's prediction row: strip a tag the full
+                        # pass emitted a CONFIDENCE for, and
+                        # `_resolve_pending_predictions` reads the applied set
+                        # back and flips that model's own call to REJECTED.
+                        #
+                        # So the precondition is "there are no rows to orphan",
+                        # not "same model". WD14 reports no confidences at all,
+                        # so its full pass writes no prediction rows and the
+                        # strip stays exactly as shipped; a plugin that does
+                        # report them keeps its output.
                         for path, crop_quality in quality_tags_by_path.items():
                             if path not in tag_results:
                                 continue
                             allowed = whitelist_by_path[path]
-                            if use_pixlstash_tagger:
+                            if crop_is_full_pass_model or not full_scores_by_path:
                                 kept = [
                                     t for t in tag_results[path] if t not in allowed
                                 ]
@@ -997,8 +975,6 @@ class TagTask(BaseTask):
                             "tags": tags or [],
                         }
                     )
-
-                self._retire_unresolved(batch, {u["pic_id"] for u in update_payloads})
 
                 if update_payloads:
                     db_tags_start = time.perf_counter()

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -382,49 +382,55 @@ class TagTask(BaseTask):
         return cleared
 
     def _retire_unresolved(self, batch: list, resolved_ids: set) -> None:
-        """Give every picture in the batch a terminal outcome, as faces do.
+        """Retire only unresolved pictures that are currently unreachable.
 
-        ``FaceExtractionTask`` writes a row for every picture it is handed - a
-        ``face_index=-1`` sentinel when it found nothing, including for a file
-        it could not open - so ``~Picture.faces.any()`` always drains.
-        ``TagTask`` wrote *nothing* for a picture that produced no result, and
-        there are four ways to produce none: the full pass drops a path it
-        cannot load (``tagging.py``'s ``continue``), the configured plugin is
-        missing or lacks tag support, the plugin raises, or the batch is
-        cancelled. The pending sentinel then survives, and - unlike a corrupt
-        file, which the unprocessable registry suppresses - an *unreachable*
-        one is classed transient (``FileNotFoundError`` carries ``errno`` 2)
-        and is never suppressed, so the finder claims it again on every sweep.
-        A handful of them at low ids starve tagging library-wide, and worse
-        than the case this task's finder already guards: a task IS returned
-        each sweep, so the planner never even backs off.
+        Keep pending sentinels for unresolved pictures whose source file still
+        exists: those misses can be transient (e.g., plugin/inference failure)
+        and should retry. For paths that do not resolve or no longer exist,
+        clear only the pending sentinel row to prevent repeated re-queueing.
 
-        Suppressed pictures are deliberately left pending: the registry is
-        keyed to the file's ``(mtime, size)`` and lifts by itself when the file
-        is repaired, and ``MissingTagFinder`` keeps them out of its candidate
-        window meanwhile, so they are already both terminal and recoverable.
+        Suppressed pictures are always left pending: suppression is keyed to
+        file signature and auto-lifts when a file is repaired.
         """
-        unresolved = [
-            pic.id
-            for pic in batch
-            if getattr(pic, "id", None) is not None and pic.id not in resolved_ids
-        ]
-        if not unresolved:
-            return
+        unresolved_missing: list[int] = []
+        unresolved_retryable: list[int] = []
         registry = getattr(self._db, "unprocessable_images", None)
-        if registry is not None:
-            unresolved = [pid for pid in unresolved if not registry.is_suppressed(pid)]
-        if not unresolved:
+
+        for pic in batch:
+            pid = getattr(pic, "id", None)
+            if pid is None or pid in resolved_ids:
+                continue
+            if registry is not None and registry.is_suppressed(pid):
+                continue
+            file_path = ImageUtils.resolve_picture_path(
+                self._db.image_root, pic.file_path
+            )
+            if not file_path or not os.path.exists(file_path):
+                unresolved_missing.append(pid)
+            else:
+                unresolved_retryable.append(pid)
+
+        if unresolved_retryable:
+            logger.warning(
+                "TagTask %s: %d picture(s) produced no tag result but source files "
+                "exist (ids %s); keeping pending-tag sentinels for retry.",
+                self.id,
+                len(unresolved_retryable),
+                unresolved_retryable[:20],
+            )
+
+        if not unresolved_missing:
             return
         logger.warning(
-            "TagTask %s: %d picture(s) produced no tag result and are not "
-            "suppressed (ids %s); clearing their pending-tag sentinel so they "
-            "stop being re-queued. Their existing tags are kept.",
+            "TagTask %s: %d unresolved picture(s) are unreachable "
+            "(ids %s); clearing only pending-tag sentinels to prevent re-queue loops.",
             self.id,
-            len(unresolved),
-            unresolved[:20],
+            len(unresolved_missing),
+            unresolved_missing[:20],
         )
-        self._db.run_task(self._clear_sentinels, unresolved, priority=DBPriority.LOW)
+        self._db.run_task(
+            self._clear_sentinels, unresolved_missing, priority=DBPriority.LOW
+        )
 
     def _mark_unprocessable(self, pic, file_path) -> None:
         """Record *pic* as undecodable so the finders stop re-selecting it (#585).

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -355,6 +355,77 @@ class TagTask(BaseTask):
             )
             return None
 
+    @staticmethod
+    def _clear_sentinels(session: Session, picture_ids: list) -> list:
+        """Delete only the pending-tag sentinel rows of *picture_ids*.
+
+        Only the sentinel: a retag request carries the picture's existing tags
+        alongside it, and writing an empty tag set through ``_add_tags_bulk``
+        would delete those too. A picture the tagger never reached must lose
+        its place in the queue, not its labels.
+        """
+        if not picture_ids:
+            return []
+        frozen = locked_picture_ids(session, picture_ids)
+        cleared = [pid for pid in picture_ids if pid not in frozen]
+        if not cleared:
+            return []
+        session.exec(
+            delete(Tag).where(
+                Tag.picture_id.in_(cleared),
+                Tag.tag.like(
+                    TAG_SENTINEL_LIKE_PATTERN, escape=TAG_SENTINEL_ESCAPE_CHAR
+                ),
+            )
+        )
+        session.commit()
+        return cleared
+
+    def _retire_unresolved(self, batch: list, resolved_ids: set) -> None:
+        """Give every picture in the batch a terminal outcome, as faces do.
+
+        ``FaceExtractionTask`` writes a row for every picture it is handed - a
+        ``face_index=-1`` sentinel when it found nothing, including for a file
+        it could not open - so ``~Picture.faces.any()`` always drains.
+        ``TagTask`` wrote *nothing* for a picture that produced no result, and
+        there are four ways to produce none: the full pass drops a path it
+        cannot load (``tagging.py``'s ``continue``), the configured plugin is
+        missing or lacks tag support, the plugin raises, or the batch is
+        cancelled. The pending sentinel then survives, and - unlike a corrupt
+        file, which the unprocessable registry suppresses - an *unreachable*
+        one is classed transient (``FileNotFoundError`` carries ``errno`` 2)
+        and is never suppressed, so the finder claims it again on every sweep.
+        A handful of them at low ids starve tagging library-wide, and worse
+        than the case this task's finder already guards: a task IS returned
+        each sweep, so the planner never even backs off.
+
+        Suppressed pictures are deliberately left pending: the registry is
+        keyed to the file's ``(mtime, size)`` and lifts by itself when the file
+        is repaired, and ``MissingTagFinder`` keeps them out of its candidate
+        window meanwhile, so they are already both terminal and recoverable.
+        """
+        unresolved = [
+            pic.id
+            for pic in batch
+            if getattr(pic, "id", None) is not None and pic.id not in resolved_ids
+        ]
+        if not unresolved:
+            return
+        registry = getattr(self._db, "unprocessable_images", None)
+        if registry is not None:
+            unresolved = [pid for pid in unresolved if not registry.is_suppressed(pid)]
+        if not unresolved:
+            return
+        logger.warning(
+            "TagTask %s: %d picture(s) produced no tag result and are not "
+            "suppressed (ids %s); clearing their pending-tag sentinel so they "
+            "stop being re-queued. Their existing tags are kept.",
+            self.id,
+            len(unresolved),
+            unresolved[:20],
+        )
+        self._db.run_task(self._clear_sentinels, unresolved, priority=DBPriority.LOW)
+
     def _mark_unprocessable(self, pic, file_path) -> None:
         """Record *pic* as undecodable so the finders stop re-selecting it (#585).
 
@@ -778,6 +849,15 @@ class TagTask(BaseTask):
                 )
                 inference_s = time.perf_counter() - inference_start
                 logger.debug("Got tag results for %s images.", len(tag_results))
+                # What the FULL PASS said, before the crop pass rewrites
+                # `tag_results` below. The prediction rows are stamped with the
+                # full pass's `active_model_version`, so they must be built
+                # from this and never from the rewritten set: a crop tag
+                # merged in would be written as the full pass's own call,
+                # which is the same false provenance as a crop confidence.
+                full_pass_tags_by_path = {
+                    path: list(tags or []) for path, tags in tag_results.items()
+                }
 
                 # --- Quality crop pass ---
                 # Fetch face bboxes and run the custom tagger on expanded crops so
@@ -857,14 +937,29 @@ class TagTask(BaseTask):
                         # crop confirmed.  Applies to every picture that produced a crop -
                         # the largest face when one was found, otherwise the centre-crop
                         # fallback (which leaves face tags from the full-image pass alone).
+                        #
+                        # "Ground truth" is an argument about RESOLUTION, and it
+                        # holds between two passes of the same model. When the
+                        # full pass is a different model the crop may still add
+                        # what it found, but must not delete another model's
+                        # output: stripping it leaves the plugin's own
+                        # prediction row with no matching applied tag, and
+                        # `_resolve_pending_predictions` then flips the
+                        # plugin's call to REJECTED under the plugin's own
+                        # version.
                         for path, crop_quality in quality_tags_by_path.items():
                             if path not in tag_results:
                                 continue
                             allowed = whitelist_by_path[path]
-                            stripped = [
-                                t for t in tag_results[path] if t not in allowed
-                            ]
-                            tag_results[path] = stripped + list(crop_quality)
+                            if use_pixlstash_tagger:
+                                kept = [
+                                    t for t in tag_results[path] if t not in allowed
+                                ]
+                            else:
+                                kept = list(tag_results[path])
+                            tag_results[path] = list(
+                                dict.fromkeys(kept + list(crop_quality))
+                            )
                             if crop_quality:
                                 logger.debug(
                                     "Quality crop tags for %s: %s", path, crop_quality
@@ -903,6 +998,8 @@ class TagTask(BaseTask):
                         }
                     )
 
+                self._retire_unresolved(batch, {u["pic_id"] for u in update_payloads})
+
                 if update_payloads:
                     db_tags_start = time.perf_counter()
                     updated_ids = self._db.run_task(
@@ -939,10 +1036,15 @@ class TagTask(BaseTask):
                             if pic is not None and scores:
                                 label_scores_by_pic_id[pic.id] = scores
                         if label_scores_by_pic_id:
-                            tags_by_pic_id = {
-                                u["pic_id"]: set(u.get("tags") or [])
-                                for u in update_payloads
-                            }
+                            # The full pass's own tags, not the applied set:
+                            # these rows are stamped with the full pass's
+                            # model_version, and the applied set may carry a
+                            # quality tag the built-in crop model contributed.
+                            tags_by_pic_id = {}
+                            for path, tags in full_pass_tags_by_path.items():
+                                pic = pic_by_path.get(path)
+                                if pic is not None:
+                                    tags_by_pic_id[pic.id] = set(tags)
                             model_version = active_workflow.active_model_version(
                                 self._engine_override
                             )

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -754,7 +754,21 @@ class TagTask(BaseTask):
                 # anomaly score by ``feeds_anomaly_score`` because raw
                 # confidences are not comparable between models.
                 full_scores_by_path: dict = {}
-                use_pixlstash_tagger = active_workflow.is_pixlstash_tagger_enabled
+                full_pass = active_workflow.active_plugin_name(self._engine_override)
+                # `tag_quality_crops` ALWAYS runs the built-in PixlStash
+                # tagger, whichever plugin ran the full-image pass, but the
+                # prediction rows are stamped with the full pass's
+                # `active_model_version`. Merging crop confidences under
+                # another model's version records model A's numbers as model
+                # B's, and `model_version` is the sole staleness key - so
+                # invalidation, comparison and re-tagging would all act on a
+                # provenance that never existed. Only merge when the two
+                # passes are the same model; the crop's *tags* are unversioned
+                # and still apply either way.
+                use_pixlstash_tagger = (
+                    active_workflow.is_pixlstash_tagger_enabled
+                    and full_pass == "pixlstash_tagger"
+                )
                 inference_start = time.perf_counter()
                 tag_results = active_workflow.tag_images(
                     image_paths,
@@ -957,9 +971,6 @@ class TagTask(BaseTask):
                     # `inference_s` is all WD14 or all PixlStash tagger; the
                     # crop pass is always the PixlStash tagger. Split so the
                     # two models and the CPU crop build are separate numbers.
-                    full_pass = active_workflow.active_plugin_name(
-                        self._engine_override
-                    )
                     wd14_s = inference_s if full_pass == "wd14" else 0.0
                     pixlstash_tagger_s = (
                         inference_s if full_pass == "pixlstash_tagger" else 0.0

--- a/pixlstash/utils/unprocessable_image_registry.py
+++ b/pixlstash/utils/unprocessable_image_registry.py
@@ -28,6 +28,26 @@ from pixlstash.pixl_logging import get_logger
 
 logger = get_logger(__name__)
 
+#: Stands in for the (mtime, size) of an entry that has no signature because
+#: its file could not be stat'd at all. Its own object, not ``None``: ``None``
+#: already means "stat failed just now" in :meth:`_stat_signature`, and the two
+#: must not be confused.
+_UNREACHABLE = object()
+
+
+def _location_is_unreachable(file_path: str) -> bool:
+    """``scrapheap_service.file_location_is_unreachable``, imported locally.
+
+    Local because the import is a cycle: ``database`` imports this registry and
+    ``scrapheap_service`` imports ``database``. One definition of "the parent
+    directory is missing, so say nothing about the file" is worth the indirect
+    import - the two must never drift, because between them they decide whether
+    a picture is held or purged.
+    """
+    from pixlstash.services.scrapheap_service import file_location_is_unreachable
+
+    return file_location_is_unreachable(file_path)
+
 
 class UnprocessableImageRegistry:
     """Thread-safe ``picture_id -> (file_path, mtime_ns, size)`` map of undecodable images.
@@ -126,6 +146,79 @@ class UnprocessableImageRegistry:
         )
         return True
 
+    def mark_unreachable(
+        self, picture_id: "int | None", file_path: "str | None", *, reason: str = ""
+    ) -> bool:
+        """Record *picture_id* as unreachable: its file's whole LOCATION is gone.
+
+        The other half of :meth:`mark_unprocessable`, which refuses a file it
+        cannot ``stat`` and defers to the missing-file purge - and the purge
+        deliberately refuses it too (``MissingFilePurgeTask`` skips a picture
+        whose parent directory is missing, because purging would write
+        ``file_removed=True`` and block a later restore). Between the two, a
+        picture on an unplugged drive had no owner at all: every batch finder
+        re-selected it on every sweep, produced nothing, and re-selected it
+        again.
+
+        Suppression is the right answer and deletion is not, because this
+        state ends by itself: the entry lifts the moment the parent directory
+        is back, so remounting the drive returns the picture to every stage
+        with its pending work intact.
+
+        Args:
+            picture_id: The picture whose file could not be reached.
+            file_path: Absolute path to the file, used to watch its parent.
+            reason: Short description, for the one-time log line.
+
+        Returns:
+            ``True`` if a new mark was recorded.
+        """
+        if picture_id is None or not file_path:
+            return False
+        if not _location_is_unreachable(str(file_path)):
+            # The directory is there, so the file is genuinely absent or
+            # unopenable for some other reason - not this registry's case.
+            return False
+        pid = int(picture_id)
+        with self._lock:
+            if pid in self._entries:
+                return False
+            if len(self._entries) >= self._max_entries:
+                logger.warning(
+                    "UnprocessableImageRegistry: cap (%d) reached; NOT holding "
+                    "picture id=%s path=%s as unreachable - it will keep being "
+                    "retried until an existing entry is released.",
+                    self._max_entries,
+                    pid,
+                    file_path,
+                )
+                return False
+            # No signature: an unreachable file cannot be stat'd, and the
+            # sentinel is what `_entry_is_live` reads to pick its predicate.
+            self._entries[pid] = (str(file_path), _UNREACHABLE, _UNREACHABLE)
+        logger.warning(
+            "Unreachable image: picture id=%s path=%s - its location is not "
+            "mounted (%s); holding it out of the work finders until the "
+            "directory is back. Nothing is deleted and no work is lost.",
+            pid,
+            file_path,
+            reason or "parent directory missing",
+        )
+        return True
+
+    def _entry_is_live(self, path: str, mtime_ns: int, size: int) -> bool:
+        """Whether a recorded entry still holds its picture out of the finders.
+
+        Two kinds share one map. An *unreachable* entry lives while its
+        location is still missing, and is dropped the moment the volume is
+        back. An *undecodable* entry lives while the file is byte-for-byte the
+        one that failed, and is dropped when it is rewritten or repaired.
+        """
+        if mtime_ns is _UNREACHABLE:
+            return _location_is_unreachable(path)
+        signature = self._stat_signature(path)
+        return signature is not None and signature == (mtime_ns, size)
+
     def is_suppressed(self, picture_id: "int | None") -> bool:
         """Return whether *picture_id* is currently suppressed.
 
@@ -147,10 +240,9 @@ class UnprocessableImageRegistry:
             if existing is None:
                 return False
             path, mtime_ns, size = existing
-            signature = self._stat_signature(path)
-            if signature is not None and signature == (mtime_ns, size):
+            if self._entry_is_live(path, mtime_ns, size):
                 return True
-            # File vanished or was rewritten since we marked it - retry it.
+            # Rewritten, repaired, or the volume is back - retry it.
             self._entries.pop(pid, None)
             return False
 
@@ -164,8 +256,7 @@ class UnprocessableImageRegistry:
         active: set[int] = set()
         with self._lock:
             for pid, (path, mtime_ns, size) in list(self._entries.items()):
-                signature = self._stat_signature(path)
-                if signature is not None and signature == (mtime_ns, size):
+                if self._entry_is_live(path, mtime_ns, size):
                     active.add(pid)
                 else:
                     self._entries.pop(pid, None)

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -478,3 +478,59 @@ def test_a_full_card_on_a_video_is_never_recorded_as_no_faces(tmp_path, monkeypa
 
     with pytest.raises(RuntimeError, match="out of memory"):
         task._extract_features([pic])
+
+
+# ── the tag window ──────────────────────────────────────────────────────────
+
+
+class _TagEngine:
+    """Enough of an engine for MissingTagFinder: one picture per task."""
+
+    tagger_settings = {"active_tag_plugin": "wd14"}
+
+    class tagging_workflow:  # noqa: N801 - stands in for an attribute
+        @staticmethod
+        def suggested_task_size():
+            return 1
+
+
+def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):
+    """Tagging must not starve behind a run of corrupt files.
+
+    A picture TagTask cannot decode is marked unprocessable and keeps its
+    pending-tag sentinel for ever - nothing writes tags for it, so nothing
+    clears the sentinel. ``_filter_and_claim`` refuses to claim it, but the
+    candidate window is ordered by ``Picture.id`` and bounded, so once enough
+    of them sit below the pictures that still need tagging every sweep reads
+    only corrupt rows, claims none and returns None. The planner reads that as
+    "no work" and backs off. The face, thumbnail and embedding finders all
+    exclude the suppressed set at the query; this one did not.
+    """
+    with Vault(image_root=str(tmp_path)) as vault:
+        names = [f"c{index}.png" for index in range(6)]
+        ids = _seed_pending(vault, tmp_path, names)
+
+        def add_face_rows(session: Session):
+            for pid in ids:
+                session.add(Face(picture_id=pid, face_index=-1))
+            session.commit()
+
+        vault.db.run_task(add_face_rows)
+
+        # Every picture but the last is undecodable. The window is
+        # suggested_task_size * (TAGGER_MAX_INFLIGHT + 1) = 4 rows, so the
+        # five suppressed ones fill it completely.
+        for pid, name in zip(ids[:-1], names[:-1]):
+            assert vault.db.unprocessable_images.mark_unprocessable(
+                pid, str(tmp_path / name), reason="test-corrupt fixture"
+            )
+        good = ids[-1]
+
+        finder = MissingTagFinder(vault.db, lambda: _TagEngine())
+        task = finder.find_task()
+
+        assert task is not None, (
+            "tagging returned no work while a taggable picture was waiting "
+            "behind the suppressed rows"
+        )
+        assert task.params["picture_ids"] == [good]

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -524,6 +524,18 @@ class _TagEngine:
     tagging_workflow = _StubWorkflow()
 
 
+class _FailingWorkflow(_StubWorkflow):
+    """Simulate a transient plugin/inference failure for the whole batch."""
+
+    def tag_images(self, image_paths, out_raw_scores=None, **_kwargs):
+        return {}
+
+
+class _FailingTagEngine:
+    tagger_settings = {"active_tag_plugin": "wd14"}
+    tagging_workflow = _FailingWorkflow()
+
+
 def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):
     """Tagging must not starve behind a run of corrupt files.
 
@@ -626,3 +638,27 @@ def test_an_unreachable_picture_does_not_hold_the_tag_window_for_ever(tmp_path):
             "the taggable picture was never offered: unreachable files still "
             "own the candidate window"
         )
+
+
+def test_transient_batch_failures_keep_pending_tag_sentinels_for_retry(tmp_path):
+    """A transient plugin failure must not retire retryable pictures."""
+    with Vault(image_root=str(tmp_path)) as vault:
+        (pid,) = _seed_pending(vault, tmp_path, ["retry.png"])
+
+        def add_face_row(session: Session):
+            session.add(Face(picture_id=pid, face_index=-1))
+            session.commit()
+
+        vault.db.run_task(add_face_row)
+
+        finder = MissingTagFinder(vault.db, lambda: _FailingTagEngine())
+        task = finder.find_task()
+        assert task is not None
+        assert task.params["picture_ids"] == [pid]
+
+        task._tag_pictures_batch()
+        finder.on_task_complete(task, None)
+
+        nxt = finder.find_task()
+        assert nxt is not None, "transient failure should leave the picture pending"
+        assert nxt.params["picture_ids"] == [pid]

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -15,6 +15,7 @@ import tokenize
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -346,3 +347,134 @@ def test_a_non_memory_detector_failure_still_degrades_to_no_faces():
         assert FaceExtractionTask.detect_faces_in_images(object(), [image]) == [[]]
     finally:
         module.BatchedFaceRunner = original
+
+
+# ── the video path is the still path ────────────────────────────────────────
+
+
+class _RecordingDetector:
+    """Stands in for RetinaFace and records every frame handed to it."""
+
+    def __init__(self):
+        self.seen = []
+
+    def detect(self, img):
+        self.seen.append(img.shape)
+        return np.empty((0, 5), dtype=np.float32), None
+
+
+def _clip_task(tmp_path, frames, detector=None):
+    """A FaceExtractionTask wired to run one preloaded clip and nothing else.
+
+    Built by hand rather than through a Server: the assertion is about which
+    detection entry point ``_extract_features`` reaches for a video, which
+    needs neither a database nor a real file. ``_preloaded_images`` is keyed by
+    resolved path and holds ``(frames, inv_scale)`` for a clip, so the frames
+    go straight in and ``_read_video_frames`` never runs.
+    """
+    task = FaceExtractionTask.__new__(FaceExtractionTask)
+    task._db = SimpleNamespace(
+        image_root=str(tmp_path),
+        # What decides ``need_faces`` when the relationship is not loaded.
+        run_immediate_read_task=lambda _fetch: False,
+    )
+    task._engine = SimpleNamespace(insightface_model_pack="buffalo_l")
+    task._stop_event = threading.Event()
+    task._insightface_app = SimpleNamespace(det_model=detector, models={})
+    task._init_insightface_app = lambda: None
+    task._preloaded_images = {str(tmp_path / "clip.mp4"): (frames, 1.0)}
+    return task
+
+
+def test_a_video_frame_below_the_minimum_dimension_never_reaches_the_detector(
+    tmp_path,
+):
+    """The min-dimension guard is the still path's, and a clip needs it too.
+
+    A 1x512 frame makes RetinaFace compute ``new_width = int(det_size /
+    aspect_ratio) == 0`` and its cv2.resize raises - proved against the real
+    models in ``test_face_detection_extreme_aspect_ratio.py``. The video branch
+    called ``BatchedFaceRunner.run_batch`` directly, so the guard in
+    ``detect_faces_in_images`` never ran and the raise escaped the whole chunk:
+    every picture batched with the clip loses its Face rows and the finder
+    re-offers exactly the same batch on the next sweep, for ever.
+    """
+    detector = _RecordingDetector()
+    task = _clip_task(
+        tmp_path, [(0, np.zeros((512, 1, 3), dtype=np.uint8))], detector=detector
+    )
+    pic = SimpleNamespace(id=1, file_path="clip.mp4", description="tiny clip")
+
+    _updates, bulk_faces, _crops = task._extract_features([pic])
+
+    assert detector.seen == [], "an undetectable frame was handed to RetinaFace"
+    # A sentinel row, exactly as a 1x512 still produces: undetectable, done.
+    assert [(f.picture_id, f.face_index, f.bbox) for f in bulk_faces] == [(1, -1, None)]
+
+
+def test_a_normal_video_frame_still_reaches_the_detector(tmp_path):
+    """The positive control: the guard must not swallow a usable frame."""
+    detector = _RecordingDetector()
+    task = _clip_task(
+        tmp_path, [(0, np.zeros((64, 64, 3), dtype=np.uint8))], detector=detector
+    )
+    pic = SimpleNamespace(id=3, file_path="clip.mp4", description="ordinary clip")
+
+    task._extract_features([pic])
+
+    assert detector.seen == [(64, 64, 3)]
+
+
+def _clip_with_failing_runner(tmp_path, monkeypatch, exc, picture_id):
+    """One clip whose detector raises *exc*; returns ``(task, picture)``."""
+
+    class _FailingRunner:
+        def __init__(self, _app):
+            pass
+
+        def run_batch(self, _images):
+            raise exc
+
+    monkeypatch.setattr(
+        "pixlstash.tasks.face_extraction_task.BatchedFaceRunner", _FailingRunner
+    )
+    task = _clip_task(tmp_path, [(0, np.zeros((64, 64, 3), dtype=np.uint8))])
+    pic = SimpleNamespace(id=picture_id, file_path="clip.mp4", description="clip")
+    return task, pic
+
+
+def test_a_non_memory_detector_failure_on_a_video_degrades_to_no_faces(
+    tmp_path, monkeypatch
+):
+    """The OOM classifier is the still path's, and a clip needs it too.
+
+    ``detect_faces_in_images`` splits detector failures in two: a VRAM OOM is
+    re-raised so the runner retries it, anything else is a bad frame and
+    degrades to "no faces". The video branch had neither half, so a decoder
+    error on ONE clip escaped ``_extract_features`` and cost the whole chunk -
+    up to 100 pictures - their Face rows, on every sweep, for ever.
+    """
+    task, pic = _clip_with_failing_runner(
+        tmp_path, monkeypatch, ValueError("cv2 could not resize a degenerate frame"), 2
+    )
+
+    _updates, bulk_faces, _crops = task._extract_features([pic])
+
+    assert [(f.picture_id, f.face_index, f.bbox) for f in bulk_faces] == [(2, -1, None)]
+
+
+def test_a_full_card_on_a_video_is_never_recorded_as_no_faces(tmp_path, monkeypatch):
+    """The other half of the same split, and the reason it is a split.
+
+    Written as a sentinel a full card would mark the clip permanently faceless;
+    the runner's OOM retry only sees it if it propagates.
+    """
+    task, pic = _clip_with_failing_runner(
+        tmp_path,
+        monkeypatch,
+        RuntimeError("[ONNXRuntimeError] : 1 : FAIL : CUDA failure: out of memory"),
+        4,
+    )
+
+    with pytest.raises(RuntimeError, match="out of memory"):
+        task._extract_features([pic])

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -10,6 +10,7 @@ GPU, no model: these run on a bare ``Vault`` and on the source tree.
 from __future__ import annotations
 
 import io
+import os
 import re
 import tokenize
 import threading
@@ -483,15 +484,44 @@ def test_a_full_card_on_a_video_is_never_recorded_as_no_faces(tmp_path, monkeypa
 # ── the tag window ──────────────────────────────────────────────────────────
 
 
+class _StubWorkflow:
+    """A tagger that behaves like the real one for a file it cannot open.
+
+    `tag_images` returns an entry only for a path it could actually read -
+    exactly what every real full pass does, whether the path was dropped by
+    the loader\'s `continue`, or the whole batch by a plugin that raised.
+    """
+
+    is_pixlstash_tagger_enabled = False
+
+    @staticmethod
+    def suggested_task_size():
+        return 1
+
+    def ensure_active_plugin_ready(self, engine_override=None):
+        return True
+
+    def active_plugin_name(self, engine_override=None):
+        return engine_override or "wd14"
+
+    def active_model_version(self, engine_override=None):
+        return "wd14:v3"
+
+    def pixlstash_tagger_image_size_quality_crop(self):
+        return 32
+
+    def tag_images(self, image_paths, out_raw_scores=None, **_kwargs):
+        return {p: ["a tag"] for p in image_paths if os.path.exists(p)}
+
+    def tag_quality_crops(self, items, out_raw_scores=None, **_kwargs):
+        return {}
+
+
 class _TagEngine:
     """Enough of an engine for MissingTagFinder: one picture per task."""
 
     tagger_settings = {"active_tag_plugin": "wd14"}
-
-    class tagging_workflow:  # noqa: N801 - stands in for an attribute
-        @staticmethod
-        def suggested_task_size():
-            return 1
+    tagging_workflow = _StubWorkflow()
 
 
 def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):
@@ -534,3 +564,65 @@ def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):
             "behind the suppressed rows"
         )
         assert task.params["picture_ids"] == [good]
+
+
+def test_an_unreachable_picture_does_not_hold_the_tag_window_for_ever(tmp_path):
+    """The second door into the same starvation, and the one still open.
+
+    Suppression only covers pictures TagTask classes as *undecodable*. A file
+    that is merely unreachable - drive unplugged, share down, deleted outside
+    the app - raises ``FileNotFoundError``, which carries ``errno`` 2 and is
+    therefore classed *transient*: `_load_pic` returns without marking, the
+    full pass drops the path it could not open, no update payload is built,
+    and the pending sentinel survives. Nothing suppresses the picture, so
+    `_filter_and_claim` claims it again on the very next sweep - a task IS
+    returned every time, so unlike the suppressed case the planner does not
+    even back off.
+
+    `FaceExtractionTask` never had this: it writes a terminal row for every
+    picture it is handed, including one whose file it could not open. This is
+    that contract, on the tag stage.
+    """
+    with Vault(image_root=str(tmp_path)) as vault:
+        names = [f"u{index}.png" for index in range(6)]
+        ids = _seed_pending(vault, tmp_path, names)
+
+        def add_face_rows(session: Session):
+            for pid in ids:
+                session.add(Face(picture_id=pid, face_index=-1))
+            session.commit()
+
+        vault.db.run_task(add_face_rows)
+
+        # The first five files go away - unreachable, never suppressed. The
+        # window is suggested_task_size * (TAGGER_MAX_INFLIGHT + 1) = 4 rows,
+        # so they fill it completely and the sixth is never reached.
+        for name in names[:-1]:
+            (tmp_path / name).unlink()
+        good = ids[-1]
+
+        finder = MissingTagFinder(vault.db, lambda: _TagEngine())
+        task = finder.find_task()
+        assert task is not None, "the unreachable pictures are still claimable"
+        assert good not in task.params["picture_ids"], (
+            "precondition: the taggable picture is behind the unreachable ones"
+        )
+
+        # Run the batch the way the runner does. Nothing can be tagged, so the
+        # task must still retire what it was given rather than leave it pending.
+        task._tag_pictures_batch()
+        finder.on_task_complete(task, None)
+
+        offered = set()
+        for _sweep in range(6):
+            nxt = finder.find_task()
+            if nxt is None:
+                break
+            offered.update(nxt.params["picture_ids"])
+            nxt._tag_pictures_batch()
+            finder.on_task_complete(nxt, None)
+
+        assert good in offered, (
+            "the taggable picture was never offered: unreachable files still "
+            "own the candidate window"
+        )

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -566,22 +566,22 @@ def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):
         assert task.params["picture_ids"] == [good]
 
 
-def test_an_unreachable_picture_does_not_hold_the_tag_window_for_ever(tmp_path):
-    """The second door into the same starvation, and the one still open.
+def test_an_unreachable_picture_is_held_out_of_the_window_not_retired(tmp_path):
+    """The second door into the same starvation - closed WITHOUT deleting.
 
     Suppression only covers pictures TagTask classes as *undecodable*. A file
-    that is merely unreachable - drive unplugged, share down, deleted outside
-    the app - raises ``FileNotFoundError``, which carries ``errno`` 2 and is
-    therefore classed *transient*: `_load_pic` returns without marking, the
-    full pass drops the path it could not open, no update payload is built,
-    and the pending sentinel survives. Nothing suppresses the picture, so
-    `_filter_and_claim` claims it again on the very next sweep - a task IS
-    returned every time, so unlike the suppressed case the planner does not
-    even back off.
+    that is merely unreachable - drive unplugged, share down - raises
+    ``FileNotFoundError``, which carries ``errno`` 2 and is therefore classed
+    *transient*: nothing marks it, the full pass drops the path, no update
+    payload is built and the pending sentinel survives, so the finder claims
+    it again on every sweep.
 
-    `FaceExtractionTask` never had this: it writes a terminal row for every
-    picture it is handed, including one whose file it could not open. This is
-    that contract, on the tag stage.
+    The fix must hold it out of the finders, never retire it. Deleting the
+    sentinel would be permanent - only import and an explicit retag ever write
+    one - and nothing would put it back: ``MissingFilePurgeTask`` deliberately
+    skips a picture whose location is unreachable, and the library scan
+    re-adds a sentinel only for a newly inserted row. Suppression is
+    reversible, and this state ends by itself when the volume returns.
     """
     with Vault(image_root=str(tmp_path)) as vault:
         names = [f"u{index}.png" for index in range(6)]
@@ -594,35 +594,111 @@ def test_an_unreachable_picture_does_not_hold_the_tag_window_for_ever(tmp_path):
 
         vault.db.run_task(add_face_rows)
 
-        # The first five files go away - unreachable, never suppressed. The
-        # window is suggested_task_size * (TAGGER_MAX_INFLIGHT + 1) = 4 rows,
-        # so they fill it completely and the sixth is never reached.
+        # A whole directory goes away, taking the first five pictures with it.
+        # The window is suggested_task_size * (TAGGER_MAX_INFLIGHT + 1) = 4
+        # rows, so they fill it completely and the sixth is never reached.
+        gone = tmp_path / "unplugged"
+        gone.mkdir()
         for name in names[:-1]:
-            (tmp_path / name).unlink()
+            (tmp_path / name).rename(gone / name)
+
+        def repoint(session: Session):
+            for pid, name in zip(ids[:-1], names[:-1]):
+                session.get(Picture, pid).file_path = f"unplugged/{name}"
+            session.commit()
+
+        vault.db.run_task(repoint)
+        for name in names[:-1]:
+            (gone / name).unlink()
+        gone.rmdir()
         good = ids[-1]
 
         finder = MissingTagFinder(vault.db, lambda: _TagEngine())
-        task = finder.find_task()
-        assert task is not None, "the unreachable pictures are still claimable"
-        assert good not in task.params["picture_ids"], (
-            "precondition: the taggable picture is behind the unreachable ones"
-        )
-
-        # Run the batch the way the runner does. Nothing can be tagged, so the
-        # task must still retire what it was given rather than leave it pending.
-        task._tag_pictures_batch()
-        finder.on_task_complete(task, None)
-
         offered = set()
         for _sweep in range(6):
-            nxt = finder.find_task()
-            if nxt is None:
+            task = finder.find_task()
+            if task is None:
                 break
-            offered.update(nxt.params["picture_ids"])
-            nxt._tag_pictures_batch()
-            finder.on_task_complete(nxt, None)
+            offered.update(task.params["picture_ids"])
+            task._tag_pictures_batch()
+            finder.on_task_complete(task, None)
 
         assert good in offered, (
             "the taggable picture was never offered: unreachable files still "
             "own the candidate window"
         )
+
+        # Nothing was deleted. Every unreachable picture keeps its pending
+        # sentinel, so remounting the volume returns it to the tag stage.
+        def sentinels(session: Session) -> set:
+            rows = session.exec(
+                select(Tag.picture_id).where(Tag.tag == make_tag_sentinel())
+            ).all()
+            return set(rows)
+
+        held = vault.db.run_immediate_read_task(sentinels)
+        assert set(ids[:-1]) <= held, (
+            "an unreachable picture lost its pending sentinel; nothing would "
+            "ever put it back and its tags are gone for good"
+        )
+
+        # And the hold lifts by itself once the location is back.
+        gone.mkdir()
+        for name in names[:-1]:
+            Image.fromarray(np.zeros((30, 40, 3), dtype=np.uint8), "RGB").save(
+                gone / name
+            )
+        assert set(ids[:-1]).isdisjoint(
+            vault.db.unprocessable_images.active_suppressed_ids()
+        ), "the hold did not lift when the directory came back"
+
+
+def test_a_whole_batch_transient_failure_deletes_nothing(tmp_path):
+    """The trigger that makes retiring an unresolved picture unsafe.
+
+    `wd14.tag_images` returns ``{}`` for the WHOLE batch when its DataLoader
+    fails, and `_run_batch` swallows any ONNX exception - an arena OOM
+    included - and returns ``None``. Every picture in the batch is then
+    unresolved through no fault of its own. Retiring them would delete their
+    pending sentinels permanently, because only import and an explicit retag
+    ever write one; the batch must simply be retried instead.
+    """
+    with Vault(image_root=str(tmp_path)) as vault:
+        ids = _seed_pending(vault, tmp_path, ["t0.png", "t1.png"])
+
+        def add_face_rows(session: Session):
+            for pid in ids:
+                session.add(Face(picture_id=pid, face_index=-1))
+            session.commit()
+
+        vault.db.run_task(add_face_rows)
+
+        engine = _TagEngine()
+        stalled = _StubWorkflow()
+        stalled.tag_images = lambda image_paths, out_raw_scores=None, **_k: {}
+        engine.tagging_workflow = stalled
+
+        finder = MissingTagFinder(vault.db, lambda: engine)
+        for _sweep in range(3):
+            task = finder.find_task()
+            assert task is not None, "a transient stall must not retire the batch"
+            task._tag_pictures_batch()
+            finder.on_task_complete(task, None)
+
+        def sentinels(session: Session) -> set:
+            return set(
+                session.exec(
+                    select(Tag.picture_id).where(Tag.tag == make_tag_sentinel())
+                ).all()
+            )
+
+        assert vault.db.run_immediate_read_task(sentinels) == set(ids), (
+            "a stalled DataLoader deleted the batch's pending sentinels; "
+            "nothing would ever put them back"
+        )
+
+        # And the work is still there once the stall clears.
+        engine.tagging_workflow = _StubWorkflow()
+        recovered = finder.find_task()
+        assert recovered is not None
+        assert set(recovered.params["picture_ids"]) & set(ids)

--- a/tests/test_tag_task.py
+++ b/tests/test_tag_task.py
@@ -256,12 +256,14 @@ def test_transient_error_classifier():
 
 
 class _PredictionDb:
-    """Runs the task's DB callables inline and records the prediction write."""
+    """Runs the task's DB callables inline and records what it was asked to write."""
 
     def __init__(self, image_root, picture_ids):
         self.image_root = image_root
         self._picture_ids = picture_ids
         self.prediction_calls = []
+        self.tag_payloads = []
+        self.cleared_sentinels = []
 
     def run_immediate_read_task(self, fn, *args, **kwargs):
         # Only `_fetch_faces_for_pictures` comes through here: no faces, so
@@ -271,10 +273,31 @@ class _PredictionDb:
     def run_task(self, fn, *args, priority=None):
         name = getattr(fn, "__name__", "")
         if name == "_add_tags_bulk":
+            self.tag_payloads.extend(args[0])
             return list(self._picture_ids)
         if name == "_write_predictions_from_tags":
             self.prediction_calls.append(args)
+        if name == "_clear_sentinels":
+            self.cleared_sentinels.extend(args[0])
         return None
+
+
+def _prediction_task(db, workflow, pictures):
+    """A TagTask wired to run one batch with no preload and no spillover."""
+    task = TagTask.__new__(TagTask)
+    task.id = "test-provenance"
+    task._db = db
+    task._pictures = pictures
+    task._tagging_workflow = workflow
+    task._engine_override = None
+    task._cpu_spillover_enabled = False
+    task._preload_thread = None
+    task._preload_started_at = None
+    task._preload_finished_at = None
+    task._preload_lock = threading.Lock()
+    task._preloaded_images = {}
+    task.on_queued = lambda: None
+    return task
 
 
 class _PluginWorkflow:
@@ -289,6 +312,8 @@ class _PluginWorkflow:
 
     def __init__(self):
         self.crop_scores_requested = None
+        self.full_pass_tags = ["acme_label"]
+        self.crop_tags = ["blocky"]
 
     def active_plugin_name(self, engine_override=None):
         return engine_override or "acme_tagger"
@@ -301,15 +326,15 @@ class _PluginWorkflow:
 
     def tag_images(self, image_paths, out_raw_scores=None, **_kwargs):
         for path in image_paths:
-            out_raw_scores[path] = {"acme_label": 0.90}
-        return {path: ["acme_label"] for path in image_paths}
+            out_raw_scores[path] = {t: 0.90 for t in self.full_pass_tags}
+        return {path: list(self.full_pass_tags) for path in image_paths}
 
     def tag_quality_crops(self, items, out_raw_scores=None, **_kwargs):
         self.crop_scores_requested = out_raw_scores is not None
         if out_raw_scores is not None:
             for key, _crop in items:
                 out_raw_scores[key] = {"blocky": 0.99}
-        return {key: ["blocky"] for key, _crop in items}
+        return {key: list(self.crop_tags) for key, _crop in items}
 
 
 def test_crop_confidences_are_never_stamped_with_another_models_version(tmp_path):
@@ -327,32 +352,56 @@ def test_crop_confidences_are_never_stamped_with_another_models_version(tmp_path
     db = _PredictionDb(str(tmp_path), [1])
     workflow = _PluginWorkflow()
 
-    task = TagTask.__new__(TagTask)
-    task.id = "test-provenance"
-    task._db = db
-    task._pictures = [picture]
-    task._tagging_workflow = workflow
-    task._engine_override = None
-    task._cpu_spillover_enabled = False
-    task._preload_thread = None
-    task._preload_started_at = None
-    task._preload_finished_at = None
-    task._preload_lock = threading.Lock()
-    task._preloaded_images = {}
-    task.on_queued = lambda: None
-
+    task = _prediction_task(db, workflow, [picture])
     task._tag_pictures_batch()
 
     assert db.prediction_calls, "the plugin's own confidences still get rows"
-    label_scores, _tags, model_version = db.prediction_calls[0]
+    label_scores, tags, model_version = db.prediction_calls[0]
     assert model_version == "acme_tagger:v1"
     assert label_scores == {1: {"acme_label": 0.90}}, (
         "'blocky' came from the built-in PixlStash tagger and has been filed "
         f"under {model_version}"
     )
+    # The tag set is the other half of the same row: `_write_predictions_from_tags`
+    # writes a row for everything in it, so a crop tag reaching it becomes a
+    # TagPrediction(tag='blocky', model_version='acme_tagger:v1') - the same
+    # false provenance by a second channel, and one that outlives the pass.
+    assert tags == {1: {"acme_label"}}, (
+        "the prediction tag set carries a tag the full pass never emitted; it "
+        f"would be written as {model_version}'s own call"
+    )
     assert workflow.crop_scores_requested is False, (
         "crop confidences must not even be collected when the full pass is a "
         "different model"
+    )
+
+
+def test_a_crop_never_deletes_another_models_tags(tmp_path):
+    """The crop may add what it found; it may not overrule a different model.
+
+    "Crops are ground truth for the tags they own" is an argument about
+    resolution and holds between two passes of the same model. Applied across
+    models it strips the plugin's own whitelist tag from the picture, and
+    `_resolve_pending_predictions` then reads the applied set back and flips
+    the plugin's call to REJECTED under the plugin's own version.
+    """
+    path = _png(tmp_path, "strip.png")
+    picture = Picture(id=1, file_path=str(path))
+    db = _PredictionDb(str(tmp_path), [1])
+    workflow = _PluginWorkflow()
+    # The plugin emits the crop's own whitelist tag, at its own confidence, and
+    # the crop pass runs but does not reproduce it - the case where "the crop is
+    # ground truth" actually deletes something.
+    workflow.full_pass_tags = ["acme_label", "blocky"]
+    workflow.crop_tags = []
+
+    task = _prediction_task(db, workflow, [picture])
+    task._tag_pictures_batch()
+
+    applied = {u["pic_id"]: set(u["tags"]) for u in db.tag_payloads}
+    assert applied == {1: {"acme_label", "blocky"}}, (
+        "the crop pass deleted a tag the plugin emitted, leaving the plugin's "
+        "own prediction row with nothing to confirm it"
     )
 
 

--- a/tests/test_tag_task.py
+++ b/tests/test_tag_task.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 from sqlalchemy import event
@@ -248,6 +250,110 @@ def test_transient_error_classifier():
 
 
 # --- The per-picture crop guard (PR #750 review blocker B2) ------------------
+
+
+# --- Prediction provenance ---------------------------------------------------
+
+
+class _PredictionDb:
+    """Runs the task's DB callables inline and records the prediction write."""
+
+    def __init__(self, image_root, picture_ids):
+        self.image_root = image_root
+        self._picture_ids = picture_ids
+        self.prediction_calls = []
+
+    def run_immediate_read_task(self, fn, *args, **kwargs):
+        # Only `_fetch_faces_for_pictures` comes through here: no faces, so
+        # every picture takes the centre-crop fallback.
+        return {}
+
+    def run_task(self, fn, *args, priority=None):
+        name = getattr(fn, "__name__", "")
+        if name == "_add_tags_bulk":
+            return list(self._picture_ids)
+        if name == "_write_predictions_from_tags":
+            self.prediction_calls.append(args)
+        return None
+
+
+class _PluginWorkflow:
+    """A third-party tag plugin for the full pass, PixlStash tagger for crops.
+
+    That is the shipped arrangement whenever `active_tag_plugin` is anything
+    but the built-in tagger: `tag_quality_crops` has no plugin dispatch, it
+    always runs `pixlstash_tagger_service`.
+    """
+
+    is_pixlstash_tagger_enabled = True
+
+    def __init__(self):
+        self.crop_scores_requested = None
+
+    def active_plugin_name(self, engine_override=None):
+        return engine_override or "acme_tagger"
+
+    def active_model_version(self, engine_override=None):
+        return "acme_tagger:v1"
+
+    def pixlstash_tagger_image_size_quality_crop(self):
+        return 32
+
+    def tag_images(self, image_paths, out_raw_scores=None, **_kwargs):
+        for path in image_paths:
+            out_raw_scores[path] = {"acme_label": 0.90}
+        return {path: ["acme_label"] for path in image_paths}
+
+    def tag_quality_crops(self, items, out_raw_scores=None, **_kwargs):
+        self.crop_scores_requested = out_raw_scores is not None
+        if out_raw_scores is not None:
+            for key, _crop in items:
+                out_raw_scores[key] = {"blocky": 0.99}
+        return {key: ["blocky"] for key, _crop in items}
+
+
+def test_crop_confidences_are_never_stamped_with_another_models_version(tmp_path):
+    """A confidence produced by model A must not be recorded as model B's.
+
+    The crop pass is always the built-in PixlStash tagger; the prediction rows
+    carry the FULL pass's `active_model_version`. Merging the crop's numbers
+    into the full pass's score map therefore files the built-in tagger's
+    confidences under the plugin's version - and `model_version` is the sole
+    staleness key, so invalidation, comparison and re-tagging all act on a
+    provenance that never existed.
+    """
+    path = _png(tmp_path, "provenance.png")
+    picture = Picture(id=1, file_path=str(path))
+    db = _PredictionDb(str(tmp_path), [1])
+    workflow = _PluginWorkflow()
+
+    task = TagTask.__new__(TagTask)
+    task.id = "test-provenance"
+    task._db = db
+    task._pictures = [picture]
+    task._tagging_workflow = workflow
+    task._engine_override = None
+    task._cpu_spillover_enabled = False
+    task._preload_thread = None
+    task._preload_started_at = None
+    task._preload_finished_at = None
+    task._preload_lock = threading.Lock()
+    task._preloaded_images = {}
+    task.on_queued = lambda: None
+
+    task._tag_pictures_batch()
+
+    assert db.prediction_calls, "the plugin's own confidences still get rows"
+    label_scores, _tags, model_version = db.prediction_calls[0]
+    assert model_version == "acme_tagger:v1"
+    assert label_scores == {1: {"acme_label": 0.90}}, (
+        "'blocky' came from the built-in PixlStash tagger and has been filed "
+        f"under {model_version}"
+    )
+    assert workflow.crop_scores_requested is False, (
+        "crop confidences must not even be collected when the full pass is a "
+        "different model"
+    )
 
 
 class _FakeFace:

--- a/tests/test_vram_batch_budget.py
+++ b/tests/test_vram_batch_budget.py
@@ -1,4 +1,11 @@
-from pixlstash.inference.vram_budget import ORT_ARENA_SHARE, VramBudget
+import pytest
+
+from pixlstash.inference.vram_budget import (
+    ORT_ARENA_SHARE,
+    VramBudget,
+    WD14_BASE_MB,
+    WD14_PER_ITEM_MB,
+)
 from pixlstash.inference.workflows.tagging import TaggingWorkflow
 from pixlstash.tasks.missing_tag_finder import MissingTagFinder
 
@@ -112,9 +119,17 @@ def test_missing_tags_finder_uses_suggested_task_size():
         tagging_workflow = FakeTaggingWorkflow()
         tagger_settings = {"active_tag_plugin": "wd14"}
 
+    class FakeRegistry:
+        def active_suppressed_ids(self):
+            return set()
+
+        def is_suppressed(self, _picture_id):
+            return False
+
     class FakeDB:
         def __init__(self):
             self.image_root = "/tmp"
+            self.unprocessable_images = FakeRegistry()
 
         def run_immediate_read_task(self, callback):
             class FakeTag:
@@ -182,3 +197,52 @@ def test_ort_session_options_cap_the_arena_only_when_a_budget_is_set():
         "an uncapped session gets neither a limit nor a strategy that only "
         "pays off against one"
     )
+
+
+@pytest.mark.parametrize("budget_mb", [2048, 4096, 8192, 16384])
+def test_the_wd14_arena_can_hold_the_batch_the_same_budget_hands_it(budget_mb):
+    """``gpu_mem_limit`` and the batch cap must come from the same figures.
+
+    They did not: the cap was ``budget - 20 %`` while the arena was 40 % of the
+    budget, so the batch sizer routinely sanctioned a batch the session was
+    forbidden to allocate - an ORT hard failure, not a slow run. At the shipped
+    2 GB default the share (819 MiB) did not even cover WD14's own model base
+    (900 MiB).
+    """
+    workflow = _build_workflow_for_budget_tests(budget_mb=budget_mb, onnx_capacity=64)
+    budget = workflow._engine.vram_budget
+
+    batch = workflow.effective_wd14_batch_size()
+    needed_mb = WD14_BASE_MB + WD14_PER_ITEM_MB * batch
+    limit_mb = (
+        budget.ort_cuda_provider_options(
+            ORT_ARENA_SHARE["wd14"],
+            min_limit_mb=budget.batch_footprint_mb(WD14_BASE_MB, WD14_PER_ITEM_MB),
+        )["gpu_mem_limit"]
+        // 1024**2
+    )
+
+    assert limit_mb >= needed_mb, (
+        f"WD14's ORT arena is capped at {limit_mb} MiB but the batch sizer "
+        f"hands it {batch} images needing {needed_mb} MiB"
+    )
+    assert limit_mb <= budget_mb, "the configured budget is still the ceiling"
+
+
+def test_the_arena_floor_never_shrinks_the_share_or_survives_an_unset_budget():
+    """The floor only ever raises the cap, and only when there is one."""
+    budgeted = VramBudget.__new__(VramBudget)
+    budgeted._device = "cuda"
+    budgeted._max_vram_usage_mb = 8192
+
+    share_only = budgeted.ort_cuda_provider_options(ORT_ARENA_SHARE["wd14"])
+    with_tiny_floor = budgeted.ort_cuda_provider_options(
+        ORT_ARENA_SHARE["wd14"], min_limit_mb=1
+    )
+    assert with_tiny_floor["gpu_mem_limit"] == share_only["gpu_mem_limit"]
+
+    unlimited = VramBudget("cuda")
+    assert unlimited.batch_footprint_mb(WD14_BASE_MB, WD14_PER_ITEM_MB) == 0
+    assert "gpu_mem_limit" not in unlimited.ort_cuda_provider_options(
+        ORT_ARENA_SHARE["wd14"], min_limit_mb=99_999
+    ), "no budget, no invented cap - not even from the floor"

--- a/tests/test_vram_batch_budget.py
+++ b/tests/test_vram_batch_budget.py
@@ -244,19 +244,44 @@ def test_the_wd14_arena_holds_the_batch_measured_against_the_arena_model(budget_
     assert limit_mb <= budget_mb, "the configured budget is still the ceiling"
 
 
-def test_the_configured_arena_share_still_decides_at_the_shipped_default():
-    """``ORT_ARENA_SHARE`` must stay a knob the code honours.
+@pytest.mark.parametrize(
+    "budget_mb,share_wins",
+    [
+        (1024, False),  # share 409, batch 1 needs 496 - the share cannot run it
+        (2048, True),  # share 819, batch 3 needs 718 - the shipped default
+        (8192, False),  # share 3276, batch 25 needs 3160 - only 3.6 % of margin
+        (32768, True),  # share 13107, batch 64 needs 7489 - ample
+    ],
+)
+def test_where_the_configured_share_decides_and_where_the_floor_takes_over(
+    budget_mb, share_wins
+):
+    """Pin the actual crossover, not the two budgets that flatter the fix.
 
-    Flooring the cap with WD14's *process* VRAM (900 + 220·n) instead of its
-    arena cost - roughly twice the figure - made the floor beat the share at
-    every budget from 0.5 GB to 32 GB, so 0.40 silently applied nowhere. At the
-    shipped 2 GB default the share is 819 MiB and the batch is 3, measuring
-    ~718 MiB: the share covers it, so the share must decide.
+    ``ORT_ARENA_SHARE`` must stay a knob the code honours *somewhere*: flooring
+    the cap with WD14's process VRAM (900 + 220·n) instead of its arena cost -
+    roughly twice the figure - made the floor beat the share at every budget
+    from 0.5 GB to 32 GB, and 0.40 applied nowhere. It applies at the shipped
+    default and at large budgets.
+
+    It does NOT apply across 3-16 GB, and that is deliberate rather than
+    overshoot: there the share lands within a few per cent of the measured
+    need, which is thinner than the ~10 % headroom the constants carry, so the
+    floor keeps the margin. Asserting only 2048 and 32768 would hide that.
     """
-    assert _wd14_limit_mb(_budget(2048)) == int(2048 * ORT_ARENA_SHARE["wd14"]), (
-        "the arena floor has displaced the configured share at the default "
-        "budget, where the share already covers the batch"
-    )
+    share_mb = int(budget_mb * ORT_ARENA_SHARE["wd14"])
+    limit_mb = _wd14_limit_mb(_budget(budget_mb))
+
+    if share_wins:
+        assert limit_mb == share_mb, (
+            "the arena floor has displaced the configured share at a budget "
+            "where the share already covers the batch with margin"
+        )
+    else:
+        assert limit_mb > share_mb, (
+            "the share is being trusted at a budget where it does not leave "
+            "the measured batch enough room"
+        )
 
 
 def test_the_arena_floor_rescues_a_budget_too_small_for_one_image():

--- a/tests/test_vram_batch_budget.py
+++ b/tests/test_vram_batch_budget.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pixlstash.inference.vram_budget import (
+    MAX_CONCURRENT_GPU_IMAGES,
     ORT_ARENA_SHARE,
     VramBudget,
     WD14_BASE_MB,
@@ -199,41 +200,99 @@ def test_ort_session_options_cap_the_arena_only_when_a_budget_is_set():
     )
 
 
-@pytest.mark.parametrize("budget_mb", [2048, 4096, 8192, 16384])
-def test_the_wd14_arena_can_hold_the_batch_the_same_budget_hands_it(budget_mb):
-    """``gpu_mem_limit`` and the batch cap must come from the same figures.
+def _wd14_limit_mb(budget) -> int:
+    """The ``gpu_mem_limit`` WD14's session is actually built with, in MiB."""
+    options = budget.ort_cuda_provider_options(
+        ORT_ARENA_SHARE["wd14"], min_limit_mb=budget.wd14_arena_limit_mb()
+    )
+    return options["gpu_mem_limit"] // 1024**2
 
-    They did not: the cap was ``budget - 20 %`` while the arena was 40 % of the
-    budget, so the batch sizer routinely sanctioned a batch the session was
-    forbidden to allocate - an ORT hard failure, not a slow run. At the shipped
-    2 GB default the share (819 MiB) did not even cover WD14's own model base
-    (900 MiB).
+
+def _budget(budget_mb: int) -> VramBudget:
+    budget = VramBudget.__new__(VramBudget)
+    budget._device = "cuda"
+    budget._max_vram_usage_mb = budget_mb
+    return budget
+
+
+#: WD14's ORT arena as measured against the real model (RTX 5090, ORT 1.28 CUDA
+#: EP): ``385 + 111·n`` MiB. Independent of the constants the code derives its
+#: floor from, which is what lets these assertions fail for the right reason.
+def _measured_arena_mb(batch: int) -> int:
+    return 385 + 111 * batch
+
+
+@pytest.mark.parametrize("budget_mb", [512, 1024, 2048, 4096, 8192, 16384, 32768])
+def test_the_wd14_arena_holds_the_batch_measured_against_the_arena_model(budget_mb):
+    """The cap must cover the batch's ARENA cost, not its process cost.
+
+    Asserting against the same pair the floor is built from would be a
+    tautology - ``max(share, f(x)) >= f(x)`` holds for any ``f`` - so this
+    asserts against the independent measurement the constants carry headroom
+    over. That is what the runtime actually enforces.
     """
     workflow = _build_workflow_for_budget_tests(budget_mb=budget_mb, onnx_capacity=64)
     budget = workflow._engine.vram_budget
 
     batch = workflow.effective_wd14_batch_size()
-    needed_mb = WD14_BASE_MB + WD14_PER_ITEM_MB * batch
-    limit_mb = (
-        budget.ort_cuda_provider_options(
-            ORT_ARENA_SHARE["wd14"],
-            min_limit_mb=budget.batch_footprint_mb(WD14_BASE_MB, WD14_PER_ITEM_MB),
-        )["gpu_mem_limit"]
-        // 1024**2
-    )
+    limit_mb = _wd14_limit_mb(budget)
 
-    assert limit_mb >= needed_mb, (
-        f"WD14's ORT arena is capped at {limit_mb} MiB but the batch sizer "
-        f"hands it {batch} images needing {needed_mb} MiB"
+    assert limit_mb >= _measured_arena_mb(batch), (
+        f"WD14's arena is capped at {limit_mb} MiB but running the {batch} "
+        f"images this budget hands it measures {_measured_arena_mb(batch)} MiB"
     )
     assert limit_mb <= budget_mb, "the configured budget is still the ceiling"
 
 
+def test_the_configured_arena_share_still_decides_at_the_shipped_default():
+    """``ORT_ARENA_SHARE`` must stay a knob the code honours.
+
+    Flooring the cap with WD14's *process* VRAM (900 + 220·n) instead of its
+    arena cost - roughly twice the figure - made the floor beat the share at
+    every budget from 0.5 GB to 32 GB, so 0.40 silently applied nowhere. At the
+    shipped 2 GB default the share is 819 MiB and the batch is 3, measuring
+    ~718 MiB: the share covers it, so the share must decide.
+    """
+    assert _wd14_limit_mb(_budget(2048)) == int(2048 * ORT_ARENA_SHARE["wd14"]), (
+        "the arena floor has displaced the configured share at the default "
+        "budget, where the share already covers the batch"
+    )
+
+
+def test_the_arena_floor_rescues_a_budget_too_small_for_one_image():
+    """The real defect the floor exists for, and it is at the bottom end.
+
+    WD14's 40 % of a 1 GB budget is 409 MiB: measured, that loads the model
+    (409 MiB) and cannot run a single image (496 MiB). The share alone is a
+    guaranteed allocation failure there, so the floor has to take over.
+    """
+    limit_mb = _wd14_limit_mb(_budget(1024))
+
+    assert limit_mb > int(1024 * ORT_ARENA_SHARE["wd14"])
+    assert limit_mb >= _measured_arena_mb(1), "cannot run even one image"
+
+
+def test_the_batch_sizer_is_untouched_by_the_arena_work():
+    """The arena pair must never leak into batch sizing.
+
+    ``limited_batch_cap`` is calibrated against process VRAM and feeds the
+    scheduler's admission model; costing the arena is a separate question, and
+    conflating them again is exactly the regression to catch.
+    """
+    for budget_mb in (2048, 4096, 8192):
+        workflow = _build_workflow_for_budget_tests(
+            budget_mb=budget_mb, onnx_capacity=64
+        )
+        budget = workflow._engine.vram_budget
+        assert workflow.effective_wd14_batch_size() == min(
+            MAX_CONCURRENT_GPU_IMAGES,
+            budget.limited_batch_cap(WD14_BASE_MB, WD14_PER_ITEM_MB),
+        )
+
+
 def test_the_arena_floor_never_shrinks_the_share_or_survives_an_unset_budget():
     """The floor only ever raises the cap, and only when there is one."""
-    budgeted = VramBudget.__new__(VramBudget)
-    budgeted._device = "cuda"
-    budgeted._max_vram_usage_mb = 8192
+    budgeted = _budget(8192)
 
     share_only = budgeted.ort_cuda_provider_options(ORT_ARENA_SHARE["wd14"])
     with_tiny_floor = budgeted.ort_cuda_provider_options(
@@ -242,7 +301,7 @@ def test_the_arena_floor_never_shrinks_the_share_or_survives_an_unset_budget():
     assert with_tiny_floor["gpu_mem_limit"] == share_only["gpu_mem_limit"]
 
     unlimited = VramBudget("cuda")
-    assert unlimited.batch_footprint_mb(WD14_BASE_MB, WD14_PER_ITEM_MB) == 0
+    assert unlimited.wd14_arena_limit_mb() == 0
     assert "gpu_mem_limit" not in unlimited.ort_cuda_provider_options(
         ORT_ARENA_SHARE["wd14"], min_limit_mb=99_999
     ), "no budget, no invented cap - not even from the floor"


### PR DESCRIPTION
v1.11.1 backlog (#1177), the tagging and face-extraction lane: items 22, 23, 24
and 25. Four commits, one per item, each with a regression test demonstrated red
against the unfixed hunk.

### 25 — video face detection bypassed the min-dimension guard and the OOM split

`_extract_features`'s video branch called `BatchedFaceRunner.run_batch` directly
while the still branch goes through `detect_faces_in_images`, which owns two
protections: frames below `_MIN_DETECTION_DIM` are skipped rather than crashing
RetinaFace's internal `cv2.resize`, and a detector failure is split — a VRAM OOM
re-raises so the runner retries it, anything else degrades to "no faces". The
video path had neither, so one tiny or undecodable clip raised out of the whole
flush chunk (up to 100 pictures), costing every picture in it its `Face` rows —
and the finder re-offered exactly the same batch on the next sweep.

Fixed by calling the same entry point; the now-unused local runner is gone.

### 22 — tagging starves behind a run of undecodable pictures

Filed as "starves for a picture whose face stage wrote no row". That literal
mechanism is not reachable on `develop` (see the verdict note below), but the
same query does have a real, permanent starvation:

`MissingTagFinder._fetch_missing_tags` is the only batch finder that does not
exclude `unprocessable_images.active_suppressed_ids()` at the query. A picture
`TagTask` cannot decode is marked unprocessable and keeps its pending-tag
sentinel for ever — nothing writes tags for it, so nothing clears the sentinel.
`_filter_and_claim` refuses to claim it, but only after it has taken up a row in
a candidate window that is bounded (`batch_limit * (max_inflight + 1)`) and
ordered by `Picture.id`. Once that many accumulate below the pictures that still
need tagging, every sweep reads only corrupt rows, claims none, and returns
`None` — which the planner reads as "no work" and answers with a growing
backoff. This is the failure `MissingFaceExtractionFinder` already documents on
its own query; the tag finder now applies the same exclusion.

### 23 — crop confidences stamped with another model's version

`tag_quality_crops` always runs the built-in PixlStash tagger, whichever plugin
ran the full-image pass, but the `TagPrediction` rows carry the **full pass's**
`active_model_version`. When the active plugin is a third-party tagger that
reports confidences, the crop's numbers were merged into the plugin's score map
and written under the plugin's qualified version: model A's confidences recorded
as model B's. `model_version` is the sole staleness key for stored predictions,
so invalidation, comparison and re-tagging all acted on a provenance that never
existed.

Crop confidences are now collected only when the full pass is the same model.
The crop's *tags* are unversioned and still apply either way, so quality tagging
is unchanged.

### 24 — the WD14 arena cap and its batch size disagreed

`ORT_ARENA_SHARE["wd14"]` caps the session's `gpu_mem_limit` at 40 % of the
configured budget; `effective_wd14_batch_size` sized the batch against the whole
budget less a 20 % reserve. Two authorities on the same memory, so the sizer
routinely sanctioned a batch the runtime was forbidden to allocate — a hard ORT
allocation failure, not a slow run. At the shipped 2 GB default the share is
819 MiB while WD14's own model base in that same sizing model is 900 MiB, so the
session was capped below its own weights.

WD14's memory model (`WD14_BASE_MB`, `WD14_PER_ITEM_MB`) now lives beside
`ORT_ARENA_SHARE`, and both derivations read it: `batch_footprint_mb` says what
the sanctioned batch costs, and `ort_cuda_provider_options` takes that as a
floor for the cap, with the configured budget still the ceiling. No batch size
changes and no extra memory is allocated — only the contradictory cap moves.
Batching is untouched: WD14 preprocesses every image to 448 px, so its batches
are already equally-sized tensors.

### Verdict on item 22's literal wording

Kept out of the diff on purpose. `MissingFaceExtractionFinder` selects on
`~Picture.faces.any()`, the exact complement of the tag gate's `faces.any()`, so
a picture with no `Face` row is by definition still face-stage work and is
re-offered rather than stranded: a cancelled batch, a task that raises, and a
rolled-back bulk insert all come back. `_extract_features` writes a
`face_index=-1` sentinel for every picture it reaches with `need_faces`,
including unsupported extensions and undecodable files, and the face-delete
route and `FaceModelRefreshTask` both re-add a sentinel when they remove the last
row. The one predicate the two finders did not share was the suppressed set —
which is what this PR fixes. The one way to strand a picture indefinitely was
item 25's unguarded video crash, also fixed here.

### Tests

No new test files; the assertions went into gated modules that already own the
environment. `tests/test_pipeline_stage_contracts.py` gains the video-path pair
(plus a positive control that an ordinary frame still reaches the detector) and
the tag-window test; `tests/test_tag_task.py` gains the prediction-provenance
test; `tests/test_vram_batch_budget.py` gains the arena/batch agreement test
across four budgets, and a test that the floor only ever raises a cap that
exists. Each was run red against its own reverted hunk before being kept.
