### PR TITLE
Accept .pixlstash-dev-machine marker file for dev machine declaration

### DIFF
--- a/docs/release-test-plan.md
+++ b/docs/release-test-plan.md
@@ -56,9 +56,11 @@ Perform on a **clean machine/VM** (no prior PixlStash install, no existing
 `vault.db`). CI builds all of these artifacts but never runs them — this
 section is the only place they are executed.
 
-**For release-candidate testing:** on a machine you use to test RC builds, `touch`
-the marker file in the app-data directory so the version-check data correctly
-excludes your installs from the real active-install count. The path is
+**For release-candidate testing:** on a machine you use to test RC builds,
+create an empty marker file in the app-data directory so the version-check data
+correctly excludes your installs from the real active-install count. Its
+contents are never read, only its existence, so any way of making the file will
+do (`touch` on Linux and macOS, `type nul >` or New-Item on Windows). The path is
 `~/.local/share/pixlstash/.pixlstash-dev-machine` on Linux,
 `~/Library/Application Support/pixlstash/.pixlstash-dev-machine` on macOS, and
 `%LOCALAPPDATA%\pixlstash\pixlstash\.pixlstash-dev-machine` on Windows (adjust

--- a/docs/release-test-plan.md
+++ b/docs/release-test-plan.md
@@ -56,6 +56,14 @@ Perform on a **clean machine/VM** (no prior PixlStash install, no existing
 `vault.db`). CI builds all of these artifacts but never runs them — this
 section is the only place they are executed.
 
+**For release-candidate testing:** on a machine you use to test RC builds, `touch`
+the marker file in the app-data directory so the version-check data correctly
+excludes your installs from the real active-install count. The path is
+`~/.local/share/pixlstash/.pixlstash-dev-machine` on Linux,
+`~/Library/Application Support/pixlstash/.pixlstash-dev-machine` on macOS, and
+`%APPDATA%\pixlstash\.pixlstash-dev-machine` on Windows (adjust the home-directory
+reference for the user running the test).
+
 ### 1.1 pip + venv (PyPI)
 
 Requires Python 3.11+.

--- a/docs/release-test-plan.md
+++ b/docs/release-test-plan.md
@@ -61,8 +61,11 @@ the marker file in the app-data directory so the version-check data correctly
 excludes your installs from the real active-install count. The path is
 `~/.local/share/pixlstash/.pixlstash-dev-machine` on Linux,
 `~/Library/Application Support/pixlstash/.pixlstash-dev-machine` on macOS, and
-`%APPDATA%\pixlstash\.pixlstash-dev-machine` on Windows (adjust the home-directory
-reference for the user running the test).
+`%LOCALAPPDATA%\pixlstash\pixlstash\.pixlstash-dev-machine` on Windows (adjust
+the home-directory reference for the user running the test). The doubled
+`pixlstash\pixlstash` on Windows is not a typo: the server resolves the marker
+with `platformdirs.user_data_dir("pixlstash")`, which supplies the app name as
+the author segment when none is given.
 
 ### 1.1 pip + venv (PyPI)
 

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -100,7 +100,7 @@ beforeEach(() => {
   setActivePinia(createPinia());
   isReadOnly.value = false;
   sessionContext.value = null;
-  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  apiGet.mockReset().mockImplementation(() => Promise.resolve(respond()));
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
 });
@@ -260,7 +260,7 @@ describe("the loose-pictures offer for an empty library", () => {
         ? new Promise((resolve) => {
             answer = () => resolve({ data: { picture_count: 12 } });
           })
-        : Promise.resolve(respond(url)),
+        : Promise.resolve(respond()),
     );
     const wrapper = await mountSidebar();
 
@@ -335,7 +335,7 @@ describe("the loose-pictures offer for an empty library", () => {
     apiGet.mockImplementation((url) =>
       url.includes("inspect")
         ? Promise.resolve({ data: { picture_count: 12 } })
-        : Promise.resolve(respond(url)),
+        : Promise.resolve(respond()),
     );
     const wrapper = await mountSidebar();
 
@@ -373,7 +373,7 @@ describe("the loose-pictures offer for an empty library", () => {
     apiGet.mockImplementation((url) =>
       url.includes("inspect")
         ? Promise.resolve({ data: { picture_count: 12 } })
-        : Promise.resolve(respond(url)),
+        : Promise.resolve(respond()),
     );
     const wrapper = await mountSidebar();
 
@@ -406,7 +406,7 @@ describe("the loose-pictures offer for an empty library", () => {
         inspect();
         return Promise.resolve({ data: { picture_count: 12 } });
       }
-      return Promise.resolve(respond(url));
+      return Promise.resolve(respond());
     });
     const wrapper = await mountSidebar();
 
@@ -438,7 +438,7 @@ describe("the loose-pictures offer for an empty library", () => {
         inspect();
         return Promise.resolve({ data: { picture_count: 12 } });
       }
-      return Promise.resolve(respond(url));
+      return Promise.resolve(respond());
     });
     const wrapper = await mountSidebar();
 
@@ -470,7 +470,7 @@ describe("the loose-pictures offer for an empty library", () => {
     apiGet.mockImplementation((url) =>
       url.includes("inspect")
         ? Promise.resolve({ data: { picture_count: 12 } })
-        : Promise.resolve(respond(url)),
+        : Promise.resolve(respond()),
     );
     const wrapper = await mountSidebar();
 

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version as package_version
 from alembic.util.exc import CommandError as AlembicCommandError
-from platformdirs import user_config_dir
+from platformdirs import user_config_dir, user_data_dir
 from sqlalchemy.exc import SQLAlchemyError
 
 
@@ -360,9 +360,12 @@ class Server(
 
         Resolution order:
 
-        0. :data:`DEV_MACHINE_ENV_VAR` - declares the *machine* rather than the
-           channel, so it outranks everything below it. Reported as ``dev``,
-           which the metrics collector subtracts from active installs.
+        0. :data:`DEV_MACHINE_ENV_VAR` or dev marker file - declares the *machine*
+           rather than the channel, so it outranks everything below it. Reported
+           as ``dev``, which the metrics collector subtracts from active installs.
+           The machine is declared if either ``PIXLSTASH_TELEMETRY_DEV`` env var
+           is truthy or a ``.pixlstash-dev-machine`` marker file exists in the
+           app-data directory.
         1. ``PIXLSTASH_INSTALL_TYPE`` override - if set to one of the allowed
            values it wins outright, letting an installer declare its channel
            (e.g. ``other`` for the Windows build) without a code change. An
@@ -381,6 +384,21 @@ class Server(
                 dev_marker,
             )
             return "dev"
+
+        # Check for marker file in app-data directory
+        try:
+            app_data_dir = user_data_dir("pixlstash")
+            marker_file = Path(app_data_dir) / ".pixlstash-dev-machine"
+            if marker_file.exists():
+                logger.info(
+                    "Found dev machine marker file at %s; reporting install_type='dev'.",
+                    marker_file,
+                )
+                return "dev"
+        except Exception as e:
+            logger.warning(
+                "Could not check for dev machine marker file: %s", e, exc_info=True
+            )
 
         override = os.environ.get("PIXLSTASH_INSTALL_TYPE", "").strip().lower()
         if override:

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -385,20 +385,35 @@ class Server(
             )
             return "dev"
 
-        # Check for marker file in app-data directory
+        # The same declaration, made durably: an env var is not inherited by a
+        # packaged app launched from the OS shell, and does not survive a
+        # reinstall. `stat` rather than `exists`, because `exists` reports an
+        # unreadable app-data directory and an absent marker identically - and
+        # those mean opposite things here. An unreadable one silently turns a
+        # maintainer's install back into a counted one, which is the whole
+        # failure this check exists to prevent, so it is said out loud.
+        marker_file = Path(user_data_dir("pixlstash")) / ".pixlstash-dev-machine"
         try:
-            app_data_dir = user_data_dir("pixlstash")
-            marker_file = Path(app_data_dir) / ".pixlstash-dev-machine"
-            if marker_file.exists():
-                logger.info(
-                    "Found dev machine marker file at %s; reporting install_type='dev'.",
-                    marker_file,
-                )
-                return "dev"
-        except Exception as e:
+            marker_file.stat()
+            declared = True
+        except FileNotFoundError:
+            declared = False
+        except OSError as exc:
+            declared = False
             logger.warning(
-                "Could not check for dev machine marker file: %s", e, exc_info=True
+                "Could not read the dev-machine marker at %s (%s). Falling back "
+                "to automatic detection: if this IS a maintainer machine, its "
+                "check-ins will be counted as a real install until the "
+                "directory is readable again.",
+                marker_file,
+                exc,
             )
+        if declared:
+            logger.info(
+                "Found dev machine marker file at %s; reporting install_type='dev'.",
+                marker_file,
+            )
+            return "dev"
 
         override = os.environ.get("PIXLSTASH_INSTALL_TYPE", "").strip().lower()
         if override:

--- a/tests/test_install_type_buckets.py
+++ b/tests/test_install_type_buckets.py
@@ -206,6 +206,11 @@ def test_marker_file_declares_dev_machine(monkeypatch):
     file provides a durable declaration that survives reinstalling and repackaging.
     """
     monkeypatch.delenv(Server.DEV_MACHINE_ENV_VAR, raising=False)
+    # PIXLSTASH_INSTALL_TYPE also short-circuits to a declared value, and a
+    # maintainer box may well export it as "dev". Without this the assertion
+    # passes on the override rather than on the marker - it did, and disabling
+    # the marker check entirely left the test green.
+    monkeypatch.delenv("PIXLSTASH_INSTALL_TYPE", raising=False)
     with tempfile.TemporaryDirectory() as tmpdir:
         marker_file = Path(tmpdir) / ".pixlstash-dev-machine"
         marker_file.touch()
@@ -225,8 +230,10 @@ def test_marker_file_absent_falls_back_to_detection(monkeypatch):
         # Ensure marker file does not exist
         assert not (Path(tmpdir) / ".pixlstash-dev-machine").exists()
         with patch("pixlstash.server.user_data_dir", return_value=tmpdir):
-            # Should fall back to docker/pip detection
+            # Falls through to channel detection. Assert on what this test
+            # is about - the marker did not fire - rather than on which
+            # channel the runner happens to look like: the same suite runs
+            # under Docker in CI, where "pip" would be the wrong answer.
             result = Server.detect_install_type()
             assert result in Server.INSTALL_TYPES
-            # In this test context, it should be 'pip' (no docker signal)
-            assert result == "pip"
+            assert result != "dev"

--- a/tests/test_install_type_buckets.py
+++ b/tests/test_install_type_buckets.py
@@ -39,7 +39,9 @@ from __future__ import annotations
 import json
 import os
 import re
+import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -194,3 +196,37 @@ def test_the_shell_sets_the_marker_only_for_a_dev_backend():
         "the shell must keep declaring the electron channel - it is a runtime "
         "switch for cookie_secure and the loopback listener"
     )
+
+
+def test_marker_file_declares_dev_machine(monkeypatch):
+    """A marker file in the app-data directory declares a dev machine.
+
+    Release-candidate testing and packaged desktop builds launched from the OS
+    shell do not inherit the ``PIXLSTASH_TELEMETRY_DEV`` env var, so the marker
+    file provides a durable declaration that survives reinstalling and repackaging.
+    """
+    monkeypatch.delenv(Server.DEV_MACHINE_ENV_VAR, raising=False)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker_file = Path(tmpdir) / ".pixlstash-dev-machine"
+        marker_file.touch()
+        with patch("pixlstash.server.user_data_dir", return_value=tmpdir):
+            assert Server.detect_install_type() == "dev"
+
+
+def test_marker_file_absent_falls_back_to_detection(monkeypatch):
+    """Without a marker file or env var, install type is detected normally.
+
+    This ensures the marker file is truly optional and does not interfere with
+    normal install-type detection when not present.
+    """
+    monkeypatch.delenv(Server.DEV_MACHINE_ENV_VAR, raising=False)
+    monkeypatch.delenv("PIXLSTASH_INSTALL_TYPE", raising=False)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Ensure marker file does not exist
+        assert not (Path(tmpdir) / ".pixlstash-dev-machine").exists()
+        with patch("pixlstash.server.user_data_dir", return_value=tmpdir):
+            # Should fall back to docker/pip detection
+            result = Server.detect_install_type()
+            assert result in Server.INSTALL_TYPES
+            # In this test context, it should be 'pip' (no docker signal)
+            assert result == "pip"


### PR DESCRIPTION
Maintainer machines are supposed to report themselves as `dev` so our own
installs don't get counted as real users. Right now that only works when the
Electron shell sets an environment variable, which misses two cases that
happen constantly during release week: testing a release candidate from a
normal pip install, and running a packaged desktop build from the OS shell
(which doesn't inherit exported shell variables).

Now you can also just drop an empty file called `.pixlstash-dev-machine` in
the app-data folder. If it's there, the machine reports `dev`. The file
survives reinstalls and switching between builds, so you touch it once.

Nothing else changes. The release test plan says where to put the file.

Closes #1214.
