### PR TITLE
One destination blocklist, shared by every route that writes files (#1206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,7 @@ jobs:
           tests/test_label_ledger.py
           tests/test_libraries_routes.py
           tests/test_library_backup.py
+          tests/test_library_destination_blocklist.py
           tests/test_library_generation_coordinator.py
           tests/test_library_insights.py
           tests/test_library_layout.py

--- a/changelog.d/1206-backend.md
+++ b/changelog.d/1206-backend.md
@@ -1,0 +1,17 @@
+- Export to folder now refuses a destination inside *any* of your libraries,
+  not only the one you are looking at. Exporting into another library's folder
+  used to be accepted, and everything written there came back as a fresh set of
+  pictures the next time you opened it.
+- Deleted pictures no longer use the GPU for tagging. The "awaiting tagging"
+  number left them out while the tagger went on working through them, so the
+  count could read zero while your card stayed busy.
+- PixlStash now says so when the WD14 tagger falls back to the CPU. It asked
+  onnxruntime what the build supports rather than what the tagger actually
+  loaded, so a GPU that could not be used looked exactly like one that was.
+- Background work no longer stalls re-checking files on a drive that has gone
+  away. The list of files to skip was rebuilt several times a sweep, and every
+  rebuild waited on the missing drive.
+- `pixlstash-cli plugins install --with-deps` now lists the pip options a
+  plugin's `requirements.txt` reaches through an `-r` include or a line
+  continuation. The include line was shown, but not the `--index-url` behind
+  it that decides where the packages come from.

--- a/changelog.d/destination-blocklist-siblings.md
+++ b/changelog.d/destination-blocklist-siblings.md
@@ -1,0 +1,8 @@
+- Adding a watch folder now refuses one that sits inside another of your
+  libraries, inside a reference folder, or inside a folder you already watch.
+  A watch folder set to delete after import used to accept any of those and
+  then copy the pictures into the library you had open and delete the
+  originals, leaving the library that owned them pointing at files that were
+  gone.
+- Moving a reference folder now refuses a destination inside another library or
+  inside a watched folder, and says so before anything is moved.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -167,6 +167,7 @@ pixlstash/
 │   ├── face_tags.py
 │   ├── path_mapper.py
 │   ├── path_utils.py                    # resolve_path_within (moved out of service/)
+│   ├── library_roots.py                 # The one blocklist of directories a library owns
 │   ├── serialization_utils.py           # safe_model_dict (moved out of service/)
 │   ├── system_utils.py                  # default_max_vram_gb (moved out of service/)
 │   ├── host_path_utils.py
@@ -1479,6 +1480,7 @@ This rule is enforced by **`tests/test_architecture_guardrails.py::test_services
 | [utils/caption_file_utils.py](../pixlstash/utils/caption_file_utils.py) | Sidecar `.txt` caption I/O |
 | [utils/face_tags.py](../pixlstash/utils/face_tags.py) | Face-derived tag helpers |
 | [utils/library_layout.py](../pixlstash/utils/library_layout.py) | The library layout model — `render` / `is_true` (§13) |
+| [utils/library_roots.py](../pixlstash/utils/library_roots.py) | The single list of directories this installation reads or writes as library content, and the refusal every route that writes or moves files into a caller-named folder shares (#1206 item 1) |
 | [utils/path_mapper.py](../pixlstash/utils/path_mapper.py) | Host↔container path translation |
 | [utils/host_path_utils.py](../pixlstash/utils/host_path_utils.py) | Host-aware path resolution |
 | [utils/reference_folder_watcher.py](../pixlstash/utils/reference_folder_watcher.py) | watchdog-based folder monitoring |

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -23,6 +23,7 @@ import ast
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -984,14 +985,13 @@ def read_requirements(requirements: Path) -> list[str]:
 #: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
 #: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
 #: pull the second file in, so all four have to be recognised here.
-#: An ``-r``/``-c`` include and its target. The target is a quoted string OR a
-#: bare token, in that order: pip parses these lines with shlex, so
-#: ``-r "deps/with spaces/base.txt"`` is a legal include, and a bare ``\S+``
-#: stopped at the first space and silently failed to follow it.
-_INCLUDE_RE = re.compile(
-    r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)"
-    r"(\"[^\"]+\"|'[^']+'|\S+)"
-)
+#: The ``-r``/``-c`` option itself. The TARGET is not matched here: pip parses
+#: these lines with :mod:`shlex`, and hand-rolled quoting disagrees with it in
+#: a way that matters -- ``-r "a"b.txt`` is one token ``ab.txt`` to pip, but a
+#: quoted-or-bare alternation reads ``a``. Listing the options of one file
+#: while pip reads another defeats the whole point of showing them, so the
+#: target is taken from ``shlex.split`` in :func:`_include_target`.
+_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)")
 
 
 def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
@@ -1010,7 +1010,13 @@ def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
     match = _INCLUDE_RE.match(line)
     if match is None:
         return None
-    target = match.group(1).strip("\"'")
+    try:
+        words = shlex.split(line[match.end() :])
+    except ValueError:
+        # An unbalanced quote. pip will not read this line either; refuse
+        # rather than guess, and the line is still listed by the caller.
+        return None
+    target = words[0] if words else ""
     # `urlparse(...).scheme` was too eager: it reads `base:1.txt` as scheme
     # "base", so a legal relative filename containing a colon was refused and
     # its options went unlisted -- the same incompleteness this is fixing.

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -984,7 +984,14 @@ def read_requirements(requirements: Path) -> list[str]:
 #: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
 #: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
 #: pull the second file in, so all four have to be recognised here.
-_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)(\S+)")
+#: An ``-r``/``-c`` include and its target. The target is a quoted string OR a
+#: bare token, in that order: pip parses these lines with shlex, so
+#: ``-r "deps/with spaces/base.txt"`` is a legal include, and a bare ``\S+``
+#: stopped at the first space and silently failed to follow it.
+_INCLUDE_RE = re.compile(
+    r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)"
+    r"(\"[^\"]+\"|'[^']+'|\S+)"
+)
 
 
 def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
@@ -1004,7 +1011,13 @@ def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
     if match is None:
         return None
     target = match.group(1).strip("\"'")
-    if not target or urlparse(target).scheme:
+    # `urlparse(...).scheme` was too eager: it reads `base:1.txt` as scheme
+    # "base", so a legal relative filename containing a colon was refused and
+    # its options went unlisted -- the same incompleteness this is fixing.
+    # Containment below is what actually enforces safety (a URL resolves to
+    # nothing inside the plugin folder and is refused there), so this test only
+    # has to catch the obvious case early.
+    if not target or "://" in target:
         return None
     try:
         resolved = (parent.parent / target).resolve()

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -959,17 +959,64 @@ def resolve_requirements(requirements: Path) -> list[DependencyChange]:
     return sorted(changes, key=lambda change: change.name.lower())
 
 
+#: A trailing backslash and the whitespace either side of it: one option to
+#: pip, so one line here.  The surrounding whitespace goes with it, or the
+#: joined line carries the indent of the continuation into the middle of it.
+_CONTINUATION_RE = re.compile(r"[^\S\n]*\\\n[^\S\n]*")
+
+
 def read_requirements(requirements: Path) -> list[str]:
-    """Return the requirement lines, so the CLI can show them before running pip."""
+    """Return the requirement lines, so the CLI can show them before running pip.
+
+    A line ending in a backslash is joined to the next one first, because pip
+    does the same: ``--index-url \\`` on its own line and the URL on the next is
+    ONE option to pip, and reading them as two showed the option without what
+    it points at (#1206 item 8).
+    """
+    source = _CONTINUATION_RE.sub(" ", read_source(requirements).replace("\r\n", "\n"))
     return [
         line.strip()
-        for line in read_source(requirements).splitlines()
+        for line in source.splitlines()
         if line.strip() and not line.strip().startswith("#")
     ]
 
 
+#: ``-r``/``-c`` and their long forms, with the file they name.  pip accepts
+#: ``-r f``, ``-rf``, ``--requirement f`` and ``--requirement=f``; all four
+#: pull the second file in, so all four have to be recognised here.
+_INCLUDE_RE = re.compile(r"^(?:(?:--requirement|--constraint)[=\s]+|(?:-r|-c)\s*)(\S+)")
+
+
+def _include_target(line: str, parent: Path, root: Path) -> "Path | None":
+    """The file an ``-r``/``-c`` option line points at, if it is safe to read.
+
+    pip resolves the path relative to the file the option is written in, so
+    that is what is resolved here.
+
+    SECURITY: the line is written by the plugin author and nothing has been
+    installed yet, so following it must not become a way to read the machine.
+    Anything that leaves the plugin's own folder -- an absolute path, a ``..``
+    escape, a URL, a symlink out -- is refused rather than followed, and so is
+    anything that is not a regular file.  The include line itself is still
+    listed either way, so a refusal hides nothing from the reader.
+    """
+    match = _INCLUDE_RE.match(line)
+    if match is None:
+        return None
+    target = match.group(1).strip("\"'")
+    if not target or urlparse(target).scheme:
+        return None
+    try:
+        resolved = (parent.parent / target).resolve()
+    except OSError:
+        return None
+    if not resolved.is_relative_to(root) or not resolved.is_file():
+        return None
+    return resolved
+
+
 def pip_options(requirements: Path) -> list[str]:
-    """Return every option line in *requirements* -- each line starting ``-``.
+    """Return every option line *requirements* reaches -- each starting ``-``.
 
     SECURITY: a plugin's ``requirements.txt`` is written by the plugin author,
     and pip honours option lines in it.  Some of them decide where packages
@@ -986,14 +1033,45 @@ def pip_options(requirements: Path) -> list[str]:
     verbatim and lets the reader judge, rather than claiming per line what each
     one does.
 
-    Only **this file** is read.  ``-r``/``-c`` pull in further files that pip
-    also honours, and an option set in one of those is not listed here -- the
-    include line itself is, which is the visible trace of it.  This is
-    information for the reader rather than a gate, so it is described honestly
-    rather than made exhaustive: following includes is a containment problem of
-    its own and would not change what installs.
+    ``-r``/``-c`` includes are followed, because pip honours the options in the
+    file they name exactly as if they had been written here, and showing only
+    the include line left the ``--index-url`` behind it unlisted (#1206 item
+    8).  A line from an included file is tagged with the file it came from.
+    Only files inside the plugin's own folder are followed
+    (:func:`_include_target`), each is read once so a cycle terminates, and a
+    file that cannot be read contributes a line saying so rather than being
+    passed over in silence.
     """
-    return [line for line in read_requirements(requirements) if line.startswith("-")]
+    root = requirements.parent.resolve()
+    options: list[str] = []
+    seen: set[Path] = set()
+    pending: list[Path] = [requirements]
+    while pending:
+        current = pending.pop(0)
+        resolved = current.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        # Named relative to the plugin folder: two `base.txt` under different
+        # subfolders must not read as the same file.
+        where = (
+            ""
+            if resolved == requirements.resolve()
+            else f"   [in {resolved.relative_to(root).as_posix()}]"
+        )
+        try:
+            lines = read_requirements(current)
+        except PluginError as exc:
+            options.append(f"(could not read {current.name}: {exc})")
+            continue
+        for line in lines:
+            if not line.startswith("-"):
+                continue
+            options.append(f"{line}{where}")
+            included = _include_target(line, current, root)
+            if included is not None:
+                pending.append(included)
+    return options
 
 
 def install_requirements(changes: list[DependencyChange]) -> None:

--- a/pixlstash/plugin_install.py
+++ b/pixlstash/plugin_install.py
@@ -1057,20 +1057,33 @@ def pip_options(requirements: Path) -> list[str]:
     the include line left the ``--index-url`` behind it unlisted (#1206 item
     8).  A line from an included file is tagged with the file it came from.
     Only files inside the plugin's own folder are followed
-    (:func:`_include_target`), each is read once so a cycle terminates, and a
-    file that cannot be read contributes a line saying so rather than being
-    passed over in silence.
+    (:func:`_include_target`), each *file* is read once so a cycle terminates,
+    and a file that cannot be read contributes a line saying so rather than
+    being passed over in silence.
+
+    "Once" is per file, not per spelling: the read set is keyed on
+    ``(st_dev, st_ino)``.  ``resolve()`` does not case-canonicalise, so on a
+    case-insensitive filesystem ``-r base.txt`` and ``-r BASE.TXT`` are two
+    keys for one file, and a plugin listing the same file under many spellings
+    - or under a hardlink - had it read once per spelling (#1206 review).
     """
     root = requirements.parent.resolve()
     options: list[str] = []
-    seen: set[Path] = set()
+    seen: set[object] = set()
     pending: list[Path] = [requirements]
     while pending:
         current = pending.pop(0)
         resolved = current.resolve()
-        if resolved in seen:
+        try:
+            info = resolved.stat()
+            key: object = (info.st_dev, info.st_ino)
+        except OSError:
+            # Unreadable: `read_requirements` below reports it, and the path is
+            # the best identity available for not reporting it twice.
+            key = resolved
+        if key in seen:
             continue
-        seen.add(resolved)
+        seen.add(key)
         # Named relative to the plugin folder: two `base.txt` under different
         # subfolders must not read as the same file.
         where = (

--- a/pixlstash/routes/import_folders.py
+++ b/pixlstash/routes/import_folders.py
@@ -13,6 +13,7 @@ from pixlstash.db_models.import_folder import ImportFolder
 from pixlstash.db_models.picture import Picture
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.host_path_utils import is_absolute_host_path, normalize_host_path
+from pixlstash.utils.library_roots import refuse_path_inside_a_library
 from pixlstash.utils.reference_folder_validator import validate_reference_folder_path
 
 logger = get_logger(__name__)
@@ -158,6 +159,21 @@ def create_router(server) -> APIRouter:
                 status_code=400,
                 detail="Host path is required in Docker mode.",
             )
+
+        # The `image_root` check inside `insert` below knew only that one root,
+        # and compared it lexically. A watch folder pointed at a reference
+        # folder, at an existing watch folder, or at another registered library
+        # imports that folder's contents into the active library - and one
+        # carrying `delete_after_import` then unlinks each source file
+        # (`tasks/watch_folder_import_task.py`), so the library that owns those
+        # pictures is left with rows pointing at files that are gone. Same list
+        # the folder export refuses against, shared rather than copied a third
+        # time (#1206 item 1).
+        #
+        # Outside the DB task on purpose: this reads the folder tables itself,
+        # and a read nested inside `run_task` would be a session inside a
+        # session.
+        refuse_path_inside_a_library(folder, server, server.vault)
 
         label = payload.label if payload.label is not None else os.path.basename(folder)
 

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -14,8 +14,7 @@ from pydantic import BaseModel, ConfigDict
 from typing import Optional
 
 from pixlstash.pixl_logging import get_logger
-from pixlstash.services.config_service import get_import_folder_paths
-from pixlstash.utils.path_utils import LibraryRootsUnavailable, path_is_within
+from pixlstash.utils.library_roots import refuse_path_inside_a_library
 from pixlstash.utils.reference_folder_validator import validate_reference_folder_path
 
 
@@ -200,77 +199,19 @@ def register_routes(router, server):
         # so it is not deduplicated, and a folder carrying
         # `delete_after_import` then os.remove()s the file it has just
         # imported - so the export destroys its own output.
+        #
+        # The roots are the shared list in `utils.library_roots`, not a copy:
+        # this route grew the complete one while `POST /import-folders` and the
+        # reference-folder routes kept partial ones, which is what #1206 item 1
+        # asked to be fixed by having one list.
         vault = request.state.library_lease.vault
-        library_roots = [getattr(vault, "image_root", None)]
-        # Both lists are a *blocklist* here, so a list that cannot be read must
-        # refuse. Treating either as empty turns the check off silently and
-        # lets the destination land in the very folder it exists to keep the
-        # export out of (#1177 item 59 and its import-folder sibling).
-        try:
-            library_roots.extend(vault.reference_folder_roots())
-            library_roots.extend(get_import_folder_paths(vault))
-            # Every OTHER registered library is the same hazard as this one.
-            # A library's folder IS its image_root (it is where `vault.db`
-            # lives), so an export written into one comes back as new pictures
-            # the moment that library is opened - and this route only ever sees
-            # the active lease's vault, so nothing above notices. Registered
-            # paths are all that is read: another library's reference and watch
-            # folders live in ITS vault, which is not open here, and opening
-            # someone else's vault to answer an export question is a worse
-            # trade than the narrower check. Attached libraries only - a
-            # detached one is not being read by anything, and the refusal below
-            # speaks of "your library".
-            library_roots.extend(
-                library.path for library in server.library_registry.list_libraries()
-            )
-        except LibraryRootsUnavailable as exc:
-            logger.warning(
-                "Refusing the folder export to %s: a library root list could "
-                "not be read, so the destination cannot be shown to be "
-                "outside the library: %s",
-                resolved_destination,
-                exc,
-            )
-            raise HTTPException(
-                status_code=503,
-                detail=(
-                    "PixlStash could not check your reference folders and "
-                    "watched folders just now, so it cannot confirm this "
-                    "destination is outside your library. Try again in a "
-                    "moment."
-                ),
-            ) from exc
-        except Exception as exc:
-            # The registry read is the same blocklist discipline: a list that
-            # cannot be read must refuse, because an empty answer reads as
-            # "there are no other libraries to protect".
-            logger.warning(
-                "Refusing the folder export to %s: the library registry could "
-                "not be read, so the destination cannot be shown to be outside "
-                "every library: %s",
-                resolved_destination,
-                exc,
-            )
-            raise HTTPException(
-                status_code=503,
-                detail=(
-                    "PixlStash could not check your libraries just now, so it "
-                    "cannot confirm this destination is outside them. Try "
-                    "again in a moment."
-                ),
-            ) from exc
-        for root in library_roots:
-            if root and path_is_within(resolved_destination, root):
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "That folder is part of your library - PixlStash "
-                        "reads it - so everything exported into it would be "
-                        "imported straight back in. Choose a folder outside "
-                        "this library, its reference folders and its import "
-                        "folders, and outside any other library's folder."
-                    ),
-                )
+        refuse_path_inside_a_library(
+            resolved_destination,
+            server,
+            vault,
+            # 400 since #1177; the sibling callers answer 409.
+            status_code=400,
+        )
         # A folder export writes plain files, unlike a ZIP: a name that
         # collides with something already in the destination is silently
         # overwritten (shutil.copy2 / open(..., "w") don't refuse). Requiring

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -140,8 +140,8 @@ def register_routes(router, server):
             "Queues an asynchronous export task that writes pictures straight "
             "into a folder on the machine running PixlStash, then opens that "
             "folder in the host file manager. The destination must be an "
-            "empty, writable, existing directory outside the library, its "
-            "reference folders and its import folders. "
+            "empty, writable, existing directory outside every registered "
+            "library, this library's reference folders and its import folders. "
             "Local owner, on that machine, only - see POST /pictures/export "
             "for a ZIP you can download from anywhere instead."
         ),
@@ -209,6 +209,20 @@ def register_routes(router, server):
         try:
             library_roots.extend(vault.reference_folder_roots())
             library_roots.extend(get_import_folder_paths(vault))
+            # Every OTHER registered library is the same hazard as this one.
+            # A library's folder IS its image_root (it is where `vault.db`
+            # lives), so an export written into one comes back as new pictures
+            # the moment that library is opened - and this route only ever sees
+            # the active lease's vault, so nothing above notices. Registered
+            # paths are all that is read: another library's reference and watch
+            # folders live in ITS vault, which is not open here, and opening
+            # someone else's vault to answer an export question is a worse
+            # trade than the narrower check. Attached libraries only - a
+            # detached one is not being read by anything, and the refusal below
+            # speaks of "your library".
+            library_roots.extend(
+                library.path for library in server.library_registry.list_libraries()
+            )
         except LibraryRootsUnavailable as exc:
             logger.warning(
                 "Refusing the folder export to %s: a library root list could "
@@ -226,6 +240,25 @@ def register_routes(router, server):
                     "moment."
                 ),
             ) from exc
+        except Exception as exc:
+            # The registry read is the same blocklist discipline: a list that
+            # cannot be read must refuse, because an empty answer reads as
+            # "there are no other libraries to protect".
+            logger.warning(
+                "Refusing the folder export to %s: the library registry could "
+                "not be read, so the destination cannot be shown to be outside "
+                "every library: %s",
+                resolved_destination,
+                exc,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "PixlStash could not check your libraries just now, so it "
+                    "cannot confirm this destination is outside them. Try "
+                    "again in a moment."
+                ),
+            ) from exc
         for root in library_roots:
             if root and path_is_within(resolved_destination, root):
                 raise HTTPException(
@@ -234,7 +267,8 @@ def register_routes(router, server):
                         "That folder is part of your library - PixlStash "
                         "reads it - so everything exported into it would be "
                         "imported straight back in. Choose a folder outside "
-                        "your library, reference folders and import folders."
+                        "your libraries, their reference folders and their "
+                        "import folders."
                     ),
                 )
         # A folder export writes plain files, unlike a ZIP: a name that

--- a/pixlstash/routes/pictures/_export.py
+++ b/pixlstash/routes/pictures/_export.py
@@ -267,8 +267,8 @@ def register_routes(router, server):
                         "That folder is part of your library - PixlStash "
                         "reads it - so everything exported into it would be "
                         "imported straight back in. Choose a folder outside "
-                        "your libraries, their reference folders and their "
-                        "import folders."
+                        "this library, its reference folders and its import "
+                        "folders, and outside any other library's folder."
                     ),
                 )
         # A folder export writes plain files, unlike a ZIP: a name that

--- a/pixlstash/routes/reference_folders.py
+++ b/pixlstash/routes/reference_folders.py
@@ -30,6 +30,7 @@ from pixlstash.utils.caption_file_utils import (
     writeback_path,
 )
 from pixlstash.utils.host_path_utils import is_absolute_host_path, normalize_host_path
+from pixlstash.utils.library_roots import refuse_path_inside_a_library
 from pixlstash.utils.library_layout import (
     DEFAULT_LAYOUT,
     folder_name,
@@ -650,6 +651,17 @@ def create_router(server) -> APIRouter:
         # folder somewhere the blocklist never saw. `model_folders.py` already
         # does this and its comment says this route did too; it did not.
         folder = os.path.realpath(folder)
+        # `_validate_reference_folder_conflicts` covers `image_root` and the
+        # other reference-folder rows; it does not know about this library's
+        # watch folders or about any other registered library. A reference
+        # folder overlapping a `delete_after_import` watch folder is scanned by
+        # one subsystem and emptied by the other. Same shared list the folder
+        # export and `POST /import-folders` refuse against (#1206 item 1).
+        #
+        # Before the DB task, not inside it: this reads the folder tables
+        # itself, and a read nested in `run_task` would be a session inside a
+        # session.
+        refuse_path_inside_a_library(folder, server, server.vault)
 
         label = payload.label if payload.label is not None else os.path.basename(folder)
 
@@ -742,6 +754,22 @@ def create_router(server) -> APIRouter:
         request: Request,
         payload: ReferenceFolderUpdateRequest = Body(...),
     ):
+        # Repointing a row is a destination check like the create route's, and
+        # for the same reason it runs before the DB task rather than inside it.
+        # The row's current folder is its own root, not a conflict with itself.
+        if "folder" in payload.model_fields_set and payload.folder is not None:
+            candidate = os.path.realpath(os.path.normpath(payload.folder))
+            current = server.vault.db.run_immediate_read_task(
+                lambda session: getattr(
+                    session.get(ReferenceFolder, folder_id), "folder", None
+                )
+            )
+            refuse_path_inside_a_library(
+                candidate,
+                server,
+                server.vault,
+                ignore_roots=(current,) if current else (),
+            )
 
         def update(session: Session):
             rf = session.get(ReferenceFolder, folder_id)
@@ -1007,6 +1035,19 @@ def create_router(server) -> APIRouter:
 
         old_root, new_root, picture_ids = server.vault.db.run_task(
             fetch_and_validate, priority=DBPriority.IMMEDIATE
+        )
+
+        # This route physically `shutil.move`s every file below `old_root`, so
+        # a destination inside another registered library moves the pictures
+        # into a folder that library will index, and a destination inside a
+        # `delete_after_import` watch folder hands them to a watcher that
+        # imports and then unlinks them. `_validate_relocation_destination`
+        # above knows only `image_root` and the other reference-folder rows
+        # (#1206 item 1). Checked before the first move; the row being
+        # relocated is its own root, and the nesting check above has already
+        # refused a destination inside it.
+        refuse_path_inside_a_library(
+            new_root, server, server.vault, ignore_roots=(old_root,)
         )
 
         if not os.path.isdir(old_root):

--- a/pixlstash/tagger_plugins/wd14.py
+++ b/pixlstash/tagger_plugins/wd14.py
@@ -120,14 +120,6 @@ class WD14Service:
         with self._load_lock:
             if self.is_loaded():
                 return
-            if self._device == "cuda":
-                providers = ort.get_available_providers()
-                if "CUDAExecutionProvider" not in providers:
-                    logger.warning(
-                        "CUDAExecutionProvider unavailable for onnxruntime "
-                        "(WD14 tagger will use CPU; all PyTorch models still use CUDA). "
-                        "Fix with: pip uninstall -y onnxruntime && pip install onnxruntime-gpu"
-                    )
             self._init_onnx_session()
             if self._rating_tags is None or self._general_tags is None:
                 self._load_tags()
@@ -304,8 +296,37 @@ class WD14Service:
                         else ["CPUExecutionProvider"]
                     ),
                 )
+        self._warn_if_the_session_fell_back_to_cpu()
         self._input_name = self._ort_sess.get_inputs()[0].name
         self._onnx_batch_capacity = self._resolve_batch_capacity()
+
+    def _warn_if_the_session_fell_back_to_cpu(self) -> None:
+        """Say so when the session did not get the accelerator it asked for.
+
+        ``ort.get_available_providers()`` says what the onnxruntime build
+        SUPPORTS, not what can load. A provider whose shared libraries are
+        missing - the CUDA one needs ``libcublasLt`` - is still listed, still
+        requested, and then silently dropped, so the old check passed while
+        every tag ran on the CPU at a fraction of the speed with nothing said
+        (#1206 item 3b, live on a development box). ``get_providers()`` is the
+        session's own answer, so it is the only one worth asking.
+        """
+        if self._device == "cpu" or self._ort_sess is None:
+            return
+        active = self._ort_sess.get_providers() or ["CPUExecutionProvider"]
+        if active[0] != "CPUExecutionProvider":
+            logger.debug("WD14 tagger session is running on %s", active[0])
+            return
+        logger.warning(
+            "WD14 tagger asked onnxruntime for device %s, but the session "
+            "loaded with %s: tagging will run on the CPU at a fraction of the "
+            "speed. The usual cause is an execution provider this build "
+            "advertises whose libraries are not installed (the CUDA provider "
+            "needs libcublasLt). Fix with: pip uninstall -y onnxruntime && "
+            "pip install onnxruntime-gpu",
+            self._device,
+            active[0],
+        )
 
     def _resolve_batch_capacity(self) -> int:
         if self._ort_sess is None:

--- a/pixlstash/tasks/missing_tag_finder.py
+++ b/pixlstash/tasks/missing_tag_finder.py
@@ -13,7 +13,7 @@ from pixlstash.db_models import (
 from pixlstash.services.set_lock_service import locked_picture_id_subquery
 from pixlstash.worker_config import TAGGER_MAX_INFLIGHT
 from .base_task_finder import BaseTaskFinder
-from .tag_task import TagTask
+from .tag_task import TagTask, taggable_picture_clauses
 
 # Every sentinel value starts with TAG_PENDING_SENTINEL (``__tag`` or
 # ``__tag:<engine>``), so the half-open range [``__tag``, ``__tah``) is the
@@ -141,8 +141,15 @@ class MissingTagFinder(BaseTaskFinder):
         # selected again on the very next sweep - an unbounded inference loop.
         # One definition on both sides is what closes it.
         locked_member = ~Picture.id.in_(locked_picture_id_subquery())
+        # `taggable_picture_clauses` is the predicate `TagTask.count_missing_tags`
+        # applies, imported rather than repeated: the two disagreed (#1206 item
+        # 3), so the "awaiting tagging" number excluded scrapheaped pictures
+        # while this query kept selecting them and spending the GPU on them.
         stmt = select(Picture).where(
-            Picture.id.in_(pending), faces_known, locked_member
+            Picture.id.in_(pending),
+            faces_known,
+            locked_member,
+            *taggable_picture_clauses(),
         )
         if suppressed_ids:
             stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -93,6 +93,22 @@ def _file_is_readable(file_path: str) -> bool:
         return False
 
 
+def taggable_picture_clauses() -> tuple:
+    """The picture rows tagging may touch: not soft-deleted, and with a file.
+
+    One definition, because two queries have to answer identically: the
+    "awaiting tagging" number (:meth:`TagTask.count_missing_tags`) and the
+    selection the work planner actually runs
+    (``MissingTagFinder._fetch_missing_tags``). They did not (#1206 item 3) -
+    the count applied both clauses and the selection applied neither, so the
+    number read zero while the GPU went on tagging pictures the owner had put
+    in the scrapheap. A picture restored from the scrapheap keeps its pending
+    sentinel and is picked up again on the next sweep, so nothing is lost by
+    holding it out while it is deleted.
+    """
+    return (Picture.deleted.is_(False), Picture.file_path.is_not(None))
+
+
 class TagTask(BaseTask):
     """Task that tags a batch of pictures and persists tag updates."""
 
@@ -1321,8 +1337,7 @@ class TagTask(BaseTask):
             select(func.count())
             .select_from(Picture)
             .where(Picture.tags.any(has_sentinel))
-            .where(Picture.deleted.is_(False))
-            .where(Picture.file_path.is_not(None))
+            .where(*taggable_picture_clauses())
         ).one()
         if isinstance(result, (tuple, list)):
             return result[0]

--- a/pixlstash/utils/library_roots.py
+++ b/pixlstash/utils/library_roots.py
@@ -1,0 +1,145 @@
+"""The directories a PixlStash installation reads or writes as library content.
+
+One list, several callers, because it used to be three partial ones and the
+gaps were exactly the routes that move files:
+
+* ``POST /pictures/export/folder`` knew every root (#1177 item 2, #1206 item 1).
+* ``POST /import-folders`` knew only the active vault's ``image_root``, so a
+  watch folder could be pointed at another library's folder or at one of this
+  library's own reference folders - and one carrying ``delete_after_import``
+  then copies every file into the active library and unlinks the original,
+  leaving the owning library's rows pointing at files that are gone.
+* The reference-folder create/update/relocate routes knew ``image_root`` and
+  the other reference-folder rows, so a relocation would physically move
+  pictures into another library's folder, or into a ``delete_after_import``
+  watch folder that then eats them.
+
+Issue #1206 item 1 asked for one shared list. This is it.
+"""
+
+from collections.abc import Iterable
+
+from fastapi import HTTPException
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.config_service import get_import_folder_paths
+from pixlstash.utils.path_utils import LibraryRootsUnavailable, path_is_within
+from pixlstash.utils.reference_folder_validator import canonical_path
+
+logger = get_logger(__name__)
+
+#: Said once, to every caller, because the answer is the same one on each of
+#: their screens: this folder already belongs to a library, choose another.
+PATH_INSIDE_LIBRARY_DETAIL = (
+    "That folder is part of your library - PixlStash reads it - so anything "
+    "put there would be imported straight back in, or moved out from under "
+    "the library that owns it. Choose a folder outside this library, its "
+    "reference folders and its import folders, and outside any other "
+    "library's folder."
+)
+
+#: The lists below are a *blocklist*, so one that cannot be read must refuse.
+#: Treating a failed read as an empty list turns the check off silently and
+#: permits exactly what it exists to refuse (#1177 item 59).
+ROOTS_UNAVAILABLE_DETAIL = (
+    "PixlStash could not check your reference folders, watched folders and "
+    "libraries just now, so it cannot confirm this folder is outside them. "
+    "Try again in a moment."
+)
+
+
+def library_content_roots(server, vault) -> list[str]:
+    """Every directory this installation reads or writes as library content.
+
+    Args:
+        server: The running server, for the hub's library registry.
+        vault: The vault whose reference and import folders to include. Callers
+            hold a lease on one library; the registry supplies the rest.
+
+    Returns:
+        The root directories, in no particular order and not resolved. Use
+        :func:`~pixlstash.utils.path_utils.path_is_within`, which resolves both
+        sides, rather than comparing these as strings.
+
+    Raises:
+        LibraryRootsUnavailable: A list could not be read, so the answer is
+            "we do not know" rather than "there are none".
+    """
+    roots = [getattr(vault, "image_root", None)]
+    try:
+        roots.extend(vault.reference_folder_roots())
+        roots.extend(get_import_folder_paths(vault))
+        # Every OTHER registered library is the same hazard as this one: a
+        # library's folder IS its image_root (it is where `vault.db` lives), so
+        # files written into one come back as new pictures the moment that
+        # library is opened, and only the active lease's vault is open here.
+        # Registered paths are all that is read - another library's reference
+        # and watch folders live in ITS vault, and opening someone else's vault
+        # to answer this question is a worse trade than the narrower check.
+        #
+        # `include_detached=True`: a detached library is not being read *today*,
+        # but re-attaching it is one click and everything written into it then
+        # imports as new pictures. One keyword, no extra read.
+        roots.extend(
+            library.path
+            for library in server.library_registry.list_libraries(include_detached=True)
+        )
+    except Exception as exc:
+        # Including LibraryRootsUnavailable, deliberately: one failure shape for
+        # the caller to map, and the original is chained for the log.
+        logger.warning(
+            "Could not list the roots this installation owns, so no path can "
+            "be shown to be outside them: %s",
+            exc,
+        )
+        raise LibraryRootsUnavailable(
+            f"Could not list the roots this installation owns: {exc}"
+        ) from exc
+    return [root for root in roots if root]
+
+
+def refuse_path_inside_a_library(
+    path: str,
+    server,
+    vault,
+    *,
+    ignore_roots: Iterable[str] = (),
+    status_code: int = 409,
+) -> None:
+    """Refuse *path* when it lies inside a directory the installation owns.
+
+    Args:
+        path: An absolute path a caller wants files written to or moved into.
+        server: The running server.
+        vault: The vault holding the active lease.
+        ignore_roots: Roots that are *this caller's own* and so not a conflict -
+            the reference folder being repointed, for instance. Compared after
+            :func:`~pixlstash.utils.reference_folder_validator.canonical_path`,
+            so an alias of the same directory is still ignored.
+        status_code: The refusal's status. 409 (a conflict with something
+            already registered) everywhere except the folder export, which has
+            answered 400 since #1177 and whose callers read that.
+
+    Raises:
+        HTTPException: 503 when the roots could not be listed, *status_code*
+            when *path* is inside one of them.
+    """
+    try:
+        roots = library_content_roots(server, vault)
+    except LibraryRootsUnavailable as exc:
+        logger.warning(
+            "Refusing %s: the roots this installation owns could not be "
+            "listed, so it cannot be shown to be outside them: %s",
+            path,
+            exc,
+        )
+        raise HTTPException(status_code=503, detail=ROOTS_UNAVAILABLE_DETAIL) from exc
+
+    ignored = {canonical_path(root) for root in ignore_roots if root}
+    for root in roots:
+        if canonical_path(root) in ignored:
+            continue
+        if path_is_within(path, root):
+            raise HTTPException(
+                status_code=status_code, detail=PATH_INSIDE_LIBRARY_DETAIL
+            )

--- a/pixlstash/utils/unprocessable_image_registry.py
+++ b/pixlstash/utils/unprocessable_image_registry.py
@@ -23,6 +23,7 @@ needs no schema change and no migration.
 
 import os
 import threading
+import time
 
 from pixlstash.pixl_logging import get_logger
 
@@ -71,11 +72,25 @@ class UnprocessableImageRegistry:
     # realistic count.
     MAX_ENTRIES = 100_000
 
+    # How long an `active_suppressed_ids()` answer is reused before every entry
+    # is re-stat'd. The tag, face, thumbnail and embedding finders each rebuild
+    # the set on every planner sweep, and `Vault` counts with it twice more -
+    # six full walks of the map, back to back, on the planner thread. That is
+    # free while the files are local and it is not free at all for an
+    # *unreachable* entry, whose `_entry_is_live` waits on a dead mount for
+    # every stat (#1206 item 9b): exactly the case the map fills up with. The
+    # window is short enough that a repaired or remounted file is retried
+    # within seconds, and any change to the map clears the cache outright, so
+    # the staleness only ever delays a *retry* - never a suppression.
+    ACTIVE_CACHE_TTL_S = 5.0
+
     def __init__(self, max_entries: int = MAX_ENTRIES) -> None:
         self._max_entries = int(max_entries)
         self._lock = threading.Lock()
         # picture_id -> (file_path, mtime_ns, size)
         self._entries: dict[int, tuple[str, int, int]] = {}
+        # (monotonic time, ids) of the last full re-validation, or None.
+        self._active_cache: "tuple[float, frozenset[int]] | None" = None
 
     @staticmethod
     def _stat_signature(file_path: str) -> "tuple[int, int] | None":
@@ -136,6 +151,7 @@ class UnprocessableImageRegistry:
                 )
                 return False
             self._entries[pid] = (str(file_path), mtime_ns, size)
+            self._active_cache = None
         logger.warning(
             "Unprocessable image: picture id=%s path=%s could not be decoded (%s); "
             "skipping it for the rest of this server session (it will be retried "
@@ -196,6 +212,7 @@ class UnprocessableImageRegistry:
             # No signature: an unreachable file cannot be stat'd, and the
             # sentinel is what `_entry_is_live` reads to pick its predicate.
             self._entries[pid] = (str(file_path), _UNREACHABLE, _UNREACHABLE)
+            self._active_cache = None
         logger.warning(
             "Unreachable image: picture id=%s path=%s - its location is not "
             "mounted (%s); holding it out of the work finders until the "
@@ -244,22 +261,38 @@ class UnprocessableImageRegistry:
                 return True
             # Rewritten, repaired, or the volume is back - retry it.
             self._entries.pop(pid, None)
+            self._active_cache = None
             return False
 
     def active_suppressed_ids(self) -> set[int]:
         """Return the set of currently-suppressed picture ids, pruning stale entries.
 
         Re-validates every stored file signature; entries whose file changed or
-        disappeared are dropped. Cheap in practice - the map only holds genuinely
-        undecodable files, which are rare.
+        disappeared are dropped. The answer is then reused for
+        :attr:`ACTIVE_CACHE_TTL_S`, because six callers ask for it within one
+        planner sweep and an unreachable entry costs a mount timeout per stat.
+        Any write to the map drops the cache, so a newly marked picture is
+        never served from a set built before it.
         """
-        active: set[int] = set()
         with self._lock:
+            cached = self._active_cache
+            if (
+                cached is not None
+                and time.monotonic() - cached[0] < self.ACTIVE_CACHE_TTL_S
+            ):
+                return set(cached[1])
+            active: set[int] = set()
             for pid, (path, mtime_ns, size) in list(self._entries.items()):
                 if self._entry_is_live(path, mtime_ns, size):
                     active.add(pid)
                 else:
                     self._entries.pop(pid, None)
+            # Stamped after the walk, not before: `_entry_is_live` can take a
+            # while on a dead mount, and the window is meant to start when the
+            # answer is known. The age is compared against the TTL on every
+            # read rather than baked into a deadline, so lowering the TTL takes
+            # effect at once.
+            self._active_cache = (time.monotonic(), frozenset(active))
         return active
 
     def discard(self, picture_id: "int | None") -> None:
@@ -268,6 +301,7 @@ class UnprocessableImageRegistry:
             return
         with self._lock:
             self._entries.pop(int(picture_id), None)
+            self._active_cache = None
 
     def snapshot(self) -> dict[int, tuple[str, int, int]]:
         """Return a copy of the current ``{picture_id: (file_path, mtime_ns, size)}`` map."""

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -455,6 +455,51 @@ def test_pictures_export_folder_rejects_a_destination_inside_the_library():
         gc.collect()
 
 
+def test_pictures_export_folder_rejects_a_destination_inside_another_library():
+    """#1206 item 1: the blocklist knew only the library holding the lease.
+
+    A library's folder *is* its image_root, so an export written into a second
+    registered library comes back as a fresh set of pictures the moment that
+    library is opened - and this route never opens it, so nothing downstream
+    notices either.
+    """
+    from unittest import mock
+
+    temp_dir, client, server = _setup()
+    try:
+        _upload_picture(client)
+        other = server.library_registry.create(
+            os.path.join(temp_dir.name, "second-library"), "Second"
+        )
+        inside_other = os.path.join(other.path, "exported")
+        os.makedirs(inside_other, exist_ok=True)
+
+        resp = client.post(
+            "/pictures/export/folder", params={"destination": inside_other}
+        )
+        assert resp.status_code == 400, resp.text
+        assert "part of your library" in resp.json().get("detail", "")
+
+        # The positive control, in the same environment: a folder that is in no
+        # registered library is still accepted. Refusing every empty folder
+        # would satisfy the assertion above and break the feature.
+        outside = os.path.join(temp_dir.name, "outside-every-library")
+        os.makedirs(outside, exist_ok=True)
+        with mock.patch(
+            "pixlstash.utils.service.export_utils.open_in_file_manager",
+            return_value=True,
+        ):
+            accepted = client.post(
+                "/pictures/export/folder", params={"destination": outside}
+            )
+            assert accepted.status_code == 200, accepted.text
+            _wait_for_export(client, accepted.json()["task_id"])
+    finally:
+        server.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_pictures_export_folder_refuses_when_the_reference_folders_are_unreadable():
     """#1177 item 59: an unknown blocklist must refuse, not permit.
 

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -572,8 +572,11 @@ def test_pictures_export_folder_refuses_when_the_watch_folders_are_unreadable():
         def _explode(_vault):
             raise LibraryRootsUnavailable("test-induced import folder read failure")
 
+        # Patched where the shared blocklist reads it (`utils.library_roots`),
+        # not in this route: the route stopped building its own list when the
+        # three partial copies were folded into one (#1206 item 1).
         with mock.patch(
-            "pixlstash.routes.pictures._export.get_import_folder_paths", _explode
+            "pixlstash.utils.library_roots.get_import_folder_paths", _explode
         ):
             resp = client.post(
                 "/pictures/export/folder", params={"destination": destination}

--- a/tests/test_finder_query_cost.py
+++ b/tests/test_finder_query_cost.py
@@ -685,8 +685,15 @@ def test_tag_probe_is_served_by_the_tag_index(tmp_path):
 
         plan = _explain(vault, rec.only, rec.parameters[0])
         assert any("ix_tag_tag" in line for line in plan), plan
-        # The outer loop is a rowid lookup fed by the tag index, not a scan.
-        assert plan[0].startswith("SEARCH picture USING INTEGER PRIMARY KEY"), plan
+        # The outer loop is an index seek fed by the tag index, not a scan.
+        # It read ``USING INTEGER PRIMARY KEY`` until the finder started
+        # applying the same not-deleted/has-a-file clauses as
+        # ``TagTask.count_missing_tags`` (#1206 item 3); SQLite now reaches the
+        # row through ``ix_picture_deleted (deleted=? AND rowid=?)``, which
+        # pins the new predicate and the rowid in the same seek. The thing this
+        # test exists to catch is the outer loop degrading to ``SCAN picture``,
+        # which ``SEARCH`` still excludes.
+        assert plan[0].startswith("SEARCH picture"), plan
         assert not any("TEMP B-TREE" in line.upper() for line in plan), plan
 
 

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -33,6 +33,7 @@ from pixlstash.tasks.missing_image_embedding_finder import MissingImageEmbedding
 from pixlstash.tasks.missing_thumbnail_finder import MissingThumbnailFinder
 from pixlstash.tasks.quality_task import QualityTask
 from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.utils.unprocessable_image_registry import UnprocessableImageRegistry
 from pixlstash.vault import Vault
 
 # Bytes that exist on disk as a ``.jpg`` but are not a decodable image. cv2 and
@@ -291,3 +292,45 @@ def test_585_quality_metadata_backfill_marks_instead_of_raising(tmp_path):
         assert not vault.db.unprocessable_images.is_suppressed(valid_pic.id)
         assert (valid_pic.width, valid_pic.height) == (8, 8)
         assert valid_pic.format == "JPG"
+
+
+def test_the_suppressed_set_is_built_once_per_window_and_drops_on_a_mark(tmp_path):
+    """#1206 item 9b: four finders rebuilt this set on every planner sweep.
+
+    Each rebuild re-stats every entry, and an entry whose volume has gone away
+    costs a mount timeout per stat - on the planner thread. The answer is
+    therefore reused for ``ACTIVE_CACHE_TTL_S``, and any write to the map drops
+    the cache so a newly marked picture is never served from a set built before
+    it.
+    """
+    registry = UnprocessableImageRegistry()
+    first = str(tmp_path / "one.jpg")
+    second = str(tmp_path / "two.jpg")
+    _write_corrupt_jpeg(tmp_path / "one.jpg")
+    _write_corrupt_jpeg(tmp_path / "two.jpg")
+    assert registry.mark_unprocessable(1, first, reason="test fixture")
+
+    stats: list[str] = []
+    original = registry._stat_signature
+
+    def counting_stat(file_path: str):
+        stats.append(file_path)
+        return original(file_path)
+
+    registry._stat_signature = staticmethod(counting_stat)
+
+    assert registry.active_suppressed_ids() == {1}
+    assert stats == [first]
+    # Within the window, the second sweep re-stats nothing.
+    assert registry.active_suppressed_ids() == {1}
+    assert stats == [first]
+
+    # A new mark must be visible at once, cache or no cache.
+    assert registry.mark_unprocessable(2, second, reason="test fixture")
+    assert registry.active_suppressed_ids() == {1, 2}
+
+    # And closing the window re-validates.
+    stats.clear()
+    registry.ACTIVE_CACHE_TTL_S = 0.0
+    assert registry.active_suppressed_ids() == {1, 2}
+    assert sorted(stats) == sorted([first, second])

--- a/tests/test_library_destination_blocklist.py
+++ b/tests/test_library_destination_blocklist.py
@@ -1,0 +1,330 @@
+"""One blocklist, three routes that put files somewhere: #1206 item 1.
+
+``POST /pictures/export/folder`` grew the complete list of directories this
+installation reads or writes - ``image_root``, the reference folders, the watch
+folders, every registered library - while its two siblings kept partial copies
+of it:
+
+* ``POST /import-folders`` knew only the active vault's ``image_root``, so a
+  watch folder could be pointed at a reference folder or at another registered
+  library. It then imports that folder's contents into the active library, and
+  one carrying ``delete_after_import`` unlinks each source file afterwards
+  (``pixlstash/tasks/watch_folder_import_task.py``), leaving the library that
+  owns those pictures with rows pointing at files that are gone.
+* The reference-folder create/update/relocate routes knew ``image_root`` and
+  the other reference-folder rows. ``POST /reference-folders/{id}/relocate``
+  physically ``shutil.move``s every file below the old root, so its destination
+  is the one that can move pictures into another library or into a folder a
+  watcher then eats.
+
+Both siblings sit on a *wider* authorization tier than the export
+(``LOCAL_OWNER_ONLY`` vs ``LOOPBACK_OWNER_ONLY``) and they *move* files where
+the export only copies, so the partial copies were the more dangerous two.
+
+Every negative here has its positive control beside it in the same environment:
+over-blocking would break import folders and reference folders outright and
+would look exactly like the fix working.
+"""
+
+import gc
+import json
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pixlstash.server import Server
+from pixlstash.utils.path_utils import LibraryRootsUnavailable
+
+
+@pytest.fixture(scope="module")
+def _env():
+    """One logged-in Server + TestClient shared by every test in this module.
+
+    No pictures are imported anywhere in this file - every assertion is about a
+    folder registration being accepted or refused - so there is no background
+    sweep to fight and nothing to reset between tests. Isolation comes from
+    each test using its own directories under the shared temp dir and asserting
+    on *which* path was refused rather than on any count.
+    """
+    temp_dir = tempfile.TemporaryDirectory()
+    try:
+        os.makedirs(os.path.join(temp_dir.name, "images"), exist_ok=True)
+        server_config_path = os.path.join(temp_dir.name, "server-config.json")
+        with open(server_config_path, "w") as fh:
+            fh.write(json.dumps({"port": 8000}))
+        server = Server(server_config_path)
+        try:
+            client = TestClient(server.api)
+            resp = client.post(
+                "/login", json={"username": "testuser", "password": "testpassword"}
+            )
+            assert resp.status_code == 200
+            yield client, server, temp_dir.name
+        finally:
+            server.close()
+    finally:
+        temp_dir.cleanup()
+        gc.collect()
+
+
+@pytest.fixture
+def client(_env):
+    return _env[0]
+
+
+@pytest.fixture
+def server(_env):
+    return _env[1]
+
+
+@pytest.fixture
+def workspace(_env):
+    return _env[2]
+
+
+def _mkdir(*parts):
+    path = os.path.join(*parts)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _add_reference_folder(client, folder, label):
+    return client.post("/reference-folders", json={"folder": folder, "label": label})
+
+
+def _add_import_folder(client, folder, label, *, delete_after_import=False):
+    return client.post(
+        "/import-folders",
+        json={
+            "folder": folder,
+            "label": label,
+            "delete_after_import": delete_after_import,
+        },
+    )
+
+
+def test_import_folder_refuses_a_folder_inside_another_library(
+    client, server, workspace
+):
+    """A watch folder pointed at a second registered library empties it.
+
+    The watcher copies every file it finds into the *active* library and, with
+    ``delete_after_import``, unlinks the original - so the other library's
+    ``Picture`` rows end up pointing at files that no longer exist. The route
+    only ever checked the active vault's ``image_root``, which is not that
+    library.
+    """
+    other = server.library_registry.create(
+        os.path.join(workspace, "watched-second-library"), "WatchedSecond"
+    )
+    inside_other = _mkdir(other.path, "photos")
+
+    refused = _add_import_folder(
+        client, inside_other, "into-another-library", delete_after_import=True
+    )
+    assert refused.status_code == 409, refused.text
+    assert "part of your library" in refused.json().get("detail", "")
+
+    # Positive control: a folder in no library is still accepted, with the same
+    # `delete_after_import` flag. Refusing every watch folder would satisfy the
+    # assertion above and break the feature.
+    free = _mkdir(workspace, "free-watch-folder")
+    accepted = _add_import_folder(client, free, "free", delete_after_import=True)
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["folder"] == free
+
+
+def test_import_folder_refuses_a_folder_inside_a_reference_folder(client, workspace):
+    """A reference folder is scanned in place; a watch folder over it imports
+    and (with ``delete_after_import``) deletes the very files that scan indexes.
+    Neither subsystem knew about the other."""
+    reference = _mkdir(workspace, "reference-for-watch-clash")
+    added = _add_reference_folder(client, reference, "ref-for-watch-clash")
+    assert added.status_code == 200, added.text
+
+    refused = _add_import_folder(
+        client,
+        _mkdir(reference, "incoming"),
+        "over-a-reference-folder",
+        delete_after_import=True,
+    )
+    assert refused.status_code == 409, refused.text
+    assert "part of your library" in refused.json().get("detail", "")
+
+    # Positive control: a sibling of that reference folder, not inside it.
+    sibling = _mkdir(workspace, "reference-for-watch-clash-sibling")
+    accepted = _add_import_folder(client, sibling, "sibling")
+    assert accepted.status_code == 200, accepted.text
+
+
+def test_reference_folder_refuses_a_folder_inside_a_watched_folder(client, workspace):
+    """The mirror of the test above, from the other route.
+
+    ``validate_reference_folder_conflicts`` compares against ``image_root`` and
+    the other reference-folder rows only, so a reference folder laid over a
+    ``delete_after_import`` watch folder was accepted.
+    """
+    watched = _mkdir(workspace, "watched-for-reference-clash")
+    added = _add_import_folder(
+        client, watched, "watched-for-ref-clash", delete_after_import=True
+    )
+    assert added.status_code == 200, added.text
+
+    refused = _add_reference_folder(
+        client, _mkdir(watched, "pictures"), "over-a-watch-folder"
+    )
+    assert refused.status_code == 409, refused.text
+    assert "part of your library" in refused.json().get("detail", "")
+
+    # Positive control: an ordinary folder is still accepted as a reference
+    # folder in the same environment.
+    free = _mkdir(workspace, "free-reference-folder")
+    accepted = _add_reference_folder(client, free, "free-ref")
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["folder"] == free
+
+
+def test_relocating_a_reference_folder_into_another_library_is_refused(
+    client, server, workspace
+):
+    """The worst of the three: relocation MOVES the files.
+
+    ``_validate_relocation_destination`` refused a destination nested with the
+    old root and one clashing with ``image_root`` or another reference-folder
+    row, and nothing else - so relocating into a second registered library
+    physically moved the pictures into a folder that library indexes as its own.
+    """
+    source = _mkdir(workspace, "relocatable-folder")
+    with open(os.path.join(source, "a-file.txt"), "w") as fh:
+        fh.write("relocate me")
+    added = _add_reference_folder(client, source, "relocatable")
+    assert added.status_code == 200, added.text
+    folder_id = added.json()["id"]
+
+    other = server.library_registry.create(
+        os.path.join(workspace, "relocate-target-library"), "RelocateTarget"
+    )
+    into_other = os.path.join(other.path, "moved-here")
+
+    refused = client.post(
+        f"/reference-folders/{folder_id}/relocate",
+        json={"destination_folder": into_other},
+    )
+    assert refused.status_code == 409, refused.text
+    assert "part of your library" in refused.json().get("detail", "")
+    # The refusal must come before the first move, not after some of them.
+    assert os.path.isfile(os.path.join(source, "a-file.txt")), (
+        "nothing may be moved on a refusal"
+    )
+    assert not os.path.exists(into_other), "no destination may be created either"
+
+    # Positive control: relocating to an ordinary folder still works, in the
+    # same environment and for the same row.
+    good = os.path.join(workspace, "relocated-somewhere-free")
+    accepted = client.post(
+        f"/reference-folders/{folder_id}/relocate",
+        json={"destination_folder": good},
+    )
+    assert accepted.status_code == 200, accepted.text
+    assert os.path.isfile(os.path.join(good, "a-file.txt"))
+    assert not os.path.exists(os.path.join(source, "a-file.txt"))
+
+
+def test_repointing_a_reference_folder_into_its_own_subfolder_still_works(
+    client, workspace
+):
+    """The over-blocking regression this check could most easily cause.
+
+    ``PATCH /reference-folders/{id}`` repoints a row without moving anything,
+    and repointing it *into its own subtree* is legitimate - the row is its own
+    root, not a conflict with itself. A blocklist that forgot to exclude the
+    row being edited would refuse it, and the refusal would look identical to
+    the fix working.
+    """
+    root = _mkdir(workspace, "repointable-folder")
+    deeper = _mkdir(root, "2026")
+    added = _add_reference_folder(client, root, "repointable")
+    assert added.status_code == 200, added.text
+    folder_id = added.json()["id"]
+
+    moved = client.patch(f"/reference-folders/{folder_id}", json={"folder": deeper})
+    assert moved.status_code == 200, moved.text
+    assert moved.json()["folder"] == deeper
+
+
+def test_import_folder_refuses_when_the_library_list_cannot_be_read(
+    client, server, workspace
+):
+    """A blocklist that cannot be read must refuse, not permit (#1177 item 59).
+
+    ``[]`` and "we do not know" are the same value with opposite safety here,
+    so the shared helper raises and every caller answers 503. This is the
+    registry half of that rule, which had no test on either route: the folder
+    export's two 503 branches covered the reference-folder and watch-folder
+    reads only.
+    """
+    destination = _mkdir(workspace, "unreadable-registry-watch-folder")
+
+    with mock.patch.object(
+        server.library_registry,
+        "list_libraries",
+        side_effect=RuntimeError("test-induced library registry read failure"),
+    ):
+        refused = _add_import_folder(client, destination, "unreadable")
+    assert refused.status_code == 503, refused.text
+
+    # Positive control: the same folder is accepted once the registry reads.
+    accepted = _add_import_folder(client, destination, "readable-again")
+    assert accepted.status_code == 200, accepted.text
+
+
+def test_library_content_roots_wraps_every_read_failure(server):
+    """The helper's single failure shape, asserted directly.
+
+    ``LibraryRootsUnavailable`` from the folder reads and a plain exception from
+    the registry both have to reach the caller as the one type it maps to 503;
+    the export route used to carry two separate ``except`` branches for that and
+    only one of them was tested.
+    """
+    from pixlstash.utils import library_roots
+
+    with mock.patch.object(
+        server.library_registry,
+        "list_libraries",
+        side_effect=RuntimeError("test-induced registry failure"),
+    ):
+        with pytest.raises(LibraryRootsUnavailable):
+            library_roots.library_content_roots(server, server.vault)
+
+    with mock.patch.object(
+        server.vault,
+        "reference_folder_roots",
+        side_effect=LibraryRootsUnavailable("test-induced folder read failure"),
+    ):
+        with pytest.raises(LibraryRootsUnavailable):
+            library_roots.library_content_roots(server, server.vault)
+
+    # Positive control: it returns the roots when everything reads, and
+    # `image_root` is among them - an empty list would pass both negatives.
+    roots = library_roots.library_content_roots(server, server.vault)
+    assert server.vault.image_root in roots
+
+
+def test_detached_libraries_are_still_in_the_blocklist(server, workspace):
+    """``list_libraries()`` defaults to attached libraries only.
+
+    A detached library is not being read *today*, but re-attaching it is one
+    click and everything written into it then imports as new pictures, so the
+    shared list passes ``include_detached=True``.
+    """
+    from pixlstash.utils import library_roots
+
+    detached = server.library_registry.create(
+        os.path.join(workspace, "detached-library"), "Detached"
+    )
+    server.library_registry.detach(detached.id)
+
+    assert detached.path in library_roots.library_content_roots(server, server.vault)

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -145,6 +145,45 @@ def test_every_cuda_ort_session_site_is_built_from_the_budget():
     assert "engine.vram_budget.ort_cuda_provider_options(" in face_source
 
 
+def test_the_wd14_session_says_so_when_it_did_not_get_the_accelerator(monkeypatch):
+    """#1206 item 3b: only the session knows which provider actually loaded.
+
+    ``ort.get_available_providers()`` reports what the onnxruntime build
+    supports. A provider whose shared libraries are missing - the CUDA one
+    needs ``libcublasLt`` - is listed there, is requested, and is then dropped
+    without an error, so the old check passed while every tag ran on the CPU.
+    """
+    from pixlstash.tagger_plugins import wd14 as wd14_module
+
+    service = wd14_module.WD14Service(
+        device="cuda", model_dir="/nonexistent", batch_size_fn=lambda: 1
+    )
+    warnings: list[tuple] = []
+    monkeypatch.setattr(
+        wd14_module.logger, "warning", lambda *args, **_kw: warnings.append(args)
+    )
+
+    # The session asked for CUDA and got CPU: that must be said out loud.
+    service._ort_sess = SimpleNamespace(get_providers=lambda: ["CPUExecutionProvider"])
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+    assert "CPUExecutionProvider" in warnings[0]
+
+    # The positive control: a session that did get CUDA stays quiet, or the
+    # warning is noise every GPU box learns to ignore.
+    service._ort_sess = SimpleNamespace(
+        get_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+
+    # And a service that asked for the CPU has nothing to complain about.
+    service._device = "cpu"
+    service._ort_sess = SimpleNamespace(get_providers=lambda: ["CPUExecutionProvider"])
+    service._warn_if_the_session_fell_back_to_cpu()
+    assert len(warnings) == 1, warnings
+
+
 # ── §8: the maintenance finders keep their global gate ──────────────────────
 
 

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -722,15 +722,21 @@ def test_an_unreachable_picture_is_held_out_of_the_window_not_retired(tmp_path):
             "ever put it back and its tags are gone for good"
         )
 
-        # And the hold lifts by itself once the location is back.
+        # And the hold lifts by itself once the location is back. The set is
+        # reused for `ACTIVE_CACHE_TTL_S` (#1206 item 9b: six callers a sweep,
+        # and each stat of an unreachable file waits on the dead mount), so the
+        # lift lands on the next full re-validation rather than on the next
+        # call. Closing the window here rather than sleeping through it.
+        registry = vault.db.unprocessable_images
         gone.mkdir()
         for name in names[:-1]:
             Image.fromarray(np.zeros((30, 40, 3), dtype=np.uint8), "RGB").save(
                 gone / name
             )
-        assert set(ids[:-1]).isdisjoint(
-            vault.db.unprocessable_images.active_suppressed_ids()
-        ), "the hold did not lift when the directory came back"
+        registry.ACTIVE_CACHE_TTL_S = 0.0
+        assert set(ids[:-1]).isdisjoint(registry.active_suppressed_ids()), (
+            "the hold did not lift when the directory came back"
+        )
 
 
 def test_a_whole_batch_transient_failure_deletes_nothing(tmp_path):

--- a/tests/test_pipeline_stage_contracts.py
+++ b/tests/test_pipeline_stage_contracts.py
@@ -33,6 +33,7 @@ from pixlstash.tasks.missing_face_model_refresh_finder import (
 )
 from pixlstash.tasks.missing_tag_finder import MissingTagFinder
 from pixlstash.tasks.missing_tag_prediction_finder import MissingTagPredictionFinder
+from pixlstash.tasks.tag_task import TagTask
 from pixlstash.tasks.task_type import TaskType
 from pixlstash.vault import Vault
 
@@ -534,6 +535,34 @@ class _FailingWorkflow(_StubWorkflow):
 class _FailingTagEngine:
     tagger_settings = {"active_tag_plugin": "wd14"}
     tagging_workflow = _FailingWorkflow()
+
+
+def test_a_scrapheaped_picture_leaves_the_tag_window_and_the_tag_count(tmp_path):
+    """#1206 item 3: the count and the selection disagreed about the scrapheap.
+
+    ``TagTask.count_missing_tags`` excluded soft-deleted pictures; the query
+    the planner acts on did not. So "awaiting tagging" could read zero while
+    the GPU went on tagging pictures the owner had deleted. Both sides now come
+    from ``taggable_picture_clauses``, so they cannot drift apart again.
+    """
+    with Vault(image_root=str(tmp_path)) as vault:
+        live, scrapheaped = _seed_pending(vault, tmp_path, ["live.png", "gone.png"])
+
+        def add_faces_and_scrapheap(session: Session):
+            for pid in (live, scrapheaped):
+                session.add(Face(picture_id=pid, face_index=-1))
+            session.get(Picture, scrapheaped).deleted = True
+            session.commit()
+
+        vault.db.run_task(add_faces_and_scrapheap)
+
+        # Negative and positive control in one assertion: the deleted picture
+        # is gone from the window and the live one is still in it.
+        assert _tag_candidates(vault) == {live}
+        assert (
+            vault.db.run_immediate_read_task(lambda s: TagTask.count_missing_tags(s))
+            == 1
+        )
 
 
 def test_undecodable_pictures_do_not_crowd_the_tag_candidate_window(tmp_path):

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1953,6 +1953,42 @@ def test_the_listing_follows_includes_and_joins_continuations(tmp_path):
     ]
 
 
+def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
+    """Two ways the target was read wrong, both ending in a silent short list.
+
+    pip parses these lines with shlex, so a quoted target containing spaces is
+    a legal include; the pattern captured ``\\S+`` and stopped at the first
+    space, so the file was never opened. And the URL guard used
+    ``urlparse(...).scheme``, which reads ``base:1.txt`` as scheme "base" - a
+    legal relative filename refused for looking like a URL.
+
+    In both cases the include LINE was still listed, so nothing was hidden;
+    what went missing is the option inside the file it names, which is the
+    whole point of following it.
+    """
+    plugin = tmp_path / "plugin"
+    (plugin / "with space").mkdir(parents=True)
+    (plugin / "with space" / "base.txt").write_text(
+        "--index-url https://spaced.example.invalid/simple\n", encoding="utf-8"
+    )
+    (plugin / "odd:name.txt").write_text(
+        "--extra-index-url https://colon.example.invalid/simple\n", encoding="utf-8"
+    )
+    requirements = plugin / "requirements.txt"
+    requirements.write_text(
+        '-r "with space/base.txt"\n-r odd:name.txt\n', encoding="utf-8"
+    )
+
+    # Parent file's own lines first, then what each include brought in - the
+    # order `pip_options` already had, not something these cases change.
+    assert plugin_install.pip_options(requirements) == [
+        '-r "with space/base.txt"',
+        "-r odd:name.txt",
+        "--index-url https://spaced.example.invalid/simple   [in with space/base.txt]",
+        "--extra-index-url https://colon.example.invalid/simple   [in odd:name.txt]",
+    ]
+
+
 def test_the_listing_refuses_to_follow_an_include_out_of_the_plugin(tmp_path):
     """The include is author-written, so following it must not read the machine.
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1929,6 +1929,75 @@ def test_the_listing_surfaces_every_pip_option_from_the_requirements(tmp_path):
     assert plugin_install.pip_options(broad) == ["--only-binary=:all:", "--pre"]
 
 
+def test_the_listing_follows_includes_and_joins_continuations(tmp_path):
+    """#1206 item 8: pip honours both, and the warning read neither.
+
+    ``-r deps/base.txt`` pulls the second file's options in as if they had been
+    written in the first, and a line ending in a backslash is one option to
+    pip. Showing the include line and the bare ``--index-url`` was true and
+    incomplete: the URL that decides where packages come from was the part not
+    on screen.
+    """
+    plugin = tmp_path / "plugin"
+    (plugin / "deps").mkdir(parents=True)
+    (plugin / "deps" / "base.txt").write_text(
+        "--index-url \\\nhttps://packages.example.invalid/simple\nrequests\n",
+        encoding="utf-8",
+    )
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r deps/base.txt\nflask\n", encoding="utf-8")
+
+    assert plugin_install.pip_options(requirements) == [
+        "-r deps/base.txt",
+        "--index-url https://packages.example.invalid/simple   [in deps/base.txt]",
+    ]
+
+
+def test_the_listing_refuses_to_follow_an_include_out_of_the_plugin(tmp_path):
+    """The include is author-written, so following it must not read the machine.
+
+    A ``-r`` naming somewhere outside the plugin's own folder is listed and NOT
+    opened: opening it and printing back every line that starts with ``-``
+    would turn a warning into a way to read arbitrary files. Nothing is hidden
+    - the line itself is still shown.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("--index-url https://elsewhere.example.invalid\n", "utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    requirements = plugin / "requirements.txt"
+    requirements.write_text(
+        f"-r {outside}\n-r ../outside.txt\n-r https://x.example.invalid/r.txt\n",
+        encoding="utf-8",
+    )
+
+    options = plugin_install.pip_options(requirements)
+    assert options == [
+        f"-r {outside}",
+        "-r ../outside.txt",
+        "-r https://x.example.invalid/r.txt",
+    ]
+    assert not any("elsewhere.example.invalid" in line for line in options)
+
+
+def test_the_listing_survives_an_include_cycle(tmp_path):
+    """Two files naming each other must terminate, and say each option once."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r other.txt\n--pre\n", encoding="utf-8")
+    (plugin / "other.txt").write_text(
+        "-r requirements.txt\n--no-index\n", encoding="utf-8"
+    )
+
+    assert plugin_install.pip_options(requirements) == [
+        "-r other.txt",
+        "--pre",
+        "-r requirements.txt   [in other.txt]",
+        "--no-index   [in other.txt]",
+    ]
+
+
 def test_the_listing_names_the_url_a_direct_requirement_comes_from(
     pip_report, tmp_path, capsys
 ):

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1968,6 +1968,16 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     """
     plugin = tmp_path / "plugin"
     (plugin / "with space").mkdir(parents=True)
+    # pip reads `-r "a"b.txt` as the single token `ab.txt`. A quoted-or-bare
+    # regex read it as `a`, so the listing showed one file's index URL while
+    # pip honoured another's - a defeat of the feature, not a gap in it. Both
+    # files exist here because the plugin author controls the folder.
+    (plugin / "a").write_text(
+        "--index-url https://wrong.example.invalid/simple\n", encoding="utf-8"
+    )
+    (plugin / "ab.txt").write_text(
+        "--index-url https://right.example.invalid/simple\n", encoding="utf-8"
+    )
     (plugin / "with space" / "base.txt").write_text(
         "--index-url https://spaced.example.invalid/simple\n", encoding="utf-8"
     )
@@ -1976,7 +1986,7 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     )
     requirements = plugin / "requirements.txt"
     requirements.write_text(
-        '-r "with space/base.txt"\n-r odd:name.txt\n', encoding="utf-8"
+        '-r "with space/base.txt"\n-r odd:name.txt\n-r "a"b.txt\n', encoding="utf-8"
     )
 
     # Parent file's own lines first, then what each include brought in - the
@@ -1984,8 +1994,11 @@ def test_the_listing_follows_a_quoted_include_and_a_colon_in_a_name(tmp_path):
     assert plugin_install.pip_options(requirements) == [
         '-r "with space/base.txt"',
         "-r odd:name.txt",
+        '-r "a"b.txt',
         "--index-url https://spaced.example.invalid/simple   [in with space/base.txt]",
         "--extra-index-url https://colon.example.invalid/simple   [in odd:name.txt]",
+        # `ab.txt`, the file pip reads - not `a`, the file a regex saw.
+        "--index-url https://right.example.invalid/simple   [in ab.txt]",
     ]
 
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -2029,6 +2029,57 @@ def test_the_listing_refuses_to_follow_an_include_out_of_the_plugin(tmp_path):
     assert not any("elsewhere.example.invalid" in line for line in options)
 
 
+def test_the_listing_refuses_to_follow_a_symlink_out_of_the_plugin(tmp_path):
+    """``_include_target``'s docstring names "a symlink out" as refused.
+
+    The absolute, ``..`` and URL spellings each had a case above; this one did
+    not, and it is the spelling that defeats a lexical containment check - the
+    include names a plain relative filename inside the plugin folder, and only
+    resolving it shows it landing elsewhere.
+    """
+    outside = tmp_path / "outside.txt"
+    outside.write_text("--index-url https://elsewhere.example.invalid\n", "utf-8")
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    try:
+        (plugin / "link.txt").symlink_to(outside)
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover - Windows
+        pytest.skip(f"symlinks unavailable here: {exc}")
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r link.txt\n", encoding="utf-8")
+
+    options = plugin_install.pip_options(requirements)
+    assert options == ["-r link.txt"]
+    assert not any("elsewhere.example.invalid" in line for line in options)
+
+
+def test_one_file_reached_by_two_names_is_read_once(tmp_path):
+    """ "Each file is read once" must mean the file, not the spelling.
+
+    The read set was keyed on ``resolve()``, which does not case-canonicalise,
+    so on a case-insensitive filesystem ``base.txt`` and ``BASE.TXT`` were two
+    keys for one file and its options were listed twice. A hardlink is the same
+    bug reachable on every platform: two paths, one inode, ``resolve()``
+    canonicalises neither into the other.
+    """
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    (plugin / "base.txt").write_text("--no-index\n", encoding="utf-8")
+    try:
+        os.link(plugin / "base.txt", plugin / "alias.txt")
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover
+        pytest.skip(f"hardlinks unavailable here: {exc}")
+    requirements = plugin / "requirements.txt"
+    requirements.write_text("-r base.txt\n-r alias.txt\n", encoding="utf-8")
+
+    options = plugin_install.pip_options(requirements)
+    assert options == [
+        "-r base.txt",
+        "-r alias.txt",
+        "--no-index   [in base.txt]",
+    ], "the second name is one more file to read, not one more copy of its options"
+
+
 def test_the_listing_survives_an_include_cycle(tmp_path):
     """Two files naming each other must terminate, and say each option once."""
     plugin = tmp_path / "plugin"


### PR DESCRIPTION
### What broke

Three routes decide whether a folder the caller named is safe to put files in, and each kept its own partial list of the folders a library already owns.

- Adding a watch folder only checked the current library's own storage. Pointing one at another library's folder, or at a reference folder, was accepted; with "delete after import" it then copies every picture into the open library and deletes the original, so the library that owned them is left pointing at files that are gone.
- Creating, repointing or relocating a reference folder only checked the current library's storage and the other reference folders. Relocate physically moves the files, so its destination could be another library's folder, or a watched folder that then eats them.

Both routes are reachable from the LAN, where the export that had the complete list is loopback-only.

### What changed

- The complete list lives in one place now (`pixlstash/utils/library_roots.py`) and all three routes refuse against it. Nothing new was written for the export; its inline list moved.
- The list no longer skips detached libraries — re-attaching one is a click, and everything written there then imports as new pictures.
- Refusals happen before anything is copied or moved, and a list that cannot be read refuses rather than reading as "nothing to protect".
- Repointing a reference folder into its own subfolder still works; that is the over-blocking regression this could have caused, and it has a test.
- Unrelated small fix in the same review batch: the plugin `requirements.txt` reader deduplicated files by path spelling rather than by file, so one file named two ways was read twice.

Carries #1218's commits until that merges; base is `develop`.