### PR TITLE
Reset host to loopback when remote access is turned off (#1177 items 65, 63)

### DIFF
--- a/changelog.d/1177-electron-host-reset.md
+++ b/changelog.d/1177-electron-host-reset.md
@@ -1,0 +1,5 @@
+- Fixed: turning remote access off now puts the server back on this machine
+  only. Turning it on had written "listen on every network interface" into the
+  settings file and turning it off left that line behind, so if you later
+  started PixlStash from the command line instead of the desktop app, it came
+  up reachable from the network you had switched off.

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -618,6 +618,14 @@ function showServerLogs(): void {
 /** Port offered for the external listener when the config has none yet. */
 const DEFAULT_EXTERNAL_PORT = 9537;
 
+/**
+ * What `host` goes back to when remote access is turned off. This is the value
+ * `Server.init_server_config` writes into a server config that has no `host`
+ * (`pixlstash/server.py`), so the file ends up saying what a never-enabled one
+ * would have said rather than carrying a desktop-only invention.
+ */
+const LOOPBACK_HOST = 'localhost';
+
 /** This machine's non-loopback IPv4 addresses, for showing reachable URLs. */
 function lanAddresses(): string[] {
   const out: string[] = [];
@@ -691,8 +699,15 @@ async function writeServerSettings(settings: ServerSettings): Promise<void> {
     cfg.port = settings.port;
   }
   cfg.require_ssl = settings.ssl;
-  // Bind all interfaces when remote access is on so other devices can reach it.
-  if (settings.enabled) cfg.host = '0.0.0.0';
+  // Bind all interfaces when remote access is on so other devices can reach it,
+  // and put `host` back to the loopback default when it is off. The desktop
+  // backend ignores `host` unless `external_server_enabled` is set, so leaving a
+  // stale `0.0.0.0` behind was invisible here - but the standalone server binds
+  // `config["host"]` directly, and the two read the same file, so turning remote
+  // access off had to stop meaning "still listening on every interface if you
+  // ever start it the other way". LOOPBACK_HOST is the value server.py writes
+  // into a fresh server config, not a new one invented here.
+  cfg.host = settings.enabled ? '0.0.0.0' : LOOPBACK_HOST;
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(cfg, null, 2));
   // Keep the tray's "Enable server" checkbox in sync with the new config.
@@ -1356,8 +1371,25 @@ function registerIpc(): void {
   });
 
   // What is in the folder someone picked, for the verdict under the field: a
-  // library PixlStash made before, a folder of pictures, or nothing yet. Read
-  // only, and bounded - see InspectFolder.
+  // library PixlStash made before, a folder of pictures, or nothing yet.
+  //
+  // What this channel promises: it never writes, it never follows a symlink out
+  // of the tree, it stops at InspectFolder's caps (20k files / 2.5 s) rather
+  // than crawling a disk, and it only answers the bundled setup page
+  // (requireSetupRenderer).
+  //
+  // What it does NOT promise, deliberately: the path is not restricted. Unlike
+  // `setup:commit`, which takes only a path PixlStash offered
+  // (requireOfferedPath), this one inspects whatever it is handed and reports
+  // whether it exists, a picture count and byte total, the drive's free space,
+  // and - when a `vault.db` is there - counts read from it with the bundled
+  // Python's sqlite3 in read-only mode. That is an existence-and-contents oracle
+  // over the whole filesystem, and it is fine here: the only caller is the
+  // wizard page, whose paths come from our own defaults or from the folder
+  // dialog the person at the keyboard drove. There is no remote content and no
+  // third party to feed it a path, and refusing arbitrary paths would only risk
+  // breaking first-run setup. Revisit if this channel is ever opened to a page
+  // that renders content PixlStash did not author.
   ipcMain.handle('setup:inspect', async (event, path?: string) => {
     requireSetupRenderer(event, 'setup:inspect');
     return inspectFolder(path || '', bundledInterpreter());

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -294,4 +294,34 @@ describe('the path-taking IPC handlers validate before they use the value', () =
       'validating the payload shape does not gate the capability',
     );
   });
+
+  /**
+   * `host` is written by `writeServerSettings` and read back by the *standalone*
+   * server, which binds `config["host"]` directly. The desktop backend ignores
+   * it unless `external_server_enabled` is set, so a one-way `if (enabled)
+   * cfg.host = '0.0.0.0'` left no visible trace here while leaving the shared
+   * config file saying "listen on every interface" after remote access was
+   * turned back off.
+   *
+   * Both directions, because writing the loopback default unconditionally would
+   * be the opposite regression - it would quietly stop remote access working.
+   */
+  it('writeServerSettings sets host both ways, not just on', () => {
+    const start = main.indexOf('async function writeServerSettings(');
+    assert.ok(start >= 0, 'writeServerSettings not found');
+    const body = main.slice(start, main.indexOf('\nfunction ', start));
+    assert.match(
+      body,
+      /cfg\.host = settings\.enabled \? '0\.0\.0\.0' : LOOPBACK_HOST;/,
+      'host must be assigned on both branches',
+    );
+    assert.doesNotMatch(
+      body,
+      /if \(settings\.enabled\) cfg\.host/,
+      'a one-way assignment leaves 0.0.0.0 in the config after remote access is turned off',
+    );
+    // And the off value is the one the backend itself writes into a fresh
+    // config, not a value invented in the desktop shell.
+    assert.match(main, /^const LOOPBACK_HOST = 'localhost';$/m);
+  });
 });


### PR DESCRIPTION
Electron lane of #1177: two items, one behaviour fix and one documented decision.

## Item 65 — `host` was never reset when the external listener is disabled

`writeServerSettings` (`electron/src/main.ts`) did `if (settings.enabled) cfg.host = '0.0.0.0';` with no else branch, so turning remote access on wrote "bind every interface" into the server config and turning it off left it there.

Invisible in the desktop app, which ignores `host` unless `external_server_enabled` is set — but the **standalone server binds `config["host"]` directly** (`Server.run`), and the two can read the same config file. So the config kept saying "listen on every interface" after the switch was turned off. Present since v1.10.2.

Now: `cfg.host = settings.enabled ? '0.0.0.0' : LOOPBACK_HOST;`. `LOOPBACK_HOST` is `'localhost'`, which is the value `Server.init_server_config` writes into a server config that has no `host` — the file ends up saying what a never-enabled one would have said, rather than carrying a value invented in the desktop shell.

Changelog fragment added, since a released version shows this.

## Item 63 — `setup:inspect` takes an arbitrary path: **dropped, docstring only**

Judged and not fixed. `setup:inspect` is read-only, capped (20k files / 2.5 s), and already gated to the bundled wizard page by `requireSetupRenderer` (#1201). Its only caller is `electron/src/renderer/setup.js`, whose paths come from PixlStash's own `offerPath` defaults or from the native folder dialog the person at the keyboard drove. There is no remote content in that renderer and no third party who can feed it a path. Restricting the path buys nothing here and risks the worst regression available — over-blocking first-run setup.

What did change is the comment above the handler, which previously read "Read only, and bounded" and stopped there. It now states the promises (never writes, no symlinks out of the tree, capped, wizard-page-only) **and** the non-promise: the path is unrestricted, unlike `setup:commit`'s `requireOfferedPath`, and this is an existence-and-contents oracle over the filesystem. It names the condition that would change the answer — this channel being opened to a page rendering content PixlStash did not author.

## Tests

`electron/test/pathIpcValidation.test.ts` gains one source-text assertion next to the existing `server:setSettings` ones (same precedent: `main.ts` registers handlers as a side effect of an Electron boot and exposes no module boundary). It pins **both** directions — `enabled` still gives `0.0.0.0`, and the off branch is assigned rather than skipped — plus the value of `LOOPBACK_HOST`, so writing the loopback default unconditionally is caught as the opposite regression.

Verified it has teeth: restoring the one-way `if (settings.enabled)` line turns it red, and only it (234 pass / 1 fail).

The derived-from-source IPC guardrails in `urlPolicy.test.ts` are untouched and still pass — handler registration did not change, only the comment above one handler.

`npm run lint` (tsc --noEmit) clean; `npm test` 235/235.
