### PR TITLE
Remove dead reference-create path; name Moves Review's removal

### DIFF
--- a/changelog.d/moves-review-resolve-label.md
+++ b/changelog.d/moves-review-resolve-label.md
@@ -1,0 +1,4 @@
+- Fixed: the Moves Review screen's resolve button could say only "Apply this
+  move" for an ambiguous move that would leave a folder with no membership, or
+  several, left behind - naming nothing about what clicking it actually
+  removes.

--- a/frontend/src/components/editors/FolderEditor.vue
+++ b/frontend/src/components/editors/FolderEditor.vue
@@ -328,8 +328,10 @@
             </div>
           </div>
 
-          <!-- Reference-only: caption file sync (edit) -->
-          <div v-if="!isImport" class="editor-sync-section">
+          <!-- Reference-only: caption file sync (edit mode). Gated on edit
+               like the allow-delete row below: create is import-only now, and
+               a control the create submit does not read must not be shown. -->
+          <div v-if="!isImport && isEditMode" class="editor-sync-section">
             <button
               type="button"
               class="editor-sync-header"

--- a/frontend/src/components/editors/FolderEditor.vue
+++ b/frontend/src/components/editors/FolderEditor.vue
@@ -46,9 +46,7 @@
               ref="pathInputRef"
               v-model="localHostPath"
               label="Local folder (host path)"
-              :placeholder="
-                isImport ? '/home/you/Pictures/import' : '/home/you/Pictures'
-              "
+              placeholder="/home/you/Pictures/import"
               density="comfortable"
               variant="filled"
               hide-details
@@ -72,212 +70,94 @@
               >
                 {{ dockerSuggestedPath }}
               </div>
+            </div>
+
+            <div class="editor-docker-format-row">
+              <div class="editor-docker-title">Docker mount line</div>
+              <v-btn-toggle
+                v-model="shellFormat"
+                mandatory
+                density="compact"
+                class="editor-docker-shell-btns"
+              >
+                <v-btn value="linux" size="small">Linux / Mac</v-btn>
+                <v-btn value="windows" size="small">Windows</v-btn>
+              </v-btn-toggle>
+            </div>
+            <div class="editor-docker-note">
+              Add this <code>-v</code> mount to your
+              <code>docker run</code> command:
+            </div>
+            <div class="editor-docker-snippet-wrap">
+              <code class="editor-docker-snippet">{{
+                dockerMountSnippet
+              }}</code>
               <v-btn
-                v-if="!isImport"
                 variant="outlined"
                 size="small"
                 icon
                 class="editor-copy-btn"
-                title="Copy container path"
+                title="Copy mount line"
                 @click="
-                  copyToClipboard(dockerSuggestedPath, 'Container path copied.')
+                  copyToClipboard(dockerMountSnippet, 'Mount line copied.')
                 "
               >
                 <v-icon size="16">mdi-content-copy</v-icon>
               </v-btn>
             </div>
-
-            <!-- Import: flat docker instructions -->
-            <template v-if="isImport">
-              <div class="editor-docker-format-row">
-                <div class="editor-docker-title">Docker mount line</div>
-                <v-btn-toggle
-                  v-model="shellFormat"
-                  mandatory
-                  density="compact"
-                  class="editor-docker-shell-btns"
-                >
-                  <v-btn value="linux" size="small">Linux / Mac</v-btn>
-                  <v-btn value="windows" size="small">Windows</v-btn>
-                </v-btn-toggle>
-              </div>
-              <div class="editor-docker-note">
-                Add this <code>-v</code> mount to your
-                <code>docker run</code> command:
-              </div>
-              <div class="editor-docker-snippet-wrap">
-                <code class="editor-docker-snippet">{{
-                  dockerMountSnippet
-                }}</code>
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy mount line"
-                  @click="
-                    copyToClipboard(dockerMountSnippet, 'Mount line copied.')
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-              <div class="editor-docker-title">Container restart helpers</div>
-              <div class="editor-docker-note editor-docker-note--muted">
-                This removes the old container, not the image.
-              </div>
-              <div class="editor-docker-snippet-wrap">
-                <code class="editor-docker-snippet">{{
-                  dockerRemoveContainerSnippet
-                }}</code>
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy remove-container command"
-                  @click="
-                    copyToClipboard(
-                      dockerRemoveContainerSnippet,
-                      'Remove-container command copied.',
-                    )
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-              <div class="editor-docker-note">
-                Full restart command (uses your local folder mapping):
-              </div>
-              <div
-                v-if="hasExistingMounts"
-                class="editor-docker-note editor-docker-note--muted"
+            <div class="editor-docker-title">Container restart helpers</div>
+            <div class="editor-docker-note editor-docker-note--muted">
+              This removes the old container, not the image.
+            </div>
+            <div class="editor-docker-snippet-wrap">
+              <code class="editor-docker-snippet">{{
+                dockerRemoveContainerSnippet
+              }}</code>
+              <v-btn
+                variant="outlined"
+                size="small"
+                icon
+                class="editor-copy-btn"
+                title="Copy remove-container command"
+                @click="
+                  copyToClipboard(
+                    dockerRemoveContainerSnippet,
+                    'Remove-container command copied.',
+                  )
+                "
               >
-                Existing reference and import folder mounts are included.
-              </div>
-              <div class="editor-docker-snippet-wrap">
-                <code
-                  class="editor-docker-snippet editor-docker-snippet--full"
-                  >{{ dockerRestartCommandSnippet }}</code
-                >
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy full restart command"
-                  @click="
-                    copyToClipboard(
-                      dockerRestartCommandSnippet,
-                      'Restart command copied.',
-                    )
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-            </template>
-
-            <!-- Reference: boxed docker instructions with numbered steps -->
-            <div v-else class="editor-docker-instructions">
-              <div class="editor-docker-format-row">
-                <div class="editor-docker-title">Docker setup</div>
-                <v-btn-toggle
-                  v-model="shellFormat"
-                  mandatory
-                  density="compact"
-                  class="editor-docker-shell-btns"
-                >
-                  <v-btn value="linux" size="small">Linux / Mac</v-btn>
-                  <v-btn value="windows" size="small">Windows</v-btn>
-                </v-btn-toggle>
-              </div>
-              <ol>
-                <li>Add a mount to your docker run command:</li>
-              </ol>
-              <div class="editor-docker-snippet-wrap">
-                <code class="editor-docker-snippet">{{
-                  dockerMountSnippet
-                }}</code>
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy mount snippet"
-                  @click="
-                    copyToClipboard(dockerMountSnippet, 'Mount snippet copied.')
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-              <div class="editor-docker-note">
-                If restart fails because the container name already exists,
-                remove the old container first:
-              </div>
-              <div class="editor-docker-note editor-docker-note--muted">
-                This removes the old container, not the image.
-              </div>
-              <div class="editor-docker-snippet-wrap">
-                <code class="editor-docker-snippet">{{
-                  dockerRemoveContainerSnippet
-                }}</code>
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy remove-container command"
-                  @click="
-                    copyToClipboard(
-                      dockerRemoveContainerSnippet,
-                      'Remove-container command copied.',
-                    )
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-              <div class="editor-docker-note">
-                Full restart command (uses your local folder mapping):
-              </div>
-              <div
-                v-if="hasExistingMounts"
-                class="editor-docker-note editor-docker-note--muted"
+                <v-icon size="16">mdi-content-copy</v-icon>
+              </v-btn>
+            </div>
+            <div class="editor-docker-note">
+              Full restart command (uses your local folder mapping):
+            </div>
+            <div
+              v-if="hasExistingMounts"
+              class="editor-docker-note editor-docker-note--muted"
+            >
+              Existing reference and import folder mounts are included.
+            </div>
+            <div class="editor-docker-snippet-wrap">
+              <code
+                class="editor-docker-snippet editor-docker-snippet--full"
+                >{{ dockerRestartCommandSnippet }}</code
               >
-                Existing reference and import folder mounts are included from
-                configured container paths and use stored host paths when
-                available. Replace any remaining
-                <code>/absolute/host/path/for-*</code> placeholder values.
-              </div>
-              <div class="editor-docker-snippet-wrap">
-                <code
-                  class="editor-docker-snippet editor-docker-snippet--full"
-                  >{{ dockerRestartCommandSnippet }}</code
-                >
-                <v-btn
-                  variant="outlined"
-                  size="small"
-                  icon
-                  class="editor-copy-btn"
-                  title="Copy full restart command"
-                  @click="
-                    copyToClipboard(
-                      dockerRestartCommandSnippet,
-                      'Restart command copied.',
-                    )
-                  "
-                >
-                  <v-icon size="16">mdi-content-copy</v-icon>
-                </v-btn>
-              </div>
-              <ol start="2">
-                <li>Restart the container.</li>
-                <li>
-                  Add this folder in PixlStash using the container path above.
-                </li>
-              </ol>
+              <v-btn
+                variant="outlined"
+                size="small"
+                icon
+                class="editor-copy-btn"
+                title="Copy full restart command"
+                @click="
+                  copyToClipboard(
+                    dockerRestartCommandSnippet,
+                    'Restart command copied.',
+                  )
+                "
+              >
+                <v-icon size="16">mdi-content-copy</v-icon>
+              </v-btn>
             </div>
 
             <div v-if="copyStatus" class="editor-copy-status">
@@ -448,7 +328,7 @@
             </div>
           </div>
 
-          <!-- Reference-only: caption file sync (create + edit) -->
+          <!-- Reference-only: caption file sync (edit) -->
           <div v-if="!isImport" class="editor-sync-section">
             <button
               type="button"
@@ -515,10 +395,6 @@
                       e.g. <code>{{ descriptionExample }}</code>
                     </div>
                   </div>
-                </div>
-
-                <div v-if="detectInfo" class="editor-sync-detected">
-                  {{ detectInfo }}
                 </div>
               </div>
             </v-expand-transition>
@@ -637,13 +513,7 @@
 
 <script setup>
 import { computed, nextTick, ref, watch, onUnmounted } from "vue";
-import {
-  createFolder,
-  patchFolder,
-  deleteFolder,
-  // Aliased: this component wraps it in its own debounced detectSidecars().
-  detectSidecars as fetchSidecarConvention,
-} from "../../api/folders";
+import { createFolder, patchFolder, deleteFolder } from "../../api/folders";
 import { useSubmitGuard } from "../../composables/useSubmitGuard";
 import { copyText } from "../../utils/clipboard";
 import {
@@ -712,7 +582,6 @@ const localSyncTags = ref(false);
 const localDescriptionSuffix = ref(DEFAULT_DESCRIPTION_SUFFIX);
 const localTagsSuffix = ref(DEFAULT_TAGS_SUFFIX);
 const syncSectionOpen = ref(false);
-const detectInfo = ref("");
 const localAllowDelete = ref(false);
 const saveError = ref("");
 const deleteLoading = ref(false);
@@ -750,18 +619,6 @@ const isValid = computed(() => {
 const suggestedDisplayLabel = computed(() =>
   deriveLabelFromHostPath(localHostPath.value),
 );
-
-// The most recently added reference folder, used to inherit sync defaults when
-// adding a new one (so a user who switched to e.g. ".txt"/".caption" keeps it).
-const lastAddedReferenceFolder = computed(() => {
-  if (isImport.value) return null;
-  const folders = props.registeredFolders || [];
-  let best = null;
-  for (const folder of folders) {
-    if (best === null || Number(folder.id) > Number(best.id)) best = folder;
-  }
-  return best;
-});
 
 const syncSummary = computed(() => {
   const parts = [];
@@ -1020,7 +877,6 @@ watch(
     shellFormat.value = defaultShellFormat;
     confirmingDelete.value = false;
     saveError.value = "";
-    detectInfo.value = "";
     const editingFolder = activeFolder.value;
     if (editingFolder) {
       localLabel.value = editingFolder.label || "";
@@ -1046,16 +902,11 @@ watch(
       setLabelWithoutTouch("");
     }
     localDeleteAfterImport.value = false;
-    // Seed sync defaults from the most recently added reference folder, falling
-    // back to the hardcoded defaults. Folder-content detection (non-Docker) may
-    // override these once a path is entered.
-    const last = lastAddedReferenceFolder.value;
-    localSyncTags.value = last ? Boolean(last.sync_tags) : false;
-    localSyncDescriptions.value = last ? Boolean(last.sync_descriptions) : false;
-    localTagsSuffix.value = (last && last.tags_suffix) || DEFAULT_TAGS_SUFFIX;
-    localDescriptionSuffix.value =
-      (last && last.description_suffix) || DEFAULT_DESCRIPTION_SUFFIX;
-    syncSectionOpen.value = localSyncTags.value || localSyncDescriptions.value;
+    localSyncTags.value = false;
+    localSyncDescriptions.value = false;
+    localTagsSuffix.value = DEFAULT_TAGS_SUFFIX;
+    localDescriptionSuffix.value = DEFAULT_DESCRIPTION_SUFFIX;
+    syncSectionOpen.value = false;
     localAllowDelete.value = false;
     copyStatus.value = "";
     nextTick(() => {
@@ -1094,47 +945,6 @@ watch(
   { immediate: true },
 );
 
-// --- Sidecar convention detection (reference folders, non-Docker create) ---
-
-let detectTimer = null;
-
-async function detectSidecars(path) {
-  const trimmed = String(path || "").trim();
-  if (!trimmed) return;
-  try {
-    const data = await fetchSidecarConvention(trimmed);
-    // Ignore a stale response if the path changed while the request was in flight.
-    if (String(localPath.value || "").trim() !== trimmed) return;
-    const found = [];
-    if (data?.found_tags) {
-      localSyncTags.value = true;
-      if (data.tags_suffix) localTagsSuffix.value = data.tags_suffix;
-      found.push("tags");
-    }
-    if (data?.found_descriptions) {
-      localSyncDescriptions.value = true;
-      if (data.description_suffix)
-        localDescriptionSuffix.value = data.description_suffix;
-      found.push("descriptions");
-    }
-    if (found.length) {
-      syncSectionOpen.value = true;
-      detectInfo.value = `Found existing ${found.join(" and ")} sidecars in this folder.`;
-    } else {
-      detectInfo.value = "";
-    }
-  } catch {
-    // Detection is best-effort - ignore errors (e.g. an inaccessible path).
-  }
-}
-
-watch([() => props.open, localPath], ([isOpen]) => {
-  if (!isOpen || isEditMode.value || isImport.value || props.inDocker) return;
-  if (detectTimer) clearTimeout(detectTimer);
-  const path = localPath.value;
-  detectTimer = setTimeout(() => detectSidecars(path), 400);
-});
-
 function handleKeydown(event) {
   if (event.key === "Escape") emit("close");
 }
@@ -1149,10 +959,6 @@ watch(
       if (copyStatusTimer) {
         clearTimeout(copyStatusTimer);
         copyStatusTimer = null;
-      }
-      if (detectTimer) {
-        clearTimeout(detectTimer);
-        detectTimer = null;
       }
       copyStatus.value = "";
     }
@@ -1221,20 +1027,10 @@ async function submitFolder() {
             ? hostPathToSave
             : undefined,
       };
-      if (isImport.value) {
-        createData.delete_after_import = localDeleteAfterImport.value;
-      } else {
-        createData.sync_descriptions = localSyncDescriptions.value;
-        createData.sync_tags = localSyncTags.value;
-        createData.tags_suffix = suffixForSubmit(
-          localTagsSuffix.value,
-          DEFAULT_TAGS_SUFFIX,
-        );
-        createData.description_suffix = suffixForSubmit(
-          localDescriptionSuffix.value,
-          DEFAULT_DESCRIPTION_SUFFIX,
-        );
-      }
+      // Creating is only ever reachable for import folders now - see
+      // `openReferenceFolderEditor()` in SideBar.vue, which routes reference
+      // create through the mapping wizard instead of this dialog.
+      createData.delete_after_import = localDeleteAfterImport.value;
       savedResponse = await createFolder(folderKind.value, createData);
     }
     emit("saved", savedResponse || null);

--- a/frontend/src/components/views/MovesReview.test.js
+++ b/frontend/src/components/views/MovesReview.test.js
@@ -120,6 +120,64 @@ describe("MovesReview - ambiguous", () => {
     expect(resolve.text()).toContain("Only Client · Nordvik now");
   });
 
+  it("names the addition when the ambiguous item gains one", async () => {
+    const item = {
+      review_id: 8,
+      picture_id: 80,
+      old_path: "/lib/2024 Shoots/mira.png",
+      new_path: "/lib/Client · Vex/mira.png",
+      removals: [{ facet: "project", name: "2024 Shoots" }],
+      additions: [{ facet: "project", name: "Client · Vex" }],
+      current: { project: ["2024 Shoots", "Old Client"] },
+    };
+    const wrapper = await mountScreen(summary({ ambiguous: [item] }));
+    const buttons = wrapper.findAll(".mv-row--ambiguous button");
+    const resolve = buttons.find((b) => !b.text().includes("Keep both"));
+
+    expect(resolve.text()).toContain("Only Client · Vex now");
+  });
+
+  it("names what it removes when the removal leaves no survivor", async () => {
+    // removals[0] is a lone membership (nothing left once it goes); a
+    // different removal is what actually made the item ambiguous.
+    const item = {
+      review_id: 9,
+      picture_id: 90,
+      old_path: "/lib/Solo/2024 Shoots/mira.png",
+      new_path: "/lib/Client · Nordvik/mira.png",
+      removals: [
+        { facet: "project", name: "Solo" },
+        { facet: "person", name: "Mira" },
+      ],
+      additions: [],
+      current: { project: ["Solo"], person: ["Mira", "Anya"] },
+    };
+    const wrapper = await mountScreen(summary({ ambiguous: [item] }));
+    const buttons = wrapper.findAll(".mv-row--ambiguous button");
+    const resolve = buttons.find((b) => !b.text().includes("Keep both"));
+
+    expect(resolve.text()).toContain("Remove from Solo");
+    expect(resolve.text()).not.toContain("Only");
+  });
+
+  it("names what it removes when the removal leaves several survivors", async () => {
+    const item = {
+      review_id: 10,
+      picture_id: 100,
+      old_path: "/lib/B/mira.png",
+      new_path: "/lib/Client · Nordvik/mira.png",
+      removals: [{ facet: "project", name: "B" }],
+      additions: [],
+      current: { project: ["A", "B", "C"] },
+    };
+    const wrapper = await mountScreen(summary({ ambiguous: [item] }));
+    const buttons = wrapper.findAll(".mv-row--ambiguous button");
+    const resolve = buttons.find((b) => !b.text().includes("Keep both"));
+
+    expect(resolve.text()).toContain("Remove from B");
+    expect(resolve.text()).not.toContain("Only");
+  });
+
   it("the resolve button applies only that one review_id", async () => {
     const wrapper = await mountScreen(summary({ ambiguous: [AMBIGUOUS_ITEM] }));
     const buttons = wrapper.findAll(".mv-row--ambiguous button");

--- a/frontend/src/components/views/MovesReview.vue
+++ b/frontend/src/components/views/MovesReview.vue
@@ -296,7 +296,13 @@ function changeShape(item) {
  * A removal that leaves no survivor (a lone membership) or several (three or
  * more before the move) has no single name to land on, so it names what the
  * click removes instead of what remains - shorter than listing every
- * survivor, and still says exactly what happens. */
+ * survivor, and still says exactly what happens.
+ *
+ * The trailing "Apply this move" is unreachable, not a third case: a review
+ * is only ambiguous when one of its removals names a facet the picture has
+ * more than one of (`reconcile_move` in `pixlstash/utils/library_layout.py`),
+ * so every item this renders has at least one removal. It is here so the
+ * button never renders blank if that ever stops being true. */
 function onlyNowLabel(item) {
   const addition = (item.additions || [])[0];
   if (addition) return `Only ${addition.name} now`;

--- a/frontend/src/components/views/MovesReview.vue
+++ b/frontend/src/components/views/MovesReview.vue
@@ -281,8 +281,9 @@ function changeShape(item) {
   };
 }
 
-/** The resolve button's label - always names what the owner ends up with,
- * never a generic verb, because this button applies a removal.
+/** The resolve button's label - always names either what the owner ends up
+ * with or what is being taken away, never a generic verb, because this
+ * button applies a removal.
  *
  * The canonical ambiguous case (the design mock's own example) has NO
  * addition: the picture already belongs to the folder it moved into, so
@@ -290,7 +291,12 @@ function changeShape(item) {
  * destination there is one of the picture's own `current` names for the
  * ambiguous facet - specifically the one that is not being removed - so it
  * is derived from `current`, never left to a fallback string that would say
- * nothing about what clicking the button actually does. */
+ * nothing about what clicking the button actually does.
+ *
+ * A removal that leaves no survivor (a lone membership) or several (three or
+ * more before the move) has no single name to land on, so it names what the
+ * click removes instead of what remains - shorter than listing every
+ * survivor, and still says exactly what happens. */
 function onlyNowLabel(item) {
   const addition = (item.additions || [])[0];
   if (addition) return `Only ${addition.name} now`;
@@ -300,6 +306,10 @@ function onlyNowLabel(item) {
       (name) => name !== removal.name,
     );
     if (remaining.length === 1) return `Only ${remaining[0]} now`;
+    // Leaving none or leaving several: naming the one survivor no longer
+    // works, and listing every survivor gets long fast. Name what the click
+    // actually removes instead - shorter, and honest either way.
+    return `Remove from ${removal.name}`;
   }
   return "Apply this move";
 }


### PR DESCRIPTION
## Summary

Issue #1177, items 54 and 33.

- **Item 54 (deletion):** `FolderEditor`'s reference-create branch is
  unreachable - `openReferenceFolderEditor()` in `SideBar.vue` always routes
  the create case through the folder-mapping wizard now (`mode:
  "local_import"`), so the reference-type `<FolderEditor>` instance is only
  ever opened with a non-null folder (edit mode). Removed the dead
  create-mode Docker instructions block, the sidecar-autodetect
  watcher/function that only ran for reference-create, the "seed sync
  defaults from the last reference folder" computed (only meaningful for the
  same dead combination), and the corresponding dead branch in the create
  submit handler. Reference-folder *editing* is untouched. Backend's commit
  service `mode="reference"` default is left alone - it's a public API
  default on `/folder-structure/commit`, reachable by any direct caller
  regardless of what the frontend currently sends.

- **Item 33 (fix):** `MovesReview.vue`'s resolve-button label fell back to
  the generic "Apply this move" exactly in the two destructive cases - a
  removal leaving no survivor, or leaving several - where it said least about
  what clicking it does. It now names what the click removes in both cases.

## Test plan

- [x] `npx eslint` clean on both changed components
- [x] Full frontend unit suite green (3946 tests)
- [x] New `MovesReview.test.js` cases for the two previously-uncovered
      branches confirmed red against the prior code, green after the fix