### PR TITLE
Frontend and Electron leftovers from the v1.11.1 reviews (#1206)

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -295,10 +295,18 @@ apply `?path=` on them (it guards on `folderKey`). The folder an "About your
 library" finding points at (§9.3) has no id of any kind, which is what this
 param is for. **It also carries the sidebar's subfolder selection.**
 `FolderTreeNode.vue` requires `rfId`, so a subfolder click takes
-`pushRouteForCurrentSelection`'s ref-folder branch; the branch now pushes the
-`pathPrefix` as `?path=` alongside the id, and `SideBar.routeSubfolderUnder`
-reads it back once the folder listing is in, selecting the subfolder rather
-than the folder root. The id still owns `referenceFolderId`, so
+`pushRouteForCurrentSelection`'s ref-folder branch; the branch pushes `?path=`
+alongside the id, and `SideBar.routeSubfolderUnder` reads it back once the
+folder listing is in, selecting the subfolder rather than the folder root.
+**On an id-carrying route that query is RELATIVE to the folder the id names**
+(`SideBar._subPathUnder` builds it, and it reaches the branch as the payload's
+`subPath`). The id already says where the folder is, so repeating the absolute
+path only put the owner's folder tree in the address bar and in browser history
+(#1206 item 9); a folder ROOT is therefore `/ref-folder/:id` with no query at
+all. `routeSubfolderUnder` still accepts an ABSOLUTE `?path=`, because links
+shared and history entries made before that carry one — and because `/`, the
+only folder-facet route with no id, has nothing to be relative to. The id still
+owns `referenceFolderId`, so
 `reference_folder_id` stays in the grid query — the query only says which
 folder *inside* it is open. **The sidebar watcher watches `?path=` alongside
 `activeFolderKey`, and has to.** Two sibling subfolders of one folder push

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -1868,8 +1868,13 @@ payload the sidebar emits and therefore to the listing API's existing
 so the route never applies it directly — but it does ride along there, because
 it is also how the sidebar's own subfolder selection stays in the URL: a
 subfolder click carries an `rfId` and so takes the ref-folder branch, which
-pushes `/ref-folder/:id?path=<abs folder>`, and the sidebar restores the
-subfolder from the query once the folder listing is in.
+pushes `/ref-folder/:id?path=<folder under it>`, and the sidebar restores the
+subfolder from the query once the folder listing is in. **There the path is
+relative to the folder the id names**, since the id already says where that
+folder is and spelling it out only put the owner's folder tree in the address
+bar (#1206 item 9); a folder root pushes no query. An absolute `?path=` is
+still read, which is what a link shared before that carries and the only shape
+available on `/`.
 
 **`?face=with_face|without_face`** is the face facet, additive like
 `?stack_state=` — an absent or unrecognised value leaves

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, posix as pathPosix, resolve, win32 as pathWin32 } from 'node:path';
+import { pathKey } from './urlPolicy';
 
 /** Compute accelerators a PixlStash runtime can target. */
 export type Accel = 'cpu' | 'cu128' | 'rocm' | 'metal';
@@ -84,11 +85,12 @@ export type PathPurpose = 'library' | 'backends';
  * and `~/pictures` are two different directories, so folding there would let a
  * path that was never offered match one that was. Same rule, and the same
  * `process.platform` switch, as {@link normalizeBackendsRoot}.
+ *
+ * Defined in `urlPolicy.ts` and re-exported here: this file imports `electron`
+ * at module load and that one does not, so the renderer-page guards can share
+ * the definition rather than keep a second one that disagrees (#1206 item 2).
  */
-export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
-  const resolved = resolve(path.trim());
-  return platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
+export { pathKey };
 
 // Key -> the path as PixlStash actually offered it. A Map rather than a Set so
 // the value that flows on is the one the main process vouched for, never the

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1249,10 +1249,13 @@ function registerDownloadHandling(): void {
  * (#1177 item 62). Binding to a `webContents` cannot separate them; the
  * document loaded in the sending frame can.
  *
- * `startup:*` is deliberately NOT gated: `takePendingTelemetry`,
- * `takePendingMapping` and `askQuestion` are the running app's own channels
- * (`useAppConfig.js`, `SideBar.vue`), and gating them would break the upgrade
- * privacy question and the folder-mapping handoff.
+ * `startup:*` is the running app's own family (`useAppConfig.js`,
+ * `SideBar.vue`), so gating it HERE would break the upgrade privacy question
+ * and the folder-mapping handoff. `startup:askQuestion` is gated on the app
+ * window instead (requireAppRenderer, #1206 item 4) because it replaces the
+ * document with the wizard; `takePendingTelemetry` and `takePendingMapping`
+ * only hand back an answer this process parked for the page that is about to
+ * ask, and stay open.
  */
 function requireSetupRenderer(event: Electron.IpcMainInvokeEvent, channel: string): void {
   // The frame, not the webContents: a frame the library page created has its
@@ -1511,7 +1514,14 @@ function registerIpc(): void {
   // The app asking for a question it cannot answer itself. It hands the window
   // back to the startup framework rather than opening a dialog over a library
   // that is already on screen; `setup:commit` brings the window back.
-  ipcMain.handle('startup:askQuestion', async (_e, step?: string) => {
+  //
+  // Gated on the app window (#1206 item 4). It writes no config and repoints no
+  // library, but it replaces the document with the full-screen wizard, so any
+  // page that could reach it could throw the owner out of the library and lose
+  // whatever was unsaved. `useAppConfig.js` - which runs in the backend-served
+  // app - is the only caller, and `requireAppRenderer` is exactly that audience.
+  ipcMain.handle('startup:askQuestion', async (event, step?: string) => {
+    requireAppRenderer(event, 'startup:askQuestion');
     if (step !== 'privacy') {
       console.warn(`[startup] refusing an unknown startup step: ${step}`);
       return false;

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -2,6 +2,28 @@ import { resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
+ * The lookup key for a path, matching the platform's own idea of path identity:
+ * resolved, and case-folded on Windows only.
+ *
+ * THE canonical rule, re-exported by `config.ts` (which cannot own it - it
+ * imports `electron` at module load, and this module is loaded by tests that
+ * have no Electron). Two copies of this rule is exactly the bug #1206 item 2
+ * describes: `config.ts` folded case and this file did not, so a `file://` URL
+ * whose drive letter came back in a different case than `RENDERER_DIR` spells
+ * it made {@link isBundledRendererPage} answer false for the wizard page
+ * itself - and `requireSetupRenderer` then refused every `setup:*` channel,
+ * with no way through first-run setup.
+ *
+ * Windows filesystems are case-insensitive, so `C:\\x` and `c:\\x` are one
+ * directory. POSIX is case-SENSITIVE, where folding would let `/opt/Renderer`
+ * pass as `/opt/renderer` - a different directory, and one we did not bundle.
+ */
+export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
+  const resolved = resolve(path.trim());
+  return platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+/**
  * A URL safe to write to the log: enough to identify what was blocked, never
  * the `user:password@` userinfo the URL may carry and never a page-authored
  * payload. Schemes with no origin report origin `null`; of those only `file:`
@@ -45,12 +67,15 @@ export function redactUrl(target: string): string {
  * file is the answer, so `index.html` and `permissions.html` are refused too.
  * The path is resolved and compared whole: a prefix test would accept a sibling
  * directory sharing the prefix, and `fileURLToPath` is what stops a percent-
- * encoded traversal reaching the comparison as text.
+ * encoded traversal reaching the comparison as text. Compared through
+ * {@link pathKey}, so the two halves may disagree about casing on Windows -
+ * where they name one directory - and never on POSIX, where they do not.
  */
 export function isBundledRendererPage(
   target: string,
   rendererDir: string,
   page: string,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   let url: URL;
   try {
@@ -61,7 +86,7 @@ export function isBundledRendererPage(
   if (url.protocol !== 'file:') return false;
   try {
     const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
-    return resolve(fileURLToPath(url)) === resolve(dir, page);
+    return pathKey(fileURLToPath(url), platform) === pathKey(resolve(dir, page), platform);
   } catch {
     return false;
   }
@@ -142,6 +167,7 @@ export function isAllowedNavigation(
   target: string,
   currentUrl: string | null,
   rendererDir: string,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   let url: URL;
   try {
@@ -162,10 +188,13 @@ export function isAllowedNavigation(
   // Normalise the trailing separator here rather than trust the caller: without
   // it a sibling directory sharing the prefix (…/renderer-evil) would pass.
   if (url.protocol === 'file:') {
-    const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
+    // Through pathKey for the same reason isBundledRendererPage is: on Windows
+    // a differently-cased drive letter names the same directory, and refusing
+    // it would block our own bundled pages from loading.
+    const base = pathKey(rendererDir, platform);
     try {
-      const path = resolve(fileURLToPath(url));
-      return path === dir.slice(0, -1) || path.startsWith(dir);
+      const path = pathKey(fileURLToPath(url), platform);
+      return path === base || path.startsWith(base + sep);
     } catch (e) {
       console.warn(`[nav] blocking unresolvable file:// URL ${redactUrl(target)}:`, e);
       return false;

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -362,13 +362,23 @@ describe('IPC gating is complete, not opt-in', () => {
     assert.match(main, /isBackendOrigin\(sender, currentUrl\)/);
   });
 
-  it('leaves the app-renderer startup:* channels open', () => {
+  it('never gates a startup:* channel on the WIZARD page', () => {
     // takePendingTelemetry / takePendingMapping / askQuestion are called BY the
-    // library app (useAppConfig.js, SideBar.vue). Gating them would break the
-    // upgrade privacy question and the folder-mapping handoff.
+    // library app (useAppConfig.js, SideBar.vue). Gating them on setup.html
+    // would break the upgrade privacy question and the folder-mapping handoff.
     for (const [channel, body] of handlers.filter(([c]) => c.startsWith('startup:'))) {
       assert.doesNotMatch(body, /requireSetupRenderer/, `${channel} must stay open`);
     }
+  });
+
+  it('gates startup:askQuestion on the app window (#1206 item 4)', () => {
+    // It writes nothing, but it replaces the document with the full-screen
+    // wizard - so an ungated one let any page throw the owner out of the
+    // library and lose unsaved work. The two `takePending*` channels stay open:
+    // they only hand back an answer this process parked for the page asking.
+    const [, askQuestion] = handlers.find(([c]) => c === 'startup:askQuestion') ?? [];
+    assert.ok(askQuestion, 'startup:askQuestion not found');
+    assert.match(askQuestion, /requireAppRenderer\(event, 'startup:askQuestion'\)/);
   });
 });
 

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -202,13 +202,23 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * side closed by making "safe by omission" a machine fact
  * (`test_all_routes_declare_access_policy`). Deriving the set means a new
  * `setup:*` or `server:*` channel is covered the moment it exists.
+ *
+ * #1206 item 10: the pattern was `ipcMain.handle(\s*'`, which is three ways to
+ * be invisible to it - `handleOnce`, a double-quoted or backtick name, and a
+ * computed one. All three could be added at once and this file stayed green.
+ * The first two are read now; the third CANNOT be, so it is made loud rather
+ * than skipped (`every handler opener is read` below).
  */
+const NAMED_HANDLE = /ipcMain\.handle(?:Once)?\(\s*(['"`])([^'"`]+)\1/;
+/** The same opener with the channel name left unconstrained. */
+const ANY_HANDLE = /ipcMain\.handle(?:Once)?\(/;
+
 function ipcHandlers(main: string): Array<[string, string]> {
   const found: Array<[string, string]> = [];
-  const opener = /ipcMain\.handle\(\s*'([^']+)'/g;
+  const opener = new RegExp(NAMED_HANDLE.source, 'g');
   const starts: Array<[string, number]> = [];
   for (let m = opener.exec(main); m !== null; m = opener.exec(main)) {
-    starts.push([m[1], m.index]);
+    starts.push([m[2], m.index]);
   }
   starts.forEach(([channel, at], i) => {
     const end = i + 1 < starts.length ? starts[i + 1][1] : main.length;
@@ -264,6 +274,38 @@ describe('IPC gating is complete, not opt-in', () => {
   // __dirname is dist-test/test at run time; the sources are two levels up.
   const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
   const handlers = ipcHandlers(main);
+
+  // A channel name built at run time cannot be read out of the source, so it
+  // cannot be checked for a gate either. Refuse it here rather than let the
+  // sweep walk past it: this is the difference between a guardrail with a gap
+  // and one that says where the gap is.
+  it('every handler opener is read, so a computed channel name cannot hide', () => {
+    const total = main.match(new RegExp(ANY_HANDLE.source, 'g'))?.length ?? 0;
+    assert.equal(
+      handlers.length,
+      total,
+      `${total - handlers.length} ipcMain.handle call(s) name their channel with ` +
+        'something other than a plain string literal, so nothing here can tell ' +
+        'whether they are gated. Give the channel a literal name.',
+    );
+  });
+
+  it('reads handleOnce, double quotes and backticks', () => {
+    const synthetic = [
+      "ipcMain.handleOnce('once:channel', () => 1);",
+      'ipcMain.handle("double:quoted", () => 2);',
+      'ipcMain.handle(`backticked`, () => 3);',
+    ].join('\n');
+    assert.deepEqual(
+      ipcHandlers(synthetic).map(([c]) => c),
+      ['once:channel', 'double:quoted', 'backticked'],
+    );
+    // A computed name is an opener the sweep cannot name: zero handlers found,
+    // one opener present, which is exactly the discrepancy the count test reads.
+    const computed = 'ipcMain.handle(CHANNEL, () => 4);';
+    assert.equal(ipcHandlers(computed).length, 0);
+    assert.equal(computed.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
 
   it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {
     const channels = handlers.map(([c]) => c);

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -159,6 +159,37 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
       assert.equal(isSetup(bad), false, `${bad} must not pass as the setup screen`);
     }
   });
+
+  // #1206 item 2. `config.ts` folded case on Windows and this file did not, so
+  // a `file://` URL whose casing differed from RENDERER_DIR's answered false
+  // for the wizard page itself - and requireSetupRenderer then refused EVERY
+  // `setup:*` channel, leaving first-run setup with no way through. Windows is
+  // where a drive letter's case can differ between two APIs; POSIX is where
+  // folding would be the security bug, so both directions are pinned here.
+  //
+  // Exercised with POSIX-shaped paths and an explicit `platform`, because
+  // `resolve()` uses the HOST's semantics: a `C:\` literal would not normalise
+  // on the Linux runner. The casing rule is what is under test, not `resolve`.
+  describe('path casing follows the platform', () => {
+    const UPPER = resolve('/opt/PixlStash/dist/Renderer') + sep;
+    const page = pathToFileURL(UPPER + 'setup.html').href;
+
+    it('accepts a differently-cased spelling of the same Windows directory', () => {
+      assert.ok(isBundledRendererPage(page, RENDERER_DIR, 'setup.html', 'win32'));
+      assert.ok(isAllowedNavigation(page, BACKEND, RENDERER_DIR, 'win32'));
+    });
+
+    it('refuses it on POSIX, where that is a different directory', () => {
+      assert.equal(isBundledRendererPage(page, RENDERER_DIR, 'setup.html', 'linux'), false);
+      assert.equal(isAllowedNavigation(page, BACKEND, RENDERER_DIR, 'linux'), false);
+    });
+
+    it('still refuses a prefix-sharing sibling once case is folded', () => {
+      const sibling = pathToFileURL(resolve('/opt/pixlstash/dist/RENDERER-evil') + sep + 'setup.html').href;
+      assert.equal(isBundledRendererPage(sibling, RENDERER_DIR, 'setup.html', 'win32'), false);
+      assert.equal(isAllowedNavigation(sibling, BACKEND, RENDERER_DIR, 'win32'), false);
+    });
+  });
 });
 
 /**

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -209,9 +209,20 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * The first two are read now; the third CANNOT be, so it is made loud rather
  * than skipped (`every handler opener is read` below).
  */
-const NAMED_HANDLE = /ipcMain\.handle(?:Once)?\(\s*(['"`])([^'"`]+)\1/;
+/**
+ * Whitespace or a comment. TypeScript allows either between the method name
+ * and its `(`, so a handler registered with a block or line comment sitting in
+ * that gap is invisible to BOTH patterns below - the opener count would agree
+ * with the named count and nothing would go red. Same silent bypass as item
+ * 10, one token further along. (Not written out as an example here: the
+ * example's own comment terminator would end this one.)
+ */
+const OPENER_GAP = '(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\n]*\\n)*';
+const NAMED_HANDLE = new RegExp(
+  `ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(\\s*(['"\`])([^'"\`]+)\\1`,
+);
 /** The same opener with the channel name left unconstrained. */
-const ANY_HANDLE = /ipcMain\.handle(?:Once)?\(/;
+const ANY_HANDLE = new RegExp(`ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(`);
 
 function ipcHandlers(main: string): Array<[string, string]> {
   const found: Array<[string, string]> = [];
@@ -305,6 +316,28 @@ describe('IPC gating is complete, not opt-in', () => {
     const computed = 'ipcMain.handle(CHANNEL, () => 4);';
     assert.equal(ipcHandlers(computed).length, 0);
     assert.equal(computed.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
+
+  it('reads an opener with a comment before its paren', () => {
+    // TypeScript allows a comment between the method name and `(`. Before this
+    // it hid the handler from the named sweep AND from the opener count, so
+    // the two agreed and the "cannot hide" test above stayed green - a silent
+    // bypass rather than a loud one. Built from pieces so this file does not
+    // contain a comment terminator that would end its own.
+    const block = '/' + '* hidden *' + '/';
+    const commented = [
+      `ipcMain.handle${block}('block:commented', () => 1);`,
+      'ipcMain.handleOnce // trailing\n(\'line:commented\', () => 2);',
+    ].join('\n');
+    assert.deepEqual(
+      ipcHandlers(commented).map(([c]) => c),
+      ['block:commented', 'line:commented'],
+    );
+    // And a computed name hidden the same way is still counted as an opener,
+    // so it fails loudly instead of vanishing.
+    const hidden = `ipcMain.handle${block}(CHANNEL, () => 3);`;
+    assert.equal(ipcHandlers(hidden).length, 0);
+    assert.equal(hidden.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
   });
 
   it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -2507,9 +2507,18 @@ async function deleteReferenceFolderById(id) {
   if (!window.confirm(`Remove reference folder "${folderLabel}"?`)) return;
   try {
     await deleteFolder("reference", id);
-    if (selectedFolderKey.value === `rf-${id}`) {
+    // On the FOLDER, not on the row key. A selected SUBfolder's key is
+    // `path-<abs path>` (crossing 1 in the map above), so matching `rf-<id>`
+    // saw only the root row: deleting the folder from under a selected
+    // subfolder left the highlight, `selectedFolderReferenceId` and the
+    // scanning light on a folder that no longer exists (#1206 item 12). The
+    // import-folder branch below is the shape this now copies - all four
+    // pieces of the selection, not just the key.
+    if (_folderId(selectedFolderReferenceId.value) === id) {
       selectedFolderKey.value = null;
+      selectedFolderReferenceId.value = null;
       emit("select-folder", null);
+      sidebarStore.folderScanning = false;
     }
     await fetchReferenceFolders();
   } catch (e) {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -994,9 +994,9 @@ async function referenceFolderSaved(savedFolder = null) {
 
 async function referenceFolderDeleted() {
   closeReferenceFolderEditor();
-  // If we were browsing this folder, clear the selection
-  selectedFolderKey.value = null;
-  selectedFolderReferenceId.value = null;
+  // If we were browsing this folder, clear the selection. The editor's delete
+  // button is the other way into #1206 item 12 - same leak, different entry.
+  clearFolderSelection();
   emit("select-folder", null);
   sidebarStore.folderScanning = false;
   await fetchReferenceFolders();
@@ -1036,8 +1036,7 @@ async function importFolderSaved() {
     (entry) => Number(entry.id) === selectedId,
   );
   if (!selectedImportFolder) {
-    selectedFolderKey.value = null;
-    selectedFolderReferenceId.value = null;
+    clearFolderSelection();
     emit("select-folder", null);
     sidebarStore.folderScanning = false;
     return;
@@ -1056,8 +1055,7 @@ async function importFolderDeleted() {
     Number.isFinite(deletedId) &&
     selectedFolderKey.value === `if-${deletedId}`
   ) {
-    selectedFolderKey.value = null;
-    selectedFolderReferenceId.value = null;
+    clearFolderSelection();
     emit("select-folder", null);
     sidebarStore.folderScanning = false;
   }
@@ -2561,6 +2559,22 @@ async function deleteSetsByIds(ids) {
   }
 }
 
+/** Forget the sidebar's folder selection - all four pieces of it.
+ *
+ * They are written together by `handleFolderNodeSelect` and must be cleared
+ * together. Clearing a subset leaves state the UI cannot show but the route
+ * watcher still reads: after a delete, `selectedFolderRouteKey` has already
+ * changed, so the watcher's `=== oldKey` guard never matches and a leftover
+ * `selectedFolderPath` / `selectedFolderSubPath` is never collected. Both
+ * delete branches used to clear two of the four (#1206 item 12).
+ */
+function clearFolderSelection() {
+  selectedFolderKey.value = null;
+  selectedFolderReferenceId.value = null;
+  selectedFolderPath.value = null;
+  selectedFolderSubPath.value = null;
+}
+
 async function deleteReferenceFolderById(id) {
   const folder = referenceFolders.value.find((rf) => rf.id === id);
   if (!folder) return;
@@ -2576,8 +2590,7 @@ async function deleteReferenceFolderById(id) {
     // import-folder branch below is the shape this now copies - all four
     // pieces of the selection, not just the key.
     if (_folderId(selectedFolderReferenceId.value) === id) {
-      selectedFolderKey.value = null;
-      selectedFolderReferenceId.value = null;
+      clearFolderSelection();
       emit("select-folder", null);
       sidebarStore.folderScanning = false;
     }
@@ -2599,8 +2612,7 @@ async function deleteImportFolderById(id) {
   try {
     await deleteFolder("import", id);
     if (selectedFolderKey.value === `if-${id}`) {
-      selectedFolderKey.value = null;
-      selectedFolderReferenceId.value = null;
+      clearFolderSelection();
       emit("select-folder", null);
       sidebarStore.folderScanning = false;
     }
@@ -4165,10 +4177,7 @@ watch(
     if (!newKey) {
       // Route left a folder view - clear the sidebar's folder highlight.
       if (oldKey && selectedFolderRouteKey.value === oldKey) {
-        selectedFolderKey.value = null;
-        selectedFolderReferenceId.value = null;
-        selectedFolderPath.value = null;
-        selectedFolderSubPath.value = null;
+        clearFolderSelection();
       }
       return;
     }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -496,6 +496,11 @@ const selectedFolderReferenceId = ref(null); // numeric reference-folder id or n
 /** The absolute folder path the selection is filtering on, or null. The row key
     above cannot carry it: a folder ROOT row's key is `rf-{id}`. */
 const selectedFolderPath = ref(null);
+/** The same folder said RELATIVE to its reference folder's root - the sidebar's
+    copy of what it last handed `?path=`, and `null` for the root itself. The
+    URL carries this rather than the absolute path so the owner's folder tree is
+    not in the address bar or the browser history (#1206 item 9). */
+const selectedFolderSubPath = ref(null);
 const dragOverReferenceTargetKey = ref(null);
 
 // Reference folder editor state
@@ -521,13 +526,22 @@ const librariesStore = useLibrariesStore();
 //   2. Route key    `viewStore.activeFolderKey`: `rf-<id>` | `if-<id>`.
 //      Identifies a FOLDER. Never `path-`: a route has no row.
 //   3. Route path   `?path=`. A URL - any separator spelling, and editable.
+//      On an `rf-`/`if-` route it is now RELATIVE to the folder the id names
+//      (#1206 item 9: the id already says where the folder is, so repeating the
+//      owner's absolute path only put their folder tree in the address bar and
+//      the browser history). An ABSOLUTE one is still read, because links and
+//      history entries written before that carry one. On `/` - the only route
+//      with no folder id - it stays absolute, since nothing else names it.
+//      `selectedFolderSubPath` is the sidebar's copy of what it last wrote.
 //   4. Grid filter  `selectedFolderFilter.pathPrefix`, which reaches the
 //      listing as `file_path_prefix`: a literal LIKE against the stored
 //      `file_path`, so it MUST be in the server's spelling.
 //   5. Tree path    `entry.path` from the browse listing. Server spelling.
 //
-// Four crossings are legitimate, and each has one owner:
+// Five crossings are legitimate, and each has one owner:
 //   1 -> 2         `selectedFolderRouteKey`
+//   4 -> 3         `_subPathUnder`, via `handleFolderNodeSelect` (the only
+//                  place a server path is allowed to become a URL path)
 //   2 + 3 -> 1,4   `routeSubfolderUnder`  (the only place a URL path is
 //                  allowed to become a server path)
 //   4 vs 3         the watcher's "already in sync" test, through `_urlPath`.
@@ -595,13 +609,51 @@ function _urlPath(p) {
 }
 
 /**
+ * `path` said relative to `root`, or `null` when it is not inside it (the root
+ * ITSELF included - that is "no subfolder", not "an empty one").
+ *
+ * The one crossing from the server's spelling into the URL's. The tail keeps
+ * the path's OWN separators: `routeSubfolderUnder` re-spells on the way back,
+ * and re-spelling here as well would only make the two disagree.
+ *
+ * Folding `\` into `/` is for a WINDOWS root only, on the same rule and for the
+ * same reason as `routeSubfolderUnder`: on POSIX a `\` is an ordinary character
+ * in a folder's NAME, and folding would slice the tail at a character that does
+ * not separate anything.
+ */
+function _subPathUnder(root, path) {
+  const rootPath = _normPath(root);
+  const here = _normPath(path);
+  if (!rootPath || !here) return null;
+  const windows = _pathSeparator(rootPath) === "\\";
+  const base = windows ? _urlPath(rootPath) : rootPath;
+  const under = windows ? _urlPath(here) : here;
+  // One character for one character, so the tail can be sliced out of the
+  // ORIGINAL spelling at the offset the folded comparison found.
+  return under.startsWith(`${base}/`) ? here.slice(rootPath.length + 1) : null;
+}
+
+/** Whether a `?path=` names a folder outright rather than one inside another.
+    A tail sliced by `_subPathUnder` never starts with a separator and never
+    carries a drive letter, so those are what tell the two apart. */
+function _isAbsolutePath(p) {
+  return /^([a-zA-Z]:)?[\\/]/.test(String(p || ""));
+}
+
+/**
  * The `?path=` on the current folder route, when it names a folder INSIDE
  * `root` rather than `root` itself.
  *
- * A subfolder click pushes `/ref-folder/:id?path=<abs path>`, and this is what
- * reads it back so a reload or a shared link lands on the subfolder the URL
- * names instead of the folder root. `null` means "the route names the folder
- * itself", which is the ordinary case and the pre-existing behaviour.
+ * A subfolder click pushes `/ref-folder/:id?path=<tail under the folder>`, and
+ * this is what reads it back so a reload or a shared link lands on the
+ * subfolder the URL names instead of the folder root. `null` means "the route
+ * names the folder itself", which is the ordinary case.
+ *
+ * **Both shapes of `?path=` are read.** A tail is what the sidebar writes now
+ * (#1206 item 9); an ABSOLUTE path is what it wrote before, so links already
+ * shared and history entries already made keep working - and a `/` route,
+ * which has no id to be relative to, has no other shape available. An absolute
+ * one that is not inside this folder is still `null`, the same refusal as ever.
  *
  * Matched through `_urlPath`, so the two sides may disagree about separators
  * and still match. They come from the same server and normally agree, but the
@@ -628,20 +680,18 @@ function routeSubfolderUnder(root) {
   const raw = _normPath(filter.pathPrefix);
   const rootPath = _normPath(root);
   const sep = _pathSeparator(rootPath);
-  // Folding `\` into `/` is for a WINDOWS root only, where both characters
-  // separate and a URL may legitimately spell either. A POSIX root is compared
-  // raw, because there `\` is an ordinary character in a folder's name and
-  // folding would make `?path=/x/a/b/2024` - a different folder, or none -
-  // read as a subfolder of `/x/a\b` and then be rewritten into it.
+  // An absolute `?path=` is sliced against the root (and refused when it names
+  // somewhere else); a relative one already IS the tail. `_subPathUnder` folds
+  // `\` into `/` for a WINDOWS root only, where both characters separate and a
+  // URL may legitimately spell either. A POSIX root is compared raw, because
+  // there `\` is an ordinary character in a folder's name and folding would
+  // make `?path=/x/a/b/2024` - a different folder, or none - read as a
+  // subfolder of `/x/a\b` and then be rewritten into it.
+  const rawTail = _isAbsolutePath(raw) ? _subPathUnder(rootPath, raw) : raw;
+  if (!rawTail) return null;
   const windows = sep === "\\";
-  // `_urlPath` swaps one character for one character, so both stay aligned
-  // with `raw` and the tail can be sliced back out of the ORIGINAL spelling.
-  const here = windows ? _urlPath(raw) : raw;
-  const base = windows ? _urlPath(rootPath) : rootPath;
-  if (!base || here === base || !here.startsWith(`${base}/`)) return null;
-  const rawTail = raw.slice(base.length + 1);
-  // Re-spelt only on Windows, for the same reason: on POSIX the tail's own
-  // backslashes are part of a name, so this is genuinely a no-op there.
+  // Re-spelt only on Windows: on POSIX the tail's own backslashes are part of
+  // a name, so this is genuinely a no-op there.
   const tail = windows ? rawTail.split(/[\\/]/).join(sep) : rawTail;
   return {
     pathPrefix: `${rootPath}${sep}${tail}`,
@@ -1246,7 +1296,18 @@ function handleFolderNodeSelect(key, payload) {
     selectedFolderReferenceId.value = null;
   }
   selectedFolderPath.value = payload?.pathPrefix ?? null;
-  emit("select-folder", payload);
+  // What the URL will say. The id already names the folder, so `?path=` only
+  // has to say which folder INSIDE it - and saying it absolutely put the
+  // owner's whole folder tree in the address bar and the browser history
+  // (#1206 item 9). `null` for the folder root, which needs no query at all.
+  const root =
+    referenceFolders.value.find((rf) => rf.id === selectedFolderReferenceId.value)
+      ?.folder ?? null;
+  const subPath = _subPathUnder(root, payload?.pathPrefix);
+  selectedFolderSubPath.value = subPath;
+  // Added only when there IS one, so a folder root's and an import folder's
+  // payload stay exactly the object they were.
+  emit("select-folder", subPath ? { ...payload, subPath } : payload);
   // Emit immediately on selection so ImageGrid updates before next poll tick.
   sidebarStore.folderScanning = selectedFolderScanning.value;
 }
@@ -4107,6 +4168,7 @@ watch(
         selectedFolderKey.value = null;
         selectedFolderReferenceId.value = null;
         selectedFolderPath.value = null;
+        selectedFolderSubPath.value = null;
       }
       return;
     }
@@ -4129,12 +4191,20 @@ watch(
     // the emit pushed the re-spelled path as a NEW url, and Back returned to
     // the original spelling and started the round again. A shared Windows link
     // could not be navigated away from.
+    //
+    // Both spellings of the sidebar's own path are offered, because both
+    // spellings of `?path=` arrive (see `routeSubfolderUnder`):
+    // `selectedFolderSubPath` is what the sidebar wrote into the URL itself,
+    // `selectedFolderPath` is what an absolute link from before that carries.
+    // Comparing only the absolute one would leave the sidebar unable to
+    // recognise the very URL it had just pushed - the loop above, again.
     const showingSubfolder = selectedFolderKey.value?.startsWith("path-");
     const routePath = _urlPath(newPath);
+    const mine = [selectedFolderSubPath.value, selectedFolderPath.value];
     if (
       selectedFolderRouteKey.value === newKey &&
       (newPath
-        ? routePath !== "" && _urlPath(selectedFolderPath.value) === routePath
+        ? routePath !== "" && mine.some((p) => p && _urlPath(p) === routePath)
         : !showingSubfolder)
     ) {
       return;

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -167,6 +167,47 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 5,
       pathPrefix: SUB,
+      // What the URL will say next time: relative to the folder its id names,
+      // so the owner's folder tree stays out of the address bar (#1206 item 9).
+      subPath: "2024/summer",
+      label: "summer",
+    });
+
+    wrapper.unmount();
+  });
+
+  // #1206 item 9. The URL now says the subfolder relative to the folder its id
+  // already names, so a reference-folder click stops putting the owner's whole
+  // folder tree in the address bar and in browser history. The absolute form
+  // every other test in this file uses is still read - that is what links
+  // shared, and history entries made, before this carry.
+  it("selects the subfolder a relative query names", async () => {
+    const wrapper = await mountSidebar();
+    routeToFolder("2024/summer");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: SUB,
+      subPath: "2024/summer",
+      label: "summer",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("re-spells a relative query into a Windows folder's separators", async () => {
+    // Same rule as the absolute case: `file_path_prefix` is a literal LIKE
+    // against the stored `file_path`, so a slash-spelled prefix on a Windows
+    // library matches nothing.
+    const wrapper = await mountSidebar();
+    routeToFolder("2024/summer", "rf-6");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 6,
+      pathPrefix: `${WIN_ROOT}\\2024\\summer`,
+      subPath: "2024\\summer",
       label: "summer",
     });
 
@@ -263,6 +304,7 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 5,
       pathPrefix: other,
+      subPath: "2023/winter",
       label: "winter",
     });
 
@@ -327,6 +369,17 @@ describe("restoring /ref-folder/:id", () => {
         "a POSIX SUBfolder whose name contains a backslash",
         "rf-7",
         `${ODD_ROOT}/c\\d`,
+      ],
+      // The shape the sidebar writes now (#1206 item 9). Every absolute case
+      // above is a link or a history entry from BEFORE it, which is why both
+      // shapes are here rather than one replacing the other.
+      ["a POSIX subfolder, said relative to its folder", "rf-5", "2024/summer"],
+      ["a Windows subfolder, said relative to its folder", "rf-6", "2024\\summer"],
+      ["the same Windows subfolder, slash-spelled", "rf-6", "2024/summer"],
+      [
+        "a relative tail whose own name contains a backslash",
+        "rf-7",
+        "c\\d",
       ],
     ];
 
@@ -415,6 +468,9 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 7,
       pathPrefix: `${ODD_ROOT}/c\\d`,
+      // And the tail written into the URL keeps that backslash too: on POSIX
+      // it is a character in a name, not a separator, at both ends of the trip.
+      subPath: "c\\d",
       label: "c\\d",
     });
 
@@ -440,6 +496,7 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 6,
       pathPrefix: `${WIN_ROOT}\\2024\\summer`,
+      subPath: "2024\\summer",
       label: "summer",
     });
 

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -111,11 +111,16 @@ function respond(url) {
   return { data: [] };
 }
 
-async function mountSidebar() {
+/**
+ * `teleport: true` renders the teleported layer (the sidebar's context menu
+ * lives there) instead of leaving it stubbed, which `shallow` does by default.
+ */
+async function mountSidebar({ teleport = false } = {}) {
   const wrapper = mount(SideBar, {
     shallow: true,
     props: { backendUrl: "/api/v1" },
     global: {
+      stubs: teleport ? { teleport: false } : {},
       config: {
         compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
       },
@@ -437,6 +442,34 @@ describe("restoring /ref-folder/:id", () => {
       pathPrefix: `${WIN_ROOT}\\2024\\summer`,
       label: "summer",
     });
+
+    wrapper.unmount();
+  });
+
+  // #1206 item 12. The cleanup matched `rf-<id>`, which is the ROOT row's key;
+  // a selected subfolder's key is `path-<abs path>`, so removing the folder
+  // under it left the highlight and the scanning light on a folder that no
+  // longer existed. Matching on the folder the selection belongs to is what the
+  // import-folder branch already did.
+  it("clears a selected subfolder when its reference folder is removed", async () => {
+    const wrapper = await mountSidebar({ teleport: true });
+    const sidebarStore = useSidebarStore();
+    routeToFolder(SUB);
+    await flushPromises();
+    expect(sidebarStore.folderScanning).toBe(true);
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const rows = wrapper.findAll(".sidebar-folder-root-row");
+    await rows[0].trigger("contextmenu");
+    await flushPromises();
+    // The context menu is teleported to <body>, so it is not under `wrapper`.
+    const remove = document.querySelector(".sidebar-ctx-item--danger");
+    expect(remove).not.toBe(null);
+    remove.click();
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toBe(null);
+    expect(sidebarStore.folderScanning).toBe(false);
 
     wrapper.unmount();
   });

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -265,7 +265,15 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       // screen. The id still owns the payload - `useViewStore.applyView`
       // refuses to overwrite it from `?path=` on a folder route, and the
       // sidebar restores the subfolder from the query instead.
-      const folderQuery = f.pathPrefix ? { path: f.pathPrefix } : {};
+      //
+      // `subPath`, NOT `pathPrefix`: the id already says where the folder is,
+      // so repeating the absolute path only put the owner's folder tree in the
+      // address bar and in browser history (#1206 item 9). The sidebar builds
+      // it (`SideBar._subPathUnder`) and reads it back
+      // (`SideBar.routeSubfolderUnder`, which still accepts the absolute form a
+      // link shared before this carries). A folder ROOT has no subPath and
+      // therefore no query at all, which is where it started.
+      const folderQuery = f.subPath ? { path: f.subPath } : {};
       if (f.referenceFolderId != null) {
         pushAppRoute({
           name: "ref-folder",
@@ -284,8 +292,13 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       }
       // A folder payload with no id of any kind - what an "About your
       // library" finding points at. It travels as `?path=` rather than being
-      // dropped, and `useViewStore.parseFolderPath` reads it back.
-      pushAppRoute({ name: "all-pictures", query: folderQuery });
+      // dropped, and `useViewStore.parseFolderPath` reads it back. ABSOLUTE
+      // here, unlike the two branches above: there is no id for it to be
+      // relative to, so the path is the only thing that names this folder.
+      pushAppRoute({
+        name: "all-pictures",
+        query: f.pathPrefix ? { path: f.pathPrefix } : {},
+      });
       return;
     }
 

--- a/frontend/src/composables/useAppNavigationFolders.test.js
+++ b/frontend/src/composables/useAppNavigationFolders.test.js
@@ -56,6 +56,8 @@ function mountNav() {
 
 const ROOT = "/home/me/library/refs";
 const SUB = "/home/me/library/refs/2024/summer";
+/** SUB said the way the URL now says it: relative to the folder the id names. */
+const SUBTAIL = "2024/summer";
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -67,25 +69,34 @@ beforeEach(() => {
 });
 
 describe("a reference-folder click", () => {
-  it("keeps the subfolder in the URL", () => {
+  it("keeps the subfolder in the URL, relative to the folder", () => {
+    // `subPath`, not `pathPrefix`: the id already names the folder, so the
+    // query only has to say which folder inside it. Repeating the absolute
+    // path put the owner's folder tree in the address bar and in their browser
+    // history for no navigational gain (#1206 item 9).
     const { wrapper, api } = mountNav();
 
     api.handleSelectFolder({
       referenceFolderId: 5,
       pathPrefix: SUB,
+      subPath: SUBTAIL,
       label: "summer",
     });
 
     expect(nav.push).toHaveBeenCalledWith({
       name: "ref-folder",
       params: { id: "5" },
-      query: { path: SUB },
+      query: { path: SUBTAIL },
     });
+    expect(JSON.stringify(nav.push.mock.calls)).not.toContain(ROOT);
 
     wrapper.unmount();
   });
 
-  it("names the folder root when that is what was clicked", () => {
+  it("names the folder root with no query at all", () => {
+    // The root row's click carries `pathPrefix: folder.folder` and no
+    // `subPath`, because the root is not inside itself. `/ref-folder/5` says
+    // everything there is to say.
     const { wrapper, api } = mountNav();
 
     api.handleSelectFolder({
@@ -97,7 +108,7 @@ describe("a reference-folder click", () => {
     expect(nav.push).toHaveBeenCalledWith({
       name: "ref-folder",
       params: { id: "5" },
-      query: { path: ROOT },
+      query: {},
     });
 
     wrapper.unmount();


### PR DESCRIPTION
Frontend and Electron leftovers from the v1.11.1 reviews (#1206). One commit
per item.

* First-run setup could be impossible on Windows: Two files disagreed about
whether drive letters are case-sensitive; when they disagreed, the wizard
decided it wasn't a real page and refused every step.

*A test guarding our IPC handlers was easy to sneak past.
