### PR TITLE
Backend leftovers from the v1.11.1 adversarial reviews (#1206)

### DIFF
--- a/changelog.d/1206-backend.md
+++ b/changelog.d/1206-backend.md
@@ -1,0 +1,17 @@
+- Export to folder now refuses a destination inside *any* of your libraries,
+  not only the one you are looking at. Exporting into another library's folder
+  used to be accepted, and everything written there came back as a fresh set of
+  pictures the next time you opened it.
+- Deleted pictures no longer use the GPU for tagging. The "awaiting tagging"
+  number left them out while the tagger went on working through them, so the
+  count could read zero while your card stayed busy.
+- PixlStash now says so when the WD14 tagger falls back to the CPU. It asked
+  onnxruntime what the build supports rather than what the tagger actually
+  loaded, so a GPU that could not be used looked exactly like one that was.
+- Background work no longer stalls re-checking files on a drive that has gone
+  away. The list of files to skip was rebuilt several times a sweep, and every
+  rebuild waited on the missing drive.
+- `pixlstash-cli plugins install --with-deps` now lists the pip options a
+  plugin's `requirements.txt` reaches through an `-r` include or a line
+  continuation. The include line was shown, but not the `--index-url` behind
+  it that decides where the packages come from.

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -23,6 +23,7 @@ import ast
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -984,14 +985,13 @@ def read_requirements(requirements: Path) -> list[str]:
 #: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
 #: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
 #: pull the second file in, so all four have to be recognised here.
-#: An ``-r``/``-c`` include and its target. The target is a quoted string OR a
-#: bare token, in that order: pip parses these lines with shlex, so
-#: ``-r "deps/with spaces/base.txt"`` is a legal include, and a bare ``\S+``
-#: stopped at the first space and silently failed to follow it.
-_INCLUDE_RE = re.compile(
-    r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)"
-    r"(\"[^\"]+\"|'[^']+'|\S+)"
-)
+#: The ``-r``/``-c`` option itself. The TARGET is not matched here: pip parses
+#: these lines with :mod:`shlex`, and hand-rolled quoting disagrees with it in
+#: a way that matters -- ``-r "a"b.txt`` is one token ``ab.txt`` to pip, but a
+#: quoted-or-bare alternation reads ``a``. Listing the options of one file
+#: while pip reads another defeats the whole point of showing them, so the
+#: target is taken from ``shlex.split`` in :func:`_include_target`.
+_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)")
 
 
 def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
@@ -1010,7 +1010,13 @@ def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
     match = _INCLUDE_RE.match(line)
     if match is None:
         return None
-    target = match.group(1).strip("\"'")
+    try:
+        words = shlex.split(line[match.end() :])
+    except ValueError:
+        # An unbalanced quote. pip will not read this line either; refuse
+        # rather than guess, and the line is still listed by the caller.
+        return None
+    target = words[0] if words else ""
     # `urlparse(...).scheme` was too eager: it reads `base:1.txt` as scheme
     # "base", so a legal relative filename containing a colon was refused and
     # its options went unlisted -- the same incompleteness this is fixing.

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -984,7 +984,14 @@ def read_requirements(requirements: Path) -> list[str]:
 #: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
 #: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
 #: pull the second file in, so all four have to be recognised here.
-_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)(\S+)")
+#: An ``-r``/``-c`` include and its target. The target is a quoted string OR a
+#: bare token, in that order: pip parses these lines with shlex, so
+#: ``-r "deps/with spaces/base.txt"`` is a legal include, and a bare ``\S+``
+#: stopped at the first space and silently failed to follow it.
+_INCLUDE_RE = re.compile(
+    r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)"
+    r"(\"[^\"]+\"|'[^']+'|\S+)"
+)
 
 
 def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
@@ -1004,7 +1011,13 @@ def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
     if match is None:
         return None
     target = match.group(1).strip("\"'")
-    if not target or urlparse(target).scheme:
+    # `urlparse(...).scheme` was too eager: it reads `base:1.txt` as scheme
+    # "base", so a legal relative filename containing a colon was refused and
+    # its options went unlisted -- the same incompleteness this is fixing.
+    # Containment below is what actually enforces safety (a URL resolves to
+    # nothing inside the plugin folder and is refused there), so this test only
+    # has to catch the obvious case early.
+    if not target or "://" in target:
         return None
     try:
         resolved = (parent.parent / target).resolve()

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -959,17 +959,64 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
     return sorted(changes, key=lambda change: change.name.lower())
 
 
+#: A trailing backslash and the whitespace either side of it: one option to
+#: pip, so one line here.  The surrounding whitespace goes with it, or the
+#: joined line carries the indent of the continuation into the middle of it.
+_CONTINUATION_RE = re.compile(r"[^\S\n]*\\\n[^\S\n]*")
+
+
 def read_requirements(requirements: Path) -> list[str]:
-    """Return the requirement lines, so the CLI can show them before running pip."""
+    """Return the requirement lines, so the CLI can show them before running pip.
+
+    A line ending in a backslash is joined to the next one first, because pip
+    does the same: ``--index-url \\`` on its own line and the URL on the next is
+    ONE option to pip, and reading them as two showed the option without what
+    it points at (#1206 item 8).
+    """
+    source = _CONTINUATION_RE.sub(" ", read_source(requirements).replace("\r\n", "\n"))
     return [
         line.strip()
-        for line in read_source(requirements).splitlines()
+        for line in source.splitlines()
         if line.strip() and not line.strip().startswith("#")
     ]
 
 
+#: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
+#: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
+#: pull the second file in, so all four have to be recognised here.
+_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)(\S+)")
+
+
+def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
+    """The file an ``-r``/``-c`` option line points at, if it is safe to read.
+
+    pip resolves the path relative to the file the option is written in, so
+    that is what is resolved here.
+
+    SECURITY: the line is written by the plugin author and nothing has been
+    installed yet, so following it must not become a way to read the machine.
+    Anything that leaves the plugin's own folder -- an absolute path, a ``..``
+    escape, a URL, a symlink out -- is refused rather than followed, and so is
+    anything that is not a regular file.  The include line itself is still
+    listed either way, so a refusal hides nothing from the reader.
+    """
+    match = _INCLUDE_RE.match(line)
+    if match is None:
+        return None
+    target = match.group(1).strip("\"'")
+    if not target or urlparse(target).scheme:
+        return None
+    try:
+        resolved = (parent.parent / target).resolve()
+    except OSError:
+        return None
+    if not resolved.is_relative_to(root) or not resolved.is_file():
+        return None
+    return resolved
+
+
 def pip_options(requirements: Path) -> list[str]:
-    """Return every option line in *requirements* -- each line starting ``-``.
+    """Return every option line *requirements* reaches -- each starting ``-``.
 
     SECURITY: a plugin's ``requirements.txt`` is written by the plugin author,
     and pip honours option lines in it.  Some of them decide where packages
@@ -986,14 +1033,45 @@ def pip_options(requirements: Path) -> list[str]:
     verbatim and lets the reader judge, rather than claiming per line what each
     one does.
 
-    Only **this file** is read.  ``-r``/``-c`` pull in further files that pip
-    also honours, and an option set in one of those is not listed here -- the
-    include line itself is, which is the visible trace of it.  This is
-    information for the reader rather than a gate, so it is described honestly
-    rather than made exhaustive: following includes is a containment problem of
-    its own and would not change what installs.
+    ``-r``/``-c`` includes are followed, because pip honours the options in the
+    file they name exactly as if they had been written here, and showing only
+    the include line left the ``--index-url`` behind it unlisted (#1206 item
+    8).  A line from an included file is tagged with the file it came from.
+    Only files inside the plugin's own folder are followed
+    (:func:`_include_target`), each is read once so a cycle terminates, and a
+    file that cannot be read contributes a line saying so rather than being
+    passed over in silence.
     """
-    return [line for line in read_requirements(requirements) if line.startswith("-")]
+    root = requirements.parent.resolve()
+    options: list[str] = []
+    seen: set[Path] = set()
+    pending: list[Path] = [requirements]
+    while pending:
+        current = pending.pop(0)
+        resolved = current.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        # Named relative to the plugin folder: two `base.txt` under different
+        # subfolders must not read as the same file.
+        where = (
+            ""
+            if resolved == requirements.resolve()
+            else f"   [in {resolved.relative_to(root).as_posix()}]"
+        )
+        try:
+            lines = read_requirements(current)
+        except PluginError as exc:
+            options.append(f"(could not read {current.name}: {exc})")
+            continue
+        for line in lines:
+            if not line.startswith("-"):
+                continue
+            options.append(f"{line}{where}")
+            included = _include_target(line, current, root)
+            if included is not None:
+                pending.append(included)
+    return options
 
 
 def install_requirements(changes: list[DependencyChange]) -> None:

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -140,8 +140,8 @@ def register_routes(router, server):
             "Queues an asynchronous export task that writes pictures straight "
             "into a folder on the machine running PixlStash, then opens that "
             "folder in the host file manager. The destination must be an "
-            "empty, writable, existing directory outside the library, its "
-            "reference folders and its import folders. "
+            "empty, writable, existing directory outside every registered "
+            "library, this library's reference folders and its import folders. "
             "Local owner, on that machine, only - see POST /pictures/export "
             "for a ZIP you can download from anywhere instead."
         ),
@@ -209,6 +209,20 @@ def register_routes(router, server):
         try:
             library_roots.extend(vault.reference_folder_roots())
             library_roots.extend(get_import_folder_paths(vault))
+            # Every OTHER registered library is the same hazard as this one.
+            # A library's folder IS its image_root (it is where `vault.db`
+            # lives), so an export written into one comes back as new pictures
+            # the moment that library is opened - and this route only ever sees
+            # the active lease's vault, so nothing above notices. Registered
+            # paths are all that is read: another library's reference and watch
+            # folders live in ITS vault, which is not open here, and opening
+            # someone else's vault to answer an export question is a worse
+            # trade than the narrower check. Attached libraries only - a
+            # detached one is not being read by anything, and the refusal below
+            # speaks of "your library".
+            library_roots.extend(
+                library.path for library in server.library_registry.list_libraries()
+            )
         except LibraryRootsUnavailable as exc:
             logger.warning(
                 "Refusing the folder export to %s: a library root list could "
@@ -226,6 +240,25 @@ def register_routes(router, server):
                     "moment."
                 ),
             ) from exc
+        except Exception as exc:
+            # The registry read is the same blocklist discipline: a list that
+            # cannot be read must refuse, because an empty answer reads as
+            # "there are no other libraries to protect".
+            logger.warning(
+                "Refusing the folder export to %s: the library registry could "
+                "not be read, so the destination cannot be shown to be outside "
+                "every library: %s",
+                resolved_destination,
+                exc,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "PixlStash could not check your libraries just now, so it "
+                    "cannot confirm this destination is outside them. Try "
+                    "again in a moment."
+                ),
+            ) from exc
         for root in library_roots:
             if root and path_is_within(resolved_destination, root):
                 raise HTTPException(
@@ -234,7 +267,8 @@ def register_routes(router, server):
                         "That folder is part of your library - PixlStash "
                         "reads it - so everything exported into it would be "
                         "imported straight back in. Choose a folder outside "
-                        "your library, reference folders and import folders."
+                        "your libraries, their reference folders and their "
+                        "import folders."
                     ),
                 )
         # A folder export writes plain files, unlike a ZIP: a name that

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -267,8 +267,8 @@ def register_routes(router, server):
                         "That folder is part of your library - PixlStash "
                         "reads it - so everything exported into it would be "
                         "imported straight back in. Choose a folder outside "
-                        "your libraries, their reference folders and their "
-                        "import folders."
+                        "this library, its reference folders and its import "
+                        "folders, and outside any other library's folder."
                     ),
                 )
         # A folder export writes plain files, unlike a ZIP: a name that

--- a/pixlstash/tagger_plugins/wd14.py
+++ b/pixlstash/tagger_plugins/wd14.py
@@ -120,14 +120,6 @@ class WD14Service:
         with self._load_lock:
             if self.is_loaded():
                 return
-            if self._device == "cuda":
-                providers = ort.get_available_providers()
-                if "CUDAExecutionProvider" not in providers:
-                    logger.warning(
-                        "CUDAExecutionProvider unavailable for onnxruntime "
-                        "(WD14 tagger will use CPU; all PyTorch models still use CUDA). "
-                        "Fix with: pip uninstall -y onnxruntime && pip install onnxruntime-gpu"
-                    )
             self._init_onnx_session()
             if self._rating_tags is None or self._general_tags is None:
                 self._load_tags()
@@ -304,8 +296,37 @@ class WD14Service:
                         else ["CPUExecutionProvider"]
                     ),
                 )
+        self._warn_if_the_session_fell_back_to_cpu()
         self._input_name = self._ort_sess.get_inputs()[0].name
         self._onnx_batch_capacity = self._resolve_batch_capacity()
+
+    def _warn_if_the_session_fell_back_to_cpu(self) -> None:
+        """Say so when the session did not get the accelerator it asked for.
+
+        ``ort.get_available_providers()`` says what the onnxruntime build
+        SUPPORTS, not what can load. A provider whose shared libraries are
+        missing - the CUDA one needs ``libcublasLt`` - is still listed, still
+        requested, and then silently dropped, so the old check passed while
+        every tag ran on the CPU at a fraction of the speed with nothing said
+        (#1206 item 3b, live on a development box). ``get_providers()`` is the
+        session's own answer, so it is the only one worth asking.
+        """
+        if self._device == "cpu" or self._ort_sess is None:
+            return
+        active = self._ort_sess.get_providers() or ["CPUExecutionProvider"]
+        if active[0] != "CPUExecutionProvider":
+            logger.debug("WD14 tagger session is running on %s", active[0])
+            return
+        logger.warning(
+            "WD14 tagger asked onnxruntime for device %s, but the session "
+            "loaded with %s: tagging will run on the CPU at a fraction of the "
+            "speed. The usual cause is an execution provider this build "
+            "advertises whose libraries are not installed (the CUDA provider "
+            "needs libcublasLt). Fix with: pip uninstall -y onnxruntime && "
+            "pip install onnxruntime-gpu",
+            self._device,
+            active[0],
+        )
 
     def _resolve_batch_capacity(self) -> int:
         if self._ort_sess is None:

--- a/pixlstash/tasks/missing_tag_finder.py
+++ b/pixlstash/tasks/missing_tag_finder.py
@@ -13,7 +13,7 @@ from pixlstash.db_models import (
 from pixlstash.services.set_lock_service import locked_picture_id_subquery
 from pixlstash.worker_config import TAGGER_MAX_INFLIGHT
 from .base_task_finder import BaseTaskFinder
-from .tag_task import TagTask
+from .tag_task import TagTask, taggable_picture_clauses
 
 # Every sentinel value starts with TAG_PENDING_SENTINEL (``__tag`` or
 # ``__tag:<engine>``), so the half-open range [``__tag``, ``__tah``) is the
@@ -141,8 +141,15 @@ class MissingTagFinder(BaseTaskFinder):
         # selected again on the very next sweep - an unbounded inference loop.
         # One definition on both sides is what closes it.
         locked_member = ~Picture.id.in_(locked_picture_id_subquery())
+        # `taggable_picture_clauses` is the predicate `TagTask.count_missing_tags`
+        # applies, imported rather than repeated: the two disagreed (#1206 item
+        # 3), so the "awaiting tagging" number excluded scrapheaped pictures
+        # while this query kept selecting them and spending the GPU on them.
         stmt = select(Picture).where(
-            Picture.id.in_(pending), faces_known, locked_member
+            Picture.id.in_(pending),
+            faces_known,
+            locked_member,
+            *taggable_picture_clauses(),
         )
         if suppressed_ids:
             stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -93,6 +93,22 @@ def _file_is_readable(file_path: str) -> bool:
         return False
 
 
+def taggable_picture_clauses() -> tuple:
+    """The picture rows tagging may touch: not soft-deleted, and with a file.
+
+    One definition, because two queries have to answer identically: the
+    "awaiting tagging" number (:meth:`TagTask.count_missing_tags`) and the
+    selection the work planner actually runs
+    (``MissingTagFinder._fetch_missing_tags``). They did not (#1206 item 3) -
+    the count applied both clauses and the selection applied neither, so the
+    number read zero while the GPU went on tagging pictures the owner had put
+    in the scrapheap. A picture restored from the scrapheap keeps its pending
+    sentinel and is picked up again on the next sweep, so nothing is lost by
+    holding it out while it is deleted.
+    """
+    return (Picture.deleted.is_(False), Picture.file_path.is_not(None))
+
+
 class TagTask(BaseTask):
     """Task that tags a batch of pictures and persists tag updates."""
 
@@ -1321,8 +1337,7 @@ class TagTask(BaseTask):
             select(func.count())
             .select_from(Picture)
             .where(Picture.tags.any(has_sentinel))
-            .where(Picture.deleted.is_(False))
-            .where(Picture.file_path.is_not(None))
+            .where(*taggable_picture_clauses())
         ).one()
         if isinstance(result, (tuple, list)):
             return result[0]

--- a/pixlstash/utils/unprocessable_image_registry.py
+++ b/pixlstash/utils/unprocessable_image_registry.py
@@ -23,6 +23,7 @@ needs no schema change and no migration.
 
 import os
 import threading
+import time
 
 from pixlstash.pixl_logging import get_logger
 
@@ -71,11 +72,25 @@ class UnprocessableImageRegistry:
     # realistic count.
     MAX_ENTRIES = 100_000
 
+    # How long an `active_suppressed_ids()` answer is reused before every entry
+    # is re-stat'd. The tag, face, thumbnail and embedding finders each rebuild
+    # the set on every planner sweep, and `Vault` counts with it twice more -
+    # six full walks of the map, back to back, on the planner thread. That is
+    # free while the files are local and it is not free at all for an
+    # *unreachable* entry, whose `_entry_is_live` waits on a dead mount for
+    # every stat (#1206 item 9b): exactly the case the map fills up with. The
+    # window is short enough that a repaired or remounted file is retried
+    # within seconds, and any change to the map clears the cache outright, so
+    # the staleness only ever delays a *retry* - never a suppression.
+    ACTIVE_CACHE_TTL_S = 5.0
+
     def __init__(self, max_entries: int = MAX_ENTRIES) -> None:
         self._max_entries = int(max_entries)
         self._lock = threading.Lock()
         # picture_id -> (file_path, mtime_ns, size)
         self._entries: dict[int, tuple[str, int, int]] = {}
+        # (monotonic time, ids) of the last full re-validation, or None.
+        self._active_cache: "tuple[float, frozenset[int]] | None" = None
 
     @staticmethod
     def _stat_signature(file_path: str) -> "tuple[int, int] | None":
@@ -136,6 +151,7 @@ class UnprocessableImageRegistry:
                 )
                 return False
             self._entries[pid] = (str(file_path), mtime_ns, size)
+            self._active_cache = None
         logger.warning(
             "Unprocessable image: picture id=%s path=%s could not be decoded (%s); "
             "skipping it for the rest of this server session (it will be retried "
@@ -196,6 +212,7 @@ class UnprocessableImageRegistry:
             # No signature: an unreachable file cannot be stat'd, and the
             # sentinel is what `_entry_is_live` reads to pick its predicate.
             self._entries[pid] = (str(file_path), _UNREACHABLE, _UNREACHABLE)
+            self._active_cache = None
         logger.warning(
             "Unreachable image: picture id=%s path=%s - its location is not "
             "mounted (%s); holding it out of the work finders until the "
@@ -244,22 +261,38 @@ class UnprocessableImageRegistry:
                 return True
             # Rewritten, repaired, or the volume is back - retry it.
             self._entries.pop(pid, None)
+            self._active_cache = None
             return False
 
     def active_suppressed_ids(self) -> set[int]:
         """Return the set of currently-suppressed picture ids, pruning stale entries.
 
         Re-validates every stored file signature; entries whose file changed or
-        disappeared are dropped. Cheap in practice - the map only holds genuinely
-        undecodable files, which are rare.
+        disappeared are dropped. The answer is then reused for
+        :attr:`ACTIVE_CACHE_TTL_S`, because six callers ask for it within one
+        planner sweep and an unreachable entry costs a mount timeout per stat.
+        Any write to the map drops the cache, so a newly marked picture is
+        never served from a set built before it.
         """
-        active: set[int] = set()
         with self._lock:
+            cached = self._active_cache
+            if (
+                cached is not None
+                and time.monotonic() - cached[0] < self.ACTIVE_CACHE_TTL_S
+            ):
+                return set(cached[1])
+            active: set[int] = set()
             for pid, (path, mtime_ns, size) in list(self._entries.items()):
                 if self._entry_is_live(path, mtime_ns, size):
                     active.add(pid)
                 else:
                     self._entries.pop(pid, None)
+            # Stamped after the walk, not before: `_entry_is_live` can take a
+            # while on a dead mount, and the window is meant to start when the
+            # answer is known. The age is compared against the TTL on every
+            # read rather than baked into a deadline, so lowering the TTL takes
+            # effect at once.
+            self._active_cache = (time.monotonic(), frozenset(active))
         return active
 
     def discard(self, picture_id: "int | None") -> None:
@@ -268,6 +301,7 @@ class UnprocessableImageRegistry:
             return
         with self._lock:
             self._entries.pop(int(picture_id), None)
+            self._active_cache = None
 
     def snapshot(self) -> dict[int, tuple[str, int, int]]:
         """Return a copy of the current ``{picture_id: (file_path, mtime_ns, size)}`` map."""

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -455,6 +455,51 @@ def test_pictures_export_folder_rejects_a_destination_inside_the_library():
         gc.collect()
 
 
+def test_pictures_export_folder_rejects_a_destination_inside_another_library():
+    """#1206 item 1: the blocklist knew only the library holding the lease.
+
+    A library's folder *is* its image_root, so an export written into a second
+    registered library comes back as a fresh set of pictures the moment that
+    library is opened - and this route never opens it, so nothing downstream
+    notices either.
+    """
+    from unittest import mock
+
+    temp_dir, client, server = _setup()
+    try:
+        _upload_picture(client)
+        other = server.library_registry.create(
+            os.path.join(temp_dir.name, "second-library"), "Second"
+        )
+        inside_other = os.path.join(other.path, "exported")
+        os.makedirs(inside_other, exist_ok=True)
+
+        resp = client.post(
+            "/pictures/export/folder", params={"destination": inside_other}
+        )
+        assert resp.status_code == 400, resp.text
+        assert "part of your library" in resp.json().get("detail", "")
+
+        # The positive control, in the same environment: a folder that is in no
+        # registered library is still accepted. Refusing every empty folder
+        # would satisfy the assertion above and break the feature.
+        outside = os.path.join(temp_dir.name, "outside-every-library")
+        os.makedirs(outside, exist_ok=True)
+        with mock.patch(
+            "pixlstash.utils.service.export_utils.open_in_file_manager",
+            return_value=True,
+        ):
+            accepted = client.post(
+                "/pictures/export/folder", params={"destination": outside}
+            )
+            assert accepted.status_code == 200, accepted.text
+            _wait_for_export(client, accepted.json()["task_id"])
+    finally:
+        server.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_pictures_export_folder_refuses_when_the_reference_folders_are_unreadable():
     """#1177 item 59: an unknown blocklist must refuse, not permit.
 

--- a/tests/test_finder_query_cost.py
+++ b/tests/test_finder_query_cost.py
@@ -685,8 +685,15 @@ def test_tag_probe_is_served_by_the_tag_index(tmp_path):
 
         plan = _explain(vault, rec.only, rec.parameters[0])
         assert any("ix_tag_tag" in line for line in plan), plan
-        # The outer loop is a rowid lookup fed by the tag index, not a scan.
-        assert plan[0].startswith("SEARCH picture USING INTEGER PRIMARY KEY"), plan
+        # The outer loop is an index seek fed by the tag index, not a scan.
+        # It read ``USING INTEGER PRIMARY KEY`` until the finder started
+        # applying the same not-deleted/has-a-file clauses as
+        # ``TagTask.count_missing_tags`` (#1206 item 3); SQLite now reaches the
+        # row through ``ix_picture_deleted (deleted=? AND rowid=?)``, which
+        # pins the new predicate and the rowid in the same seek. The thing this
+        # test exists to catch is the outer loop degrading to ``SCAN picture``,
+        # which ``SEARCH`` still excludes.
+        assert plan[0].startswith("SEARCH picture"), plan
         assert not any("TEMP B-TREE" in line.upper() for line in plan), plan
 
 

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -33,6 +33,7 @@ from pixlstash.tasks.missing_image_embedding_finder import MissingImageEmbedding
 from pixlstash.tasks.missing_thumbnail_finder import MissingThumbnailFinder
 from pixlstash.tasks.quality_task import QualityTask
 from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.utils.unprocessable_image_registry import UnprocessableImageRegistry
 from pixlstash.vault import Vault
 
 # Bytes that exist on disk as a ``.jpg`` but are not a decodable image. cv2 and
@@ -291,3 +292,45 @@ def test_585_quality_metadata_backfill_marks_instead_of_raising(tmp_path):
         assert not vault.db.unprocessable_images.is_suppressed(valid_pic.id)
         assert (valid_pic.width, valid_pic.height) == (8, 8)
         assert valid_pic.format == "JPG"
+
+
+def test_the_suppressed_set_is_built_once_per_window_and_drops_on_a_mark(tmp_path):
+    """#1206 item 9b: four finders rebuilt this set on every planner sweep.
+
+    Each rebuild re-stats every entry, and an entry whose volume has gone away
+    costs a mount timeout per stat - on the planner thread. The answer is
+    therefore reused for ``ACTIVE_CACHE_TTL_S``, and any write to the map drops
+    the cache so a newly marked picture is never served from a set built before
+    it.
+    """
+    registry = UnprocessableImageRegistry()
+    first = str(tmp_path / "one.jpg")
+    second = str(tmp_path / "two.jpg")
+    _write_corrupt_jpeg(tmp_path / "one.jpg")
+    _write_corrupt_jpeg(tmp_path / "two.jpg")
+    assert registry.mark_unprocessable(1, first, reason="test fixture")
+
+    stats: list[str] = []
+    original = registry._stat_signature
+
+    def counting_stat(file_path: str):
+        stats.append(file_path)
+        return original(file_path)
+
+    registry._stat_signature = staticmethod(counting_stat)
+
+    assert registry.active_suppressed_ids() == {1}
+    assert stats == [first]
+    # Within the window, the second sweep re-stats nothing.
+    assert registry.active_suppressed_ids() == {1}
+    assert stats == [first]
+
+    # A new mark must be visible at once, cache or no cache.
+    assert registry.mark_unprocessable(2, second, reason="test fixture")
+    assert registry.active_suppressed_ids() == {1, 2}
+
+    # And closing the window re-validates.
+    stats.clear()
+    registry.ACTIVE_CACHE_TTL_S = 0.0
+    assert registry.active_suppressed_ids() == {1, 2}
+    assert sorted(stats) == sorted([first, second])

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -145,6 +145,45 @@ def test_every_cuda_ort_session_site_is_built_from_the_budget():
     assert "engine.vram_budget.ort_cuda_provider_options(" in face_source
 
 
+def test_the_wd14_session_says_so_when_it_did_not_get_the_accelerator(monkeypatch):
+    """#1206 item 3b: only the session knows which provider actually loaded.
+
+    ``ort.get_available_providers()`` reports what the onnxruntime build
+    supports. A provider whose shared libraries are missing - the CUDA one
+    needs ``libcublasLt`` - is listed there, is requested, and is then dropped
+    without an error, so the old check passed while every tag ran on the CPU.
+    """
+    from pixlstash.tagger_plugins import wd14 as wd14_module
+
+    service = wd14_module.WD14Service(
+        device="cuda", model_dir="/nonexistent", batch_size_fn=lambda: 1
+    )
+    warnings: list[tuple] = []
+    monkeypatch.setattr(
+        wd14_module.logger, "warning", lambda *args, **_kw: warnings.append(args)
+    )
+
+    # The session asked for CUDA and got CPU: that must be said out loud.
+    service._ort_sess = SimpleNamespace(get_providers=lambda: ["CPUExecutionProvider"])
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+    assert "CPUExecutionProvider" in warnings[0]
+
+    # The positive control: a session that did get CUDA stays quiet, or the
+    # warning is noise every GPU box learns to ignore.
+    service._ort_sess = SimpleNamespace(
+        get_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+
+    # And a service that asked for the CPU has nothing to complain about.
+    service._device = "cpu"
+    service._ort_sess = SimpleNamespace(get_providers=lambda: ["CPUExecutionProvider"])
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+
+
 # ── §8: the maintenance finders keep their global gate ──────────────────────
 
 

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -722,15 +722,21 @@ def test_an_unreachable_picture_is_held_out_of_the_window_not_retired(tmp_path):
             "ever put it back and its tags are gone for good"
         )
 
-        # And the hold lifts by itself once the location is back.
+        # And the hold lifts by itself once the location is back. The set is
+        # reused for `ACTIVE_CACHE_TTL_S` (#1206 item 9b: six callers a sweep,
+        # and each stat of an unreachable file waits on the dead mount), so the
+        # lift lands on the next full re-validation rather than on the next
+        # call. Closing the window here rather than sleeping through it.
+        registry = vault.db.unprocessable_images
         gone.mkdir()
         for name in names[:-1]:
             Image.fromarray(np.zeros((30, 40, 3), dtype=np.uint8), "RGB").save(
                 gone / name
             )
-        assert set(ids[:-1]).isdisjoint(
-            vault.db.unprocessable_images.active_suppressed_ids()
-        ), "the hold did not lift when the directory came back"
+        registry.ACTIVE_CACHE_TTL_S = 0.0
+        assert set(ids[:-1]).isdisjoint(registry.active_suppressed_ids()), (
+            "the hold did not lift when the directory came back"
+        )
 
 
 def test_a_whole_batch_transient_failure_deletes_nothing(tmp_path):

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -33,6 +33,7 @@ from pixlstash.tasks.missing_face_model_refresh_finder import (
 )
 from pixlstash.tasks.missing_tag_finder import MissingTagFinder
 from pixlstash.tasks.missing_tag_prediction_finder import MissingTagPredictionFinder
+from pixlstash.tasks.tag_task import TagTask
 from pixlstash.tasks.task_type import TaskType
 from pixlstash.vault import Vault
 
@@ -534,6 +535,34 @@ class _FailingWorkflow(_StubWorkflow):
 class _FailingTagEngine:
     tagger_settings = {"active_tag_plugin": "wd14"}
     tagging_workflow = _FailingWorkflow()
+
+
+def test_a_scrapheaped_picture_leaves_the_tag_window_and_the_tag_count(tmp_path):
+    """#1206 item 3: the count and the selection disagreed about the scrapheap.
+
+    ``TagTask.count_missing_tags`` excluded soft-deleted pictures; the query
+    the planner acts on did not. So "awaiting tagging" could read zero while
+    the GPU went on tagging pictures the owner had deleted. Both sides now come
+    from ``taggable_picture_clauses``, so they cannot drift apart again.
+    """
+    with Vault(image_root=str(tmp_path)) as vault:
+        live, scrapheaped = _seed_pending(vault, tmp_path, ["live.png", "gone.png"])
+
+        def add_faces_and_scrapheap(session: Session):
+            for pid in (live, scrapheaped):
+                session.add(Face(picture_id=pid, face_index=-1))
+            session.get(Picture, scrapheaped).deleted = True
+            session.commit()
+
+        vault.db.run_task(add_faces_and_scrapheap)
+
+        # Negative and positive control in one assertion: the deleted picture
+        # is gone from the window and the live one is still in it.
+        assert _tag_candidates(vault) == {live}
+        assert (
+            vault.db.run_immediate_read_task(lambda s: TagTask.count_missing_tags(s))
+            == 1
+        )
 
 
 def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1953,6 +1953,42 @@ def test_the_listing_follows_includes_and_joins_continuations(tmp_path):
     ]
 
 
+def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
+    """Two ways the target was read wrong, both ending in a silent short list.
+
+    pip parses these lines with shlex, so a quoted target containing spaces is
+    a legal include; the pattern captured ``\\S+`` and stopped at the first
+    space, so the file was never opened. And the URL guard used
+    ``urlparse(...).scheme``, which reads ``base:1.txt`` as scheme "base" - a
+    legal relative filename refused for looking like a URL.
+
+    In both cases the include LINE was still listed, so nothing was hidden;
+    what went missing is the option inside the file it names, which is the
+    whole point of following it.
+    """
+    plugin = tmp_path / "plugin"
+    (plugin / "with space").mkdir(parents=True)
+    (plugin / "with space" / "base.txt").write_text(
+        "--index-url https://spaced.example.invalid/simple\n", encoding="utf-8"
+    )
+    (plugin / "odd:name.txt").write_text(
+        "--extra-index-url https://colon.example.invalid/simple\n", encoding="utf-8"
+    )
+    requirements = plugin / "requirements.txt"
+    requirements.write_text(
+        '-r "with space/base.txt"\n-r odd:name.txt\n', encoding="utf-8"
+    )
+
+    # Parent file's own lines first, then what each include brought in - the
+    # order `pip_options` already had, not something these cases change.
+    assert plugin_install.pip_options(requirements) == [
+        '-r "with space/base.txt"',
+        "-r odd:name.txt",
+        "--index-url https://spaced.example.invalid/simple   [in with space/base.txt]",
+        "--extra-index-url https://colon.example.invalid/simple   [in odd:name.txt]",
+    ]
+
+
 def test_the_listing_refuses_to_follow_an_include_out_of_the_plugin(tmp_path):
     """The include is author-written, so following it must not read the machine.
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1929,6 +1929,75 @@ def test_the_listing_surfaces_every_pip_option_from_the_requirements(tmp_path):
     assert plugin_install.pip_options(broad) == ["--only-binary=:all:", "--pre"]
 
 
+def test_the_listing_follows_includes_and_joins_continuations(tmp_path):
+    """#1206 item 8: pip honours both, and the warning read neither.
+
+    ``-r deps/base.txt`` pulls the second file's options in as if they had been
+    written in the first, and a line ending in a backslash is one option to
+    pip. Showing the include line and the bare ``--index-url`` was true and
+    incomplete: the URL that decides where packages come from was the part not
+    on screen.
+    """
+    plugin = tmp_path / "plugin"
+    (plugin / "deps").mkdir(parents=True)
+    (plugin / "deps" / "base.txt").write_text(
+        "--index-url \\\nhttps://packages.example.invalid/simple\nrequests\n",
+        encoding="utf-8",
+    )
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r deps/base.txt\nflask\n", encoding="utf-8")
+
+    assert plugin_install.pip_options(requirements) == [
+        "-r deps/base.txt",
+        "--index-url https://packages.example.invalid/simple   [in deps/base.txt]",
+    ]
+
+
+def test_the_listing_refuses_to_follow_an_include_out_of_the_plugin(tmp_path):
+    """The include is author-written, so following it must not read the machine.
+
+    A ``-r`` naming somewhere outside the plugin's own folder is listed and NOT
+    opened: opening it and printing back every line that starts with ``-``
+    would turn a warning into a way to read arbitrary files. Nothing is hidden
+    - the line itself is still shown.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("--index-url https://elsewhere.example.invalid\n", "utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    requirements = plugin / "requirements.txt"
+    requirements.write_text(
+        f"-r {outside}\n-r ../outside.txt\n-r https://x.example.invalid/r.txt\n",
+        encoding="utf-8",
+    )
+
+    options = plugin_install.pip_options(requirements)
+    assert options == [
+        f"-r {outside}",
+        "-r ../outside.txt",
+        "-r https://x.example.invalid/r.txt",
+    ]
+    assert not any("elsewhere.example.invalid" in line for line in options)
+
+
+def test_the_listing_survives_an_include_cycle(tmp_path):
+    """Two files naming each other must terminate, and say each option once."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r other.txt\n--pre\n", encoding="utf-8")
+    (plugin / "other.txt").write_text(
+        "-r requirements.txt\n--no-index\n", encoding="utf-8"
+    )
+
+    assert plugin_install.pip_options(requirements) == [
+        "-r other.txt",
+        "--pre",
+        "-r requirements.txt   [in other.txt]",
+        "--no-index   [in other.txt]",
+    ]
+
+
 def test_the_listing_names_the_url_a_direct_requirement_comes_from(
     pip_report, tmp_path, capsys
 ):

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1968,6 +1968,16 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     """
     plugin = tmp_path / "plugin"
     (plugin / "with space").mkdir(parents=True)
+    # pip reads `-r "a"b.txt` as the single token `ab.txt`. A quoted-or-bare
+    # regex read it as `a`, so the listing showed one file's index URL while
+    # pip honoured another's - a defeat of the feature, not a gap in it. Both
+    # files exist here because the plugin author controls the folder.
+    (plugin / "a").write_text(
+        "--index-url https://wrong.example.invalid/simple\n", encoding="utf-8"
+    )
+    (plugin / "ab.txt").write_text(
+        "--index-url https://right.example.invalid/simple\n", encoding="utf-8"
+    )
     (plugin / "with space" / "base.txt").write_text(
         "--index-url https://spaced.example.invalid/simple\n", encoding="utf-8"
     )
@@ -1976,7 +1986,7 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     )
     requirements = plugin / "requirements.txt"
     requirements.write_text(
-        '-r "with space/base.txt"\n-r odd:name.txt\n', encoding="utf-8"
+        '-r "with space/base.txt"\n-r odd:name.txt\n-r "a"b.txt\n', encoding="utf-8"
     )
 
     # Parent file's own lines first, then what each include brought in - the
@@ -1984,8 +1994,11 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     assert plugin_install.pip_options(requirements) == [
         '-r "with space/base.txt"',
         "-r odd:name.txt",
+        '-r "a"b.txt',
         "--index-url https://spaced.example.invalid/simple   [in with space/base.txt]",
         "--extra-index-url https://colon.example.invalid/simple   [in odd:name.txt]",
+        # `ab.txt`, the file pip reads - not `a`, the file a regex saw.
+        "--index-url https://right.example.invalid/simple   [in ab.txt]",
     ]
 
 


### PR DESCRIPTION
Backend leftovers from the v1.11.1 reviews (#1206). One commit per item.

* You could export pictures into another one of your libraries. That library
would then import them as new copies next time you opened it. Now refused.

* The tagger could claim it was using the GPU when it wasn't. It asked the
library what it *supports* instead of what actually loaded. Now it asks the
session what it got, and warns if it fell back to CPU.

* Deleted pictures were still being tagged. The "awaiting tagging" number
excluded them; the thing picking the work didn't. Both use the same rule now.

* Plugin dependency warnings missed half the file. If a plugin's
requirements pointed at another file, the options in it weren't listed. Now
they are, but only for files inside the plugin's own folder.
