### PR TITLE
chore: release v1.11.1rc2 website update

### DIFF
--- a/website/api/v1.11/openapi.json
+++ b/website/api/v1.11/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PixlStash API",
     "description": "<a href=\"https://pixlstash.dev\" target=\"_blank\" rel=\"noopener\">\n  <img\n    src=\"scalar-assets/logo.png\"\n    alt=\"PixlStash\"\n    width=\"120\"\n    style=\"float: right; margin: 0 0 16px 24px\"\n  />\n</a>\n\n# Simplify your image workflow\n\n**PixlStash is a self-hosted, open-source image library for creators.** It imports your\npictures and videos, auto-tags and captions them with local AI models, recognises\ncharacters and faces, scores image quality, runs natural-language semantic search and\ndrives ComfyUI workflows - all on your own hardware, with no cloud and no lock-in.\n\n**Integrate with scripts, pipelines and external tools** - fetch images, metadata, tags and\nmore. This REST API exposes everything the app can do - **pictures, tags, stacks, sets,\ncharacters and projects** - so you can script imports, build integrations and automate your pipeline.\n\n### \u2192 Learn more and download at **[pixlstash.dev](https://pixlstash.dev)**\n\n<div style=\"clear: both\"></div>\n\n---\n\n## What can you do with this?\n\nDrive any tool or pipeline you can script. For a worked example, see the\n[**PixlStash LM Studio plugin**](https://github.com/pikselkroken/pixlstash-lmstudio) -\nit uses this API to let a locally-running LLM illustrate its chat replies with\nmatching pictures from your PixlStash library.\n\n## Quick start\n\nCreate an API token (steps below), then fetch your first 50 pictures - replace\n`your-pixlstash-host` with your server's address:\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\n## Authentication\n\nEvery request authenticates with a personal **API token**, sent as a Bearer header:\n\n```http\nAuthorization: Bearer YOUR_TOKEN\n```\n\nTokens have one of two access types:\n\n| Access type | Can do | Notes |\n| --- | --- | --- |\n| **Full access** | Read **and** write - everything your account can do | Never put a full-access token in a URL |\n| **Read-only** | `GET` requests only | May also be passed as a `?token=\u2026` query parameter (handy for share links) |\n\n## Creating a token\n\n**1. Open Settings** - click the gear icon in the top toolbar.\n\n![Open Settings from the top toolbar](scalar-assets/WhereIsUserSettings.jpg)\n\n**2. Open the *Account Settings* tab.**\n\n![The Account Settings tab](scalar-assets/ScreenshotsUserSettings.jpg)\n\n**3. Create the token** - in the **API Tokens** section, type a description, choose an\naccess type (*Full access* or *Read-only*), optionally tick *Apply watermark*, then click\n**Create Token**.\n\n![The API Tokens section in Account Settings](scalar-assets/ScreenshotTokens.jpg)\n\n**4. Copy it now** - the token is shown **only once**. Copy it and store it somewhere safe;\nyou won't be able to see it again.\n\n![Copy the newly created token](scalar-assets/ScreenshotToken.jpg)\n\n## Using the token\n\nThe API is served under `/api/v1`. Send your token in the `Authorization` header on every\nrequest, replacing `your-pixlstash-host` with the address of your PixlStash server. To\nconfirm a token is valid:\n\n```bash\ncurl https://your-pixlstash-host/api/v1/check-session \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\nA **read-only** token may instead be passed in the query string for quick read requests\n(never do this with a full-access token):\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50&token=YOUR_READ_TOKEN\"\n```\n\nBrowse the endpoints below for full request and response details.\n",
-    "version": "1.11.0"
+    "version": "1.11.1rc2"
   },
   "paths": {
     "/api/v1/pictures": {
@@ -2872,7 +2872,6 @@
                     "id": 0,
                     "name": "string",
                     "description": "string",
-                    "cover_image_path": "string",
                     "extra_metadata": "string",
                     "created_at": "2026-01-01T00:00:00Z",
                     "image_count": 0
@@ -2926,7 +2925,6 @@
                   "id": 0,
                   "name": "string",
                   "description": "string",
-                  "cover_image_path": "string",
                   "extra_metadata": "string",
                   "created_at": "2026-01-01T00:00:00Z",
                   "image_count": 0
@@ -3101,7 +3099,6 @@
                   "id": 0,
                   "name": "string",
                   "description": "string",
-                  "cover_image_path": "string",
                   "extra_metadata": "string",
                   "created_at": "2026-01-01T00:00:00Z",
                   "image_count": 0
@@ -3171,7 +3168,6 @@
                   "id": 0,
                   "name": "string",
                   "description": "string",
-                  "cover_image_path": "string",
                   "extra_metadata": "string",
                   "created_at": "2026-01-01T00:00:00Z",
                   "image_count": 0
@@ -9376,7 +9372,7 @@
           "pictures"
         ],
         "summary": "Start picture export-to-folder job",
-        "description": "Queues an asynchronous export task that writes pictures straight into a folder on the machine running PixlStash, then opens that folder in the host file manager. The destination must be an empty, writable, existing directory. Local owner, on that machine, only - see POST /pictures/export for a ZIP you can download from anywhere instead.",
+        "description": "Queues an asynchronous export task that writes pictures straight into a folder on the machine running PixlStash, then opens that folder in the host file manager. The destination must be an empty, writable, existing directory outside every registered library, this library's reference folders and its import folders. Local owner, on that machine, only - see POST /pictures/export for a ZIP you can download from anywhere instead.",
         "operationId": "export_pictures_folder_api_v1_pictures_export_folder_post",
         "parameters": [
           {
@@ -9544,7 +9540,6 @@
                   "processed": 0,
                   "progress": 0.0,
                   "download_url": "string",
-                  "destination": "string",
                   "opened": true
                 }
               }
@@ -13060,7 +13055,7 @@
           "libraries"
         ],
         "summary": "Add a library",
-        "description": "Attaches the folder when it already holds a vault, and starts a fresh library in it when it does not. No file is moved, renamed or copied either way. The folder must already exist - the picker's `New folder` button makes one, so this route never creates a directory the owner did not point at - and starting a fresh library there restricts it to the owner (0700), because it is about to hold the vault database. The folder is re-inspected here rather than trusted from the picker's answer, so one that became covered in between is still refused.",
+        "description": "Attaches the folder when it already holds a vault, and starts a fresh library in it when it does not. No file is moved, renamed or copied either way. The folder must already exist - the picker's `New folder` button makes one, so this route never creates a directory the owner did not point at - and its permissions are left exactly as they are: the vault database inside it is created owner-only whatever the folder allows. The folder is re-inspected here rather than trusted from the picker's answer, so one that became covered in between is still refused.",
         "operationId": "add_library_api_v1_libraries_post",
         "requestBody": {
           "content": {
@@ -19592,17 +19587,6 @@
             ],
             "title": "Download Url"
           },
-          "destination": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Destination"
-          },
           "opened": {
             "anyOf": [
               {
@@ -24596,17 +24580,6 @@
             ],
             "title": "Description"
           },
-          "cover_image_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Image Path"
-          },
           "extra_metadata": {
             "anyOf": [
               {
@@ -24731,17 +24704,6 @@
             ],
             "title": "Description"
           },
-          "cover_image_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Image Path"
-          },
           "extra_metadata": {
             "anyOf": [
               {
@@ -24821,17 +24783,6 @@
               }
             ],
             "title": "Description"
-          },
-          "cover_image_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cover Image Path"
           },
           "extra_metadata": {
             "anyOf": [


### PR DESCRIPTION
Automated website update triggered by release **v1.11.1rc2**.

Changes included:
- `website/api/v{major}.{minor}/` — versioned OpenAPI docs (Scalar UI)
  generated from the release tag's own backend code. The generator
  also heals any older version pages still on ReDoc and drops the
  legacy top-level `openapi.json`.
- `website/latest-version.json` — updated to this release (if it is
  strictly newer than the currently published version; skipped otherwise).
  The `[Security: ...]` tag was taken from the release tag's own `CHANGELOG.md`.
- `website/latest-version/{docker,pip,electron,other,dev}.json` — per-install-type
  manifests carrying the **identical** payload as the legacy file. These
  back the PATH-encoded version-check URLs so Cloudflare zone analytics can
  bucket active installs by type, and separate our own declared `dev`
  machines from real installs.
  Updated/skipped in lock-step with the legacy `latest-version.json` above.
- `SECURITY.md` — the supported-versions table, rewritten so the new
  minor is the only supported one and the minor it replaces is demoted.
  Skipped for pre-releases and for anything that is not a newer minor
  than the table already names.