### PR TITLE
Run CI and the docker builds on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,7 +823,7 @@ jobs:
         if: steps.fixture.outputs.present == 'true'
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -938,7 +938,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: electron/package-lock.json
       - name: Run desktop tests
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Build frontend
@@ -151,7 +151,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: electron/package-lock.json
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Build the Vue frontend ──────────────────────────────────────────
-FROM node:22-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 
 WORKDIR /build/frontend
 COPY frontend/package*.json ./

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -16,7 +16,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Stage 1: Build the Vue frontend ──────────────────────────────────────────
-FROM node:22-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 
 WORKDIR /build/frontend
 COPY frontend/package*.json ./

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,5 +1,5 @@
 # ── Stage 1: Build the Vue frontend ──────────────────────────────────────────
-FROM node:22-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 
 WORKDIR /build/frontend
 COPY frontend/package*.json ./


### PR DESCRIPTION
Node 20 reached end-of-life in April 2026, and Electron already requires Node 22.12 or newer, so the jobs pinned to 20 were building below the toolchain's own floor. Node 24 is the current LTS (supported until April 2028) and matches what the frontend, vitest and Electron suites already run on locally.

Every `actions/setup-node` pin and the three `frontend-builder` Docker stages now use Node 24. No action SHAs, permissions, triggers or secrets change.

Every dependency's `engines` range admits Node 24 (vite `^20.19.0 || >=22.12.0`, vitest `>=24.0.0`, electron `>=22.12.0`, eslint `>=24`).