### PR TITLE
Setup: install the GPU runtime before reading the library

### DIFF
--- a/changelog.d/setup-install-gpu-before-read.md
+++ b/changelog.d/setup-install-gpu-before-read.md
@@ -1,0 +1,4 @@
+- Changed: first-run setup now finishes installing the GPU runtime before it
+  reads your library, instead of reading it while the runtime downloads. The
+  read used to run on the CPU whatever hardware you had, which on a large
+  library took longer than waiting for the download would have.

--- a/docs/desktop-backend-migration.md
+++ b/docs/desktop-backend-migration.md
@@ -242,33 +242,45 @@ window never changes size** as you move through it.
 
 **The order of a first run is `src/setup/RunSetup.ts`, and it is tested there.**
 `setup:commit` is the wiring that hands it the real collaborators; the function
-itself takes them as arguments, so every outcome can be driven in a unit test:
-either of the two concurrent jobs finishing first, a read that returns nothing,
-throws, or never starts, a download that fails, a machine with no GPU, an
-identity import that refuses, and a backend that will not start.
-`electron/test/runSetup.test.ts` is that matrix, and it asserts the ORDER rather
-than the outcome, because the order is the part with more cases than anyone can
-hold in their head.
+itself takes them as arguments, so every outcome can be driven in a unit test: a
+read that returns nothing, throws, or never starts, a download that fails, a
+machine with no GPU, an identity import that refuses, and a backend that will
+not start. `electron/test/runSetup.test.ts` is that matrix, and it asserts the
+ORDER rather than the outcome, because the order is the part with more cases
+than anyone can hold in their head.
 
 `setup:commit` writes the desktop config, parks the privacy answer, then — when
-a GPU runtime was chosen — **starts the backend on the bundled runtime before
-downloading it**. The ~2.5 GB download is network; the first read of the library
-is disk and CPU, and none of it wants a GPU, so `startAndLoad(accel, repair,
-navigate = false)` brings the server up without taking the window off the setup
-screen, and the library is hashed and thumbnailed through the download. **The chosen folder is read at the same time**, through the app's own
+a GPU runtime was chosen — **downloads it before starting the backend at all**,
+activates it, and starts once on it (`startAndLoad(accel, repair, navigate =
+false)`, which brings the server up without taking the window off the setup
+screen). **Then** the chosen folder is read, through the app's own
 `/folder-structure/read` (`src/setup/ReadLibraryFolder.ts`, with the loopback
-session cookie): the read is disk work, the download is network, and the setup
-screen shows a line for each with a four-slide tour of the app between them. A
-completed read's **result** is parked in `userData/pending-mapping.json` -
-the result, not its task id, because the task lives in the server process's
-memory and the backend restarts onto the GPU runtime before the app loads, so a
-parked id answers "Task not found". `SideBar`'s loose-picture offer takes the
-result and opens the wizard straight on the mapping questions, which asks the
-server nothing at all. A read that fails, stalls or cannot start costs the overlap and
-nothing else — the app reads the folder itself, exactly as before. When the
-overlay lands it is activated and the backend restarts onto it — the planner
-picks up whatever is still outstanding — and that start is the one that
-navigates the window into the library.
+session cookie), and only when the read is done does
+`navigateToRunningServer()` hand the window over. One backend process per
+setup, and it is the GPU one.
+
+**The download and the read used to run at the same time, and that was a loss.**
+A backend's device is fixed when the process is spawned — `deviceFor(accel)`
+becomes an env var, the overlay is a `PYTHONPATH` prefix, and InsightFace picks
+its execution providers the first time it initialises — so a server started
+before the overlay lands runs the *whole* read's face pass on CPU, and nothing
+can move it afterwards. The read is on setup's critical path: the window is not
+handed over until it finishes. Overlapping therefore bought one download's worth
+of time and paid for it with a CPU face pass, which on a real library is minutes
+slower than the GPU one. Waiting is quicker whenever the CPU read is more than
+one download slower than the GPU read.
+
+A completed read's **result** is parked in `userData/pending-mapping.json` — the
+result, not its task id, because the task lives in the server process's memory
+and a parked id answered "Task not found" back when a restart came between the
+read and the app. `SideBar`'s loose-picture offer takes the result and opens the
+wizard straight on the mapping questions, which asks the server nothing at all.
+A read that fails, stalls or cannot start costs the wizard its head start and
+nothing else — the app reads the folder itself, exactly as before, and setup
+still hands the window over. The setup screen shows a line for the download and
+a line for the server, with a four-slide tour of the app between them; because
+the backend now starts only after the download, a `starting` phase is also the
+news that the download is finished, which is what marks its line Installed.
 
 **A start that fails during setup is handled here, not thrown at the screen.**
 The backend refuses to run against a group-writable library folder (mode 775),

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -835,9 +835,9 @@ function deviceFor(accel: Accel | null): string | undefined {
  * session, load the UI.
  *
  * `navigate: false` starts the server and leaves the window where it is. That
- * is what lets first-run setup read the library while a GPU runtime downloads:
- * the reading is disk and CPU work with nothing to wait for, the download is
- * network, and the window stays on the setup screen until both are done.
+ * is what lets first-run setup read the library on the backend it just started
+ * - on the GPU runtime, once one is installed - and hand the window over only
+ * when the read is done, with `navigateToRunningServer`.
  */
 async function startAndLoad(
   accel: Accel | null,
@@ -857,8 +857,9 @@ async function startAndLoad(
     }
   });
   const running = await serverProcess.start(overlayFor(accel), deviceFor(accel), recovery);
-  // Setup talks to this server while the GPU runtime downloads, so where it is
-  // and how to authenticate to it outlive this function.
+  // Setup reads the library folder through this server after the launch
+  // returns, so where it is and how to authenticate to it outlive this
+  // function.
   runningServer = { url: running.url, sessionToken: running.sessionToken };
 
   // Inject the pre-authenticated loopback session cookie so the window opens
@@ -874,8 +875,22 @@ async function startAndLoad(
 
   currentUrl = running.url;
   if (!navigate) return;
-  sendPhase({ phase: 'ready', url: running.url });
-  await mainWindow?.loadURL(running.url);
+  await navigateToRunningServer();
+}
+
+/**
+ * Hand the window over to the running backend: the last act of a launch, and
+ * the last act of first-run setup.
+ *
+ * Setup needs it separately from {@link startAndLoad} because it starts the
+ * backend without navigating (`navigate: false`) and then reads the library
+ * folder on it. The mapping that read parks is collected by the app as it
+ * loads, so the window may only be handed over once the read has finished.
+ */
+async function navigateToRunningServer(): Promise<void> {
+  if (!runningServer) return;
+  sendPhase({ phase: 'ready', url: runningServer.url });
+  await mainWindow?.loadURL(runningServer.url);
 }
 
 /** Which accelerator overlay (if any) should we launch with right now? */
@@ -1502,7 +1517,7 @@ function registerIpc(): void {
               )
             : null,
         announceReading: () => sendPhase({ phase: 'reading' }),
-        announceInstallFailed: (message) => sendPhase({ phase: 'installFailed', message }),
+        navigateToApp: () => navigateToRunningServer(),
       });
     },
   );

--- a/electron/src/renderer/setup.js
+++ b/electron/src/renderer/setup.js
@@ -128,9 +128,6 @@ let inspection = null;
 let inspectSeq = 0;
 let privacyVariant = 'fresh';
 let privacyChoice = null;
-// True once the runtime install has reported anything, which is also when the
-// backend is already up reading the library behind it.
-let reading = false;
 // A step that came back with an error. The install step keeps it on screen
 // rather than dropping the user at the first question with nothing to read.
 let failed = false;
@@ -737,8 +734,8 @@ els.next.addEventListener('click', () => {
 });
 
 // The installer's own last word, on the runtime's line only. It must never
-// touch the reading line: the whole point of starting the server first is that
-// the two run at once, and one line overwriting the other hides that.
+// touch the server line: each row is one thing's progress, and a downloader
+// writing over the row that reports the backend hides both.
 api.onProgress((p) => {
   if (!busy) return;
   // pip names each wheel's size as it starts it and says nothing more until the
@@ -755,12 +752,11 @@ api.onProgress((p) => {
   });
 });
 
-// The shell's own phases. 'starting' before the reading has begun is the first
-// backend coming up; after it, the restart onto the GPU runtime.
+// The shell's own phases. The backend starts ONCE, after any runtime download,
+// so a 'starting' is also the news that the download is over.
 api.onPhase((p) => {
   if (!busy) return;
   if (p.phase === 'reading') {
-    reading = true;
     if (p.failed) {
       // The read could not start. Say so on its own line rather than leaving a
       // bar moving forever over work that is not happening: the app reads the
@@ -785,25 +781,17 @@ api.onPhase((p) => {
       fraction: typeof p.fraction === 'number' && p.fraction >= 0 ? p.fraction : -1,
     });
   } else if (p.phase === 'starting') {
-    if (reading) {
-      setLine('runtime', { state: 'done', note: '', value: 'Installed', fraction: 1 });
-      setLine('server', {
-        name: 'Starting PixlStash on your GPU',
-        state: 'running',
-        note: '',
-        value: '',
-        fraction: -1,
-      });
-    } else {
-      setLine('server', { name: 'Starting PixlStash', state: 'running' });
-    }
-  } else if (p.phase === 'installFailed' && p.message) {
-    // The download is over and the read is not: setup will not settle until the
-    // read finishes, which on a big library is minutes. Stop the runtime bar and
-    // say why NOW rather than letting it draw a download that already failed;
-    // the controls come back with the rejection, as for any other failure.
-    setLine('runtime', { state: 'todo', note: '', value: 'Failed', fraction: -1 });
-    showError(String(p.message));
+    // A runtime line means this setup downloaded one, and nothing starts until
+    // that download is done - so the line is finished, whatever it last drew.
+    const onGpu = lines.some((line) => line.id === 'runtime');
+    setLine('runtime', { state: 'done', note: '', value: 'Installed', fraction: 1 });
+    setLine('server', {
+      name: onGpu ? 'Starting PixlStash on your GPU' : 'Starting PixlStash',
+      state: 'running',
+      note: '',
+      value: '',
+      fraction: -1,
+    });
   } else if (p.phase === 'error' && p.message) {
     showError(String(p.message));
   }

--- a/electron/src/setup/ReadLibraryFolder.ts
+++ b/electron/src/setup/ReadLibraryFolder.ts
@@ -1,12 +1,14 @@
 /**
- * Read the chosen library folder while the GPU runtime downloads.
+ * Read the chosen library folder before the window becomes the library.
  *
  * The read is the app's own `/folder-structure/read` - the same work the "Add a
  * library" wizard starts when it opens over a fresh library. Doing it here is
- * what turns two waits into one: the download is network, the read is disk, and
- * the setup screen is already on screen with a progress line and a tour to fill
- * it. By the time the window becomes the library, the folders are read and the
- * wizard opens on its questions instead of on a progress bar.
+ * what lets the wizard open on its questions instead of on a progress bar: the
+ * setup screen already has a progress line and a tour to spend the wait on.
+ *
+ * It runs AFTER the GPU runtime is installed and the backend has started on it,
+ * not alongside the download. The face pass is inference, and a backend cannot
+ * change device once it is running - see `RunSetup`.
  *
  * Nothing here writes: the read proposes what each folder level looks like and
  * the owner still answers, in the app, before a single file is touched.
@@ -44,8 +46,8 @@ const POLL_MS = 700;
 /**
  * A read of a big library takes minutes; one that has said nothing for this
  * long has not "not finished yet", it has stopped answering. Giving up here
- * costs the overlap and nothing else: the app starts its own read as it always
- * did.
+ * costs the wizard its head start and nothing else: the app starts its own read
+ * as it always did.
  */
 const SILENCE_LIMIT_MS = 10 * 60 * 1000;
 
@@ -57,11 +59,13 @@ function cookieHeader(sessionToken: string): Record<string, string> {
  * Start the read and follow it to the end.
  *
  * @returns the read's own RESULT when it completed, or null when it could not
- *   be started or did not finish. The result rather than the task id, because
- *   the task lives in the server's memory and the backend restarts onto the GPU
- *   runtime before the app ever loads: a parked task id resolved to "Task not
- *   found" every time. A null is not an error the user has to see - the app
- *   reads the folder itself, as it always did.
+ *   be started or did not finish. The result rather than the task id: the task
+ *   lives in the server's memory, and parking an id made the app ask a server
+ *   that had been restarted onto the GPU runtime, which answered "Task not
+ *   found" every time. The restart is gone - the read runs on the GPU backend
+ *   now - but the result is still the thing worth keeping, since the app wants
+ *   what was read, not who read it. A null is not an error the user has to see
+ *   - the app reads the folder itself, as it always did.
  */
 export async function readLibraryFolder(
   fetcher: Fetcher,

--- a/electron/src/setup/RunSetup.ts
+++ b/electron/src/setup/RunSetup.ts
@@ -4,12 +4,12 @@
  *
  * This lives outside `main.ts` because the interesting part is the ORDER, and
  * the order has more outcomes than anyone can hold in their head: the download
- * and the folder read run at the same time, so either can finish first; the
- * read can fail, stall, or return nothing; the identity import can refuse; the
- * backend can demand a permission repair the user may decline; and a machine
- * with no GPU skips half of it. Every one of those is a real first run for
- * somebody, and none of them can be exercised through an IPC handler that needs
- * Electron, a window and a real 2.5 GB download.
+ * has to finish before the backend starts, or the read it feeds runs on the CPU
+ * runtime; the read can fail, stall, or return nothing; the identity import can
+ * refuse; the backend can demand a permission repair the user may decline; and
+ * a machine with no GPU skips half of it. Every one of those is a real first
+ * run for somebody, and none of them can be exercised through an IPC handler
+ * that needs Electron, a window and a real 2.5 GB download.
  */
 
 export type SetupChoices = {
@@ -61,13 +61,13 @@ export type SetupDeps<Accel> = {
   /** Tell the setup screen the reading has begun. */
   announceReading: () => void;
   /**
-   * Tell the setup screen the download failed, at the moment it failed.
+   * Point the window at the running backend: the end of setup.
    *
-   * The read still has to finish before anything restarts, and on a large
-   * library that is minutes - minutes the screen otherwise spent drawing a
-   * download that was already over.
+   * Separate from `startBackend` because the read has to finish first. The
+   * mapping it parks is collected by the app as it loads, so a window handed
+   * over before the read ends is a window that opens on a progress bar.
    */
-  announceInstallFailed: (message: string) => void;
+  navigateToApp: () => Promise<void>;
 };
 
 /**
@@ -137,50 +137,38 @@ async function afterConfig<Accel>(
 
   const gpu = deps.gpu;
   if (!choices?.useGpu || !gpu) {
-    // Nothing to download, so nothing to overlap with: start, and go.
+    // Nothing to download, so nothing to wait for: start, and go.
     await deps.setActiveAccel(null);
     await deps.startBackend(await deps.activeOverlayAccel(), true);
     return;
   }
 
-  // A ~2.5 GB download and the first read of the library have nothing to say to
-  // each other: one is network, the other disk, and none of the reading wants a
-  // GPU. The backend starts on the bundled runtime FIRST - without navigating,
-  // so the setup screen keeps reporting - and reads while the overlay
-  // downloads. The restart at the end is the only thing the GPU is needed for,
-  // and the work done in the meantime survives it.
-  await deps.setActiveAccel(null);
-  await deps.startBackend(null, false);
+  // The download and the read used to run AT THE SAME TIME, the read on the
+  // bundled CPU runtime, and on most machines that was a loss. Nothing can move
+  // a running backend onto the GPU - the device is fixed when the process is
+  // spawned and InsightFace picks its providers on first use - so overlapping
+  // meant the whole face pass ran on CPU. Waiting is quicker whenever the CPU
+  // read is more than one download slower than the GPU read, which on a real
+  // library it is by minutes: the overlap saved the download and paid for it
+  // several times over.
+  //
+  // So: download, start once, on the GPU, and read on it. The read still ends
+  // before the window becomes the library, which is what keeps the wizard
+  // opening on its questions instead of on a progress bar.
+  await deps.installOverlay(gpu);
+  await deps.setActiveAccel(gpu);
+  await deps.startBackend(gpu, false);
+
   deps.announceReading();
   deps.parkMapping(null);
-
-  const read = deps
-    .readFolder(imageRoot)
-    .then((result) => {
-      if (result) deps.parkMapping({ path: imageRoot, result });
-    })
-    .catch((e) => {
-      // A read that throws costs the overlap and nothing else: the app reads
-      // the folder itself, exactly as it did before any of this existed.
-      console.warn('[startup] the folder read failed:', e);
-    });
-
   try {
-    await deps.installOverlay(gpu);
-  } catch (error) {
-    // Say it now. The read still has to finish (below), and on a big library
-    // that is minutes; without this the screen spent them drawing a download
-    // that had already failed, and the message arrived with the wait's end
-    // rather than with the failure.
-    deps.announceInstallFailed(error instanceof Error ? error.message : String(error));
-    await read;
-    throw error;
+    const result = await deps.readFolder(imageRoot);
+    if (result) deps.parkMapping({ path: imageRoot, result });
+  } catch (e) {
+    // A read that throws costs the wizard its head start and nothing else: the
+    // app reads the folder itself, exactly as it did before any of this existed.
+    console.warn('[startup] the folder read failed:', e);
   }
-  // Whichever finished first, the read gets to end before the restart takes its
-  // server away - and on the failure path above too, because the retry the
-  // screen offers starts a new backend over this one.
-  await read;
 
-  await deps.setActiveAccel(gpu);
-  await deps.startBackend(gpu, true);
+  await deps.navigateToApp();
 }

--- a/electron/test/runSetup.test.ts
+++ b/electron/test/runSetup.test.ts
@@ -4,11 +4,12 @@ import { describe, it, beforeEach } from 'node:test';
 import { runFirstRunSetup, type SetupChoices, type SetupDeps } from '../src/setup/RunSetup';
 
 /**
- * First run has more outcomes than it looks like it does. The download and the
- * folder read run at the same time, so EITHER can finish first; the read can
- * fail, return nothing, or throw; the identity import can refuse; the backend
- * can refuse to start; and a machine with no GPU skips half of it. This is the
- * whole matrix, driven through fakes that record the order of what happened.
+ * First run has more outcomes than it looks like it does. The download has to
+ * finish before the backend starts, or the read it feeds runs on the CPU
+ * runtime; the read can fail, return nothing, or throw; the identity import can
+ * refuse; the backend can refuse to start; and a machine with no GPU skips half
+ * of it. This is the whole matrix, driven through fakes that record the order
+ * of what happened.
  */
 
 type Accel = 'cu128';
@@ -62,7 +63,9 @@ function makeDeps(overrides: Partial<SetupDeps<Accel>> = {}): SetupDeps<Accel> {
       return READ_RESULT;
     },
     announceReading: () => log.push('announceReading'),
-    announceInstallFailed: (message) => log.push(`installFailed:${message}`),
+    navigateToApp: async () => {
+      log.push('navigate');
+    },
     ...overrides,
   };
 }
@@ -77,29 +80,39 @@ beforeEach(() => {
 });
 
 describe('first-run setup, with a GPU runtime to install', () => {
-  it('starts the backend before the download, or nothing overlaps', async () => {
+  it('downloads before the backend starts, or the read runs on the CPU runtime', async () => {
+    // The device is fixed when the backend process is spawned. A backend
+    // started before the overlay lands reads the whole library on the CPU, and
+    // nothing can move it afterwards - which is what this order exists for.
     await runFirstRunSetup(CHOICES, makeDeps());
 
-    const startedAt = log.indexOf('start:bundled:stay');
     const installedAt = log.indexOf('install:cu128');
-    assert.ok(startedAt >= 0 && installedAt > startedAt, log.join(' → '));
+    const startedAt = log.indexOf('start:cu128:stay');
+    const readAt = log.indexOf('read');
+    assert.ok(installedAt >= 0 && installedAt < startedAt, log.join(' → '));
+    assert.ok(startedAt < readAt, log.join(' → '));
   });
 
-  it('reads and downloads at the same time, then restarts onto the GPU', async () => {
+  it('starts the backend exactly once, on the GPU', async () => {
+    await runFirstRunSetup(CHOICES, makeDeps());
+
+    assert.deepEqual(started, [{ accel: 'cu128', navigate: false }]);
+  });
+
+  it('downloads, starts on the GPU, reads on it, then hands the window over', async () => {
     await runFirstRunSetup(CHOICES, makeDeps());
 
     assert.deepEqual(log, [
       'config:/home/me/Pictures',
       'parkTelemetry',
-      'activeAccel:none',
-      'start:bundled:stay',
+      'install:cu128',
+      'activeAccel:cu128',
+      'start:cu128:stay',
       'announceReading',
       'clearMapping',
       'read',
-      'install:cu128',
       'parkMapping',
-      'activeAccel:cu128',
-      'start:cu128:navigate',
+      'navigate',
     ]);
     assert.deepEqual(parkedMapping.at(-1), {
       path: '/home/me/Pictures',
@@ -107,51 +120,31 @@ describe('first-run setup, with a GPU runtime to install', () => {
     });
   });
 
-  it('waits for a read that is still going when the download finishes first', async () => {
+  it('does not hand the window over until the read has finished', async () => {
+    // The app collects the parked mapping as it loads, so a window handed over
+    // mid-read opens on a progress bar with nothing parked for it.
     const read = deferred<Record<string, unknown> | null>();
-    const setup = runFirstRunSetup(
-      CHOICES,
-      makeDeps({
-        readFolder: () => read.promise,
-        installOverlay: async (accel) => log.push(`install:${accel}`),
-      }),
-    );
-    // Let the install finish while the read is still outstanding.
+    const setup = runFirstRunSetup(CHOICES, makeDeps({ readFolder: () => read.promise }));
     await new Promise((r) => setImmediate(r));
-    assert.ok(log.includes('install:cu128'), 'the download got there first');
-    assert.ok(!started.some((s) => s.navigate), 'nothing may navigate yet');
+
+    assert.ok(log.includes('start:cu128:stay'), 'the GPU backend is up');
+    assert.ok(!log.includes('navigate'), 'nothing may navigate yet');
 
     read.resolve(READ_RESULT);
     await setup;
 
+    assert.equal(log.at(-1), 'navigate');
     assert.deepEqual(parkedMapping.at(-1), {
       path: '/home/me/Pictures',
       result: READ_RESULT,
     });
-    assert.deepEqual(started.at(-1), { accel: 'cu128', navigate: true });
-  });
-
-  it('does not restart early when the read finishes first', async () => {
-    const install = deferred<void>();
-    const setup = runFirstRunSetup(
-      CHOICES,
-      makeDeps({ installOverlay: async () => install.promise }),
-    );
-    await new Promise((r) => setImmediate(r));
-    assert.ok(log.includes('read'), 'the read got there first');
-    assert.equal(started.length, 1, 'the GPU restart must wait for the download');
-
-    install.resolve();
-    await setup;
-
-    assert.deepEqual(started.at(-1), { accel: 'cu128', navigate: true });
   });
 
   it('parks nothing when the read finds nothing, and still finishes setup', async () => {
     await runFirstRunSetup(CHOICES, makeDeps({ readFolder: async () => null }));
 
     assert.deepEqual(parkedMapping, [null], 'only the clear at the start');
-    assert.deepEqual(started.at(-1), { accel: 'cu128', navigate: true });
+    assert.equal(log.at(-1), 'navigate');
   });
 
   it('survives a read that throws, because the app can read the folder itself', async () => {
@@ -164,11 +157,13 @@ describe('first-run setup, with a GPU runtime to install', () => {
       }),
     );
 
-    assert.deepEqual(started.at(-1), { accel: 'cu128', navigate: true });
+    assert.equal(log.at(-1), 'navigate');
     assert.deepEqual(parkedMapping, [null]);
   });
 
-  it('lets a failed download reach the screen, and does not restart onto a GPU it has not got', async () => {
+  it('starts nothing at all when the download fails', async () => {
+    // The download is now the first thing that happens, so its failure reaches
+    // the screen before a backend, a read or an activated overlay exists.
     const setup = runFirstRunSetup(
       CHOICES,
       makeDeps({
@@ -179,35 +174,10 @@ describe('first-run setup, with a GPU runtime to install', () => {
     );
 
     await assert.rejects(setup, /no wheels/);
-    assert.ok(
-      !started.some((s) => s.accel === 'cu128'),
-      'a failed install must not be activated',
-    );
-    assert.ok(log.includes('read'), 'the read still ran, and still got to finish');
-  });
-
-  it('says the download failed before waiting the read out', async () => {
-    // The read can have minutes left in it. Announcing after it is announcing
-    // when the wait ends, which is not when the thing failed.
-    const read = deferred<Record<string, unknown> | null>();
-    const setup = runFirstRunSetup(
-      CHOICES,
-      makeDeps({
-        readFolder: () => read.promise,
-        installOverlay: async () => {
-          throw new Error('no wheels for this CUDA generation');
-        },
-      }),
-    );
-    await new Promise((r) => setImmediate(r));
-
-    assert.ok(
-      log.includes('installFailed:no wheels for this CUDA generation'),
-      `said nothing while the read was still going: ${log.join(' → ')}`,
-    );
-
-    read.resolve(null);
-    await assert.rejects(setup, /no wheels/);
+    assert.deepEqual(started, [], 'no backend was started');
+    assert.ok(!log.includes('activeAccel:cu128'), 'a failed install must not be activated');
+    assert.ok(!log.includes('read'), 'nothing was read on a runtime that never arrived');
+    assert.ok(!log.includes('navigate'), 'the setup screen keeps the message');
   });
 
   it('records the install location before anything downloads into it', async () => {


### PR DESCRIPTION
First-run setup read the library while the GPU runtime downloaded, on the bundled CPU runtime. A backend's device is fixed when the process is spawned, so the whole face pass ran on CPU — and the read is on setup's critical path, so that cost more than the download it overlapped.

Now: download, activate, start once on the GPU, read on it, then hand the window over. One backend process per setup instead of two, and no restart between the read and the app.

The CPU path is unchanged — there is nothing to download there, so nothing to reorder.