### PR TITLE
Update checkboxes when adding to people, sets

### DIFF
--- a/changelog.d/set-checkbox-refresh.md
+++ b/changelog.d/set-checkbox-refresh.md
@@ -1,0 +1,3 @@
+- Fixed: adding a picture to a set, or assigning it to a person, left that row
+  unticked in the menu until you closed and reopened it, so it looked as though
+  nothing had happened.

--- a/changelog.d/set-checkbox-refresh.md
+++ b/changelog.d/set-checkbox-refresh.md
@@ -1,3 +1,3 @@
-- Fixed: adding a picture to a set, or assigning it to a person, left that row
-  unticked in the menu until you closed and reopened it, so it looked as though
-  nothing had happened.
+- Fixed: adding a picture to a set left that set unticked in the menu until you
+  closed and reopened it, so it looked as though the picture had not been
+  added.

--- a/frontend/src/components/widgets/AddToEntityControl.test.js
+++ b/frontend/src/components/widgets/AddToEntityControl.test.js
@@ -1,4 +1,4 @@
-// AddToEntityControl.vue - two suites, kept together deliberately.
+// AddToEntityControl.vue - the suites below are kept together deliberately.
 //
 // * **#646, the shared entity-list cache.** The menu is `v-if`-mounted, so every
 //   open destroys and recreates these controls. These cases pin render-from-cache
@@ -7,9 +7,12 @@
 //   `allowCreate`, the pinned "New person…" row, the no-match Create "query"… row,
 //   the single-select face mode that performs no writes, and the menu escaping a
 //   clipping / scrolling host.
+// * **Membership after a write.** `/picture_sets/membership` answers only for
+//   sets that already contain one of the pictures, so the map has no entry for
+//   the set you are adding to.
 //
 // The mocks below are bare `vi.fn()`s and each suite states its own fixtures, so
-// neither can silently inherit the other's people or sets.
+// none can silently inherit another's people or sets.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
@@ -42,6 +45,7 @@ import {
   listPictureSets,
   getPictureSetMembership,
   addPictureToSet,
+  removePictureFromSet,
 } from "../../api/pictureSets";
 import { listProjects, getProjectMembership } from "../../api/projects";
 import { listCharacters, getCharacterMembership } from "../../api/characters";
@@ -1096,5 +1100,55 @@ describe("host-driven mode", () => {
     const alice = rowFor(wrapper, "Alice");
     expect(alice.classes()).toContain("ate-item--checked");
     expect(alice.attributes("aria-selected")).toBe("true");
+  });
+});
+
+describe("membership after a write", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinia = createPinia();
+    setActivePinia(pinia);
+    listPictureSets.mockResolvedValue([
+      { id: 1, name: "Empty Set" },
+      { id: 2, name: "Other Set" },
+    ]);
+    // Picture 101 is in set 2 only, so set 1 has no entry at all -- the shape
+    // the real endpoint returns, and the whole reason for these cases.
+    getPictureSetMembership.mockResolvedValue({ 2: [101] });
+    addPictureToSet.mockResolvedValue({});
+    removePictureFromSet.mockResolvedValue({});
+  });
+
+  /** `mountControl` already defaults to a set over picture 101; this opens it. */
+  async function openMenu() {
+    const w = mountControl();
+    await w.find(".ate-btn").trigger("click");
+    await flushPromises();
+    await nextTick();
+    return w;
+  }
+
+  it("ticks the row for a set the picture was not in", async () => {
+    const w = await openMenu();
+    const row = rowByName(w, "Empty Set");
+    expect(row.classes()).not.toContain("ate-item--checked");
+
+    await row.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(addPictureToSet).toHaveBeenCalled();
+    expect(rowByName(w, "Empty Set").classes()).toContain("ate-item--checked");
+    w.unmount();
+  });
+
+  it("still ticks the row for a set that already had other members", async () => {
+    getPictureSetMembership.mockResolvedValue({ 1: [999], 2: [101] });
+    const w = await openMenu();
+    await rowByName(w, "Empty Set").trigger("click");
+    await flushPromises();
+    await nextTick();
+    expect(rowByName(w, "Empty Set").classes()).toContain("ate-item--checked");
+    w.unmount();
   });
 });

--- a/frontend/src/components/widgets/AddToEntityControl.test.js
+++ b/frontend/src/components/widgets/AddToEntityControl.test.js
@@ -48,7 +48,11 @@ import {
   removePictureFromSet,
 } from "../../api/pictureSets";
 import { listProjects, getProjectMembership } from "../../api/projects";
-import { listCharacters, getCharacterMembership } from "../../api/characters";
+import {
+  listCharacters,
+  getCharacterMembership,
+  addCharacterFaces,
+} from "../../api/characters";
 import AddToEntityControl from "./AddToEntityControl.vue";
 
 /** The #645 suite's people. Distinct from #646's CHARACTERS on purpose. */
@@ -1104,6 +1108,8 @@ describe("host-driven mode", () => {
 });
 
 describe("membership after a write", () => {
+  let mounted = null;
+
   beforeEach(() => {
     vi.clearAllMocks();
     pinia = createPinia();
@@ -1119,13 +1125,27 @@ describe("membership after a write", () => {
     removePictureFromSet.mockResolvedValue({});
   });
 
+  afterEach(() => {
+    mounted?.unmount();
+    mounted = null;
+  });
+
   /** `mountControl` already defaults to a set over picture 101; this opens it. */
   async function openMenu() {
-    const w = mountControl();
-    await w.find(".ate-btn").trigger("click");
+    mounted = mountControl();
+    await mounted.find(".ate-btn").trigger("click");
     await flushPromises();
     await nextTick();
-    return w;
+    return mounted;
+  }
+
+  /** Each character case states its own list and membership, so mocks first. */
+  async function openCharacterMenu() {
+    mounted = mountControl({ type: "character", subjectIds: ["101"] });
+    await mounted.find(".ate-btn").trigger("click");
+    await flushPromises();
+    await nextTick();
+    return mounted;
   }
 
   it("ticks the row for a set the picture was not in", async () => {
@@ -1139,16 +1159,117 @@ describe("membership after a write", () => {
 
     expect(addPictureToSet).toHaveBeenCalled();
     expect(rowByName(w, "Empty Set").classes()).toContain("ate-item--checked");
-    w.unmount();
   });
 
   it("still ticks the row for a set that already had other members", async () => {
     getPictureSetMembership.mockResolvedValue({ 1: [999], 2: [101] });
     const w = await openMenu();
+    // 999 is not 101, so the entry exists and the row still starts unticked.
+    expect(rowByName(w, "Empty Set").classes()).not.toContain(
+      "ate-item--checked",
+    );
+
     await rowByName(w, "Empty Set").trigger("click");
     await flushPromises();
     await nextTick();
     expect(rowByName(w, "Empty Set").classes()).toContain("ate-item--checked");
-    w.unmount();
+  });
+
+  it("ticks the row for a character the picture was not assigned to originally", async () => {
+    listCharacters.mockResolvedValue([
+      { id: 11, name: "Ada" },
+      { id: 12, name: "Grace" },
+    ]);
+    // 101 is Ada's, so Grace has no entry -- and 101 has a face, which is what
+    // makes it eligible to appear in Grace's membership at all.
+    getCharacterMembership.mockResolvedValue({
+      character_assignments: { 11: ["101"] },
+      pictures_with_faces: ["101"],
+    });
+    addCharacterFaces.mockResolvedValue({});
+
+    const w = await openCharacterMenu();
+
+    const grace = rowByName(w, "Grace");
+    expect(grace.classes()).not.toContain("ate-item--checked");
+
+    await grace.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(addCharacterFaces).toHaveBeenCalled();
+    expect(rowByName(w, "Grace").classes()).toContain("ate-item--checked");
+  });
+
+  it("ticks the remembered set when adding to it without the menu", async () => {
+    const w = await openMenu();
+    w.vm.lastUsedSet = { id: 1, name: "Empty Set" };
+    await nextTick();
+
+    await w.vm.addToLastSet();
+    await flushPromises();
+    await nextTick();
+
+    expect(addPictureToSet).toHaveBeenCalled();
+    expect(rowByName(w, "Empty Set").classes()).toContain("ate-item--checked");
+  });
+
+  it("reads a character row unticked when the member has no face", async () => {
+    listCharacters.mockResolvedValue([
+      { id: 11, name: "Ada" },
+      { id: 12, name: "Grace" },
+    ]);
+    // The server says Grace holds 101; 101 has no face. Only the render-time
+    // narrowing can resolve that, so this case is the one that pins it.
+    getCharacterMembership.mockResolvedValue({
+      character_assignments: { 12: ["101"] },
+      pictures_with_faces: [],
+    });
+
+    const w = await openCharacterMenu();
+
+    expect(rowByName(w, "Grace").classes()).not.toContain("ate-item--checked");
+  });
+
+  it("does not record a faceless picture as an optimistic member", async () => {
+    listCharacters.mockResolvedValue([
+      { id: 11, name: "Ada" },
+      { id: 12, name: "Grace" },
+    ]);
+    getCharacterMembership.mockResolvedValue({
+      character_assignments: { 11: ["101"] },
+      pictures_with_faces: [],
+    });
+    addCharacterFaces.mockResolvedValue({});
+
+    const w = await openCharacterMenu();
+
+    await rowByName(w, "Grace").trigger("click");
+    await flushPromises();
+    await nextTick();
+    expect(rowByName(w, "Grace").classes()).not.toContain("ate-item--checked");
+
+    // The row is unticked either way; what separates a filtered write from an
+    // unfiltered one is the NEXT click. A phantom member makes idsToAdd empty,
+    // and the assign silently returns instead of calling the API again.
+    await rowByName(w, "Grace").trigger("click");
+    await flushPromises();
+    await nextTick();
+    expect(addCharacterFaces).toHaveBeenCalledTimes(2);
+  });
+
+  it("unticks the row for a set the picture is removed from", async () => {
+    const w = await openMenu();
+    const row = rowByName(w, "Other Set");
+    expect(row.classes()).toContain("ate-item--checked");
+
+    await row.trigger("click");
+    await flushPromises();
+    await nextTick();
+
+    expect(removePictureFromSet).toHaveBeenCalled();
+    expect(rowByName(w, "Other Set").classes()).not.toContain(
+      "ate-item--checked",
+    );
   });
 });

--- a/frontend/src/components/widgets/AddToEntityControl.vue
+++ b/frontend/src/components/widgets/AddToEntityControl.vue
@@ -1087,7 +1087,7 @@ async function toggleSet(item) {
         pictureIds: idsToRemove,
         action: "removed",
       });
-      if (members) idsToRemove.forEach((id) => members.delete(String(id)));
+      applyOptimisticSetUpdate(item, "removed", idsToRemove);
     } else {
       await Promise.all(
         idsToAdd.map((id) => addPictureToSet(item.id, id, apiOpts.value)),
@@ -1095,7 +1095,7 @@ async function toggleSet(item) {
       statusMessage.value = `Added to ${item.name}`;
       emit("added", { setId: item.id, pictureIds: idsToAdd, action: "added" });
       lastUsedItem.value = { id: item.id, name: item.name };
-      if (members) idsToAdd.forEach((id) => members.add(String(id)));
+      applyOptimisticSetUpdate(item, "added", idsToAdd);
     }
     // The membership just moved, so the list's picture counts did too: ask the
     // server again rather than patching the shared cache from here.
@@ -1138,6 +1138,24 @@ function toggleProject(item) {
         ? "Set to unassigned"
         : `Added to ${item.name}`;
   scheduleStatusClear(1600);
+}
+
+/**
+ * Fold a just-written set membership back into `membersById`.
+ *
+ * Replacing the map rather than mutating the Set in place matches
+ * `applyOptimisticProjectUpdate`; either one re-renders the row.
+ */
+function applyOptimisticSetUpdate(item, action, ids) {
+  if (!ids?.length) return;
+  const next = { ...membersById.value };
+  const bucket = new Set(next[item.key] ?? []);
+  for (const id of ids) {
+    if (action === "removed") bucket.delete(String(id));
+    else bucket.add(String(id));
+  }
+  next[item.key] = bucket;
+  membersById.value = next;
 }
 
 function applyOptimisticProjectUpdate(item, action, ids) {

--- a/frontend/src/components/widgets/AddToEntityControl.vue
+++ b/frontend/src/components/widgets/AddToEntityControl.vue
@@ -1087,7 +1087,7 @@ async function toggleSet(item) {
         pictureIds: idsToRemove,
         action: "removed",
       });
-      applyOptimisticSetUpdate(item, "removed", idsToRemove);
+      applyOptimisticMembership(item.key, "removed", idsToRemove);
     } else {
       await Promise.all(
         idsToAdd.map((id) => addPictureToSet(item.id, id, apiOpts.value)),
@@ -1095,7 +1095,7 @@ async function toggleSet(item) {
       statusMessage.value = `Added to ${item.name}`;
       emit("added", { setId: item.id, pictureIds: idsToAdd, action: "added" });
       lastUsedItem.value = { id: item.id, name: item.name };
-      applyOptimisticSetUpdate(item, "added", idsToAdd);
+      applyOptimisticMembership(item.key, "added", idsToAdd);
     }
     // The membership just moved, so the list's picture counts did too: ask the
     // server again rather than patching the shared cache from here.
@@ -1141,20 +1141,20 @@ function toggleProject(item) {
 }
 
 /**
- * Fold a just-written set membership back into `membersById`.
+ * Update membersById based on just-written updates.
  *
  * Replacing the map rather than mutating the Set in place matches
  * `applyOptimisticProjectUpdate`; either one re-renders the row.
  */
-function applyOptimisticSetUpdate(item, action, ids) {
+function applyOptimisticMembership(key, action, ids) {
   if (!ids?.length) return;
   const next = { ...membersById.value };
-  const bucket = new Set(next[item.key] ?? []);
+  const bucket = new Set(next[key] ?? []);
   for (const id of ids) {
     if (action === "removed") bucket.delete(String(id));
     else bucket.add(String(id));
   }
-  next[item.key] = bucket;
+  next[key] = bucket;
   membersById.value = next;
 }
 
@@ -1207,8 +1207,7 @@ async function toggleCharacter(item) {
       await removeCharacterFaces(item.id, ids, apiOpts.value);
       statusMessage.value = `Removed from ${item.name}`;
       emit("removed", { characterId: item.id, pictureIds: ids });
-      const members = membersById.value?.[item.key];
-      if (members) ids.forEach((id) => members.delete(String(id)));
+      applyOptimisticMembership(item.key, "removed", ids);
       closeMenu();
     } catch (e) {
       statusMessage.value = reportToggleFailure(e, "Failed to remove");
@@ -1224,13 +1223,13 @@ async function toggleCharacter(item) {
       await addCharacterFaces(item.id, idsToAdd, apiOpts.value);
       statusMessage.value = `Assigned to ${item.name}`;
       emit("added", { characterId: item.id, pictureIds: ids });
-      // Only update the optimistic member cache for pictures that actually have
-      // faces - faceless pictures can't be reflected in the membership state.
-      if (members) {
-        idsToAdd
-          .filter((id) => picturesWithFaces.value.has(String(id)))
-          .forEach((id) => members.add(String(id)));
-      }
+      // Only pictures that actually have faces - a faceless picture cannot be
+      // a character member, so the optimistic update must not invent one.
+      applyOptimisticMembership(
+        item.key,
+        "added",
+        idsToAdd.filter((id) => picturesWithFaces.value.has(String(id))),
+      );
       closeMenu();
     } catch (e) {
       statusMessage.value = reportToggleFailure(e, "Failed to assign");
@@ -1258,8 +1257,7 @@ async function addToLastSet() {
       ids.map((id) => addPictureToSet(item.id, id, apiOpts.value)),
     );
     statusMessage.value = `Added to ${item.name}`;
-    const members = membersById.value?.[String(item.id)];
-    if (members) ids.forEach((id) => members.add(String(id)));
+    applyOptimisticMembership(String(item.id), "added", ids);
     emit("added", { setId: item.id, pictureIds: ids, action: "added" });
     scheduleStatusClear();
     return { success: true, setName: item.name };


### PR DESCRIPTION
## What this changes

When you add an image to a set or mark a person, the checkbox now shows checks without having to go back into the image.

## Why

I ran into this issue as a user.

## How it was verified

I tried this as a user.  I right clicked on an image in the grid view and went into the People menu, and I went into the image and added it to a set. I then started to do it again, and checked that the checkbox was checked.

There are also some automated tests but I am less sure about those.

## Contributor licence agreement

Required only for changes under `pixlstash/**` (the backend). Tick the box
yourself; nobody can tick it on your behalf. The check wants this exact line
with an `x` in it, so edit the box rather than rewriting the sentence.

- [x] I have read and agree to the CLA in `pixlstash/CLA.md`.
