### PR TITLE
Close the by-omission hole in the Electron IPC guardrail (#1206)

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -295,10 +295,18 @@ apply `?path=` on them (it guards on `folderKey`). The folder an "About your
 library" finding points at (§9.3) has no id of any kind, which is what this
 param is for. **It also carries the sidebar's subfolder selection.**
 `FolderTreeNode.vue` requires `rfId`, so a subfolder click takes
-`pushRouteForCurrentSelection`'s ref-folder branch; the branch now pushes the
-`pathPrefix` as `?path=` alongside the id, and `SideBar.routeSubfolderUnder`
-reads it back once the folder listing is in, selecting the subfolder rather
-than the folder root. The id still owns `referenceFolderId`, so
+`pushRouteForCurrentSelection`'s ref-folder branch; the branch pushes `?path=`
+alongside the id, and `SideBar.routeSubfolderUnder` reads it back once the
+folder listing is in, selecting the subfolder rather than the folder root.
+**On an id-carrying route that query is RELATIVE to the folder the id names**
+(`SideBar._subPathUnder` builds it, and it reaches the branch as the payload's
+`subPath`). The id already says where the folder is, so repeating the absolute
+path only put the owner's folder tree in the address bar and in browser history
+(#1206 item 9); a folder ROOT is therefore `/ref-folder/:id` with no query at
+all. `routeSubfolderUnder` still accepts an ABSOLUTE `?path=`, because links
+shared and history entries made before that carry one — and because `/`, the
+only folder-facet route with no id, has nothing to be relative to. The id still
+owns `referenceFolderId`, so
 `reference_folder_id` stays in the grid query — the query only says which
 folder *inside* it is open. **The sidebar watcher watches `?path=` alongside
 `activeFolderKey`, and has to.** Two sibling subfolders of one folder push

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -1868,8 +1868,13 @@ payload the sidebar emits and therefore to the listing API's existing
 so the route never applies it directly — but it does ride along there, because
 it is also how the sidebar's own subfolder selection stays in the URL: a
 subfolder click carries an `rfId` and so takes the ref-folder branch, which
-pushes `/ref-folder/:id?path=<abs folder>`, and the sidebar restores the
-subfolder from the query once the folder listing is in.
+pushes `/ref-folder/:id?path=<folder under it>`, and the sidebar restores the
+subfolder from the query once the folder listing is in. **There the path is
+relative to the folder the id names**, since the id already says where that
+folder is and spelling it out only put the owner's folder tree in the address
+bar (#1206 item 9); a folder root pushes no query. An absolute `?path=` is
+still read, which is what a link shared before that carries and the only shape
+available on `/`.
 
 **`?face=with_face|without_face`** is the face facet, additive like
 `?stack_state=` — an absent or unrecognised value leaves

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -1874,7 +1874,10 @@ relative to the folder the id names**, since the id already says where that
 folder is and spelling it out only put the owner's folder tree in the address
 bar (#1206 item 9); a folder root pushes no query. An absolute `?path=` is
 still read, which is what a link shared before that carries and the only shape
-available on `/`.
+available on `/`. **Either shape must name somewhere INSIDE the folder**: a
+`?path=` that climbs out — an absolute one under another folder, or either
+shape carrying a `.` or `..` segment — selects the folder root instead, the
+same refusal an out-of-tree absolute path has always got.
 
 **`?face=with_face|without_face`** is the face facet, additive like
 `?stack_state=` — an absent or unrecognised value leaves

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -89,6 +89,13 @@ export type PathPurpose = 'library' | 'backends';
  * Defined in `urlPolicy.ts` and re-exported here: this file imports `electron`
  * at module load and that one does not, so the renderer-page guards can share
  * the definition rather than keep a second one that disagrees (#1206 item 2).
+ *
+ * It does NOT trim, and the two callers below trim their own input instead. The
+ * readonly wizard field arrives trimmed by the renderer, so this file wants
+ * padding forgiven; `urlPolicy.ts` compares paths parsed out of a `file://` URL,
+ * where forgiving it would let `setup.html%20` answer for the bundled wizard
+ * page on POSIX. Trimming a path someone typed and normalising a URL are two
+ * different jobs, so the one that only this file needs stays in this file.
  */
 export { pathKey };
 
@@ -107,7 +114,8 @@ export function offerPath<T extends string | null | undefined>(
   platform: NodeJS.Platform = process.platform,
 ): T {
   if (typeof path === 'string' && path.trim()) {
-    offeredPaths[purpose].set(pathKey(path, platform), resolve(path.trim()));
+    // Trimmed HERE, not inside pathKey: see the note on the re-export above.
+    offeredPaths[purpose].set(pathKey(path.trim(), platform), resolve(path.trim()));
   }
   return path;
 }
@@ -134,7 +142,8 @@ export function requireOfferedPath(
   if (typeof value !== 'string' || !value.trim()) {
     throw new Error(`${what} must be a folder path, not ${shown}.`);
   }
-  const offered = offeredPaths[purpose].get(pathKey(value, platform));
+  // Trimmed HERE, not inside pathKey: see the note on the re-export above.
+  const offered = offeredPaths[purpose].get(pathKey(value.trim(), platform));
   if (offered === undefined) {
     throw new Error(
       `${what} ${shown} was not offered by PixlStash for this choice. Choose ` +

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, posix as pathPosix, resolve, win32 as pathWin32 } from 'node:path';
+import { pathKey } from './urlPolicy';
 
 /** Compute accelerators a PixlStash runtime can target. */
 export type Accel = 'cpu' | 'cu128' | 'rocm' | 'metal';
@@ -84,11 +85,12 @@ export type PathPurpose = 'library' | 'backends';
  * and `~/pictures` are two different directories, so folding there would let a
  * path that was never offered match one that was. Same rule, and the same
  * `process.platform` switch, as {@link normalizeBackendsRoot}.
+ *
+ * Defined in `urlPolicy.ts` and re-exported here: this file imports `electron`
+ * at module load and that one does not, so the renderer-page guards can share
+ * the definition rather than keep a second one that disagrees (#1206 item 2).
  */
-export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
-  const resolved = resolve(path.trim());
-  return platform === 'win32' ? resolved.toLowerCase() : resolved;
-}
+export { pathKey };
 
 // Key -> the path as PixlStash actually offered it. A Map rather than a Set so
 // the value that flows on is the one the main process vouched for, never the

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1249,10 +1249,13 @@ function registerDownloadHandling(): void {
  * (#1177 item 62). Binding to a `webContents` cannot separate them; the
  * document loaded in the sending frame can.
  *
- * `startup:*` is deliberately NOT gated: `takePendingTelemetry`,
- * `takePendingMapping` and `askQuestion` are the running app's own channels
- * (`useAppConfig.js`, `SideBar.vue`), and gating them would break the upgrade
- * privacy question and the folder-mapping handoff.
+ * `startup:*` is the running app's own family (`useAppConfig.js`,
+ * `SideBar.vue`), so gating it HERE would break the upgrade privacy question
+ * and the folder-mapping handoff. `startup:askQuestion` is gated on the app
+ * window instead (requireAppRenderer, #1206 item 4) because it replaces the
+ * document with the wizard; `takePendingTelemetry` and `takePendingMapping`
+ * only hand back an answer this process parked for the page that is about to
+ * ask, and stay open.
  */
 function requireSetupRenderer(event: Electron.IpcMainInvokeEvent, channel: string): void {
   // The frame, not the webContents: a frame the library page created has its
@@ -1511,7 +1514,14 @@ function registerIpc(): void {
   // The app asking for a question it cannot answer itself. It hands the window
   // back to the startup framework rather than opening a dialog over a library
   // that is already on screen; `setup:commit` brings the window back.
-  ipcMain.handle('startup:askQuestion', async (_e, step?: string) => {
+  //
+  // Gated on the app window (#1206 item 4). It writes no config and repoints no
+  // library, but it replaces the document with the full-screen wizard, so any
+  // page that could reach it could throw the owner out of the library and lose
+  // whatever was unsaved. `useAppConfig.js` - which runs in the backend-served
+  // app - is the only caller, and `requireAppRenderer` is exactly that audience.
+  ipcMain.handle('startup:askQuestion', async (event, step?: string) => {
+    requireAppRenderer(event, 'startup:askQuestion');
     if (step !== 'privacy') {
       console.warn(`[startup] refusing an unknown startup step: ${step}`);
       return false;

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -2,6 +2,28 @@ import { resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
+ * The lookup key for a path, matching the platform's own idea of path identity:
+ * resolved, and case-folded on Windows only.
+ *
+ * THE canonical rule, re-exported by `config.ts` (which cannot own it - it
+ * imports `electron` at module load, and this module is loaded by tests that
+ * have no Electron). Two copies of this rule is exactly the bug #1206 item 2
+ * describes: `config.ts` folded case and this file did not, so a `file://` URL
+ * whose drive letter came back in a different case than `RENDERER_DIR` spells
+ * it made {@link isBundledRendererPage} answer false for the wizard page
+ * itself - and `requireSetupRenderer` then refused every `setup:*` channel,
+ * with no way through first-run setup.
+ *
+ * Windows filesystems are case-insensitive, so `C:\\x` and `c:\\x` are one
+ * directory. POSIX is case-SENSITIVE, where folding would let `/opt/Renderer`
+ * pass as `/opt/renderer` - a different directory, and one we did not bundle.
+ */
+export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
+  const resolved = resolve(path.trim());
+  return platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+/**
  * A URL safe to write to the log: enough to identify what was blocked, never
  * the `user:password@` userinfo the URL may carry and never a page-authored
  * payload. Schemes with no origin report origin `null`; of those only `file:`
@@ -45,12 +67,15 @@ export function redactUrl(target: string): string {
  * file is the answer, so `index.html` and `permissions.html` are refused too.
  * The path is resolved and compared whole: a prefix test would accept a sibling
  * directory sharing the prefix, and `fileURLToPath` is what stops a percent-
- * encoded traversal reaching the comparison as text.
+ * encoded traversal reaching the comparison as text. Compared through
+ * {@link pathKey}, so the two halves may disagree about casing on Windows -
+ * where they name one directory - and never on POSIX, where they do not.
  */
 export function isBundledRendererPage(
   target: string,
   rendererDir: string,
   page: string,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   let url: URL;
   try {
@@ -61,7 +86,7 @@ export function isBundledRendererPage(
   if (url.protocol !== 'file:') return false;
   try {
     const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
-    return resolve(fileURLToPath(url)) === resolve(dir, page);
+    return pathKey(fileURLToPath(url), platform) === pathKey(resolve(dir, page), platform);
   } catch {
     return false;
   }
@@ -142,6 +167,7 @@ export function isAllowedNavigation(
   target: string,
   currentUrl: string | null,
   rendererDir: string,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   let url: URL;
   try {
@@ -162,10 +188,13 @@ export function isAllowedNavigation(
   // Normalise the trailing separator here rather than trust the caller: without
   // it a sibling directory sharing the prefix (…/renderer-evil) would pass.
   if (url.protocol === 'file:') {
-    const dir = rendererDir.endsWith(sep) ? rendererDir : rendererDir + sep;
+    // Through pathKey for the same reason isBundledRendererPage is: on Windows
+    // a differently-cased drive letter names the same directory, and refusing
+    // it would block our own bundled pages from loading.
+    const base = pathKey(rendererDir, platform);
     try {
-      const path = resolve(fileURLToPath(url));
-      return path === dir.slice(0, -1) || path.startsWith(dir);
+      const path = pathKey(fileURLToPath(url), platform);
+      return path === base || path.startsWith(base + sep);
     } catch (e) {
       console.warn(`[nav] blocking unresolvable file:// URL ${redactUrl(target)}:`, e);
       return false;

--- a/electron/src/urlPolicy.ts
+++ b/electron/src/urlPolicy.ts
@@ -17,9 +17,21 @@ import { fileURLToPath } from 'node:url';
  * Windows filesystems are case-insensitive, so `C:\\x` and `c:\\x` are one
  * directory. POSIX is case-SENSITIVE, where folding would let `/opt/Renderer`
  * pass as `/opt/renderer` - a different directory, and one we did not bundle.
+ *
+ * It does NOT trim, on either platform, and `config.ts`'s two callers trim their
+ * own input instead. Trimming a path someone TYPED is that file's job - its
+ * readonly wizard field arrives trimmed by the renderer, so padding has to be
+ * forgiven there. Here the path was parsed out of a `file://` URL, where
+ * forgiving it only widens an equality boundary: on POSIX `setup.html%20`,
+ * `%0A` and `%09` are three different files that would each answer true for the
+ * bundled wizard page. Win32 does strip a component's trailing spaces, so
+ * trimming would be *defensible* there - but nothing we load is padded
+ * (`RENDERER_DIR` comes from `__dirname`, the sender URL from Chromium), so
+ * refusing a padded spelling costs nothing and one rule is easier to keep right
+ * than two. Two different jobs; the one only `config.ts` needs stays there.
  */
 export function pathKey(path: string, platform: NodeJS.Platform = process.platform): string {
-  const resolved = resolve(path.trim());
+  const resolved = resolve(path);
   return platform === 'win32' ? resolved.toLowerCase() : resolved;
 }
 

--- a/electron/test/pathIpcValidation.test.ts
+++ b/electron/test/pathIpcValidation.test.ts
@@ -48,14 +48,24 @@ describe('requireOfferedPath', () => {
     );
   });
 
-  it('pathKey folds case only on Windows', () => {
+  it('pathKey folds case only on Windows, and never trims', () => {
     const p = resolve(sep, 'Home', 'Me', 'Pictures');
     assert.equal(pathKey(p, 'win32'), resolve(p).toLowerCase());
     assert.equal(pathKey(p, 'linux'), resolve(p));
     assert.equal(pathKey(p, 'darwin'), resolve(p));
     // Trailing separator and `..` still normalise on every platform.
-    assert.equal(pathKey(`  ${p}${sep}  `, 'linux'), resolve(p));
+    assert.equal(pathKey(`${p}${sep}`, 'linux'), resolve(p));
     assert.equal(pathKey(join(p, 'x', '..'), 'linux'), resolve(p));
+    // Padding is NOT stripped, on either platform. This key also decides
+    // whether a `file://` URL is one of our own bundled pages, and on POSIX
+    // `x ` and `x` are two different files - so trimming would let
+    // `setup.html%20` answer for `setup.html`. The callers that want a typed
+    // path forgiven (offerPath / requireOfferedPath) trim before they get here.
+    for (const platform of ['linux', 'win32'] as const) {
+      for (const padded of [`${p} `, `${p}\t`, ` ${p}`, `${p}\n`]) {
+        assert.notEqual(pathKey(padded, platform), pathKey(p, platform), `${platform} ${padded}`);
+      }
+    }
   });
 
   it('refuses a path offered for the OTHER question', () => {

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -362,13 +362,23 @@ describe('IPC gating is complete, not opt-in', () => {
     assert.match(main, /isBackendOrigin\(sender, currentUrl\)/);
   });
 
-  it('leaves the app-renderer startup:* channels open', () => {
+  it('never gates a startup:* channel on the WIZARD page', () => {
     // takePendingTelemetry / takePendingMapping / askQuestion are called BY the
-    // library app (useAppConfig.js, SideBar.vue). Gating them would break the
-    // upgrade privacy question and the folder-mapping handoff.
+    // library app (useAppConfig.js, SideBar.vue). Gating them on setup.html
+    // would break the upgrade privacy question and the folder-mapping handoff.
     for (const [channel, body] of handlers.filter(([c]) => c.startsWith('startup:'))) {
       assert.doesNotMatch(body, /requireSetupRenderer/, `${channel} must stay open`);
     }
+  });
+
+  it('gates startup:askQuestion on the app window (#1206 item 4)', () => {
+    // It writes nothing, but it replaces the document with the full-screen
+    // wizard - so an ungated one let any page throw the owner out of the
+    // library and lose unsaved work. The two `takePending*` channels stay open:
+    // they only hand back an answer this process parked for the page asking.
+    const [, askQuestion] = handlers.find(([c]) => c === 'startup:askQuestion') ?? [];
+    assert.ok(askQuestion, 'startup:askQuestion not found');
+    assert.match(askQuestion, /requireAppRenderer\(event, 'startup:askQuestion'\)/);
   });
 });
 

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -184,6 +184,27 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
       assert.equal(isAllowedNavigation(page, BACKEND, RENDERER_DIR, 'linux'), false);
     });
 
+    it('does not let percent-encoded padding answer for the page (#1206)', () => {
+      // pathKey used to `.trim()` unconditionally, so on POSIX - where `x ` and
+      // `x` are two different files - `setup.html%20`, `%0A` and `%09` each
+      // came back equal to `setup.html`. Trimming was written for a path
+      // someone TYPED, in config.ts; it had no business normalising one parsed
+      // out of a URL.
+      const setup = pathToFileURL(RENDERER_DIR + 'setup.html').href;
+      for (const platform of ['linux', 'win32'] as const) {
+        for (const pad of ['%20', '%0A', '%09']) {
+          assert.equal(
+            isBundledRendererPage(setup + pad, RENDERER_DIR, 'setup.html', platform),
+            false,
+            `${platform} ${pad}`,
+          );
+        }
+        // The page itself, unpadded, still passes - over-blocking here is the
+        // regression that breaks first-run setup outright.
+        assert.ok(isBundledRendererPage(setup, RENDERER_DIR, 'setup.html', platform));
+      }
+    });
+
     it('still refuses a prefix-sharing sibling once case is folded', () => {
       const sibling = pathToFileURL(resolve('/opt/pixlstash/dist/RENDERER-evil') + sep + 'setup.html').href;
       assert.equal(isBundledRendererPage(sibling, RENDERER_DIR, 'setup.html', 'win32'), false);
@@ -203,11 +224,15 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * (`test_all_routes_declare_access_policy`). Deriving the set means a new
  * `setup:*` or `server:*` channel is covered the moment it exists.
  *
- * #1206 item 10: the pattern was `ipcMain.handle(\s*'`, which is three ways to
- * be invisible to it - `handleOnce`, a double-quoted or backtick name, and a
- * computed one. All three could be added at once and this file stayed green.
- * The first two are read now; the third CANNOT be, so it is made loud rather
- * than skipped (`every handler opener is read` below).
+ * #1206 item 10: the pattern was `ipcMain.handle(\s*'`, which is five ways to
+ * be invisible to it - `handleOnce`, `on`/`once`, a double-quoted or backtick
+ * name, a computed one, and a concatenated one. Any of them could be added and
+ * this file stayed green. The spellings are all read now; a name that cannot be
+ * read out of the source at all is made loud rather than skipped (`every
+ * handler opener is read` below).
+ *
+ * Deriving the set is only half of it. Enumerating what the set must SATISFY is
+ * the other half - see DELIBERATELY_OPEN.
  */
 /**
  * Whitespace or a comment. TypeScript allows either between the method name
@@ -218,11 +243,31 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * example's own comment terminator would end this one.)
  */
 const OPENER_GAP = '(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\n]*\\n)*';
-const NAMED_HANDLE = new RegExp(
-  `ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(\\s*(['"\`])([^'"\`]+)\\1`,
-);
+/**
+ * Every way `ipcMain` takes a channel. `on`/`once` are the ordinary handler
+ * shape for a synchronous call (`e.returnValue = …`) and register a channel
+ * exactly as `handle` does - main.ts has none today, which is precisely why
+ * they belong here: an unswept spelling is only invisible until someone uses
+ * it. `once` is listed before `on` so the alternation cannot stop after two
+ * characters of `once`.
+ */
+const IPC_OPENER = `ipcMain\\.(?:handle(?:Once)?|once|on)${OPENER_GAP}\\(`;
+/**
+ * A channel named by a WHOLE string literal: the quoted run must reach the
+ * comma that ends the argument, and may not contain `$`.
+ *
+ * Both halves are load-bearing. `ipcMain.handle('server' + ':evil', …)` used to
+ * be read as the channel `"server"` - which does not start with `"server:"`, so
+ * it skipped the gate assertion, while still counting as one named handler
+ * against one opener, so it passed the count test too. Silently ungated in
+ * both directions. Requiring the comma means a concatenation is no longer
+ * *named*, and the count test below then reports it. `$` is excluded for the
+ * same reason one token further: `` `server:${x}` `` would otherwise be read
+ * as the literal channel `server:${x}`.
+ */
+const NAMED_HANDLE = new RegExp(`${IPC_OPENER}\\s*(['"\`])([^'"\`$]+)\\1\\s*,`);
 /** The same opener with the channel name left unconstrained. */
-const ANY_HANDLE = new RegExp(`ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(`);
+const ANY_HANDLE = new RegExp(IPC_OPENER);
 
 function ipcHandlers(main: string): Array<[string, string]> {
   const found: Array<[string, string]> = [];
@@ -237,6 +282,73 @@ function ipcHandlers(main: string): Array<[string, string]> {
   });
   return found;
 }
+
+/**
+ * The channels that carry NO renderer gate, and the reason each one is safe
+ * without one.
+ *
+ * This is what turns the sweep below from a PREFIX test into an enumeration.
+ * Before it, the only gate assertions were `setup:*` and `server:*`; the other
+ * two dozen channels were checked by nothing, and nothing recorded that this
+ * was a decision rather than an oversight - so a `desktop:runScript` added
+ * tomorrow would ship ungated and green. Same by-omission hole, and the same
+ * answer, as the Python side's `test_all_routes_declare_access_policy`: a
+ * channel in neither column fails the build.
+ *
+ * A reason here is not a waiver. It is the sentence a reviewer checks, and
+ * writing one is meant to be the moment someone notices there isn't a good one.
+ * The standing floor under all of them is `isAllowedNavigation`: no third-party
+ * page can be loaded into this window at all, so "open" means open to our own
+ * splash, wizard and library pages, not to the web.
+ */
+const DELIBERATELY_OPEN: Record<string, string> = {
+  // ---- Read-only reports about this install ----
+  'app:bootstrap': 'read-only: version, detected hardware, bundled/active accel',
+  'permissions:request': 'read-only: hands back the repair report main already built',
+  'accel:list': 'read-only: which overlays are installed and which is active',
+  'backend:getLocation': 'read-only: where overlays are installed, and the default',
+  'desktop:getPrefs': "read-only: the shell's own prefs (tray-on-close, shim state)",
+
+  // ---- Registered only while something is waiting for the answer ----
+  'permissions:resolve':
+    'registered only while the permission screen waits, and removeHandler()d the ' +
+    'moment it answers - see "exists only while the repair screen waits" below',
+
+  // ---- Hand back an answer this process parked for the page asking ----
+  'startup:takePendingTelemetry': 'take-once handback of an answer main parked; writes nothing',
+  'startup:takePendingMapping': 'take-once handback of an answer main parked; writes nothing',
+
+  // ---- No argument: the target is one PixlStash chose itself ----
+  'desktop:openLibraryFolder': 'no argument: opens the library folder main already knows',
+  'desktop:showLogs': 'no argument: opens our own log file',
+  'window:minimize': 'frameless-window title-bar control; changes no state but the window',
+  'window:toggleMaximize': 'frameless-window title-bar control; changes no state but the window',
+  'window:close': 'frameless-window title-bar control; changes no state but the window',
+
+  // ---- The person at the keyboard is the gate ----
+  'media:beginSaveAs':
+    'the destination comes from a native Save dialog, never from the caller; the ' +
+    'pending save is keyed to the sending webContents',
+  'media:completeSaveAs': 'writes only to a path beginSaveAs got from the dialog, same sender',
+  'media:cancelSaveAs': 'drops a pending save, same-sender checked; touches no file',
+  'media:copyPng': 'writes the clipboard from bytes the calling page already holds',
+  'backend:pickLocation':
+    'opens a folder dialog; the answer is only OFFERED, and backend:setLocation ' +
+    'independently re-checks it through requireOfferedPath',
+
+  // ---- Shell preferences, no library and no listener ----
+  'desktop:setPrefs': "the shell's own prefs (tray-on-close, the `pixlstash` shim); no path, no listener",
+
+  // ---- Both audiences call these, so neither gate fits: the ARGUMENT is narrowed ----
+  // The first-run wizard (a file:// page, electron/src/renderer/setup.js) and
+  // the app's Settings (ComputeSection.vue, backend-served) both call all four.
+  // requireAppRenderer would break first-run setup outright; requireSetupRenderer
+  // would break Settings. The value is what is checked instead, at the boundary.
+  'backend:setLocation': 'wizard AND Settings both call it; narrowed by requireOfferedPath',
+  'accel:install': 'wizard AND Settings both call it; narrowed by requireAccel',
+  'accel:use': 'wizard AND Settings both call it; narrowed by requireAccel',
+  'accel:remove': 'wizard AND Settings both call it; narrowed by requireAccel',
+};
 
 /**
  * `server:setSettings` decides whether this machine listens on the network:
@@ -295,27 +407,49 @@ describe('IPC gating is complete, not opt-in', () => {
     assert.equal(
       handlers.length,
       total,
-      `${total - handlers.length} ipcMain.handle call(s) name their channel with ` +
-        'something other than a plain string literal, so nothing here can tell ' +
-        'whether they are gated. Give the channel a literal name.',
+      `${total - handlers.length} ipcMain registration(s) do not name their channel ` +
+        'with one whole string literal - a computed name, a template, or a ' +
+        'concatenation - so nothing here can tell whether they are gated. ' +
+        'Give the channel a literal name.',
     );
   });
 
-  it('reads handleOnce, double quotes and backticks', () => {
+  it('reads handleOnce, on, once, double quotes and backticks', () => {
     const synthetic = [
       "ipcMain.handleOnce('once:channel', () => 1);",
       'ipcMain.handle("double:quoted", () => 2);',
       'ipcMain.handle(`backticked`, () => 3);',
+      // The synchronous handler shape. main.ts has none, so nothing here would
+      // go red if the sweep stopped reading it - which is the whole point of
+      // pinning it: it must be seen the day one arrives, not the day after.
+      "ipcMain.on('sync:channel', (e) => { e.returnValue = 1; });",
+      "ipcMain.once('sync:onceChannel', (e) => { e.returnValue = 2; });",
     ].join('\n');
     assert.deepEqual(
       ipcHandlers(synthetic).map(([c]) => c),
-      ['once:channel', 'double:quoted', 'backticked'],
+      ['once:channel', 'double:quoted', 'backticked', 'sync:channel', 'sync:onceChannel'],
     );
     // A computed name is an opener the sweep cannot name: zero handlers found,
     // one opener present, which is exactly the discrepancy the count test reads.
     const computed = 'ipcMain.handle(CHANNEL, () => 4);';
     assert.equal(ipcHandlers(computed).length, 0);
     assert.equal(computed.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
+
+  it('refuses a channel name that is only PART of the argument', () => {
+    // The quiet one. `'server' + ':evil'` was read as the channel "server",
+    // which does not start with "server:" - so it skipped the gate assertion -
+    // while still counting one named handler against one opener, so it passed
+    // the count test too. Ungated in both directions and green. Now it is not
+    // named at all, and the count test reports it like any other computed name.
+    for (const built of [
+      "ipcMain.handle('server' + ':evil', () => 1);",
+      'ipcMain.handle("desktop" + ":runScript", () => 2);',
+      'ipcMain.handle(`server:${x}`, () => 3);',
+    ]) {
+      assert.deepEqual(ipcHandlers(built), [], built);
+      assert.equal(built.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1, built);
+    }
   });
 
   it('reads an opener with a comment before its paren', () => {
@@ -338,6 +472,50 @@ describe('IPC gating is complete, not opt-in', () => {
     const hidden = `ipcMain.handle${block}(CHANNEL, () => 3);`;
     assert.equal(ipcHandlers(hidden).length, 0);
     assert.equal(hidden.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
+
+  /** The gate a handler declares for ITS OWN channel, not for a neighbour's. */
+  const gateFor = (channel: string) =>
+    new RegExp(`require(?:Setup|App)Renderer\\(event, '${channel}'\\)`);
+
+  it('EVERY channel is gated or written down as deliberately open', () => {
+    const ungated = handlers
+      .filter(([channel, body]) => !gateFor(channel).test(body))
+      .map(([channel]) => channel)
+      .filter((channel) => !(channel in DELIBERATELY_OPEN));
+    assert.deepEqual(
+      ungated,
+      [],
+      `${ungated.length} IPC channel(s) carry no requireSetupRenderer/requireAppRenderer ` +
+        'gate and are not listed in DELIBERATELY_OPEN. Gate them, or add each to the ' +
+        'map with the one-line reason it is safe without one.',
+    );
+  });
+
+  it('the deliberately-open list stays honest: no stale or contradicted entry', () => {
+    // Without this the map is a place to park a channel and forget it: a
+    // renamed channel would leave a reason behind that guards nothing, and a
+    // channel later gated would keep an entry saying it is not.
+    const byChannel = new Map(handlers);
+    for (const [channel, reason] of Object.entries(DELIBERATELY_OPEN)) {
+      const body = byChannel.get(channel);
+      assert.ok(body, `DELIBERATELY_OPEN names ${channel}, which main.ts no longer registers`);
+      assert.ok(reason.length > 20, `${channel} needs a real reason, not "${reason}"`);
+      assert.doesNotMatch(
+        body,
+        gateFor(channel),
+        `${channel} IS gated now - drop its DELIBERATELY_OPEN entry`,
+      );
+    }
+  });
+
+  it('permissions:resolve exists only while the repair screen waits', () => {
+    // Its DELIBERATELY_OPEN reason is the registration window itself, so pin
+    // that window rather than take the reason's word for it: registered inside
+    // the promise the screen is awaiting, and removed on every settle path
+    // (answered, or the window closed).
+    assert.match(main, /ipcMain\.removeHandler\('permissions:resolve'\)/);
+    assert.match(main, /const settle = \(accepted: boolean\) => \{[\s\S]{0,200}?removeHandler/);
   });
 
   it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -202,13 +202,23 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * side closed by making "safe by omission" a machine fact
  * (`test_all_routes_declare_access_policy`). Deriving the set means a new
  * `setup:*` or `server:*` channel is covered the moment it exists.
+ *
+ * #1206 item 10: the pattern was `ipcMain.handle(\s*'`, which is three ways to
+ * be invisible to it - `handleOnce`, a double-quoted or backtick name, and a
+ * computed one. All three could be added at once and this file stayed green.
+ * The first two are read now; the third CANNOT be, so it is made loud rather
+ * than skipped (`every handler opener is read` below).
  */
+const NAMED_HANDLE = /ipcMain\.handle(?:Once)?\(\s*(['"`])([^'"`]+)\1/;
+/** The same opener with the channel name left unconstrained. */
+const ANY_HANDLE = /ipcMain\.handle(?:Once)?\(/;
+
 function ipcHandlers(main: string): Array<[string, string]> {
   const found: Array<[string, string]> = [];
-  const opener = /ipcMain\.handle\(\s*'([^']+)'/g;
+  const opener = new RegExp(NAMED_HANDLE.source, 'g');
   const starts: Array<[string, number]> = [];
   for (let m = opener.exec(main); m !== null; m = opener.exec(main)) {
-    starts.push([m[1], m.index]);
+    starts.push([m[2], m.index]);
   }
   starts.forEach(([channel, at], i) => {
     const end = i + 1 < starts.length ? starts[i + 1][1] : main.length;
@@ -264,6 +274,38 @@ describe('IPC gating is complete, not opt-in', () => {
   // __dirname is dist-test/test at run time; the sources are two levels up.
   const main = readFileSync(join(__dirname, '..', '..', 'src', 'main.ts'), 'utf8');
   const handlers = ipcHandlers(main);
+
+  // A channel name built at run time cannot be read out of the source, so it
+  // cannot be checked for a gate either. Refuse it here rather than let the
+  // sweep walk past it: this is the difference between a guardrail with a gap
+  // and one that says where the gap is.
+  it('every handler opener is read, so a computed channel name cannot hide', () => {
+    const total = main.match(new RegExp(ANY_HANDLE.source, 'g'))?.length ?? 0;
+    assert.equal(
+      handlers.length,
+      total,
+      `${total - handlers.length} ipcMain.handle call(s) name their channel with ` +
+        'something other than a plain string literal, so nothing here can tell ' +
+        'whether they are gated. Give the channel a literal name.',
+    );
+  });
+
+  it('reads handleOnce, double quotes and backticks', () => {
+    const synthetic = [
+      "ipcMain.handleOnce('once:channel', () => 1);",
+      'ipcMain.handle("double:quoted", () => 2);',
+      'ipcMain.handle(`backticked`, () => 3);',
+    ].join('\n');
+    assert.deepEqual(
+      ipcHandlers(synthetic).map(([c]) => c),
+      ['once:channel', 'double:quoted', 'backticked'],
+    );
+    // A computed name is an opener the sweep cannot name: zero handlers found,
+    // one opener present, which is exactly the discrepancy the count test reads.
+    const computed = 'ipcMain.handle(CHANNEL, () => 4);';
+    assert.equal(ipcHandlers(computed).length, 0);
+    assert.equal(computed.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
 
   it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {
     const channels = handlers.map(([c]) => c);

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -159,6 +159,37 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
       assert.equal(isSetup(bad), false, `${bad} must not pass as the setup screen`);
     }
   });
+
+  // #1206 item 2. `config.ts` folded case on Windows and this file did not, so
+  // a `file://` URL whose casing differed from RENDERER_DIR's answered false
+  // for the wizard page itself - and requireSetupRenderer then refused EVERY
+  // `setup:*` channel, leaving first-run setup with no way through. Windows is
+  // where a drive letter's case can differ between two APIs; POSIX is where
+  // folding would be the security bug, so both directions are pinned here.
+  //
+  // Exercised with POSIX-shaped paths and an explicit `platform`, because
+  // `resolve()` uses the HOST's semantics: a `C:\` literal would not normalise
+  // on the Linux runner. The casing rule is what is under test, not `resolve`.
+  describe('path casing follows the platform', () => {
+    const UPPER = resolve('/opt/PixlStash/dist/Renderer') + sep;
+    const page = pathToFileURL(UPPER + 'setup.html').href;
+
+    it('accepts a differently-cased spelling of the same Windows directory', () => {
+      assert.ok(isBundledRendererPage(page, RENDERER_DIR, 'setup.html', 'win32'));
+      assert.ok(isAllowedNavigation(page, BACKEND, RENDERER_DIR, 'win32'));
+    });
+
+    it('refuses it on POSIX, where that is a different directory', () => {
+      assert.equal(isBundledRendererPage(page, RENDERER_DIR, 'setup.html', 'linux'), false);
+      assert.equal(isAllowedNavigation(page, BACKEND, RENDERER_DIR, 'linux'), false);
+    });
+
+    it('still refuses a prefix-sharing sibling once case is folded', () => {
+      const sibling = pathToFileURL(resolve('/opt/pixlstash/dist/RENDERER-evil') + sep + 'setup.html').href;
+      assert.equal(isBundledRendererPage(sibling, RENDERER_DIR, 'setup.html', 'win32'), false);
+      assert.equal(isAllowedNavigation(sibling, BACKEND, RENDERER_DIR, 'win32'), false);
+    });
+  });
 });
 
 /**

--- a/electron/test/urlPolicy.test.ts
+++ b/electron/test/urlPolicy.test.ts
@@ -209,9 +209,20 @@ describe('isBundledRendererPage — the setup screen, and only it', () => {
  * The first two are read now; the third CANNOT be, so it is made loud rather
  * than skipped (`every handler opener is read` below).
  */
-const NAMED_HANDLE = /ipcMain\.handle(?:Once)?\(\s*(['"`])([^'"`]+)\1/;
+/**
+ * Whitespace or a comment. TypeScript allows either between the method name
+ * and its `(`, so a handler registered with a block or line comment sitting in
+ * that gap is invisible to BOTH patterns below - the opener count would agree
+ * with the named count and nothing would go red. Same silent bypass as item
+ * 10, one token further along. (Not written out as an example here: the
+ * example's own comment terminator would end this one.)
+ */
+const OPENER_GAP = '(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\n]*\\n)*';
+const NAMED_HANDLE = new RegExp(
+  `ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(\\s*(['"\`])([^'"\`]+)\\1`,
+);
 /** The same opener with the channel name left unconstrained. */
-const ANY_HANDLE = /ipcMain\.handle(?:Once)?\(/;
+const ANY_HANDLE = new RegExp(`ipcMain\\.handle(?:Once)?${OPENER_GAP}\\(`);
 
 function ipcHandlers(main: string): Array<[string, string]> {
   const found: Array<[string, string]> = [];
@@ -305,6 +316,28 @@ describe('IPC gating is complete, not opt-in', () => {
     const computed = 'ipcMain.handle(CHANNEL, () => 4);';
     assert.equal(ipcHandlers(computed).length, 0);
     assert.equal(computed.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
+  });
+
+  it('reads an opener with a comment before its paren', () => {
+    // TypeScript allows a comment between the method name and `(`. Before this
+    // it hid the handler from the named sweep AND from the opener count, so
+    // the two agreed and the "cannot hide" test above stayed green - a silent
+    // bypass rather than a loud one. Built from pieces so this file does not
+    // contain a comment terminator that would end its own.
+    const block = '/' + '* hidden *' + '/';
+    const commented = [
+      `ipcMain.handle${block}('block:commented', () => 1);`,
+      'ipcMain.handleOnce // trailing\n(\'line:commented\', () => 2);',
+    ].join('\n');
+    assert.deepEqual(
+      ipcHandlers(commented).map(([c]) => c),
+      ['block:commented', 'line:commented'],
+    );
+    // And a computed name hidden the same way is still counted as an opener,
+    // so it fails loudly instead of vanishing.
+    const hidden = `ipcMain.handle${block}(CHANNEL, () => 3);`;
+    assert.equal(ipcHandlers(hidden).length, 0);
+    assert.equal(hidden.match(new RegExp(ANY_HANDLE.source, 'g'))?.length, 1);
   });
 
   it('finds the handlers at all, so an empty sweep cannot pass vacuously', () => {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -2507,9 +2507,18 @@ async function deleteReferenceFolderById(id) {
   if (!window.confirm(`Remove reference folder "${folderLabel}"?`)) return;
   try {
     await deleteFolder("reference", id);
-    if (selectedFolderKey.value === `rf-${id}`) {
+    // On the FOLDER, not on the row key. A selected SUBfolder's key is
+    // `path-<abs path>` (crossing 1 in the map above), so matching `rf-<id>`
+    // saw only the root row: deleting the folder from under a selected
+    // subfolder left the highlight, `selectedFolderReferenceId` and the
+    // scanning light on a folder that no longer exists (#1206 item 12). The
+    // import-folder branch below is the shape this now copies - all four
+    // pieces of the selection, not just the key.
+    if (_folderId(selectedFolderReferenceId.value) === id) {
       selectedFolderKey.value = null;
+      selectedFolderReferenceId.value = null;
       emit("select-folder", null);
+      sidebarStore.folderScanning = false;
     }
     await fetchReferenceFolders();
   } catch (e) {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -994,9 +994,9 @@ async function referenceFolderSaved(savedFolder = null) {
 
 async function referenceFolderDeleted() {
   closeReferenceFolderEditor();
-  // If we were browsing this folder, clear the selection
-  selectedFolderKey.value = null;
-  selectedFolderReferenceId.value = null;
+  // If we were browsing this folder, clear the selection. The editor's delete
+  // button is the other way into #1206 item 12 - same leak, different entry.
+  clearFolderSelection();
   emit("select-folder", null);
   sidebarStore.folderScanning = false;
   await fetchReferenceFolders();
@@ -1036,8 +1036,7 @@ async function importFolderSaved() {
     (entry) => Number(entry.id) === selectedId,
   );
   if (!selectedImportFolder) {
-    selectedFolderKey.value = null;
-    selectedFolderReferenceId.value = null;
+    clearFolderSelection();
     emit("select-folder", null);
     sidebarStore.folderScanning = false;
     return;
@@ -1056,8 +1055,7 @@ async function importFolderDeleted() {
     Number.isFinite(deletedId) &&
     selectedFolderKey.value === `if-${deletedId}`
   ) {
-    selectedFolderKey.value = null;
-    selectedFolderReferenceId.value = null;
+    clearFolderSelection();
     emit("select-folder", null);
     sidebarStore.folderScanning = false;
   }
@@ -2561,6 +2559,22 @@ async function deleteSetsByIds(ids) {
   }
 }
 
+/** Forget the sidebar's folder selection - all four pieces of it.
+ *
+ * They are written together by `handleFolderNodeSelect` and must be cleared
+ * together. Clearing a subset leaves state the UI cannot show but the route
+ * watcher still reads: after a delete, `selectedFolderRouteKey` has already
+ * changed, so the watcher's `=== oldKey` guard never matches and a leftover
+ * `selectedFolderPath` / `selectedFolderSubPath` is never collected. Both
+ * delete branches used to clear two of the four (#1206 item 12).
+ */
+function clearFolderSelection() {
+  selectedFolderKey.value = null;
+  selectedFolderReferenceId.value = null;
+  selectedFolderPath.value = null;
+  selectedFolderSubPath.value = null;
+}
+
 async function deleteReferenceFolderById(id) {
   const folder = referenceFolders.value.find((rf) => rf.id === id);
   if (!folder) return;
@@ -2576,8 +2590,7 @@ async function deleteReferenceFolderById(id) {
     // import-folder branch below is the shape this now copies - all four
     // pieces of the selection, not just the key.
     if (_folderId(selectedFolderReferenceId.value) === id) {
-      selectedFolderKey.value = null;
-      selectedFolderReferenceId.value = null;
+      clearFolderSelection();
       emit("select-folder", null);
       sidebarStore.folderScanning = false;
     }
@@ -2599,8 +2612,7 @@ async function deleteImportFolderById(id) {
   try {
     await deleteFolder("import", id);
     if (selectedFolderKey.value === `if-${id}`) {
-      selectedFolderKey.value = null;
-      selectedFolderReferenceId.value = null;
+      clearFolderSelection();
       emit("select-folder", null);
       sidebarStore.folderScanning = false;
     }
@@ -4165,10 +4177,7 @@ watch(
     if (!newKey) {
       // Route left a folder view - clear the sidebar's folder highlight.
       if (oldKey && selectedFolderRouteKey.value === oldKey) {
-        selectedFolderKey.value = null;
-        selectedFolderReferenceId.value = null;
-        selectedFolderPath.value = null;
-        selectedFolderSubPath.value = null;
+        clearFolderSelection();
       }
       return;
     }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -680,6 +680,19 @@ function routeSubfolderUnder(root) {
   const raw = _normPath(filter.pathPrefix);
   const rootPath = _normPath(root);
   const sep = _pathSeparator(rootPath);
+  // Containment first, and for BOTH shapes. `?path=` is URL text - it survives
+  // being shared, edited and pasted - and a `..` segment in it builds a
+  // pathPrefix pointing outside the folder. The relative branch below took its
+  // tail verbatim, so `?path=../../..` went straight through; the absolute
+  // branch sliced against the root but `_subPathUnder` compares prefixes and
+  // does not collapse `..` either, so `/root/../etc` passed it as the tail
+  // `../etc`. Nothing sliced out of a real path carries a `.` or `..` segment,
+  // so refusing one costs no legitimate link and restores the containment this
+  // function exists to enforce. Split on what actually separates under this
+  // root: on POSIX a `\` is an ordinary character in a folder's NAME, the same
+  // rule `_subPathUnder` and the re-spelling below already follow.
+  if (raw.split(sep === "\\" ? /[\\/]/ : /\//).some((s) => s === "." || s === ".."))
+    return null;
   // An absolute `?path=` is sliced against the root (and refused when it names
   // somewhere else); a relative one already IS the tail. `_subPathUnder` folds
   // `\` into `/` for a WINDOWS root only, where both characters separate and a

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -496,6 +496,11 @@ const selectedFolderReferenceId = ref(null); // numeric reference-folder id or n
 /** The absolute folder path the selection is filtering on, or null. The row key
     above cannot carry it: a folder ROOT row's key is `rf-{id}`. */
 const selectedFolderPath = ref(null);
+/** The same folder said RELATIVE to its reference folder's root - the sidebar's
+    copy of what it last handed `?path=`, and `null` for the root itself. The
+    URL carries this rather than the absolute path so the owner's folder tree is
+    not in the address bar or the browser history (#1206 item 9). */
+const selectedFolderSubPath = ref(null);
 const dragOverReferenceTargetKey = ref(null);
 
 // Reference folder editor state
@@ -521,13 +526,22 @@ const librariesStore = useLibrariesStore();
 //   2. Route key    `viewStore.activeFolderKey`: `rf-<id>` | `if-<id>`.
 //      Identifies a FOLDER. Never `path-`: a route has no row.
 //   3. Route path   `?path=`. A URL - any separator spelling, and editable.
+//      On an `rf-`/`if-` route it is now RELATIVE to the folder the id names
+//      (#1206 item 9: the id already says where the folder is, so repeating the
+//      owner's absolute path only put their folder tree in the address bar and
+//      the browser history). An ABSOLUTE one is still read, because links and
+//      history entries written before that carry one. On `/` - the only route
+//      with no folder id - it stays absolute, since nothing else names it.
+//      `selectedFolderSubPath` is the sidebar's copy of what it last wrote.
 //   4. Grid filter  `selectedFolderFilter.pathPrefix`, which reaches the
 //      listing as `file_path_prefix`: a literal LIKE against the stored
 //      `file_path`, so it MUST be in the server's spelling.
 //   5. Tree path    `entry.path` from the browse listing. Server spelling.
 //
-// Four crossings are legitimate, and each has one owner:
+// Five crossings are legitimate, and each has one owner:
 //   1 -> 2         `selectedFolderRouteKey`
+//   4 -> 3         `_subPathUnder`, via `handleFolderNodeSelect` (the only
+//                  place a server path is allowed to become a URL path)
 //   2 + 3 -> 1,4   `routeSubfolderUnder`  (the only place a URL path is
 //                  allowed to become a server path)
 //   4 vs 3         the watcher's "already in sync" test, through `_urlPath`.
@@ -595,13 +609,51 @@ function _urlPath(p) {
 }
 
 /**
+ * `path` said relative to `root`, or `null` when it is not inside it (the root
+ * ITSELF included - that is "no subfolder", not "an empty one").
+ *
+ * The one crossing from the server's spelling into the URL's. The tail keeps
+ * the path's OWN separators: `routeSubfolderUnder` re-spells on the way back,
+ * and re-spelling here as well would only make the two disagree.
+ *
+ * Folding `\` into `/` is for a WINDOWS root only, on the same rule and for the
+ * same reason as `routeSubfolderUnder`: on POSIX a `\` is an ordinary character
+ * in a folder's NAME, and folding would slice the tail at a character that does
+ * not separate anything.
+ */
+function _subPathUnder(root, path) {
+  const rootPath = _normPath(root);
+  const here = _normPath(path);
+  if (!rootPath || !here) return null;
+  const windows = _pathSeparator(rootPath) === "\\";
+  const base = windows ? _urlPath(rootPath) : rootPath;
+  const under = windows ? _urlPath(here) : here;
+  // One character for one character, so the tail can be sliced out of the
+  // ORIGINAL spelling at the offset the folded comparison found.
+  return under.startsWith(`${base}/`) ? here.slice(rootPath.length + 1) : null;
+}
+
+/** Whether a `?path=` names a folder outright rather than one inside another.
+    A tail sliced by `_subPathUnder` never starts with a separator and never
+    carries a drive letter, so those are what tell the two apart. */
+function _isAbsolutePath(p) {
+  return /^([a-zA-Z]:)?[\\/]/.test(String(p || ""));
+}
+
+/**
  * The `?path=` on the current folder route, when it names a folder INSIDE
  * `root` rather than `root` itself.
  *
- * A subfolder click pushes `/ref-folder/:id?path=<abs path>`, and this is what
- * reads it back so a reload or a shared link lands on the subfolder the URL
- * names instead of the folder root. `null` means "the route names the folder
- * itself", which is the ordinary case and the pre-existing behaviour.
+ * A subfolder click pushes `/ref-folder/:id?path=<tail under the folder>`, and
+ * this is what reads it back so a reload or a shared link lands on the
+ * subfolder the URL names instead of the folder root. `null` means "the route
+ * names the folder itself", which is the ordinary case.
+ *
+ * **Both shapes of `?path=` are read.** A tail is what the sidebar writes now
+ * (#1206 item 9); an ABSOLUTE path is what it wrote before, so links already
+ * shared and history entries already made keep working - and a `/` route,
+ * which has no id to be relative to, has no other shape available. An absolute
+ * one that is not inside this folder is still `null`, the same refusal as ever.
  *
  * Matched through `_urlPath`, so the two sides may disagree about separators
  * and still match. They come from the same server and normally agree, but the
@@ -628,20 +680,18 @@ function routeSubfolderUnder(root) {
   const raw = _normPath(filter.pathPrefix);
   const rootPath = _normPath(root);
   const sep = _pathSeparator(rootPath);
-  // Folding `\` into `/` is for a WINDOWS root only, where both characters
-  // separate and a URL may legitimately spell either. A POSIX root is compared
-  // raw, because there `\` is an ordinary character in a folder's name and
-  // folding would make `?path=/x/a/b/2024` - a different folder, or none -
-  // read as a subfolder of `/x/a\b` and then be rewritten into it.
+  // An absolute `?path=` is sliced against the root (and refused when it names
+  // somewhere else); a relative one already IS the tail. `_subPathUnder` folds
+  // `\` into `/` for a WINDOWS root only, where both characters separate and a
+  // URL may legitimately spell either. A POSIX root is compared raw, because
+  // there `\` is an ordinary character in a folder's name and folding would
+  // make `?path=/x/a/b/2024` - a different folder, or none - read as a
+  // subfolder of `/x/a\b` and then be rewritten into it.
+  const rawTail = _isAbsolutePath(raw) ? _subPathUnder(rootPath, raw) : raw;
+  if (!rawTail) return null;
   const windows = sep === "\\";
-  // `_urlPath` swaps one character for one character, so both stay aligned
-  // with `raw` and the tail can be sliced back out of the ORIGINAL spelling.
-  const here = windows ? _urlPath(raw) : raw;
-  const base = windows ? _urlPath(rootPath) : rootPath;
-  if (!base || here === base || !here.startsWith(`${base}/`)) return null;
-  const rawTail = raw.slice(base.length + 1);
-  // Re-spelt only on Windows, for the same reason: on POSIX the tail's own
-  // backslashes are part of a name, so this is genuinely a no-op there.
+  // Re-spelt only on Windows: on POSIX the tail's own backslashes are part of
+  // a name, so this is genuinely a no-op there.
   const tail = windows ? rawTail.split(/[\\/]/).join(sep) : rawTail;
   return {
     pathPrefix: `${rootPath}${sep}${tail}`,
@@ -1246,7 +1296,18 @@ function handleFolderNodeSelect(key, payload) {
     selectedFolderReferenceId.value = null;
   }
   selectedFolderPath.value = payload?.pathPrefix ?? null;
-  emit("select-folder", payload);
+  // What the URL will say. The id already names the folder, so `?path=` only
+  // has to say which folder INSIDE it - and saying it absolutely put the
+  // owner's whole folder tree in the address bar and the browser history
+  // (#1206 item 9). `null` for the folder root, which needs no query at all.
+  const root =
+    referenceFolders.value.find((rf) => rf.id === selectedFolderReferenceId.value)
+      ?.folder ?? null;
+  const subPath = _subPathUnder(root, payload?.pathPrefix);
+  selectedFolderSubPath.value = subPath;
+  // Added only when there IS one, so a folder root's and an import folder's
+  // payload stay exactly the object they were.
+  emit("select-folder", subPath ? { ...payload, subPath } : payload);
   // Emit immediately on selection so ImageGrid updates before next poll tick.
   sidebarStore.folderScanning = selectedFolderScanning.value;
 }
@@ -4107,6 +4168,7 @@ watch(
         selectedFolderKey.value = null;
         selectedFolderReferenceId.value = null;
         selectedFolderPath.value = null;
+        selectedFolderSubPath.value = null;
       }
       return;
     }
@@ -4129,12 +4191,20 @@ watch(
     // the emit pushed the re-spelled path as a NEW url, and Back returned to
     // the original spelling and started the round again. A shared Windows link
     // could not be navigated away from.
+    //
+    // Both spellings of the sidebar's own path are offered, because both
+    // spellings of `?path=` arrive (see `routeSubfolderUnder`):
+    // `selectedFolderSubPath` is what the sidebar wrote into the URL itself,
+    // `selectedFolderPath` is what an absolute link from before that carries.
+    // Comparing only the absolute one would leave the sidebar unable to
+    // recognise the very URL it had just pushed - the loop above, again.
     const showingSubfolder = selectedFolderKey.value?.startsWith("path-");
     const routePath = _urlPath(newPath);
+    const mine = [selectedFolderSubPath.value, selectedFolderPath.value];
     if (
       selectedFolderRouteKey.value === newKey &&
       (newPath
-        ? routePath !== "" && _urlPath(selectedFolderPath.value) === routePath
+        ? routePath !== "" && mine.some((p) => p && _urlPath(p) === routePath)
         : !showingSubfolder)
     ) {
       return;

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -167,6 +167,47 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 5,
       pathPrefix: SUB,
+      // What the URL will say next time: relative to the folder its id names,
+      // so the owner's folder tree stays out of the address bar (#1206 item 9).
+      subPath: "2024/summer",
+      label: "summer",
+    });
+
+    wrapper.unmount();
+  });
+
+  // #1206 item 9. The URL now says the subfolder relative to the folder its id
+  // already names, so a reference-folder click stops putting the owner's whole
+  // folder tree in the address bar and in browser history. The absolute form
+  // every other test in this file uses is still read - that is what links
+  // shared, and history entries made, before this carry.
+  it("selects the subfolder a relative query names", async () => {
+    const wrapper = await mountSidebar();
+    routeToFolder("2024/summer");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: SUB,
+      subPath: "2024/summer",
+      label: "summer",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("re-spells a relative query into a Windows folder's separators", async () => {
+    // Same rule as the absolute case: `file_path_prefix` is a literal LIKE
+    // against the stored `file_path`, so a slash-spelled prefix on a Windows
+    // library matches nothing.
+    const wrapper = await mountSidebar();
+    routeToFolder("2024/summer", "rf-6");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 6,
+      pathPrefix: `${WIN_ROOT}\\2024\\summer`,
+      subPath: "2024\\summer",
       label: "summer",
     });
 
@@ -263,6 +304,7 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 5,
       pathPrefix: other,
+      subPath: "2023/winter",
       label: "winter",
     });
 
@@ -327,6 +369,17 @@ describe("restoring /ref-folder/:id", () => {
         "a POSIX SUBfolder whose name contains a backslash",
         "rf-7",
         `${ODD_ROOT}/c\\d`,
+      ],
+      // The shape the sidebar writes now (#1206 item 9). Every absolute case
+      // above is a link or a history entry from BEFORE it, which is why both
+      // shapes are here rather than one replacing the other.
+      ["a POSIX subfolder, said relative to its folder", "rf-5", "2024/summer"],
+      ["a Windows subfolder, said relative to its folder", "rf-6", "2024\\summer"],
+      ["the same Windows subfolder, slash-spelled", "rf-6", "2024/summer"],
+      [
+        "a relative tail whose own name contains a backslash",
+        "rf-7",
+        "c\\d",
       ],
     ];
 
@@ -415,6 +468,9 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 7,
       pathPrefix: `${ODD_ROOT}/c\\d`,
+      // And the tail written into the URL keeps that backslash too: on POSIX
+      // it is a character in a name, not a separator, at both ends of the trip.
+      subPath: "c\\d",
       label: "c\\d",
     });
 
@@ -440,6 +496,7 @@ describe("restoring /ref-folder/:id", () => {
     expect(lastFolderPayload(wrapper)).toEqual({
       referenceFolderId: 6,
       pathPrefix: `${WIN_ROOT}\\2024\\summer`,
+      subPath: "2024\\summer",
       label: "summer",
     });
 

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -245,6 +245,54 @@ describe("restoring /ref-folder/:id", () => {
     wrapper.unmount();
   });
 
+  // A `?path=` that climbs out of the folder falls back to the folder root -
+  // the same refusal an absolute path naming somewhere else has always got.
+  // Reading the relative shape (#1206 item 9) made that refusal conditional on
+  // the string LOOKING absolute: `?path=../../..` was taken as the tail
+  // verbatim and built a pathPrefix outside the folder. Harmless today -
+  // `file_path_prefix` is a literal escaped LIKE and `reference_folder_id`
+  // still scopes the query, so it returns an empty grid - but it is the
+  // containment rule, and a rule that holds by accident downstream is one
+  // change away from not holding.
+  it.each([
+    ["a relative climb", "../../.."],
+    ["a climb inside a tail", "2024/../../etc"],
+    ["an absolute climb through the root", `${ROOT}/../../etc`],
+    ["a bare parent", ".."],
+    ["a same-directory segment", "2024/./summer"],
+  ])("refuses %s and falls back to the folder root", async (_name, path) => {
+    const wrapper = await mountSidebar();
+    routeToFolder(path);
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 5,
+      pathPrefix: ROOT,
+      label: "Refs",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("still reads a POSIX folder whose NAME contains a backslash", async () => {
+    // The containment check splits on `\` for a Windows root only. On POSIX a
+    // `\` is an ordinary character in a name, so `a\..\b` is one segment and
+    // must not be mistaken for a climb - the same rule `_subPathUnder` and the
+    // re-spelling already follow.
+    const wrapper = await mountSidebar();
+    routeToFolder(`${ODD_ROOT}/2024`, "rf-7");
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toEqual({
+      referenceFolderId: 7,
+      pathPrefix: `${ODD_ROOT}/2024`,
+      subPath: "2024",
+      label: "2024",
+    });
+
+    wrapper.unmount();
+  });
+
   // The teardown at the top of the same watcher compares the sidebar's own
   // selection key against the route key it is leaving. Those two stopped being
   // the same string once a subfolder could be selected: the sidebar holds

--- a/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
+++ b/frontend/src/components/panels/SideBarFolderRouteRestore.test.js
@@ -111,11 +111,16 @@ function respond(url) {
   return { data: [] };
 }
 
-async function mountSidebar() {
+/**
+ * `teleport: true` renders the teleported layer (the sidebar's context menu
+ * lives there) instead of leaving it stubbed, which `shallow` does by default.
+ */
+async function mountSidebar({ teleport = false } = {}) {
   const wrapper = mount(SideBar, {
     shallow: true,
     props: { backendUrl: "/api/v1" },
     global: {
+      stubs: teleport ? { teleport: false } : {},
       config: {
         compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
       },
@@ -437,6 +442,34 @@ describe("restoring /ref-folder/:id", () => {
       pathPrefix: `${WIN_ROOT}\\2024\\summer`,
       label: "summer",
     });
+
+    wrapper.unmount();
+  });
+
+  // #1206 item 12. The cleanup matched `rf-<id>`, which is the ROOT row's key;
+  // a selected subfolder's key is `path-<abs path>`, so removing the folder
+  // under it left the highlight and the scanning light on a folder that no
+  // longer existed. Matching on the folder the selection belongs to is what the
+  // import-folder branch already did.
+  it("clears a selected subfolder when its reference folder is removed", async () => {
+    const wrapper = await mountSidebar({ teleport: true });
+    const sidebarStore = useSidebarStore();
+    routeToFolder(SUB);
+    await flushPromises();
+    expect(sidebarStore.folderScanning).toBe(true);
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const rows = wrapper.findAll(".sidebar-folder-root-row");
+    await rows[0].trigger("contextmenu");
+    await flushPromises();
+    // The context menu is teleported to <body>, so it is not under `wrapper`.
+    const remove = document.querySelector(".sidebar-ctx-item--danger");
+    expect(remove).not.toBe(null);
+    remove.click();
+    await flushPromises();
+
+    expect(lastFolderPayload(wrapper)).toBe(null);
+    expect(sidebarStore.folderScanning).toBe(false);
 
     wrapper.unmount();
   });

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -265,7 +265,15 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       // screen. The id still owns the payload - `useViewStore.applyView`
       // refuses to overwrite it from `?path=` on a folder route, and the
       // sidebar restores the subfolder from the query instead.
-      const folderQuery = f.pathPrefix ? { path: f.pathPrefix } : {};
+      //
+      // `subPath`, NOT `pathPrefix`: the id already says where the folder is,
+      // so repeating the absolute path only put the owner's folder tree in the
+      // address bar and in browser history (#1206 item 9). The sidebar builds
+      // it (`SideBar._subPathUnder`) and reads it back
+      // (`SideBar.routeSubfolderUnder`, which still accepts the absolute form a
+      // link shared before this carries). A folder ROOT has no subPath and
+      // therefore no query at all, which is where it started.
+      const folderQuery = f.subPath ? { path: f.subPath } : {};
       if (f.referenceFolderId != null) {
         pushAppRoute({
           name: "ref-folder",
@@ -284,8 +292,13 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
       }
       // A folder payload with no id of any kind - what an "About your
       // library" finding points at. It travels as `?path=` rather than being
-      // dropped, and `useViewStore.parseFolderPath` reads it back.
-      pushAppRoute({ name: "all-pictures", query: folderQuery });
+      // dropped, and `useViewStore.parseFolderPath` reads it back. ABSOLUTE
+      // here, unlike the two branches above: there is no id for it to be
+      // relative to, so the path is the only thing that names this folder.
+      pushAppRoute({
+        name: "all-pictures",
+        query: f.pathPrefix ? { path: f.pathPrefix } : {},
+      });
       return;
     }
 

--- a/frontend/src/composables/useAppNavigationFolders.test.js
+++ b/frontend/src/composables/useAppNavigationFolders.test.js
@@ -56,6 +56,8 @@ function mountNav() {
 
 const ROOT = "/home/me/library/refs";
 const SUB = "/home/me/library/refs/2024/summer";
+/** SUB said the way the URL now says it: relative to the folder the id names. */
+const SUBTAIL = "2024/summer";
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -67,25 +69,34 @@ beforeEach(() => {
 });
 
 describe("a reference-folder click", () => {
-  it("keeps the subfolder in the URL", () => {
+  it("keeps the subfolder in the URL, relative to the folder", () => {
+    // `subPath`, not `pathPrefix`: the id already names the folder, so the
+    // query only has to say which folder inside it. Repeating the absolute
+    // path put the owner's folder tree in the address bar and in their browser
+    // history for no navigational gain (#1206 item 9).
     const { wrapper, api } = mountNav();
 
     api.handleSelectFolder({
       referenceFolderId: 5,
       pathPrefix: SUB,
+      subPath: SUBTAIL,
       label: "summer",
     });
 
     expect(nav.push).toHaveBeenCalledWith({
       name: "ref-folder",
       params: { id: "5" },
-      query: { path: SUB },
+      query: { path: SUBTAIL },
     });
+    expect(JSON.stringify(nav.push.mock.calls)).not.toContain(ROOT);
 
     wrapper.unmount();
   });
 
-  it("names the folder root when that is what was clicked", () => {
+  it("names the folder root with no query at all", () => {
+    // The root row's click carries `pathPrefix: folder.folder` and no
+    // `subPath`, because the root is not inside itself. `/ref-folder/5` says
+    // everything there is to say.
     const { wrapper, api } = mountNav();
 
     api.handleSelectFolder({
@@ -97,7 +108,7 @@ describe("a reference-folder click", () => {
     expect(nav.push).toHaveBeenCalledWith({
       name: "ref-folder",
       params: { id: "5" },
-      query: { path: ROOT },
+      query: {},
     });
 
     wrapper.unmount();


### PR DESCRIPTION
Carries #1217's commits until that PR merges; targets `develop`, not its branch.

**The IPC guardrail only checked two prefixes.** It asserted that every `setup:*` and `server:*` channel carries a gate. The other 24 channels were checked by nothing, and nothing recorded that this was a decision — so a new `desktop:runScript` would ship ungated and green. Now every channel must either carry a gate or appear in a `DELIBERATELY_OPEN` map with a one-line reason; a channel in neither fails the build. The reasons are written from the code: most of the open set is read-only, argument-less, or narrowed at the boundary instead, and four are called by both the wizard and Settings so neither gate fits.

Two ways a channel could slip past the sweep, both closed:

- `ipcMain.on(...)` was invisible to it. None exist today, which is why it belongs there — an unswept spelling is only invisible until someone uses it.
- `ipcMain.handle('server' + ':evil', …)` was read as the channel `"server"`, which does not start with `"server:"`, so it skipped the gate assertion while still counting as one named handler against one opener. Silently ungated in both directions.

Two smaller correctness fixes from the same review:

- `pathKey` trimmed whitespace, which widened a `file://` equality: on POSIX `setup.html%20` answered for the bundled wizard page. The trim was written for a typed path in `config.ts` and moves back to that file's two callers.
- A relative `?path=` on a reference-folder route was taken verbatim, so `?path=../../..` built a prefix outside the folder. Containment now holds for both shapes. No impact today — the query is still scoped by `reference_folder_id` — but the refusal had become conditional on the string looking absolute.

Every new assertion was checked to go red when the thing it guards is removed.