### PR TITLE
Queue a review when the purge sweep follows an owner move back (#1177 item 4)

### DIFF
--- a/changelog.d/purge-repair-swallows-owner-move.md
+++ b/changelog.d/purge-repair-swallows-owner-move.md
@@ -1,0 +1,4 @@
+- Move a picture out of a laid-out folder in your file manager and it is always
+  offered in the pending-moves review. A background sweep could get to the file
+  first, quietly follow it and leave nothing for the review to show, so the
+  picture kept a project or person its folder no longer said.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -6907,6 +6907,26 @@ library root is found under `None`. The task's result carries
 for exactly this reason — the two differ whenever the move happened in a root
 with no layout.
 
+**The scan is not the only thing that discovers an owner move.**
+`MissingFilePurgeTask` reads the same journal to tell a deletion from a move it
+must not purge (§26), and it reads it in both directions — so a file found back
+at a row's `old_path` is repaired there too. That direction has two causes the
+journal cannot tell apart: an undo whose rename landed and whose transaction did
+not, and the owner dragging the file out of the folder PixlStash filed it in.
+The scan *can* tell, because `claim_own_moves` matches a pair in one direction
+only and would find the reversed pair unclaimed — so it would queue a review
+where the sweep repointed `file_path` and stopped. Whichever noticed first
+decided, and once `file_path` is repointed the file is where the row says it is,
+so the next scan sees no move to follow and the reconciliation is lost for good.
+The sweep therefore queues it as well, through
+`record_pending_reviews_in_laid_out_roots` — the same recorder with the layout
+gate the scan applies inline, since the sweep has a picture id and two paths but
+has read no root. Only the backwards direction: a file at the row's `new_path`
+is our own move landing, the scan would have claimed that pair, and a review
+there is Phase 5 undoing Phase 4b's write. A crashed undo queues one too, which
+is the safe side of a distinction that cannot be made: the row is a question for
+the owner and never an applied change.
+
 **Classification never touches the row it reads until it deletes it.**
 `pending_summary_in_session` reclassifies every row against the picture's
 *current* facets and the root's *current* layout on every call — there is no

--- a/pixlstash/services/move_reconciliation_service.py
+++ b/pixlstash/services/move_reconciliation_service.py
@@ -89,6 +89,37 @@ def record_pending_reviews(
     return picture_ids
 
 
+def record_pending_reviews_in_laid_out_roots(
+    session: Session,
+    moves: Iterable[tuple[int, str, str]],
+    image_root: Optional[str] = None,
+) -> list[int]:
+    """:func:`record_pending_reviews` for a caller that has not read the layout.
+
+    The scan knows its root's layout already and applies the gate itself. The
+    reference-folder scan is not the only thing that discovers an owner move,
+    though: ``MissingFilePurgeTask`` reaches the same conclusion from the move
+    journal when a file has come back to the path PixlStash took it from, and it
+    has a picture id and two paths but no root. This looks the root up for it,
+    so both discoverers queue the same fact and neither has to grow a layout
+    query of its own.
+    """
+    pending = [(int(pid), old, new) for pid, old, new in moves]
+    if not pending:
+        return []
+    roots = layout_move_service.layout_roots(session, image_root)
+    if not roots:
+        return []
+    laid_out: set[int] = set()
+    for chunk in chunked(sorted({pid for pid, _, _ in pending})):
+        for picture in session.exec(select(Picture).where(Picture.id.in_(chunk))).all():
+            if picture.id is not None and picture.reference_folder_id in roots:
+                laid_out.add(int(picture.id))
+    return record_pending_reviews(
+        session, [move for move in pending if move[0] in laid_out]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Classification - live, every read
 # ---------------------------------------------------------------------------

--- a/pixlstash/tasks/missing_file_purge_task.py
+++ b/pixlstash/tasks/missing_file_purge_task.py
@@ -280,7 +280,7 @@ class MissingFilePurgeTask(BaseTask):
         """
         repaired = 0
         came_back: list = []
-        for picture_id, new_path, from_our_destination in repairs:
+        for picture_id, new_path, came_back_to_our_source in repairs:
             picture = session.get(Picture, picture_id)
             if picture is None:
                 continue
@@ -291,7 +291,7 @@ class MissingFilePurgeTask(BaseTask):
                 picture.file_path,
                 new_path,
             )
-            if from_our_destination and picture.file_path:
+            if came_back_to_our_source and picture.file_path:
                 came_back.append((picture_id, picture.file_path, new_path))
             picture.file_path = new_path
             session.add(picture)

--- a/pixlstash/tasks/missing_file_purge_task.py
+++ b/pixlstash/tasks/missing_file_purge_task.py
@@ -6,6 +6,9 @@ from sqlmodel import Session, select
 from pixlstash.db_models import DeletedFileLog, Picture
 from pixlstash.db_models.picture_move import RETENTION_S, PictureMove
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services.move_reconciliation_service import (
+    record_pending_reviews_in_laid_out_roots,
+)
 from pixlstash.services.scrapheap_service import file_location_is_unreachable
 from pixlstash.tasks.base_task import BaseTask, TaskPriority
 from pixlstash.utils.image_processing.image_utils import ImageUtils
@@ -100,7 +103,9 @@ class MissingFilePurgeTask(BaseTask):
 
         repaired = 0
         if repairs:
-            repaired = self._db.run_task(self._repair_moved_pictures, repairs)
+            repaired = self._db.run_task(
+                self._repair_moved_pictures, repairs, image_root
+            )
             logger.info(
                 "MissingFilePurgeTask: repaired %s picture(s) the layout engine "
                 "had moved but not finished recording; none were purged.",
@@ -149,7 +154,11 @@ class MissingFilePurgeTask(BaseTask):
           exempts;
         * no journal row at all - a genuine deletion, purged as before.
 
-        Returns ``(repairs, deferred_count, still_missing)``.
+        Returns ``(repairs, deferred_count, still_missing)``, each repair a
+        ``(picture_id, landed_path, came_back_to_our_source)`` triple - the flag
+        says which end of the journal row the file turned up at, which is what
+        :meth:`_repair_moved_pictures` needs to know whether Phase 5 is owed a
+        review as well as a repoint.
         """
         by_id: dict = {pic.id: pic for pic in candidates if pic.file_path}
         if not by_id:
@@ -164,6 +173,7 @@ class MissingFilePurgeTask(BaseTask):
         # ``RETENTION_S``, and a later picture that reuses the path must not be
         # repointed at wherever the earlier one went.
         other_end: dict = {}
+        came_back: set = set()
         stamped: dict = {}
         for row in rows:
             pic = by_id.get(row.picture_id)
@@ -179,6 +189,13 @@ class MissingFilePurgeTask(BaseTask):
                     continue
                 stamped[pic.id] = row.moved_at
                 other_end[pic.id] = there
+                # Which end the file is at decides who moved it. At new_path it
+                # is our own move finishing; at old_path the file has come back
+                # to where we took it from, which the scan would have read as
+                # the owner's doing. See _repair_moved_pictures.
+                came_back.discard(pic.id)
+                if there == row.old_path:
+                    came_back.add(pic.id)
 
         image_root = self._db.image_root
         repairs: list = []
@@ -204,7 +221,7 @@ class MissingFilePurgeTask(BaseTask):
                 deferred += 1
                 continue
             if os.path.isfile(landed):
-                repairs.append((pic.id, landed_path))
+                repairs.append((pic.id, landed_path, pic.id in came_back))
                 continue
             deferred += 1
             logger.warning(
@@ -237,10 +254,33 @@ class MissingFilePurgeTask(BaseTask):
         return rows
 
     @staticmethod
-    def _repair_moved_pictures(session: Session, repairs: list) -> int:
-        """Repoint each row at the path its file actually reached."""
+    def _repair_moved_pictures(session: Session, repairs: list, image_root=None) -> int:
+        """Repoint each row at the path its file actually reached.
+
+        **Repointing is only half of what the discovery is worth**, and which
+        half depends on the direction. A file found at the journal row's
+        ``new_path`` is our own move landing, and the reference-folder scan
+        would have claimed that pair as ours and queued nothing - repointing is
+        the whole of it.
+
+        A file found back at the row's ``old_path`` is the other case, and the
+        journal cannot tell its two causes apart: an undo whose rename landed
+        and whose transaction did not, or the owner dragging the file back out
+        of the folder PixlStash filed it in. The scan can: ``claim_own_moves``
+        matches a pair in one direction only, so it would find the reversed pair
+        unclaimed, read it as the owner's, and queue an ``ExternalMoveReview``
+        (v1.11 Phase 5). Whichever of the two sweeps notices first used to
+        decide whether that ever happened - and once this one has repointed the
+        row, the file is where the row says it is, so the next scan sees no move
+        to follow and the reconciliation is lost for good. So it is queued here
+        too, from the same fact and through the same recorder. A crashed undo
+        queues one as well, which is the safe direction: the row is a question
+        for the owner, never an applied change, and finishing the undo is what
+        it would have asked anyway.
+        """
         repaired = 0
-        for picture_id, new_path in repairs:
+        came_back: list = []
+        for picture_id, new_path, from_our_destination in repairs:
             picture = session.get(Picture, picture_id)
             if picture is None:
                 continue
@@ -251,9 +291,22 @@ class MissingFilePurgeTask(BaseTask):
                 picture.file_path,
                 new_path,
             )
+            if from_our_destination and picture.file_path:
+                came_back.append((picture_id, picture.file_path, new_path))
             picture.file_path = new_path
             session.add(picture)
             repaired += 1
+        if came_back:
+            queued = record_pending_reviews_in_laid_out_roots(
+                session, came_back, image_root
+            )
+            if queued:
+                logger.info(
+                    "MissingFilePurgeTask: queued %s move(s) for reconciliation - "
+                    "the file is back at the path PixlStash moved it from, which "
+                    "the folder scan would have read as the owner's own move.",
+                    len(queued),
+                )
         session.commit()
         return repaired
 

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -647,11 +647,12 @@ class ReferenceFolderScanTask(BaseTask):
                 self._db.run_task(
                     MissingFilePurgeTask._repair_moved_pictures,
                     repairs,
+                    self._db.image_root,
                     priority=DBPriority.LOW,
                 )
                 # The file is at the repointed path, so it is that row's file
                 # and not a new import.
-                new_paths -= {self._on_disk(path) for _, path in repairs}
+                new_paths -= {self._on_disk(path) for _, path, _ in repairs}
                 logger.info(
                     "Reference folder %s: repointed %d picture(s) PixlStash "
                     "itself had moved rather than deleting them.",

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -2956,9 +2956,7 @@ def test_a_file_the_owner_moved_back_is_queued_for_review_not_only_repointed(lib
     ]
     # And it reaches the review screen rather than being classified away.
     buckets = reconciliation.pending_summary_in_session(session, root)
-    offered = [
-        item for bucket in buckets.values() for item in bucket if bucket is not None
-    ]
+    offered = [item for bucket in buckets.values() for item in bucket]
     assert [item["picture_id"] for item in offered] == [picture_id]
 
 

--- a/tests/test_library_layout.py
+++ b/tests/test_library_layout.py
@@ -2877,6 +2877,10 @@ def test_a_move_that_crashed_before_the_row_was_written_is_repaired_not_purged(
     assert picture is not None, "the picture must survive a crashed move"
     assert picture.file_path == "2024 Shoots/Mira/0001.png"
     assert session.exec(select(DeletedFileLog)).all() == []
+    # Our own move landing. The scan would have claimed this pair as ours and
+    # queued nothing, and a review here is what would have Phase 5 undo Phase
+    # 4b's own write - the flip-flop the journal exists to prevent.
+    assert session.exec(select(ExternalMoveReview)).all() == []
 
 
 def test_an_undo_that_crashed_before_the_row_was_written_is_repaired_not_purged(
@@ -2907,6 +2911,55 @@ def test_an_undo_that_crashed_before_the_row_was_written_is_repaired_not_purged(
     assert result["purged"] == 0
     assert result["repaired"] == 1
     assert session.get(Picture, picture_id).file_path == "0002.png"
+
+
+def test_a_file_the_owner_moved_back_is_queued_for_review_not_only_repointed(library):
+    """The same backwards read, with the other cause: the owner dragged the file
+    out of the folder PixlStash filed it in, and this sweep noticed before the
+    scan did.
+
+    The two subsystems used to disagree about whose move it was. The scan matches
+    a journal pair in one direction only, so it would find the reversed pair
+    unclaimed, call it the owner's and queue an ``ExternalMoveReview``; this
+    sweep read the same row backwards, called it ours, and repointed
+    ``file_path`` and nothing else. Whichever ran first decided - and once the
+    row is repointed the file is where the row says it is, so the next scan sees
+    no move to follow and the reconciliation is lost for good: the Moves screen
+    never offers it, and the picture keeps memberships whose folder has stopped
+    being true.
+    """
+    session, root = library["session"], library["root"]
+    picture_id = library["picture_id"]
+    filed_at = "2024 Shoots/Mira/2026-08/0412.png"
+
+    # PixlStash filed the picture there itself; the scan has not run since, so
+    # the row is still unclaimed.
+    session.add(
+        PictureMove(picture_id=picture_id, old_path="0412.png", new_path=filed_at)
+    )
+    session.commit()
+    # The owner drags it back out to the library root in their file manager.
+    os.replace(os.path.join(root, filed_at), os.path.join(root, "0412.png"))
+
+    # The scan's own attribution, on this exact state: not ours.
+    assert engine.claim_own_moves(session, [(filed_at, "0412.png")]) == set()
+
+    result = _purge(library, [picture_id])
+
+    assert result["purged"] == 0
+    assert result["repaired"] == 1
+    assert session.get(Picture, picture_id).file_path == "0412.png"
+
+    queued = session.exec(select(ExternalMoveReview)).all()
+    assert [(row.picture_id, row.old_path, row.new_path) for row in queued] == [
+        (picture_id, filed_at, "0412.png")
+    ]
+    # And it reaches the review screen rather than being classified away.
+    buckets = reconciliation.pending_summary_in_session(session, root)
+    offered = [
+        item for bucket in buckets.values() for item in bucket if bucket is not None
+    ]
+    assert [item["picture_id"] for item in offered] == [picture_id]
 
 
 def test_a_file_the_owner_really_deleted_is_still_purged(library):

--- a/tests/test_library_root_scan.py
+++ b/tests/test_library_root_scan.py
@@ -413,6 +413,87 @@ def test_a_move_pixlstash_recorded_is_repointed_not_deleted(server):
     )
     assert next(p for p in after if p.file_path == "jrn/a2.png").id == moving.id
     assert _tags(server, moving.id) == ["keepme"]
+    # Our own move landing. Queueing a review here would have Phase 5 undo
+    # Phase 4b's own write, which is what the journal exists to prevent.
+    reviews = server.vault.db.run_task(
+        lambda s: s.exec(
+            select(ExternalMoveReview).where(ExternalMoveReview.picture_id == moving.id)
+        ).all()
+    )
+    assert reviews == []
+
+
+def test_an_owner_move_back_the_journal_catches_is_still_queued_for_review(server):
+    """The same journal fallback, entered from the other end.
+
+    Hash pairing refuses (a twin), so the move-pairing block queues nothing and
+    the vanished path falls through to the journal check this scan shares with
+    ``MissingFilePurgeTask``. The file is back at the row's ``old_path``, which
+    is the owner undoing what PixlStash filed - repointing it and stopping is
+    what loses the reconciliation for good, because the next scan then sees no
+    move to follow.
+    """
+    root = server.vault.image_root
+
+    def _lay_out(session: Session):
+        settings = session.exec(select(LibrarySettings)).first()
+        if settings is None:
+            settings = LibrarySettings()
+        settings.layout = format_layout(DEFAULT_LAYOUT)
+        session.add(settings)
+        if (
+            session.exec(select(Character).where(Character.name == "Mira")).first()
+            is None
+        ):
+            session.add(Character(name="Mira"))
+        session.commit()
+
+    server.vault.db.run_task(_lay_out)
+    filed = _make_image(os.path.join(root, "Mira", "back.png"), (51, 52, 53))
+    twin = os.path.join(root, "Mira", "back_twin.png")
+    with open(filed, "rb") as fh:
+        payload = fh.read()
+    with open(twin, "wb") as fh:
+        fh.write(payload)
+    old = time.time() - 600
+    os.utime(twin, (old, old))
+    _run_root_scan(server)
+    moved = next(p for p in _managed(server, "Mira/") if p.file_path == "Mira/back.png")
+
+    # PixlStash filed it there itself; the owner drags it back out.
+    def _journal(session: Session):
+        session.add(
+            PictureMove(
+                picture_id=moved.id,
+                old_path="Unassigned/back.png",
+                new_path="Mira/back.png",
+                moved_at=datetime.utcnow(),
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(_journal)
+    os.makedirs(os.path.join(root, "Unassigned"), exist_ok=True)
+    os.rename(filed, os.path.join(root, "Unassigned", "back.png"))
+    _settle_root(root)
+
+    result = _run_root_scan(server)
+
+    assert moved.id not in result["moved_picture_ids"], (
+        "the twin makes hash pairing refuse, so this reaches the journal check"
+    )
+    assert (
+        server.vault.db.run_task(lambda s: s.get(Picture, moved.id)).file_path
+        == "Unassigned/back.png"
+    ), "repointed rather than deleted and re-imported"
+    reviews = server.vault.db.run_task(
+        lambda s: s.exec(
+            select(ExternalMoveReview).where(ExternalMoveReview.picture_id == moved.id)
+        ).all()
+    )
+    assert [(r.old_path, r.new_path) for r in reviews] == [
+        ("Mira/back.png", "Unassigned/back.png")
+    ], "the owner's move must reach the review queue, not only the repoint"
 
 
 def test_one_unhashed_scrapheap_row_does_not_block_every_rename(server):


### PR DESCRIPTION
## Summary

Issue #1177 item 4, filed as *"purge repair repoints `file_path` only"*.

Two subsystems discover that a file moved and did not know about each other:
`ReferenceFolderScanTask` queues an `ExternalMoveReview` for a move the move
journal did not claim as ours, and `MissingFilePurgeTask._repair_moved_pictures`
independently repoints `Picture.file_path` from the same journal.

The concern as filed — a review offering to apply a move that already happened —
**is not a defect, and the diff does not treat it as one.** Applying a review is
a membership write: `_apply_one` mutates project/set/person and never touches a
file or writes a `PictureMove`. `_classify` never reads `file_path` either; it
reads the row's frozen paths against current facets and layout. So a repoint is
invisible to classification, applying cannot duplicate a move, and reverse order
is safe for the same reason. Reproduced all three against a real vault before
changing anything.

What *is* a defect is the mirror, and it is exactly what the note said.
`_separate_our_own_moves` reads the journal in both directions. A file found
back at a row's `old_path` has two causes the journal cannot tell apart: an undo
whose rename landed and whose transaction did not, and the owner dragging the
file out of the folder PixlStash filed it in. The scan *can* tell —
`claim_own_moves` matches a pair in one direction only, so it finds the reversed
pair unclaimed, reads it as the owner's and queues a review. The sweep called it
ours and repointed `file_path` and nothing else. Whichever ran first decided,
and once `file_path` is repointed the file is where the row says it is, so the
next scan sees no move to follow: the reconciliation is lost for good, the Moves
screen never offers it, and the picture keeps memberships whose folder has
stopped being true.

Live where it matters: `MissingFilePurgeFinder` already skips root-owned rows
because "there is no ordering that makes both safe", but reference folders —
the roots that carry a layout — got no such protection.

## The change

- `move_reconciliation_service.record_pending_reviews_in_laid_out_roots` — the
  existing recorder plus the layout gate the scan applies inline, for a caller
  that has a picture id and two paths but has read no root.
- The purge sweep's repair now carries which end of the journal row the file
  turned up at, and queues a review in the backwards direction only. A file at
  the row's `new_path` is our own move landing, the scan would have claimed that
  pair, and a review there is Phase 5 undoing Phase 4b's write — asserted
  negatively. A crashed undo queues one too, which is the safe side of a
  distinction that cannot be made: the row is a question for the owner, never an
  applied change.
- Repointing is kept. Deferring to the scan instead would reintroduce a
  `file_removed=True` purge of a live file whenever the scan's pixel match is
  ambiguous.
- `docs/backend_architecture.md` §27 and one changelog fragment.

## Tests

`tests/test_library_layout.py`, in the crash-window section beside the two tests
this sits between, reusing their fixture:

- `test_a_file_the_owner_moved_back_is_queued_for_review_not_only_repointed` —
  asserts the scan's own attribution on the exact state (`claim_own_moves`
  returns empty), then that the sweep repoints *and* queues the row, and that
  `pending_summary_in_session` offers it rather than classifying it away.
  Confirmed red against its own reverted hunk: `assert [] == [(1, '2024
  Shoots/Mira/2026-08/0412.png', '0412.png')]`.
- The forward-direction test gains the negative: no review for our own move.

`tests/test_library_layout.py` + `tests/test_reference_folder_moves.py`: 181
passed. Guardrails, `test_ci_shards.py`, `test_scrapheap_retention.py` green;
`render_backend_architecture.py --check` up to date. One unrelated failure in
`tests/test_server_simple.py::test_scrapheap_delete_forever_upgrades_stale_kept_flag`
reproduces identically on a clean `origin/develop`.