### PR TITLE
Add "none" to autotagger options

### DIFF
--- a/changelog.d/model-radio-fix.md
+++ b/changelog.d/model-radio-fix.md
@@ -1,0 +1,3 @@
+- Fixed: a tagging or description model's parameters could revert. Saving them
+  worked, but reopening that model's settings showed the values from before
+  your edit, and saving again put those back.

--- a/changelog.d/model-radio-fix.md
+++ b/changelog.d/model-radio-fix.md
@@ -1,3 +1,5 @@
 - Fixed: a tagging or description model's parameters could revert. Saving them
   worked, but reopening that model's settings showed the values from before
   your edit, and saving again put those back.
+- Turning automatic tagging or captioning off is now a choice you can see: a
+  "None" row at the top of the tagging and description model lists.

--- a/frontend/src/components/settings/BehaviourSection.test.js
+++ b/frontend/src/components/settings/BehaviourSection.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 
 vi.mock("vuetify/components", () => ({
@@ -38,7 +38,7 @@ vi.mock("../../api/taggers", () => ({
 
 import BehaviourSection from "./BehaviourSection.vue";
 
-function mountPane() {
+function mountPane(stubOverrides = {}) {
   return mount(BehaviourSection, {
     props: { open: true },
     global: {
@@ -57,9 +57,22 @@ function mountPane() {
         SettingsFieldBlock: { template: "<div><slot /></div>" },
         PluginsTable: true,
         VBtn: {
+          inheritAttrs: false,
+          emits: ["click"],
           props: ["prependIcon"],
           template: '<button @click="$emit(\'click\')"><slot /></button>',
         },
+        // inheritAttrs:false matters: without it a native click reaches the
+        // parent's @click twice -- once through the emit, once through
+        // attribute fallthrough -- and every click-counting assertion doubles.
+        "v-btn": {
+          inheritAttrs: false,
+          emits: ["click"],
+          props: ["prependIcon"],
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        "v-tooltip": { template: "<div><slot /></div>" },
+        ...stubOverrides,
       },
     },
   });
@@ -93,3 +106,151 @@ describe("BehaviourSection plugin installation help", () => {
     expect(wrapper.text()).not.toContain("pixlstash plugins install <name-or-path>");
   });
 });
+
+describe("BehaviourSection keeps the plugin tables in sync", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // `taggerSettings` is a ref, and inside a <script setup> template refs are
+  // auto-unwrapped — so `taggerSettings.value = s` in a template handler sets a
+  // property called "value" ON the settings object instead of replacing the
+  // ref's contents. The parent's copy then never moves.
+  //
+  // Asserted at the prop boundary rather than through a rendered radio:
+  // PluginsTable is stubbed in this suite, and what is under test is the
+  // parent's handler, not the child's markup.
+  it("passes an updated settings object back down to the tables", async () => {
+    const { listTaggers } = await import("../../api/taggers");
+    listTaggers.mockResolvedValue({
+      plugins: [{ name: "wd14", display_name: "WD14", supports_tags: true }],
+      settings: { active_tag_plugin: "wd14" },
+    });
+
+    const wrapper = mountPane();
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    const tables = wrapper.findAllComponents({ name: "PluginsTable" });
+    expect(tables.length).toBeGreaterThan(0);
+    expect(tables[0].props("settings")).toEqual({ active_tag_plugin: "wd14" });
+
+    // What PluginsTable emits when the active plugin is deselected.
+    tables[0].vm.$emit("update:settings", { active_tag_plugin: null });
+    await nextTick();
+
+    const after = wrapper.findAllComponents({ name: "PluginsTable" })[0];
+    expect(after.props("settings")).toEqual({ active_tag_plugin: null });
+  });
+
+  // The description table has its own copy of the same handler, and the bug
+  // was in both. Reverting only that one left the suite green, so it needs its
+  // own assertion rather than riding on the tag table's.
+  it("does the same for the description table's handler", async () => {
+    const { listTaggers } = await import("../../api/taggers");
+    listTaggers.mockResolvedValue({
+      plugins: [
+        {
+          name: "florence2",
+          display_name: "Florence-2",
+          supports_descriptions: true,
+        },
+      ],
+      settings: { active_description_plugin: "florence2" },
+    });
+
+    const wrapper = mountPane();
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    const tables = wrapper.findAllComponents({ name: "PluginsTable" });
+    expect(tables.length).toBeGreaterThan(1);
+
+    tables[1].vm.$emit("update:settings", { active_description_plugin: null });
+    await nextTick();
+
+    const after = wrapper.findAllComponents({ name: "PluginsTable" })[1];
+    expect(after.props("settings")).toEqual({ active_description_plugin: null });
+  });
+});
+
+describe("a plugin's saved parameters survive reopening its dialog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const PLUGIN = {
+    name: "wd14",
+    display_name: "WD14",
+    supports_tags: true,
+    parameter_schema: [
+      { name: "threshold", label: "Threshold", type: "number", min: 0, max: 1, step: 0.01, default: 0.35 },
+    ],
+  };
+
+  async function openPane() {
+    const { listTaggers } = await import("../../api/taggers");
+    listTaggers.mockResolvedValue({
+      plugins: [PLUGIN],
+      settings: { active_tag_plugin: "wd14", plugins: { wd14: { params: { threshold: 0.35 } } } },
+    });
+    const w = mountPane({ PluginsTable: false });
+    await flushPromises();
+    await nextTick();
+    return w;
+  }
+
+  const gear = (w) =>
+    w.findAll(".pt-col-actions button")[0];
+  const form = (w) => w.findComponent({ name: "TaggerParametersUI" });
+
+  it("shows the value you saved, not the one it opened with", async () => {
+    const { patchUserConfig } = await import("../../api/config");
+    patchUserConfig.mockResolvedValue({});
+    const w = await openPane();
+
+    await gear(w).trigger("click");
+    await nextTick();
+    expect(form(w).props("modelValue")).toEqual({ threshold: 0.35 });
+
+    // Edit and save.
+    form(w).vm.$emit("update:modelValue", { threshold: 0.9 });
+    await nextTick();
+    const save = w.findAll("button").find((b) => b.text() === "Save");
+    await save.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    // Reopen. Without the parent applying update:settings this reseeds from the
+    // stale prop and the 0.9 is gone.
+    await gear(w).trigger("click");
+    await nextTick();
+    expect(form(w).props("modelValue")).toEqual({ threshold: 0.9 });
+  });
+
+  it("does not write the old value back when you save again", async () => {
+    const { patchUserConfig } = await import("../../api/config");
+    patchUserConfig.mockResolvedValue({});
+    const w = await openPane();
+
+    await gear(w).trigger("click");
+    await nextTick();
+    form(w).vm.$emit("update:modelValue", { threshold: 0.9 });
+    await nextTick();
+    let save = w.findAll("button").find((b) => b.text() === "Save");
+    await save.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    // Reopen and save again, touching nothing. The server must not be told 0.35.
+    await gear(w).trigger("click");
+    await nextTick();
+    save = w.findAll("button").find((b) => b.text() === "Save");
+    await save.trigger("click");
+    await flushPromises();
+
+    const params = patchUserConfig.mock.calls
+      .map((c) => c[0]?.tagger_settings?.plugins?.wd14?.params?.threshold)
+      .filter((v) => v !== undefined);
+    expect(params).toEqual([0.9, 0.9]);
+  });
+});
+

--- a/frontend/src/components/settings/BehaviourSection.vue
+++ b/frontend/src/components/settings/BehaviourSection.vue
@@ -330,7 +330,7 @@ watch(
             kind="tag"
             :plugins="taggerPlugins"
             :settings="taggerSettings"
-            @update:settings="(s) => (taggerSettings.value = s)"
+            @update:settings="(s) => (taggerSettings = s)"
           />
         </SettingsFieldBlock>
         <SettingsFieldBlock class="tagger-col" title="Description plugin" top>
@@ -342,7 +342,7 @@ watch(
             kind="description"
             :plugins="taggerPlugins"
             :settings="taggerSettings"
-            @update:settings="(s) => (taggerSettings.value = s)"
+            @update:settings="(s) => (taggerSettings = s)"
           />
         </SettingsFieldBlock>
       </SettingsTwoCol>

--- a/frontend/src/components/widgets/PluginsTable.test.js
+++ b/frontend/src/components/widgets/PluginsTable.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { flushPromises } from "@vue/test-utils";
+
+vi.mock("vuetify/components", () => ({
+  VIcon: { template: "<i><slot /></i>" },
+  VDialog: {
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+    template: '<div v-if="modelValue"><slot /></div>',
+  },
+}));
+
+vi.mock("../../api/config", () => ({
+  patchUserConfig: vi.fn().mockResolvedValue({}),
+}));
+
+import { patchUserConfig } from "../../api/config";
+import PluginsTable from "./PluginsTable.vue";
+
+const PLUGINS = [
+  { name: "wd14", display_name: "WD14", supports_tags: true },
+  { name: "pixlstash_tagger", display_name: "PixlStash", supports_tags: true },
+];
+
+/**
+ * Mount the table for one capability.
+ *
+ * The fixtures carry whichever `supports_*` flag *kind* filters on, because a
+ * plugin that does not declare it is filtered out and the table renders its
+ * empty state instead -- including, deliberately, no None row: there is nothing
+ * to turn off.
+ */
+function mountTable(activePlugin, kind = "tag") {
+  const flag = kind === "tag" ? "supports_tags" : "supports_descriptions";
+  return mount(PluginsTable, {
+    props: {
+      plugins: PLUGINS.map((p) => ({ ...p, [flag]: true })),
+      kind,
+      settings: { [`active_${kind}_plugin`]: activePlugin },
+    },
+    global: {
+      stubs: { TaggerPluginSettingsDialog: true, "v-btn": true, "v-tooltip": true },
+    },
+  });
+}
+
+const radios = (w) => w.findAll('input[type="radio"]');
+/** The None radio is the first row, ahead of every plugin. */
+const noneRadio = (w) => radios(w)[0];
+/** Plugin radios, in `plugins` order, with None excluded. */
+const pluginRadios = (w) => radios(w).slice(1);
+
+describe("PluginsTable active-plugin radio", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("selects a plugin that was not active", async () => {
+    const w = mountTable(null);
+    await pluginRadios(w)[0].trigger("change");
+    await flushPromises();
+
+    expect(patchUserConfig).toHaveBeenCalledWith({
+      tagger_settings: { active_tag_plugin: "wd14" },
+    });
+    expect(w.emitted("update:settings")[0][0].active_tag_plugin).toBe("wd14");
+  });
+
+  it("switches between plugins", async () => {
+    const w = mountTable("wd14");
+    await pluginRadios(w)[1].trigger("change");
+    await flushPromises();
+
+    expect(patchUserConfig).toHaveBeenCalledWith({
+      tagger_settings: { active_tag_plugin: "pixlstash_tagger" },
+    });
+  });
+});
+
+
+describe("PluginsTable None row", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("puts None ahead of every plugin so the off state is visible", () => {
+    const w = mountTable("wd14");
+    expect(radios(w)).toHaveLength(PLUGINS.length + 1);
+    expect(w.text()).toContain("None");
+  });
+
+  it("is the checked row when no plugin is active", () => {
+    const w = mountTable(null);
+    expect(noneRadio(w).element.checked).toBe(true);
+    expect(pluginRadios(w).some((r) => r.element.checked)).toBe(false);
+  });
+
+  it("is not checked while a plugin is active", () => {
+    const w = mountTable("wd14");
+    expect(noneRadio(w).element.checked).toBe(false);
+    expect(pluginRadios(w)[0].element.checked).toBe(true);
+  });
+
+  it("clears the active plugin when chosen", async () => {
+    const w = mountTable("wd14");
+    await noneRadio(w).trigger("change");
+    await flushPromises();
+
+    expect(patchUserConfig).toHaveBeenCalledWith({
+      tagger_settings: { active_tag_plugin: null },
+    });
+    expect(w.emitted("update:settings")[0][0].active_tag_plugin).toBeNull();
+  });
+
+  it("names the capability, so the two tables do not read identically", () => {
+    expect(mountTable(null, "description").text()).toMatch(/no automatic/i);
+  });
+});
+
+
+describe("PluginsTable re-activation is inert", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does nothing when the already-active plugin is clicked again", async () => {
+    const w = mountTable("wd14");
+    await pluginRadios(w)[0].trigger("click");
+    await flushPromises();
+    expect(patchUserConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not clear the selection on a double click", async () => {
+    const w = mountTable(null);
+    const radio = pluginRadios(w)[0];
+    await radio.trigger("click");
+    await radio.trigger("change");
+    await radio.trigger("click");
+    await flushPromises();
+
+    expect(patchUserConfig).toHaveBeenCalledTimes(1);
+    expect(patchUserConfig).toHaveBeenCalledWith({
+      tagger_settings: { active_tag_plugin: "wd14" },
+    });
+  });
+});
+
+
+describe("PluginsTable with no capable plugins", () => {
+  it("shows the empty state rather than a lone None row", () => {
+    const w = mount(PluginsTable, {
+      props: { plugins: [], kind: "tag", settings: {} },
+      global: {
+        stubs: {
+          TaggerPluginSettingsDialog: true,
+          "v-btn": true,
+          "v-tooltip": true,
+        },
+      },
+    });
+    expect(w.findAll('input[type="radio"]')).toHaveLength(0);
+    expect(w.text()).toContain("No tag plugins registered.");
+  });
+});

--- a/frontend/src/components/widgets/PluginsTable.vue
+++ b/frontend/src/components/widgets/PluginsTable.vue
@@ -4,7 +4,9 @@
  *
  * Columns: Active (radio) | Name (+ description tooltip) | Loaded | Settings
  *
- * Exactly one plugin may be active for the capability (or none).
+ * Exactly one plugin may be active for the capability, or none: the first
+ * row of the table is an explicit None, so the off state is selectable
+ * rather than reached by clicking the checked radio a second time.
  *
  * Replaces the former TagPluginsTable / DescriptionPluginsTable, which were the
  * same table twice over: they differed only in which capability flag they
@@ -42,6 +44,12 @@ const supportsFlag = computed(() =>
 );
 const activeKey = computed(() => `active_${props.kind}_plugin`);
 
+const noneLabel = computed(() =>
+  props.kind === "tag"
+    ? "None — no automatic tagging"
+    : "None — no automatic captioning",
+);
+
 const capablePlugins = computed(() =>
   props.plugins.filter((p) => p[supportsFlag.value]),
 );
@@ -66,15 +74,13 @@ function openSettings(plugin) {
 async function setActive(pluginName) {
   settingActive.value = true;
   activeError.value = "";
-  // Toggle off if already active
-  const next = activePlugin.value === pluginName ? null : pluginName;
   try {
     await patchUserConfig({
-      tagger_settings: { [activeKey.value]: next },
+      tagger_settings: { [activeKey.value]: pluginName },
     });
     emit("update:settings", {
       ...props.settings,
-      [activeKey.value]: next,
+      [activeKey.value]: pluginName,
     });
   } catch (e) {
     activeError.value = errorDetail(e) || "Failed to update.";
@@ -113,6 +119,26 @@ function onParamsSaved({ name, params }) {
         </tr>
       </thead>
       <tbody>
+        <tr v-if="capablePlugins.length" class="pt-row">
+          <td class="pt-col-active">
+            <input
+              type="radio"
+              :name="`active-${kind}-plugin`"
+              value=""
+              :checked="activePlugin === null"
+              :disabled="settingActive"
+              class="pt-radio"
+              :aria-label="noneLabel"
+              @change="setActive(null)"
+            />
+          </td>
+          <td class="pt-col-name">
+            <span class="pt-plugin-name pt-none">{{ noneLabel }}</span>
+          </td>
+          <td class="pt-col-loaded"></td>
+          <td class="pt-col-actions"></td>
+        </tr>
+
         <tr
           v-for="plugin in capablePlugins"
           :key="plugin.name"
@@ -126,6 +152,7 @@ function onParamsSaved({ name, params }) {
               :checked="activePlugin === plugin.name"
               :disabled="settingActive"
               class="pt-radio"
+              :aria-label="`Use ${plugin.display_name}`"
               @change="setActive(plugin.name)"
             />
           </td>
@@ -274,6 +301,10 @@ function onParamsSaved({ name, params }) {
   font-size: var(--text-2xs);
   color: rgb(var(--v-theme-error));
   margin-top: var(--space-2);
+}
+
+.pt-none {
+  color: rgba(var(--v-theme-on-surface), var(--opacity-text-secondary));
 }
 
 .pt-empty {


### PR DESCRIPTION
## What this changes

A tagging or description model's parameters now stay as you saved them. Before this, reopening a model's settings could reapply values from before your edit, and saving from there put them back. 

The two model lists also gain an explicit "None" row, so turning automatic tagging or captioning off is something you can see and click.

## Why

I was having problems turning off the autotagger during testing, and dug into what was going on.

## How it was verified

I added some test cases, but I also am using this in my personal branch.

## Contributor licence agreement

Required only for changes under `pixlstash/**` (the backend). Tick the box
yourself; nobody can tick it on your behalf. The check wants this exact line
with an `x` in it, so edit the box rather than rewriting the sentence.

- [X] I have read and agree to the CLA in `pixlstash/CLA.md`.


I don't think I *need* to agree for this one, but I do anyway.  Anyway, please let me know if this needs some work or if I'm approaching it the wrong way.  Thanks!