### PR TITLE
Root scan waits for the first import offer to be answered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,7 @@ jobs:
           tests/test_restore.py
           tests/test_reviews_api.py
           tests/test_rocm_device_check.py
+          tests/test_root_scan_first_import.py
           tests/test_scope_table.py
           tests/test_score_agreement_stats.py
           tests/test_scrapheap_retention.py

--- a/changelog.d/root-scan-first-import.md
+++ b/changelog.d/root-scan-first-import.md
@@ -1,0 +1,5 @@
+- Fixed: importing a folder of pictures as a new library sometimes skipped the
+  questions about what its folders are. On a small library the background scan
+  indexed every picture before the screen came up, so the app saw a library
+  that was no longer empty and never made the offer. The scan now waits until
+  you have answered it, or chosen "organise later".

--- a/changelog.d/root-scan-first-import.md
+++ b/changelog.d/root-scan-first-import.md
@@ -3,3 +3,7 @@
   indexed every picture before the screen came up, so the app saw a library
   that was no longer empty and never made the offer. The scan now waits until
   you have answered it, or chosen "organise later".
+- Fixed: a click beside the import wizard closed it, mid-answer, and the empty
+  library it left behind offered "Choose a folder…", which refused the folder
+  the library already was. The wizard now ignores clicks beside it, and an
+  empty library whose folder holds pictures offers to import them instead.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4083,7 +4083,8 @@ and updates `file_path` on the existing row instead.
   gate reads the **newest** `local_import` record: it lifts when that record
   has settled as `done` or `deferred` ("organise later" is an answer: index
   everything, map nothing), or on the first picture row when there is no
-  `local_import` record at all, and is then remembered for the process. A
+  `local_import` record at all, and is asked again before every due scan
+  (a later import must be able to close it again). A
   newest record that is `pending`, `abandoned` or `superseded` (a pending
   record a later reference commit replaced) holds the gate shut, uncached,
   *over* the picture rows, because an unsettled `local_import`

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4080,11 +4080,13 @@ and updates `file_path` on the existing row instead.
   the boot scan used to answer first: a small library was indexed, tags read
   by convention and all, before the screen came up, so the grid was no longer
   empty and the mapping questions and the caption card never appeared. The
-  gate lifts on a `local_import` record that has settled as `done` or
-  `deferred` ("organise later" is an answer: index everything, map nothing),
-  or on the first picture row when no `local_import` record is `pending` or
-  `abandoned`, and is then remembered for the process. Those two states hold
-  the gate shut *over* the picture rows because an unsettled `local_import`
+  gate reads the **newest** `local_import` record: it lifts when that record
+  has settled as `done` or `deferred` ("organise later" is an answer: index
+  everything, map nothing), or on the first picture row when there is no
+  `local_import` record at all, and is then remembered for the process. A
+  newest record that is `pending`, `abandoned` or `superseded` (a pending
+  record a later reference commit replaced) holds the gate shut, uncached,
+  *over* the picture rows, because an unsettled `local_import`
   commits every chunk, so it leaves pictures behind that nobody answered for.
   A `pending` record is the commit still running, so it is the question rather
   than the answer; counting it puts the 300-second root scan into a race with

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4072,7 +4072,7 @@ and updates `file_path` on the existing row instead.
   itself (no `ReferenceFolder` row to stamp): due at boot, then every
   `_RESCAN_INTERVAL_S`, and immediately when `ReferenceFolderWatcher` — which
   watches `image_root` under the id `None` — reports a change. **Due at boot
-  has one exception** (`first_import_answered`): a library that holds no
+  has one exception** (`root_import_answered`): a library that holds no
   picture and has no *settled* `local_import` folder-mapping commit record is
   not scanned. That is a library whose owner has not been asked what the
   pictures in its folder are — the app asks when it loads an *empty* library
@@ -4084,7 +4084,16 @@ and updates `file_path` on the existing row instead.
   has settled as `done` or `deferred` ("organise later" is an answer: index
   everything, map nothing), or on the first picture row when there is no
   `local_import` record at all, and is asked again before every due scan
-  (a later import must be able to close it again). A
+  (a later import must be able to close it again). **Both halves of the
+  handoff ask it.** `ReferenceFolderScanFinder.first_import_answered` decides
+  whether a root scan is handed out at all; `ReferenceFolderScanTask._run_task`
+  asks again at start, before it walks anything, and that re-check is what
+  makes the handoff fail closed: `record_pending_commit` can write a pending
+  record between the finder's read and the runner starting the task, and a
+  task walking on that stale answer is the race the gate exists to prevent. A
+  re-check that finds the gate shut logs at info and returns without walking;
+  `_root_last_scanned` stays stamped, so `mark_root_due` or the next interval
+  is what asks again. A
   newest record that is `pending`, `abandoned` or `superseded` (a pending
   record a later reference commit replaced) holds the gate shut, uncached,
   *over* the picture rows, because an unsettled `local_import`

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4093,7 +4093,25 @@ and updates `file_path` on the existing row instead.
   task walking on that stale answer is the race the gate exists to prevent. A
   re-check that finds the gate shut logs at info and returns without walking;
   `_root_last_scanned` stays stamped, so `mark_root_due` or the next interval
-  is what asks again. A
+  is what asks again. **A second read cannot close the window after that
+  read**, which is what `vault.db.local_import_running` is for: a
+  `threading.Event` meaning "a `local_import` commit is pending", seeded from
+  the database by `Vault.__init__` (`local_import_pending`) so a
+  crash-resumed import is covered, set by `record_pending_commit` and cleared
+  by `_settle_in_session` once no `local_import` record is pending any more.
+  **The order is the mechanism.** `record_pending_commit` sets the flag
+  *before* it writes its row and therefore before `local_import_pictures`
+  walks; `ReferenceFolderScanTask` checks it *after* its own gate read and
+  again once per directory of its walk (`_import_started_mid_scan`, one
+  `is_set()` on an in-process flag, not a query). So a commit that starts after the scan's read is seen at the latest
+  one directory later, and the rows built in that one directory are reused by
+  the commit's own `insert()` rather than duplicated: the window is bounded to
+  a single directory instead of the whole walk, and it cannot be stale in the
+  direction that lets a scan keep walking during a live import. A scan that
+  stops this way logs at info, returns `skipped`, builds nothing further and
+  does not call `on_root_scanned`, so `MissingFilePurgeFinder` keeps waiting.
+  The database re-check stays alongside it for what an in-process flag cannot
+  see: a second process. A
   newest record that is `pending`, `abandoned` or `superseded` (a pending
   record a later reference commit replaced) holds the gate shut, uncached,
   *over* the picture rows, because an unsettled `local_import`

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4071,7 +4071,20 @@ and updates `file_path` on the existing row instead.
   deleted within the hour. `ReferenceFolderScanFinder` keeps the root's schedule
   itself (no `ReferenceFolder` row to stamp): due at boot, then every
   `_RESCAN_INTERVAL_S`, and immediately when `ReferenceFolderWatcher` — which
-  watches `image_root` under the id `None` — reports a change. Root mode differs
+  watches `image_root` under the id `None` — reports a change. **Due at boot
+  has one exception** (`first_import_answered`): a library that holds no
+  picture and has no folder-mapping commit record other than an abandoned one
+  is not scanned. That is a library whose owner has not been asked what the
+  pictures in its folder are — the app asks when it loads an *empty* library
+  over a folder holding pictures (the first-run offer, "Add a library"), and
+  the boot scan used to answer first: a small library was indexed, tags read
+  by convention and all, before the screen came up, so the grid was no longer
+  empty and the mapping questions and the caption card never appeared. The
+  gate lifts on the first picture row or the first commit record (done,
+  deferred, pending) and is then remembered for the process. An existing
+  library is unaffected; the one behaviour that changes is that an empty
+  library's first pictures arrive through the import offer rather than by
+  the watcher, which is the offer's whole purpose. Root mode differs
   from a reference folder exactly where `layout_move_service.LayoutRoot` says it
   does: pictures are the `reference_folder_id IS NULL` rows, `file_path` is
   written root-relative (`_stored`), the layout comes from `LibrarySettings`,

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4080,15 +4080,21 @@ and updates `file_path` on the existing row instead.
   the boot scan used to answer first: a small library was indexed, tags read
   by convention and all, before the screen came up, so the grid was no longer
   empty and the mapping questions and the caption card never appeared. The
-  gate lifts on the first picture row, or on a `local_import` record that has
-  settled as `done` or `deferred` ("organise later" is an answer: index
-  everything, map nothing), and is then remembered for the process. A
-  `pending` record is the commit still running, so it is the question rather
+  gate lifts on a `local_import` record that has settled as `done` or
+  `deferred` ("organise later" is an answer: index everything, map nothing),
+  or on the first picture row when no `local_import` record is `pending` or
+  `abandoned`, and is then remembered for the process. Those two states hold
+  the gate shut *over* the picture rows because an unsettled `local_import`
+  commits every chunk, so it leaves pictures behind that nobody answered for.
+  A `pending` record is the commit still running, so it is the question rather
   than the answer; counting it puts the 300-second root scan into a race with
   it, where the scan builds its own rows with the sidecar probe, wins, and the
   commit's `insert()` reuses them without ever applying the owner's caption
-  choices. `abandoned` is "bring nothing in" and `superseded` was replaced by
-  a newer record, so neither is an answer either. An existing
+  choices. `abandoned` is "bring nothing in", and its chunks stay indexed, so
+  reading them as the answer scans the root and imports the very files the
+  owner aborted; `superseded` was replaced by a newer record. Settled is read
+  before `abandoned`, so a later settled import outranks an earlier abandoned
+  one. An existing
   library is unaffected; the one behaviour that changes is that an empty
   library's first pictures arrive through the import offer rather than by
   the watcher, which is the offer's whole purpose. Root mode differs

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4073,15 +4073,22 @@ and updates `file_path` on the existing row instead.
   `_RESCAN_INTERVAL_S`, and immediately when `ReferenceFolderWatcher` — which
   watches `image_root` under the id `None` — reports a change. **Due at boot
   has one exception** (`first_import_answered`): a library that holds no
-  picture and has no folder-mapping commit record other than an abandoned one
-  is not scanned. That is a library whose owner has not been asked what the
+  picture and has no *settled* `local_import` folder-mapping commit record is
+  not scanned. That is a library whose owner has not been asked what the
   pictures in its folder are — the app asks when it loads an *empty* library
   over a folder holding pictures (the first-run offer, "Add a library"), and
   the boot scan used to answer first: a small library was indexed, tags read
   by convention and all, before the screen came up, so the grid was no longer
   empty and the mapping questions and the caption card never appeared. The
-  gate lifts on the first picture row or the first commit record (done,
-  deferred, pending) and is then remembered for the process. An existing
+  gate lifts on the first picture row, or on a `local_import` record that has
+  settled as `done` or `deferred` ("organise later" is an answer: index
+  everything, map nothing), and is then remembered for the process. A
+  `pending` record is the commit still running, so it is the question rather
+  than the answer; counting it puts the 300-second root scan into a race with
+  it, where the scan builds its own rows with the sidecar probe, wins, and the
+  commit's `insert()` reuses them without ever applying the owner's caption
+  choices. `abandoned` is "bring nothing in" and `superseded` was replaced by
+  a newer record, so neither is an answer either. An existing
   library is unaffected; the one behaviour that changes is that an empty
   library's first pictures arrive through the import offer rather than by
   the watcher, which is the offer's whole purpose. Root mode differs

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -428,7 +428,32 @@ sidebar accessory nobody was pointed at.
 **Every route reuses wiring App.vue already had.** `local-import` reaches
 `SideBar.startLocalImport`, `open-settings` reaches `SideBar.openSettingsDialog`
 (with `"workflows"`, where the ComfyUI URL lives), and `choose-folder` is the one
-new signal, for `SideBar.openReferenceFolderEditor`.
+new signal, for `SideBar.chooseLibraryFolder`.
+
+**`chooseLibraryFolder` re-inspects the root on every click.** A persisted
+`local_import` entry for this library reopens `FolderMappingWizard` on it
+straight away. Otherwise it asks `GET /libraries/inspect` about the active
+library's own path again, because a cached 0 from a load over an empty folder
+used to be permanent and sent the owner to "Add a library", which refuses the
+folder the library already is. A count above zero opens the wizard with
+`{ path, mode: "local_import" }`; zero, a failed inspect, and a read-only or
+remote session (`canManage` false) all fall through to the ordinary add, and a
+failed inspect leaves the cached count alone.
+
+**The button's own copy reads that count.** `useFolderMappingStore` holds
+`rootPictureCount` and `rootPictureCountCapped`, `null` until something has
+asked, and `LibraryEmptyState` switches on them: "Import the pictures already in
+this folder" / "Import them…" above zero, "Use a folder you already have" /
+"Choose a folder…" otherwise. A page reloaded onto a persisted entry has no
+count, so `offerLoosePictures` fills it from the entry's own read
+(`pictureCount`, else `result.picture_count`) and inspects only when the entry
+carries neither, opening nothing either way. When the inspect stopped at the
+endpoint's entry cap the count is a floor rather than a total, so
+`rootPictureCountCapped` makes the copy say "At least N pictures are in this
+library's folder" instead of naming a number the folder does not hold. Both refs
+are cleared on a session change, and an epoch bumped by that same reset discards
+an inspect that was already on the wire, so a count the outgoing owner asked for
+cannot land in the next session.
 
 **The empty library asks whether its own folder is empty.** The desktop's
 first-run setup creates the vault in whatever folder was chosen, and the web

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -436,9 +436,11 @@ straight away. Otherwise it asks `GET /libraries/inspect` about the active
 library's own path again, because a cached 0 from a load over an empty folder
 used to be permanent and sent the owner to "Add a library", which refuses the
 folder the library already is. A count above zero opens the wizard with
-`{ path, mode: "local_import" }`; zero, a failed inspect, and a read-only or
-remote session (`canManage` false) all fall through to the ordinary add, and a
-failed inspect leaves the cached count alone.
+`{ path, mode: "local_import" }`; zero and a read-only or remote session
+(`canManage` false) fall through to the ordinary add. A failed inspect leaves
+the cached count alone and routes on that, so it opens the wizard when the cache
+already held a count above zero and falls through only when it did not - the
+same reading of the cache as when the inspect answers.
 
 **The button's own copy reads that count.** `useFolderMappingStore` holds
 `rootPictureCount` and `rootPictureCountCapped`, `null` until something has
@@ -453,7 +455,10 @@ endpoint's entry cap the count is a floor rather than a total, so
 library's folder" instead of naming a number the folder does not hold. Both refs
 are cleared on a session change, and an epoch bumped by that same reset discards
 an inspect that was already on the wire, so a count the outgoing owner asked for
-cannot land in the next session.
+cannot land in the next session. `chooseLibraryFolder` and `offerLoosePictures`
+recheck that epoch after every await of their own and return when it moved:
+dropping the count is not enough on its own, because both of them go on to route
+from it and would put a wizard over the outgoing owner's folder.
 
 **The empty library asks whether its own folder is empty.** The desktop's
 first-run setup creates the vault in whatever folder was chosen, and the web

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -452,7 +452,14 @@ count, so `offerLoosePictures` fills it from the entry's own read
 carries neither, opening nothing either way. When the inspect stopped at the
 endpoint's entry cap the count is a floor rather than a total, so
 `rootPictureCountCapped` makes the copy say "At least N pictures are in this
-library's folder" instead of naming a number the folder does not hold. Both refs
+library's folder" instead of naming a number the folder does not hold. A
+folder-structure read's `picture_count` is a floor on the same terms whenever
+the read came back `truncated`: it stopped at `MAX_FOLDERS` and summed only the
+folders it reached, so a count sourced from one carries that flag too. Both
+entry-sourced paths do: the desktop's parked read passes its own
+`result.truncated`, and the wizard saves a `pictureCountCapped` beside
+`pictureCount` on the pending entry, which `_fillRootPictureCount` reads and
+falls back to `result.truncated` for entries written before it did. Both refs
 are cleared on a session change, and an epoch bumped by that same reset discards
 an inspect that was already on the wire, so a count the outgoing owner asked for
 cannot land in the next session. `chooseLibraryFolder` and `offerLoosePictures`

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -435,8 +435,9 @@ new signal, for `SideBar.chooseLibraryFolder`.
 straight away. Otherwise it asks `GET /libraries/inspect` about the active
 library's own path again, because a cached 0 from a load over an empty folder
 used to be permanent and sent the owner to "Add a library", which refuses the
-folder the library already is. A count above zero opens the wizard with
-`{ path, mode: "local_import" }`; zero and a read-only or remote session
+folder the library already is. A count above zero, or a capped one, opens the
+wizard with `{ path, mode: "local_import" }`; an uncapped zero and a read-only
+or remote session
 (`canManage` false) fall through to the ordinary add. A failed inspect leaves
 the cached count alone and routes on that, so it opens the wizard when the cache
 already held a count above zero and falls through only when it did not - the
@@ -451,8 +452,14 @@ count, so `offerLoosePictures` fills it from the entry's own read
 (`pictureCount`, else `result.picture_count`) and inspects only when the entry
 carries neither, opening nothing either way. When the inspect stopped at the
 endpoint's entry cap the count is a floor rather than a total, so
-`rootPictureCountCapped` makes the copy say "At least N pictures are in this
-library's folder" instead of naming a number the folder does not hold. A
+`rootPictureCountCapped` makes the copy say "Your library folder could not be
+fully counted; it holds at least N pictures" instead of naming a number the
+folder does not hold. A capped count is not evidence about an empty folder
+either, zero included: the walk can exhaust the cap on directories before it
+reaches any media, so `rootMayHoldPictures` is `rootPictureCount > 0 ||
+rootPictureCountCapped`, and both `chooseLibraryFolder` and
+`offerLoosePictures` route a capped zero to the import wizard rather than to
+"Add a library", which refuses the folder the library already is. A
 folder-structure read's `picture_count` is a floor on the same terms whenever
 the read came back `truncated`: it stopped at `MAX_FOLDERS` and summed only the
 folders it reached, so a count sourced from one carries that flag too. Both

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -431,8 +431,12 @@ sidebar accessory nobody was pointed at.
 new signal, for `SideBar.chooseLibraryFolder`.
 
 **`chooseLibraryFolder` re-inspects the root on every click.** A persisted
-`local_import` entry for this library reopens `FolderMappingWizard` on it
-straight away. Otherwise it asks `GET /libraries/inspect` about the active
+`local_import` entry for this library reopens `FolderMappingWizard` on it. That
+test is read *after* the library list has been refreshed, never before:
+`pendingForThisLibrary` matches the entry against the active library's path, so
+with no list loaded there is nothing to match and a saved entry looks absent.
+Routed on that stale answer, the click opened a fresh wizard over the very
+folder it should have resumed. Otherwise it asks `GET /libraries/inspect` about the active
 library's own path again, because a cached 0 from a load over an empty folder
 used to be permanent and sent the owner to "Add a library", which refuses the
 folder the library already is. A count above zero, or a capped one, opens the
@@ -462,11 +466,16 @@ rootPictureCountCapped`, and both `chooseLibraryFolder` and
 "Add a library", which refuses the folder the library already is. A
 folder-structure read's `picture_count` is a floor on the same terms whenever
 the read came back `truncated`: it stopped at `MAX_FOLDERS` and summed only the
-folders it reached, so a count sourced from one carries that flag too. Both
-entry-sourced paths do: the desktop's parked read passes its own
-`result.truncated`, and the wizard saves a `pictureCountCapped` beside
-`pictureCount` on the pending entry, which `_fillRootPictureCount` reads and
-falls back to `result.truncated` for entries written before it did. Both refs
+folders it reached, so a count sourced from one carries that flag too, and on
+the same terms again when it came back with `unreadable_folders > 0`, because
+those subtrees are absent from `picture_count` entirely (the folder-read
+contract, `integration_architecture.md` §20). `readIsPartial(result)` in
+`useFolderMappingStore` is the one place that reads either signal, so the three
+sites deriving a saved count's completeness cannot drift apart again. All of
+them use it: the desktop's parked read passes `readIsPartial(parked.result)`,
+and the wizard saves a `pictureCountCapped` beside `pictureCount` on the
+pending entry, which `_fillRootPictureCount` reads and falls back to
+`readIsPartial(entry.result)` for entries written before it did. Both refs
 are cleared on a session change, and an epoch bumped by that same reset discards
 an inspect that was already on the wire, so a count the outgoing owner asked for
 cannot land in the next session. `chooseLibraryFolder` and `offerLoosePictures`

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -453,8 +453,10 @@ asked, and `LibraryEmptyState` switches on them: "Import the pictures already in
 this folder" / "Import them…" above zero, "Use a folder you already have" /
 "Choose a folder…" otherwise. A page reloaded onto a persisted entry has no
 count, so `offerLoosePictures` fills it from the entry's own read
-(`pictureCount`, else `result.picture_count`) and inspects only when the entry
-carries neither, opening nothing either way. When the inspect stopped at the
+(`pictureCount`, else `result.picture_count`) and inspects when the entry
+carries neither, or carries a count whose completeness is unknown (a legacy
+entry with `pictureCount` but no `pictureCountCapped` and no result), opening
+nothing either way. When the inspect stopped at the
 endpoint's entry cap the count is a floor rather than a total, so
 `rootPictureCountCapped` makes the copy say "Your library folder could not be
 fully counted; it holds at least N pictures" instead of naming a number the

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -364,14 +364,19 @@ function openSettingsDialog(tab = "") {
   sidebarRef.value?.openSettingsDialog?.(typeof tab === "string" ? tab : "");
 }
 
-/** The empty library's "Choose a folder…" - a reference folder, read in place.
+/** The empty library's "Choose a folder…" / "Import them…".
  *
- * Not the add-folder type chooser: its other option is an import folder, which
- * copies files in, and the button that reaches this promises the opposite.
+ * The sidebar picks the route. When the library's own folder holds pictures
+ * it reopens the local_import wizard over that folder, which is the import
+ * offer again and the only way back in once the offer is dismissed - "Add a
+ * library" refuses the folder the library already is. Otherwise it is a
+ * folder read in place, added as the library's own storage.
+ *
+ * Not the add-folder type chooser either way: its other option is an import
+ * folder, which copies files in, and the button that reaches this promises
+ * the opposite.
  */
 function openAddReferenceFolder() {
-  // The sidebar decides: the library's own folder when it holds pictures
-  // (the import offer again), otherwise the ordinary add.
   sidebarRef.value?.chooseLibraryFolder?.();
 }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -370,7 +370,9 @@ function openSettingsDialog(tab = "") {
  * copies files in, and the button that reaches this promises the opposite.
  */
 function openAddReferenceFolder() {
-  sidebarRef.value?.openReferenceFolderEditor?.();
+  // The sidebar decides: the library's own folder when it holds pictures
+  // (the import offer again), otherwise the ordinary add.
+  sidebarRef.value?.chooseLibraryFolder?.();
 }
 
 /** The library is empty: let the sidebar ask whether its folder is. */

--- a/frontend/src/components/folders/FolderMappingWizard.test.js
+++ b/frontend/src/components/folders/FolderMappingWizard.test.js
@@ -287,6 +287,7 @@ describe("building the library", () => {
       mode: "local_import",
       assignments: ASSIGNMENTS,
       pictureCount: 5,
+      pictureCountCapped: false,
       autoCommit: true,
     });
     expect(setActiveLibrary).toHaveBeenCalledWith("uuid-new");

--- a/frontend/src/components/folders/FolderMappingWizard.test.js
+++ b/frontend/src/components/folders/FolderMappingWizard.test.js
@@ -432,6 +432,28 @@ describe("the empty library's own folder", () => {
       READ_RESULT,
     );
   });
+
+  it("records the live read's count, and that a partial one is a floor", async () => {
+    // This flow runs on a library that already exists, so it never reaches
+    // `build()` - the only other place the count is saved. The sidebar's own
+    // inspect says nothing about unreadable folders, so without this the
+    // empty state presents this floor as a total.
+    getFolderStructureReadStatus.mockResolvedValue({
+      status: "completed",
+      stage: "done",
+      processed: 2,
+      total: 2,
+      result: { ...READ_RESULT, unreadable_folders: 2 },
+    });
+    const wrapper = mountWizard({ resume: own });
+    await settle();
+    await button(wrapper, "Set up my library").trigger("click");
+    await settle();
+
+    const store = useFolderMappingStore();
+    expect(store.rootPictureCount).toBe(READ_RESULT.picture_count);
+    expect(store.rootPictureCountCapped).toBe(true);
+  });
 });
 
 describe("the other verdicts", () => {

--- a/frontend/src/components/folders/FolderMappingWizard.vue
+++ b/frontend/src/components/folders/FolderMappingWizard.vue
@@ -224,6 +224,9 @@ async function build(accepted) {
       mode: "local_import",
       assignments: accepted,
       pictureCount: pictureCount.value,
+      // A truncated read summed only the folders it reached, so the count it
+      // saves is a floor. The empty library's copy reads this to say so.
+      pictureCountCapped: readResult.value?.truncated === true,
       autoCommit: true,
     });
     emit("close");

--- a/frontend/src/components/folders/FolderMappingWizard.vue
+++ b/frontend/src/components/folders/FolderMappingWizard.vue
@@ -35,7 +35,10 @@ import {
   getFolderStructureReadStatus,
 } from "../../api/folderStructure";
 import { errorDetail } from "../../utils/apiError";
-import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
+import {
+  readIsPartial,
+  useFolderMappingStore,
+} from "../../stores/useFolderMappingStore";
 import {
   useLibrariesStore,
   useLibrarySwitchStore,
@@ -224,9 +227,9 @@ async function build(accepted) {
       mode: "local_import",
       assignments: accepted,
       pictureCount: pictureCount.value,
-      // A truncated read summed only the folders it reached, so the count it
+      // A partial read summed only the folders it reached, so the count it
       // saves is a floor. The empty library's copy reads this to say so.
-      pictureCountCapped: readResult.value?.truncated === true,
+      pictureCountCapped: readIsPartial(readResult.value),
       autoCommit: true,
     });
     emit("close");

--- a/frontend/src/components/folders/FolderMappingWizard.vue
+++ b/frontend/src/components/folders/FolderMappingWizard.vue
@@ -185,6 +185,18 @@ function onScanReady({ taskId, result }) {
   readTaskId.value = taskId;
   readResult.value = result;
   pictureCount.value = result.picture_count || 0;
+  // The empty-library flow opens this wizard on a library that already
+  // exists, so its live read never reaches `build()` - the only other place
+  // the count is saved. Without this the empty state keeps whatever the
+  // sidebar's uncapped inspect left behind and presents a partial read's
+  // floor as a total.
+  if (props.resume?.mode === "local_import") {
+    mappingStore.setRootPictureCount(
+      pictureCount.value,
+      readIsPartial(result),
+      mappingStore.rootCountEpoch,
+    );
+  }
   step.value = "mapping";
 }
 

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -792,7 +792,7 @@ async function chooseLibraryFolder() {
       });
     }
     if (epoch !== mappingStore.rootCountEpoch) return;
-    if (mappingStore.rootPictureCount > 0) {
+    if (mappingStore.rootMayHoldPictures) {
       openFolderMappingWizard({ path, mode: "local_import" });
       return;
     }
@@ -982,7 +982,10 @@ async function _offerLoosePictures() {
       verdict?.picture_count_capped ?? false,
       epoch,
     );
-    if (verdict?.picture_count > 0) {
+    // The store's own reading of the verdict, not `picture_count` again: a
+    // count capped at zero stopped before it reached a picture, so it is no
+    // evidence the folder is empty and the wizard is still the way in.
+    if (mappingStore.rootMayHoldPictures) {
       // The read the wizard starts saves a pending entry, which the watch
       // above would otherwise take as its cue to open the wizard again.
       autoOpenedPendingMapping = true;

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -961,6 +961,15 @@ async function _offerLoosePictures() {
   const epoch = mappingStore.rootCountEpoch;
   if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
   if (epoch !== mappingStore.rootCountEpoch) return;
+  // The refresh can be what makes a persisted entry match this library for
+  // the first time, so ask again here as `chooseLibraryFolder` does: that
+  // entry is the auto-open watcher's to resume, and a fresh offer over it
+  // would replace its saved answers with an empty wizard.
+  const saved = pendingForThisLibrary.value;
+  if (saved?.mode === "local_import") {
+    await _fillRootPictureCount(saved);
+    return;
+  }
   const path = librariesStore.activeLibrary?.path;
   if (!path || !librariesStore.canManage) return;
   // On desktop the startup screen may have read this very folder already,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -18,7 +18,10 @@ import FolderTreeNode from "../editors/FolderTreeNode.vue";
 import FolderEditor from "../editors/FolderEditor.vue";
 import FolderBrowser from "../editors/FolderBrowser.vue";
 import FolderMappingWizard from "../folders/FolderMappingWizard.vue";
-import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
+import {
+  readIsPartial,
+  useFolderMappingStore,
+} from "../../stores/useFolderMappingStore";
 import { useLibrariesStore } from "../../stores/useLibrariesStore";
 import ShareDialog from "../io/ShareDialog.vue";
 import WordmarkLogo from "../WordmarkLogo.vue";
@@ -765,13 +768,18 @@ async function chooseLibraryFolder() {
   // `setRootPictureCount` refuses the write on its own; only returning here
   // stops the routing that follows.
   const epoch = mappingStore.rootCountEpoch;
+  if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
+  if (epoch !== mappingStore.rootCountEpoch) return;
+  // Read AFTER the refresh, never before it: `pendingForThisLibrary` matches
+  // the saved entry against the active library's path, so with no list loaded
+  // yet there is no path to match and a perfectly good entry looked absent.
+  // Routing on that stale null opened a fresh wizard over the very folder this
+  // click should have resumed - and raced the auto-open watcher for it.
   const entry = pendingForThisLibrary.value;
   if (entry?.mode === "local_import") {
     openFolderMappingWizard(entry);
     return;
   }
-  if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
-  if (epoch !== mappingStore.rootCountEpoch) return;
   const path = librariesStore.activeLibrary?.path;
   if (path && librariesStore.canManage) {
     // Re-inspected on every click: a root that was empty when the count was
@@ -899,13 +907,13 @@ async function _fillRootPictureCount(entry) {
   const epoch = mappingStore.rootCountEpoch;
   if (mappingStore.rootPictureCount !== null) return;
   const counted = entry.pictureCount ?? entry.result?.picture_count;
-  // The wizard saves the read's `truncated` beside the count; an entry that
+  // The wizard saves the read's completeness beside the count; an entry that
   // carries the result itself answers from that. An entry saved before the
   // flag existed has a count of unknown completeness, so it is asked for
   // again rather than shown as a total.
   const capped =
     entry.pictureCountCapped ??
-    (entry.result ? entry.result.truncated === true : undefined);
+    (entry.result ? readIsPartial(entry.result) : undefined);
   if (counted != null && capped !== undefined) {
     mappingStore.setRootPictureCount(counted, capped, epoch);
     return;
@@ -962,11 +970,11 @@ async function _offerLoosePictures() {
   const parked = await takeParkedFolderRead();
   if (epoch !== mappingStore.rootCountEpoch) return;
   if (parked?.result && _samePath(parked.path, path)) {
-    // A truncated read stopped at `MAX_FOLDERS` and summed what it had, so its
-    // count is a floor exactly like the inspect endpoint's cap.
+    // A partial read summed only the folders it reached, so its count is a
+    // floor exactly like the inspect endpoint's cap.
     mappingStore.setRootPictureCount(
       parked.result.picture_count ?? null,
-      parked.result.truncated === true,
+      readIsPartial(parked.result),
       epoch,
     );
     autoOpenedPendingMapping = true;

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -774,6 +774,8 @@ async function chooseLibraryFolder() {
     try {
       const verdict = await inspectLibraryPath(path);
       mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+      mappingStore.rootPictureCountCapped =
+        verdict?.picture_count_capped ?? false;
     } catch (error) {
       console.warn("Could not check the library folder for pictures", {
         path,
@@ -885,6 +887,7 @@ async function _fillRootPictureCount(entry) {
   const counted = entry.pictureCount ?? entry.result?.picture_count;
   if (counted != null) {
     mappingStore.rootPictureCount = counted;
+    mappingStore.rootPictureCountCapped = false;
     return;
   }
   const path = entry.path;
@@ -892,6 +895,7 @@ async function _fillRootPictureCount(entry) {
   try {
     const verdict = await inspectLibraryPath(path);
     mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+    mappingStore.rootPictureCountCapped = verdict?.picture_count_capped ?? false;
   } catch (error) {
     console.warn("Could not check the library folder for pictures", {
       path,
@@ -930,6 +934,7 @@ async function _offerLoosePictures() {
   const parked = await takeParkedFolderRead();
   if (parked?.result && _samePath(parked.path, path)) {
     mappingStore.rootPictureCount = parked.result.picture_count ?? null;
+    mappingStore.rootPictureCountCapped = false;
     autoOpenedPendingMapping = true;
     openFolderMappingWizard({
       path,
@@ -941,6 +946,7 @@ async function _offerLoosePictures() {
   try {
     const verdict = await inspectLibraryPath(path);
     mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+    mappingStore.rootPictureCountCapped = verdict?.picture_count_capped ?? false;
     if (verdict?.picture_count > 0) {
       // The read the wizard starts saves a pending entry, which the watch
       // above would otherwise take as its cue to open the wizard again.

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -900,7 +900,11 @@ async function _fillRootPictureCount(entry) {
   if (mappingStore.rootPictureCount !== null) return;
   const counted = entry.pictureCount ?? entry.result?.picture_count;
   if (counted != null) {
-    mappingStore.setRootPictureCount(counted, false, epoch);
+    // The wizard saves the read's `truncated` beside the count; entries
+    // written before it did carry the result itself, so ask that instead.
+    const capped =
+      entry.pictureCountCapped ?? entry.result?.truncated === true;
+    mappingStore.setRootPictureCount(counted, capped, epoch);
     return;
   }
   const path = entry.path;
@@ -955,9 +959,11 @@ async function _offerLoosePictures() {
   const parked = await takeParkedFolderRead();
   if (epoch !== mappingStore.rootCountEpoch) return;
   if (parked?.result && _samePath(parked.path, path)) {
+    // A truncated read stopped at `MAX_FOLDERS` and summed what it had, so its
+    // count is a floor exactly like the inspect endpoint's cap.
     mappingStore.setRootPictureCount(
       parked.result.picture_count ?? null,
-      false,
+      parked.result.truncated === true,
       epoch,
     );
     autoOpenedPendingMapping = true;

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -767,16 +767,18 @@ async function chooseLibraryFolder() {
   if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
   const path = librariesStore.activeLibrary?.path;
   if (path && librariesStore.canManage) {
-    if (mappingStore.rootPictureCount === null) {
-      try {
-        const verdict = await inspectLibraryPath(path);
-        mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
-      } catch (error) {
-        console.warn("Could not check the library folder for pictures", {
-          path,
-          error,
-        });
-      }
+    // Re-inspected on every click: a root that was empty when the count was
+    // cached may hold pictures now, and a stale 0 sends the owner to "Add a
+    // library", which refuses the folder the library already is. A failed
+    // inspect leaves the cached count alone.
+    try {
+      const verdict = await inspectLibraryPath(path);
+      mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+    } catch (error) {
+      console.warn("Could not check the library folder for pictures", {
+        path,
+        error,
+      });
     }
     if (mappingStore.rootPictureCount > 0) {
       openFolderMappingWizard({ path, mode: "local_import" });

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -750,6 +750,42 @@ function chooseFolderType(type) {
   openReferenceFolderEditor();
 }
 
+/**
+ * The empty library's "Choose a folder…" / "Import them…".
+ *
+ * When the library's own folder holds pictures, the way in is the mapping
+ * wizard over that folder - the same one the offer opens - and never "Add a
+ * library", which refuses the folder because the library already is it. A
+ * dismissed offer therefore has a way back. Otherwise the ordinary add.
+ */
+async function chooseLibraryFolder() {
+  const entry = pendingForThisLibrary.value;
+  if (entry?.mode === "local_import") {
+    openFolderMappingWizard(entry);
+    return;
+  }
+  if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
+  const path = librariesStore.activeLibrary?.path;
+  if (path && librariesStore.canManage) {
+    if (mappingStore.rootPictureCount === null) {
+      try {
+        const verdict = await inspectLibraryPath(path);
+        mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+      } catch (error) {
+        console.warn("Could not check the library folder for pictures", {
+          path,
+          error,
+        });
+      }
+    }
+    if (mappingStore.rootPictureCount > 0) {
+      openFolderMappingWizard({ path, mode: "local_import" });
+      return;
+    }
+  }
+  openReferenceFolderEditor();
+}
+
 function openReferenceFolderEditor(rf = null) {
   if (rf === null) {
     // Adding a folder is "Add a library" now: a folder indexed in place as
@@ -865,6 +901,7 @@ async function _offerLoosePictures() {
   // progress bar over an empty grid.
   const parked = await takeParkedFolderRead();
   if (parked?.result && _samePath(parked.path, path)) {
+    mappingStore.rootPictureCount = parked.result.picture_count ?? null;
     autoOpenedPendingMapping = true;
     openFolderMappingWizard({
       path,
@@ -875,6 +912,7 @@ async function _offerLoosePictures() {
   }
   try {
     const verdict = await inspectLibraryPath(path);
+    mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
     if (verdict?.picture_count > 0) {
       // The read the wizard starts saves a pending entry, which the watch
       // above would otherwise take as its cue to open the wizard again.
@@ -4491,6 +4529,7 @@ defineExpose({
   // "Nothing is moved" one screen earlier, so routing through the chooser would
   // have the release's headline claim falsified by the next click.
   openReferenceFolderEditor,
+  chooseLibraryFolder,
   offerLoosePictures,
   startLocalImport,
   currentProjectId,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -759,6 +759,9 @@ function chooseFolderType(type) {
  * dismissed offer therefore has a way back. Otherwise the ordinary add.
  */
 async function chooseLibraryFolder() {
+  // Captured before the awaits below: a session change while the inspect is on
+  // the wire must not write the outgoing owner's count into the new session.
+  const epoch = mappingStore.rootCountEpoch;
   const entry = pendingForThisLibrary.value;
   if (entry?.mode === "local_import") {
     openFolderMappingWizard(entry);
@@ -773,9 +776,11 @@ async function chooseLibraryFolder() {
     // inspect leaves the cached count alone.
     try {
       const verdict = await inspectLibraryPath(path);
-      mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
-      mappingStore.rootPictureCountCapped =
-        verdict?.picture_count_capped ?? false;
+      mappingStore.setRootPictureCount(
+        verdict?.picture_count ?? 0,
+        verdict?.picture_count_capped ?? false,
+        epoch,
+      );
     } catch (error) {
       console.warn("Could not check the library folder for pictures", {
         path,
@@ -883,19 +888,22 @@ function offerLoosePictures() {
 /** The count for the wording above, from the entry's own read if it carries
  *  one - an entry saved before the read finished does not - else the server. */
 async function _fillRootPictureCount(entry) {
+  const epoch = mappingStore.rootCountEpoch;
   if (mappingStore.rootPictureCount !== null) return;
   const counted = entry.pictureCount ?? entry.result?.picture_count;
   if (counted != null) {
-    mappingStore.rootPictureCount = counted;
-    mappingStore.rootPictureCountCapped = false;
+    mappingStore.setRootPictureCount(counted, false, epoch);
     return;
   }
   const path = entry.path;
   if (!path) return;
   try {
     const verdict = await inspectLibraryPath(path);
-    mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
-    mappingStore.rootPictureCountCapped = verdict?.picture_count_capped ?? false;
+    mappingStore.setRootPictureCount(
+      verdict?.picture_count ?? 0,
+      verdict?.picture_count_capped ?? false,
+      epoch,
+    );
   } catch (error) {
     console.warn("Could not check the library folder for pictures", {
       path,
@@ -924,6 +932,7 @@ async function takeParkedFolderRead() {
 }
 
 async function _offerLoosePictures() {
+  const epoch = mappingStore.rootCountEpoch;
   if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
   const path = librariesStore.activeLibrary?.path;
   if (!path || !librariesStore.canManage) return;
@@ -933,8 +942,11 @@ async function _offerLoosePictures() {
   // progress bar over an empty grid.
   const parked = await takeParkedFolderRead();
   if (parked?.result && _samePath(parked.path, path)) {
-    mappingStore.rootPictureCount = parked.result.picture_count ?? null;
-    mappingStore.rootPictureCountCapped = false;
+    mappingStore.setRootPictureCount(
+      parked.result.picture_count ?? null,
+      false,
+      epoch,
+    );
     autoOpenedPendingMapping = true;
     openFolderMappingWizard({
       path,
@@ -945,8 +957,11 @@ async function _offerLoosePictures() {
   }
   try {
     const verdict = await inspectLibraryPath(path);
-    mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
-    mappingStore.rootPictureCountCapped = verdict?.picture_count_capped ?? false;
+    mappingStore.setRootPictureCount(
+      verdict?.picture_count ?? 0,
+      verdict?.picture_count_capped ?? false,
+      epoch,
+    );
     if (verdict?.picture_count > 0) {
       // The read the wizard starts saves a pending entry, which the watch
       // above would otherwise take as its cue to open the wizard again.

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -759,8 +759,11 @@ function chooseFolderType(type) {
  * dismissed offer therefore has a way back. Otherwise the ordinary add.
  */
 async function chooseLibraryFolder() {
-  // Captured before the awaits below: a session change while the inspect is on
-  // the wire must not write the outgoing owner's count into the new session.
+  // Captured before the awaits below: a session change while one of them is
+  // pending must not write the outgoing owner's count into the new session,
+  // and must not open a wizard over the outgoing owner's folder either.
+  // `setRootPictureCount` refuses the write on its own; only returning here
+  // stops the routing that follows.
   const epoch = mappingStore.rootCountEpoch;
   const entry = pendingForThisLibrary.value;
   if (entry?.mode === "local_import") {
@@ -768,6 +771,7 @@ async function chooseLibraryFolder() {
     return;
   }
   if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
+  if (epoch !== mappingStore.rootCountEpoch) return;
   const path = librariesStore.activeLibrary?.path;
   if (path && librariesStore.canManage) {
     // Re-inspected on every click: a root that was empty when the count was
@@ -787,6 +791,7 @@ async function chooseLibraryFolder() {
         error,
       });
     }
+    if (epoch !== mappingStore.rootCountEpoch) return;
     if (mappingStore.rootPictureCount > 0) {
       openFolderMappingWizard({ path, mode: "local_import" });
       return;
@@ -888,6 +893,9 @@ function offerLoosePictures() {
 /** The count for the wording above, from the entry's own read if it carries
  *  one - an entry saved before the read finished does not - else the server. */
 async function _fillRootPictureCount(entry) {
+  // No epoch recheck after the await below, unlike the two functions that
+  // route on the result: the count write is the only thing this one does
+  // after it, and `setRootPictureCount` refuses a stale epoch itself.
   const epoch = mappingStore.rootCountEpoch;
   if (mappingStore.rootPictureCount !== null) return;
   const counted = entry.pictureCount ?? entry.result?.picture_count;
@@ -932,8 +940,12 @@ async function takeParkedFolderRead() {
 }
 
 async function _offerLoosePictures() {
+  // Rechecked after every await below, same as `chooseLibraryFolder`: a
+  // session change mid-flight must open no wizard over the outgoing owner's
+  // folder, and must not claim this session's one auto-open either.
   const epoch = mappingStore.rootCountEpoch;
   if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
+  if (epoch !== mappingStore.rootCountEpoch) return;
   const path = librariesStore.activeLibrary?.path;
   if (!path || !librariesStore.canManage) return;
   // On desktop the startup screen may have read this very folder already,
@@ -941,6 +953,7 @@ async function _offerLoosePictures() {
   // doing it there: the wizard opens on its questions instead of on a second
   // progress bar over an empty grid.
   const parked = await takeParkedFolderRead();
+  if (epoch !== mappingStore.rootCountEpoch) return;
   if (parked?.result && _samePath(parked.path, path)) {
     mappingStore.setRootPictureCount(
       parked.result.picture_count ?? null,
@@ -957,6 +970,7 @@ async function _offerLoosePictures() {
   }
   try {
     const verdict = await inspectLibraryPath(path);
+    if (epoch !== mappingStore.rootCountEpoch) return;
     mappingStore.setRootPictureCount(
       verdict?.picture_count ?? 0,
       verdict?.picture_count_capped ?? false,

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -862,14 +862,40 @@ function offerLoosePictures() {
   // AND no offer, for the life of the install; there was no way into the
   // library at all. This has to stay the same test as the auto-open, so state
   // it the same way.
-  if (
-    isReadOnly.value ||
-    pendingForThisLibrary.value?.mode === "local_import"
-  ) {
-    return Promise.resolve();
+  if (isReadOnly.value) return Promise.resolve();
+  const entry = pendingForThisLibrary.value;
+  if (entry?.mode === "local_import") {
+    // Nothing to offer, but the count is still `null` on a page reloaded onto
+    // a persisted entry: the offer is what usually fills it, and the empty
+    // state's wording reads it, so the way back in said "Choose a folder…"
+    // for a folder full of pictures. Fill it and open nothing.
+    loosePicturesOffer ??= _fillRootPictureCount(entry);
+    return loosePicturesOffer;
   }
   loosePicturesOffer ??= _offerLoosePictures();
   return loosePicturesOffer;
+}
+
+/** The count for the wording above, from the entry's own read if it carries
+ *  one - an entry saved before the read finished does not - else the server. */
+async function _fillRootPictureCount(entry) {
+  if (mappingStore.rootPictureCount !== null) return;
+  const counted = entry.pictureCount ?? entry.result?.picture_count;
+  if (counted != null) {
+    mappingStore.rootPictureCount = counted;
+    return;
+  }
+  const path = entry.path;
+  if (!path) return;
+  try {
+    const verdict = await inspectLibraryPath(path);
+    mappingStore.rootPictureCount = verdict?.picture_count ?? 0;
+  } catch (error) {
+    console.warn("Could not check the library folder for pictures", {
+      path,
+      error,
+    });
+  }
 }
 
 /**

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -899,11 +899,14 @@ async function _fillRootPictureCount(entry) {
   const epoch = mappingStore.rootCountEpoch;
   if (mappingStore.rootPictureCount !== null) return;
   const counted = entry.pictureCount ?? entry.result?.picture_count;
-  if (counted != null) {
-    // The wizard saves the read's `truncated` beside the count; entries
-    // written before it did carry the result itself, so ask that instead.
-    const capped =
-      entry.pictureCountCapped ?? entry.result?.truncated === true;
+  // The wizard saves the read's `truncated` beside the count; an entry that
+  // carries the result itself answers from that. An entry saved before the
+  // flag existed has a count of unknown completeness, so it is asked for
+  // again rather than shown as a total.
+  const capped =
+    entry.pictureCountCapped ??
+    (entry.result ? entry.result.truncated === true : undefined);
+  if (counted != null && capped !== undefined) {
     mappingStore.setRootPictureCount(counted, capped, epoch);
     return;
   }

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -107,6 +107,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Belt and braces for the parked-read tests: each deletes this itself, but
+  // a failing assertion returns before it does, and the leaked desktop shim
+  // then fails every test after it as well.
+  delete window.pixlstashDesktop;
   vi.restoreAllMocks();
 });
 
@@ -334,6 +338,44 @@ describe("the loose-pictures offer for an empty library", () => {
     const empty = mount(LibraryEmptyState, { shallow: true });
     expect(empty.text()).toContain(
       "could not be fully counted; it holds at least 5,000 pictures",
+    );
+
+    empty.unmount();
+    delete window.pixlstashDesktop;
+    wrapper.unmount();
+  });
+
+  it("words a parked read that skipped unreadable folders as a floor too", async () => {
+    // `unreadable_folders > 0` means those subtrees are absent from the
+    // counts entirely (integration_architecture.md §20), so a zero here is an
+    // incomplete read, not an empty folder. Read as a total it sent the owner
+    // to "Add a library", which refuses the folder the library already is.
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    window.pixlstashDesktop = {
+      takePendingMapping: async () => ({
+        path,
+        result: {
+          levels: [],
+          picture_count: 0,
+          truncated: false,
+          unreadable_folders: 2,
+        },
+      }),
+    };
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    const mapping = useFolderMappingStore();
+    expect(mapping.rootMayHoldPictures).toBe(true);
+    expect(mapping.wizardResume).toMatchObject({ path, mode: "local_import" });
+    const empty = mount(LibraryEmptyState, { shallow: true });
+    expect(empty.text()).toContain(
+      "could not be fully counted; it may already hold pictures",
     );
 
     empty.unmount();
@@ -689,6 +731,48 @@ describe("the empty library's Choose a folder button", () => {
     libraries.canManage = true;
     return mountSidebar();
   }
+
+  it("resumes an entry the refresh only just made matchable", async () => {
+    // `pendingForThisLibrary` compares the entry's path with the ACTIVE
+    // library's, so before the list has loaded it is null for every entry
+    // there is. Read once up front, that null was still the value the routing
+    // used after the refresh, and the click opened a fresh wizard over the
+    // folder it should have resumed - racing the auto-open watcher for it.
+    const path = "/home/me/Pictures";
+    const entry = {
+      taskId: "task-7",
+      path,
+      label: "Pictures",
+      mode: "local_import",
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      if (url === "/libraries") {
+        return Promise.resolve({
+          data: {
+            libraries: [{ id: 1, name: "lib", path, is_active: true }],
+            can_manage: true,
+          },
+        });
+      }
+      return Promise.resolve(respond());
+    });
+    const wrapper = await mountSidebar();
+    const mapping = useFolderMappingStore();
+    expect(mapping.wizardOpen).toBe(false);
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(mapping.wizardResume).toEqual(entry);
+    expect(inspect).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
 
   it("re-inspects, so a root that has since filled up opens the wizard", async () => {
     // A cached 0 from a load over an empty folder used to be permanent, and

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -774,6 +774,50 @@ describe("the empty library's Choose a folder button", () => {
     wrapper.unmount();
   });
 
+  it("leaves an entry the refresh only just made matchable to the auto-open", async () => {
+    // Same race on the offer path: read before the refresh, the entry was
+    // null, and the fresh offer then wrote `{ path, mode }` over the saved
+    // taskId, assignments and autoCommit the watcher was about to resume.
+    const path = "/home/me/Pictures";
+    const entry = {
+      taskId: "task-8",
+      path,
+      label: "Pictures",
+      mode: "local_import",
+      autoCommit: true,
+      pictureCount: 4,
+      pictureCountCapped: false,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      if (url === "/libraries") {
+        return Promise.resolve({
+          data: {
+            libraries: [{ id: 1, name: "lib", path, is_active: true }],
+            can_manage: true,
+          },
+        });
+      }
+      return Promise.resolve(respond());
+    });
+    const wrapper = await mountSidebar();
+    const mapping = useFolderMappingStore();
+
+    await wrapper.vm.offerLoosePictures();
+    await flushPromises();
+
+    expect(mapping.wizardResume).toEqual(entry);
+    expect(mapping.rootPictureCount).toBe(4);
+    expect(inspect).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
   it("re-inspects, so a root that has since filled up opens the wizard", async () => {
     // A cached 0 from a load over an empty folder used to be permanent, and
     // sent the owner to "Add a library", which refuses the folder the library

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -390,12 +390,55 @@ describe("the loose-pictures offer for an empty library", () => {
 
   it("stays quiet when the pending entry is this library's own", async () => {
     // The control: an entry the auto-open WILL act on must still suppress the
-    // offer, or the owner gets the wizard twice.
+    // offer, or the owner gets the wizard twice. The count is still filled -
+    // LibraryEmptyState words its button from it - but from a read that opens
+    // nothing.
     const path = "/home/me/Pictures";
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ taskId: "task-4", path, label: "Pictures", mode: "local_import" }),
-    );
+    const entry = {
+      taskId: "task-4",
+      path,
+      label: "Pictures",
+      mode: "local_import",
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      return Promise.resolve(respond());
+    });
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+    await wrapper.vm.offerLoosePictures();
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(useFolderMappingStore().rootPictureCount).toBe(12);
+    // The auto-open's wizard, not a second one the offer put up.
+    expect(useFolderMappingStore().wizardResume).toEqual(entry);
+
+    wrapper.unmount();
+  });
+
+  it("fills the count from the entry's own read without asking again", async () => {
+    // "Add a library" saves the read's `pictureCount` with the entry. A page
+    // reloaded onto it left `rootPictureCount` null, so the empty state
+    // offered "Choose a folder…" for a folder full of pictures.
+    const path = "/home/me/Pictures";
+    const entry = {
+      taskId: "task-5",
+      path,
+      label: "Pictures",
+      mode: "local_import",
+      pictureCount: 7,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
     activeLibraryAt(path);
     const libraries = useLibrariesStore();
     libraries.hasLoadedSuccessfully = true;
@@ -413,6 +456,8 @@ describe("the loose-pictures offer for an empty library", () => {
     await wrapper.vm.offerLoosePictures();
 
     expect(inspect).not.toHaveBeenCalled();
+    expect(useFolderMappingStore().rootPictureCount).toBe(7);
+    expect(useFolderMappingStore().wizardResume).toEqual(entry);
 
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -332,10 +332,45 @@ describe("the loose-pictures offer for an empty library", () => {
     await wrapper.vm.offerLoosePictures();
 
     const empty = mount(LibraryEmptyState, { shallow: true });
-    expect(empty.text()).toContain("At least 5,000 pictures are");
+    expect(empty.text()).toContain(
+      "could not be fully counted; it holds at least 5,000 pictures",
+    );
 
     empty.unmount();
     delete window.pixlstashDesktop;
+    wrapper.unmount();
+  });
+
+  it("opens the wizard on a capped count that reached no picture", async () => {
+    // count_media_files() can exhaust its entry cap on directories before it
+    // reaches any media (utils/media_files.py), so `picture_count: 0` with
+    // `picture_count_capped: true` is an unfinished walk, not an empty
+    // folder. Read as empty, the offer left the owner with "Add a library",
+    // which refuses the folder the library already is.
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({
+            data: { picture_count: 0, picture_count_capped: true },
+          })
+        : Promise.resolve(respond()),
+    );
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    const mapping = useFolderMappingStore();
+    expect(mapping.wizardResume).toEqual({ path, mode: "local_import" });
+    const empty = mount(LibraryEmptyState, { shallow: true });
+    expect(empty.text()).toContain(
+      "could not be fully counted; it may already hold pictures",
+    );
+
+    empty.unmount();
     wrapper.unmount();
   });
 
@@ -636,6 +671,30 @@ describe("the empty library's Choose a folder button", () => {
     await wrapper.vm.chooseLibraryFolder();
 
     expect(mapping.rootPictureCount).toBe(3);
+    expect(mapping.wizardResume).toEqual({ path, mode: "local_import" });
+
+    wrapper.unmount();
+  });
+
+  it("opens the wizard on a capped count that reached no picture", async () => {
+    // Same unfinished walk as the offer's own case: a capped 0 is no evidence
+    // the folder is empty, so the click must not fall through to "Add a
+    // library", which refuses the folder the library already is.
+    const path = "/home/me/Pictures";
+    const wrapper = await mountWithManageableLibrary(path);
+    const mapping = useFolderMappingStore();
+    mapping.rootPictureCount = 0;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({
+            data: { picture_count: 0, picture_count_capped: true },
+          })
+        : Promise.resolve(respond()),
+    );
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(mapping.rootMayHoldPictures).toBe(true);
     expect(mapping.wizardResume).toEqual({ path, mode: "local_import" });
 
     wrapper.unmount();

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -501,6 +501,7 @@ describe("the loose-pictures offer for an empty library", () => {
       label: "Pictures",
       mode: "local_import",
       pictureCount: 7,
+      pictureCountCapped: false,
     };
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
     activeLibraryAt(path);
@@ -522,6 +523,41 @@ describe("the loose-pictures offer for an empty library", () => {
     expect(inspect).not.toHaveBeenCalled();
     expect(useFolderMappingStore().rootPictureCount).toBe(7);
     expect(useFolderMappingStore().wizardResume).toEqual(entry);
+
+    wrapper.unmount();
+  });
+
+  it("asks again for an entry saved before the count carried its cap", async () => {
+    // A legacy entry has a count but no `pictureCountCapped` and no result,
+    // so nothing says whether that count was a total or a floor. Showing it
+    // as a total after an upgrade would be a guess; the server is asked.
+    const path = "/home/me/Pictures";
+    const entry = {
+      taskId: "task-6",
+      path,
+      label: "Pictures",
+      mode: "local_import",
+      pictureCount: 7,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        return Promise.resolve({
+          data: { picture_count: 5000, picture_count_capped: true },
+        });
+      }
+      return Promise.resolve(respond());
+    });
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    expect(useFolderMappingStore().rootPictureCount).toBe(5000);
+    expect(useFolderMappingStore().rootPictureCountCapped).toBe(true);
 
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -71,6 +71,7 @@ vi.mock("vue-router", async () => {
 
 import { isReadOnly, sessionContext } from "../../utils/apiClient";
 import SideBar from "./SideBar.vue";
+import LibraryEmptyState from "../views/LibraryEmptyState.vue";
 import FolderMappingWizard from "../folders/FolderMappingWizard.vue";
 import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { useLibrariesStore } from "../../stores/useLibrariesStore";
@@ -306,6 +307,34 @@ describe("the loose-pictures offer for an empty library", () => {
       mode: "local_import",
     });
 
+    delete window.pixlstashDesktop;
+    wrapper.unmount();
+  });
+
+  it("words a truncated parked read as a floor, not as a total", async () => {
+    // The read stopped at `MAX_FOLDERS` and summed only the folders it
+    // reached, so its `picture_count` is a floor exactly like the inspect
+    // endpoint's cap. Passed as an exact total, the empty state named a
+    // number the folder does not hold.
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    window.pixlstashDesktop = {
+      takePendingMapping: async () => ({
+        path,
+        result: { levels: [], picture_count: 5000, truncated: true },
+      }),
+    };
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.offerLoosePictures();
+
+    const empty = mount(LibraryEmptyState, { shallow: true });
+    expect(empty.text()).toContain("At least 5,000 pictures are");
+
+    empty.unmount();
     delete window.pixlstashDesktop;
     wrapper.unmount();
   });

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -500,6 +500,56 @@ describe("the loose-pictures offer for an empty library", () => {
     wrapper.unmount();
   });
 
+  it("drops the parked read when the session changes while it is in flight", async () => {
+    // The parked read is an IPC round trip to the Electron shell, so a logout
+    // can land inside it. Its result is the outgoing owner's folder: it must
+    // open no wizard, and must not spend this session's one auto-open either,
+    // or the incoming owner's own pending entry is silently swallowed.
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    let resolveParked;
+    window.pixlstashDesktop = {
+      takePendingMapping: () =>
+        new Promise((resolve) => {
+          resolveParked = resolve;
+        }),
+    };
+    const inspect = vi.fn();
+    apiGet.mockImplementation((url) => {
+      if (url.includes("inspect")) {
+        inspect();
+        return Promise.resolve({ data: { picture_count: 12 } });
+      }
+      return Promise.resolve(respond());
+    });
+    const wrapper = await mountSidebar();
+    const mapping = useFolderMappingStore();
+
+    const offer = wrapper.vm.offerLoosePictures();
+    await flushPromises();
+    mapping.resetForSession();
+    resolveParked({ path, result: { levels: [{ depth: 1, folders: [] }] } });
+    await offer;
+
+    expect(mapping.wizardOpen).toBe(false);
+    expect(mapping.wizardResume).toBe(null);
+    expect(inspect).not.toHaveBeenCalled();
+
+    // `autoOpenedPendingMapping` untouched: the new session's own entry still
+    // gets its auto-open.
+    const entry = { taskId: "", path, label: "Pictures", mode: "local_import" };
+    mapping.save(entry);
+    await flushPromises();
+    expect(mapping.wizardOpen).toBe(true);
+    expect(mapping.wizardResume).toEqual(entry);
+
+    delete window.pixlstashDesktop;
+    wrapper.unmount();
+  });
+
   it("ignores a parked read of some other folder", async () => {
     const path = "/home/me/Pictures";
     activeLibraryAt(path);
@@ -604,6 +654,35 @@ describe("the empty library's Choose a folder button", () => {
     await click;
 
     expect(mapping.rootPictureCount).toBe(null);
+    expect(mapping.wizardResume).toBe(null);
+
+    wrapper.unmount();
+  });
+
+  it("opens nothing at all when the session changes under the inspect", async () => {
+    // The test above only proves the COUNT was dropped: `wizardResume` is null
+    // for the ordinary add too, which `openReferenceFolderEditor` opens with
+    // `wizardOpen` true. Dropping the count is not enough - the click has to
+    // stop, or the outgoing owner's folder gets a wizard in the new session.
+    const path = "/home/me/Pictures";
+    const wrapper = await mountWithManageableLibrary(path);
+    const mapping = useFolderMappingStore();
+    let resolveInspect;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? new Promise((resolve) => {
+            resolveInspect = resolve;
+          })
+        : Promise.resolve(respond()),
+    );
+
+    const click = wrapper.vm.chooseLibraryFolder();
+    await flushPromises();
+    mapping.resetForSession();
+    resolveInspect({ data: { picture_count: 42 } });
+    await click;
+
+    expect(mapping.wizardOpen).toBe(false);
     expect(mapping.wizardResume).toBe(null);
 
     wrapper.unmount();

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -580,4 +580,32 @@ describe("the empty library's Choose a folder button", () => {
 
     wrapper.unmount();
   });
+
+  it("drops a count from an inspect that resolves after the session changed", async () => {
+    // Logout notifies the reset before App.vue unmounts, so an inspect the
+    // outgoing owner started can still resolve; its count belongs to the
+    // previous library and must not repopulate the next session.
+    const path = "/home/me/Pictures";
+    const wrapper = await mountWithManageableLibrary(path);
+    const mapping = useFolderMappingStore();
+    let resolveInspect;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? new Promise((resolve) => {
+            resolveInspect = resolve;
+          })
+        : Promise.resolve(respond()),
+    );
+
+    const click = wrapper.vm.chooseLibraryFolder();
+    await flushPromises();
+    mapping.resetForSession();
+    resolveInspect({ data: { picture_count: 42 } });
+    await click;
+
+    expect(mapping.rootPictureCount).toBe(null);
+    expect(mapping.wizardResume).toBe(null);
+
+    wrapper.unmount();
+  });
 });

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -530,3 +530,54 @@ describe("the loose-pictures offer for an empty library", () => {
     wrapper.unmount();
   });
 });
+
+describe("the empty library's Choose a folder button", () => {
+  async function mountWithManageableLibrary(path) {
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    return mountSidebar();
+  }
+
+  it("re-inspects, so a root that has since filled up opens the wizard", async () => {
+    // A cached 0 from a load over an empty folder used to be permanent, and
+    // sent the owner to "Add a library", which refuses the folder the library
+    // already is.
+    const path = "/home/me/Pictures";
+    const wrapper = await mountWithManageableLibrary(path);
+    const mapping = useFolderMappingStore();
+    mapping.rootPictureCount = 0;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({ data: { picture_count: 3 } })
+        : Promise.resolve(respond()),
+    );
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(mapping.rootPictureCount).toBe(3);
+    expect(mapping.wizardResume).toEqual({ path, mode: "local_import" });
+
+    wrapper.unmount();
+  });
+
+  it("keeps the cached count and takes the old route when the inspect fails", async () => {
+    const path = "/home/me/Pictures";
+    const wrapper = await mountWithManageableLibrary(path);
+    const mapping = useFolderMappingStore();
+    mapping.rootPictureCount = 0;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.reject(new Error("offline"))
+        : Promise.resolve(respond()),
+    );
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(mapping.rootPictureCount).toBe(0);
+    expect(mapping.wizardResume).toBe(null);
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -497,7 +497,7 @@
       <!-- All three routes reuse wiring App.vue already had: `local-import`
            reaches `SideBar.startLocalImport`, `open-settings` reaches
            `SideBar.openSettingsDialog`, and `choose-folder` is the one new
-           signal, for the reference-folder editor the sidebar owns. -->
+           signal, for `SideBar.chooseLibraryFolder`. -->
       <LibraryEmptyState
         v-if="showLibraryEmptyState"
         @choose-folder="emit('choose-folder')"

--- a/frontend/src/components/views/LibraryEmptyState.test.js
+++ b/frontend/src/components/views/LibraryEmptyState.test.js
@@ -179,7 +179,23 @@ describe("when the library's own folder already holds pictures", () => {
     // picture_count_capped. The number is a floor; naming it as the total
     // would under-count the folder the owner is about to import.
     const wrapper = mountState({ rootPictureCount: 5000, capped: true });
-    expect(wrapper.text()).toContain("At least 5,000 pictures are");
+    expect(wrapper.text()).toContain(
+      "Your library folder could not be fully counted; it holds at least 5,000 pictures",
+    );
+  });
+
+  it("offers the import when a capped count reached no picture at all", async () => {
+    // count_media_files() can exhaust its entry cap on directories before it
+    // reaches any media, so a capped 0 says the walk stopped, not that the
+    // folder is empty. The ordinary "Use a folder you already have" sent the
+    // owner to "Add a library", which refuses the folder the library is.
+    const wrapper = mountState({ rootPictureCount: 0, capped: true });
+    expect(wrapper.text()).toContain(
+      "Your library folder could not be fully counted; it may already hold pictures",
+    );
+    expect(buttonLabels(wrapper)[0]).toBe("Import them…");
+    await wrapper.findAll(".library-empty__option button")[0].trigger("click");
+    expect(wrapper.emitted("choose-folder")).toHaveLength(1);
   });
 
   it("keeps the ordinary wording while the answer is unknown", () => {

--- a/frontend/src/components/views/LibraryEmptyState.test.js
+++ b/frontend/src/components/views/LibraryEmptyState.test.js
@@ -7,17 +7,23 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 
 vi.mock("vuetify/components", () => ({
   VIcon: { name: "v-icon", template: "<i><slot /></i>" },
 }));
 
 import LibraryEmptyState from "./LibraryEmptyState.vue";
+import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
-function mountState() {
+function mountState({ rootPictureCount = null } = {}) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  useFolderMappingStore().rootPictureCount = rootPictureCount;
   return mount(LibraryEmptyState, {
     global: {
+      plugins: [pinia],
       stubs: {
         // No manual `$emit("click")`: the real AppButton declares no emits, so
         // `@click` on it is plain attribute fallthrough onto its own <button>
@@ -149,5 +155,24 @@ describe("what the buttons do", () => {
     await input.trigger("change");
 
     expect(input.element.value).toBe("");
+  });
+});
+
+describe("when the library's own folder already holds pictures", () => {
+  it("offers to import them, on the same accented button", async () => {
+    // A dismissed import offer leaves an empty library over a full folder, and
+    // "Add a library" refuses that folder as already attached. The first
+    // route has to be the way back into the offer.
+    const wrapper = mountState({ rootPictureCount: 312 });
+    expect(wrapper.text()).toContain("Import the pictures already in this folder");
+    expect(wrapper.text()).toContain("312 pictures are");
+    expect(buttonLabels(wrapper)[0]).toBe("Import them…");
+    await wrapper.findAll(".library-empty__option button")[0].trigger("click");
+    expect(wrapper.emitted("choose-folder")).toHaveLength(1);
+  });
+
+  it("keeps the ordinary wording while the answer is unknown", () => {
+    const wrapper = mountState();
+    expect(buttonLabels(wrapper)[0]).toBe("Choose a folder…");
   });
 });

--- a/frontend/src/components/views/LibraryEmptyState.test.js
+++ b/frontend/src/components/views/LibraryEmptyState.test.js
@@ -17,10 +17,12 @@ import LibraryEmptyState from "./LibraryEmptyState.vue";
 import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
-function mountState({ rootPictureCount = null } = {}) {
+function mountState({ rootPictureCount = null, capped = false } = {}) {
   const pinia = createPinia();
   setActivePinia(pinia);
-  useFolderMappingStore().rootPictureCount = rootPictureCount;
+  const mapping = useFolderMappingStore();
+  mapping.rootPictureCount = rootPictureCount;
+  mapping.rootPictureCountCapped = capped;
   return mount(LibraryEmptyState, {
     global: {
       plugins: [pinia],
@@ -169,6 +171,15 @@ describe("when the library's own folder already holds pictures", () => {
     expect(buttonLabels(wrapper)[0]).toBe("Import them…");
     await wrapper.findAll(".library-empty__option button")[0].trigger("click");
     expect(wrapper.emitted("choose-folder")).toHaveLength(1);
+  });
+
+  it("says at least when the count stopped at the inspect cap", () => {
+    // /libraries/inspect stops counting at its entry cap so a folder picker
+    // can answer while somebody is looking at it, and says so with
+    // picture_count_capped. The number is a floor; naming it as the total
+    // would under-count the folder the owner is about to import.
+    const wrapper = mountState({ rootPictureCount: 5000, capped: true });
+    expect(wrapper.text()).toContain("At least 5,000 pictures are");
   });
 
   it("keeps the ordinary wording while the answer is unknown", () => {

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -5,10 +5,11 @@
  * says what it says.
  *
  * In short: three routes out rather than one, folder first and the only
- * accented one, and not a word about a "database". Presentational - every
+ * accented one, and not a word about a "database". It acts on nothing - every
  * route is emitted for the grid to place, including the chosen files, which
  * are handed up unfiltered because the grid already drops what PixlStash
- * cannot read for both drop paths.
+ * cannot read for both drop paths - but it does read one fact for itself, the
+ * root picture count in `useFolderMappingStore`, which decides its copy.
  */
 import { computed, ref } from "vue";
 import { VIcon } from "vuetify/components";
@@ -25,9 +26,10 @@ const emit = defineEmits(["choose-folder", "add-files", "connect-comfyui"]);
 // this library already is - the state a dismissed import offer leaves.
 const mappingStore = useFolderMappingStore();
 const rootPictureCount = computed(() => mappingStore.rootPictureCount ?? 0);
-// The count stopped at the inspect endpoint's entry cap, so it is a floor and
-// the sentence says so. Naming it as the total under-counts a big folder, and
-// the number this screen shows is the one the owner checks the import against.
+// The count stopped at a cap the server had to answer under, so it is a floor
+// and the sentence says so. Naming it as the total under-counts a big folder,
+// and the number this screen shows is the one the owner checks the import
+// against.
 const rootPictureCountCapped = computed(
   () => mappingStore.rootPictureCountCapped === true,
 );

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -25,6 +25,12 @@ const emit = defineEmits(["choose-folder", "add-files", "connect-comfyui"]);
 // this library already is - the state a dismissed import offer leaves.
 const mappingStore = useFolderMappingStore();
 const rootPictureCount = computed(() => mappingStore.rootPictureCount ?? 0);
+// The count stopped at the inspect endpoint's entry cap, so it is a floor and
+// the sentence says so. Naming it as the total under-counts a big folder, and
+// the number this screen shows is the one the owner checks the import against.
+const rootPictureCountCapped = computed(
+  () => mappingStore.rootPictureCountCapped === true,
+);
 
 const fileInput = ref(null);
 
@@ -76,8 +82,13 @@ function filesChosen(event) {
               >Import the pictures already in this folder</span
             >
             <span class="library-empty__detail">
+              {{ rootPictureCountCapped ? "At least" : "" }}
               {{ rootPictureCount.toLocaleString() }}
-              {{ rootPictureCount === 1 ? "picture is" : "pictures are" }}
+              {{
+                rootPictureCount === 1 && !rootPictureCountCapped
+                  ? "picture is"
+                  : "pictures are"
+              }}
               in this library's folder. They are read where they sit; nothing
               is moved.
             </span>

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -33,6 +33,11 @@ const rootPictureCount = computed(() => mappingStore.rootPictureCount ?? 0);
 const rootPictureCountCapped = computed(
   () => mappingStore.rootPictureCountCapped === true,
 );
+// A capped count is a floor, so a capped zero is not an empty folder: the walk
+// ran out of entries before it reached a picture. The route in is the import
+// either way, and the copy says the folder was not fully counted rather than
+// naming a number as the total.
+const rootMayHoldPictures = computed(() => mappingStore.rootMayHoldPictures);
 
 const fileInput = ref(null);
 
@@ -79,18 +84,21 @@ function filesChosen(event) {
           <span class="library-empty__mark" aria-hidden="true">
             <v-icon size="19">mdi-folder-outline</v-icon>
           </span>
-          <span v-if="rootPictureCount > 0" class="library-empty__text">
+          <span v-if="rootMayHoldPictures" class="library-empty__text">
             <span class="library-empty__heading"
               >Import the pictures already in this folder</span
             >
-            <span class="library-empty__detail">
-              {{ rootPictureCountCapped ? "At least" : "" }}
-              {{ rootPictureCount.toLocaleString() }}
+            <span v-if="rootPictureCountCapped" class="library-empty__detail">
+              Your library folder could not be fully counted; it
               {{
-                rootPictureCount === 1 && !rootPictureCountCapped
-                  ? "picture is"
-                  : "pictures are"
-              }}
+                rootPictureCount > 0
+                  ? `holds at least ${rootPictureCount.toLocaleString()} pictures`
+                  : "may already hold pictures"
+              }}. They are read where they sit; nothing is moved.
+            </span>
+            <span v-else class="library-empty__detail">
+              {{ rootPictureCount.toLocaleString() }}
+              {{ rootPictureCount === 1 ? "picture is" : "pictures are" }}
               in this library's folder. They are read where they sit; nothing
               is moved.
             </span>
@@ -105,7 +113,7 @@ function filesChosen(event) {
             </span>
           </span>
           <AppButton size="sm" variant="primary" @click="emit('choose-folder')">
-            {{ rootPictureCount > 0 ? "Import them…" : "Choose a folder…" }}
+            {{ rootMayHoldPictures ? "Import them…" : "Choose a folder…" }}
           </AppButton>
         </li>
 

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -92,7 +92,7 @@ function filesChosen(event) {
               Your library folder could not be fully counted; it
               {{
                 rootPictureCount > 0
-                  ? `holds at least ${rootPictureCount.toLocaleString()} pictures`
+                  ? `holds at least ${rootPictureCount.toLocaleString()} ${rootPictureCount === 1 ? "picture" : "pictures"}`
                   : "may already hold pictures"
               }}. They are read where they sit; nothing is moved.
             </span>

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -10,13 +10,21 @@
  * are handed up unfiltered because the grid already drops what PixlStash
  * cannot read for both drop paths.
  */
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { VIcon } from "vuetify/components";
 
 import AppButton from "../widgets/AppButton.vue";
+import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
 const emit = defineEmits(["choose-folder", "add-files", "connect-comfyui"]);
+
+// The one fact this screen reads for itself: whether the library's own folder
+// already holds pictures. Then the first route is "import them", because
+// "choose a folder" would lead to "Add a library", which refuses the folder
+// this library already is - the state a dismissed import offer leaves.
+const mappingStore = useFolderMappingStore();
+const rootPictureCount = computed(() => mappingStore.rootPictureCount ?? 0);
 
 const fileInput = ref(null);
 
@@ -63,7 +71,18 @@ function filesChosen(event) {
           <span class="library-empty__mark" aria-hidden="true">
             <v-icon size="19">mdi-folder-outline</v-icon>
           </span>
-          <span class="library-empty__text">
+          <span v-if="rootPictureCount > 0" class="library-empty__text">
+            <span class="library-empty__heading"
+              >Import the pictures already in this folder</span
+            >
+            <span class="library-empty__detail">
+              {{ rootPictureCount.toLocaleString() }}
+              {{ rootPictureCount === 1 ? "picture is" : "pictures are" }}
+              in this library's folder. They are read where they sit; nothing
+              is moved.
+            </span>
+          </span>
+          <span v-else class="library-empty__text">
             <span class="library-empty__heading"
               >Use a folder you already have</span
             >
@@ -73,7 +92,7 @@ function filesChosen(event) {
             </span>
           </span>
           <AppButton size="sm" variant="primary" @click="emit('choose-folder')">
-            Choose a folder…
+            {{ rootPictureCount > 0 ? "Import them…" : "Choose a folder…" }}
           </AppButton>
         </li>
 

--- a/frontend/src/components/widgets/AppDialog.test.js
+++ b/frontend/src/components/widgets/AppDialog.test.js
@@ -82,14 +82,18 @@ describe("AppDialog keyboard contract", () => {
 });
 
 describe("AppDialog backdrop", () => {
-  it("closes on a click outside, unless persistent", async () => {
+  it("closes once when Vuetify closes it, and ignores click:outside itself", async () => {
+    // Vuetify emits update:model-value=false on a scrim click or Escape
+    // exactly when the dialog is not persistent, and click:outside always.
+    // Only the former is wired, so a non-persistent dialog closes once and a
+    // persistent one - the folder-mapping wizard - not at all on a stray
+    // click; wiring both used to close the former twice and the latter once.
     const w = mountDialog();
-    await w.findComponent({ name: "v-dialog" }).vm.$emit("click:outside");
+    const dialog = w.findComponent({ name: "v-dialog" });
+    await dialog.vm.$emit("click:outside");
+    await dialog.vm.$emit("update:modelValue", false);
     expect(w.emitted("close")).toHaveLength(1);
 
-    // Vuetify emits click:outside on a persistent dialog too; it only refuses
-    // to close itself. A stray click on the scrim used to dismiss the
-    // folder-mapping wizard mid-answer this way.
     const p = mountDialog({ persistent: true });
     await p.findComponent({ name: "v-dialog" }).vm.$emit("click:outside");
     expect(p.emitted("close")).toBeUndefined();

--- a/frontend/src/components/widgets/AppDialog.test.js
+++ b/frontend/src/components/widgets/AppDialog.test.js
@@ -80,3 +80,18 @@ describe("AppDialog keyboard contract", () => {
     expect(w.emitted("accept")).toBeFalsy();
   });
 });
+
+describe("AppDialog backdrop", () => {
+  it("closes on a click outside, unless persistent", async () => {
+    const w = mountDialog();
+    await w.findComponent({ name: "v-dialog" }).vm.$emit("click:outside");
+    expect(w.emitted("close")).toHaveLength(1);
+
+    // Vuetify emits click:outside on a persistent dialog too; it only refuses
+    // to close itself. A stray click on the scrim used to dismiss the
+    // folder-mapping wizard mid-answer this way.
+    const p = mountDialog({ persistent: true });
+    await p.findComponent({ name: "v-dialog" }).vm.$emit("click:outside");
+    expect(p.emitted("close")).toBeUndefined();
+  });
+});

--- a/frontend/src/components/widgets/AppDialog.vue
+++ b/frontend/src/components/widgets/AppDialog.vue
@@ -6,7 +6,6 @@
     :persistent="persistent"
     transition="dialog-bottom-transition"
     @update:model-value="(v) => !v && emit('close')"
-    @click:outside="onClickOutside"
   >
     <div
       class="app-dialog"
@@ -78,17 +77,13 @@ const ENTER_EXEMPT =
  * so every AppDialog gets it and no page-level Escape owner is consulted
  * first. `accept` only fires for dialogs that listen for it.
  */
-/**
- * A persistent dialog ignores the backdrop, as it ignores Escape. Vuetify
- * emits `click:outside` whether or not the dialog is persistent - it only
- * stops closing ITSELF - so wiring the event straight to `close` let a stray
- * click dismiss the folder-mapping wizard mid-answer, which is the one gesture
- * that dialog exists to refuse.
- */
-function onClickOutside() {
-  if (props.persistent) return;
-  emit("close");
-}
+// The backdrop is deliberately NOT wired to `close`. Vuetify emits
+// `click:outside` whether or not the dialog is persistent - it only stops
+// closing ITSELF - so a `click:outside` handler let a stray click dismiss the
+// folder-mapping wizard mid-answer, and on a non-persistent dialog it doubled
+// the `update:model-value=false` Vuetify also emits, so owners saw `close`
+// twice. `update:model-value` is the one source: Vuetify sets it false on a
+// scrim click or Escape exactly when the dialog is not persistent.
 
 function onKeydown(e) {
   if (e.key === "Escape") {

--- a/frontend/src/components/widgets/AppDialog.vue
+++ b/frontend/src/components/widgets/AppDialog.vue
@@ -6,7 +6,7 @@
     :persistent="persistent"
     transition="dialog-bottom-transition"
     @update:model-value="(v) => !v && emit('close')"
-    @click:outside="emit('close')"
+    @click:outside="onClickOutside"
   >
     <div
       class="app-dialog"
@@ -78,6 +78,18 @@ const ENTER_EXEMPT =
  * so every AppDialog gets it and no page-level Escape owner is consulted
  * first. `accept` only fires for dialogs that listen for it.
  */
+/**
+ * A persistent dialog ignores the backdrop, as it ignores Escape. Vuetify
+ * emits `click:outside` whether or not the dialog is persistent - it only
+ * stops closing ITSELF - so wiring the event straight to `close` let a stray
+ * click dismiss the folder-mapping wizard mid-answer, which is the one gesture
+ * that dialog exists to refuse.
+ */
+function onClickOutside() {
+  if (props.persistent) return;
+  emit("close");
+}
+
 function onKeydown(e) {
   if (e.key === "Escape") {
     if (props.persistent) return;

--- a/frontend/src/stores/sessionReset.test.js
+++ b/frontend/src/stores/sessionReset.test.js
@@ -122,13 +122,15 @@ const STORES = [
     seed: (s) => {
       s.save({ taskId: "abc123", path: "/home/me/Pictures", label: "Pictures" });
       s.openWizard(s.pending);
-      s.setRootPictureCount(12, false, s.rootCountEpoch);
+      s.setRootPictureCount(12, true, s.rootCountEpoch);
     },
     isEmpty: (s) =>
       s.pending === null &&
       !s.wizardOpen &&
       s.wizardResume === null &&
-      s.rootPictureCount === null,
+      s.rootPictureCount === null &&
+      s.rootPictureCountCapped === false &&
+      !s.rootMayHoldPictures,
   },
   {
     name: "useLockedSetsStore",

--- a/frontend/src/stores/sessionReset.test.js
+++ b/frontend/src/stores/sessionReset.test.js
@@ -121,8 +121,14 @@ const STORES = [
     use: useFolderMappingStore,
     seed: (s) => {
       s.save({ taskId: "abc123", path: "/home/me/Pictures", label: "Pictures" });
+      s.openWizard(s.pending);
+      s.setRootPictureCount(12, false, s.rootCountEpoch);
     },
-    isEmpty: (s) => s.pending === null,
+    isEmpty: (s) =>
+      s.pending === null &&
+      !s.wizardOpen &&
+      s.wizardResume === null &&
+      s.rootPictureCount === null,
   },
   {
     name: "useLockedSetsStore",

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -55,6 +55,14 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
   const pending = ref(readStorage());
   const wizardOpen = ref(false);
   const wizardResume = ref(null);
+  /**
+   * How many pictures the open library's OWN folder holds on disk, as the
+   * sidebar's offer last asked the server; `null` until it has. The empty
+   * library reads it to offer "import them" instead of "choose a folder", so
+   * a dismissed offer still has a way back in - "Add a library" refuses the
+   * folder the library already is.
+   */
+  const rootPictureCount = ref(null);
 
   /** Open the one wizard; `resume` is a saved entry, or null for a fresh add. */
   function openWizard(resume = null) {
@@ -89,5 +97,14 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
   const unsubscribeSessionReset = onSessionReset(clear);
   onScopeDispose(unsubscribeSessionReset);
 
-  return { pending, save, clear, wizardOpen, wizardResume, openWizard, closeWizard };
+  return {
+    pending,
+    save,
+    clear,
+    wizardOpen,
+    wizardResume,
+    rootPictureCount,
+    openWizard,
+    closeWizard,
+  };
 });

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -63,6 +63,13 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
    * folder the library already is.
    */
   const rootPictureCount = ref(null);
+  /**
+   * True when `rootPictureCount` stopped at the inspect endpoint's entry cap,
+   * so it is a floor rather than a total: a folder picker has to answer while
+   * somebody is looking at it. The copy says "at least N" instead of naming an
+   * exact number the folder does not hold.
+   */
+  const rootPictureCountCapped = ref(false);
 
   /** Open the one wizard; `resume` is a saved entry, or null for a fresh add. */
   function openWizard(resume = null) {
@@ -100,6 +107,7 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
   function resetForSession() {
     clear();
     rootPictureCount.value = null;
+    rootPictureCountCapped.value = false;
   }
 
   const unsubscribeSessionReset = onSessionReset(resetForSession);
@@ -112,6 +120,7 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     wizardOpen,
     wizardResume,
     rootPictureCount,
+    rootPictureCountCapped,
     openWizard,
     closeWizard,
   };

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -64,8 +64,9 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
    */
   const rootPictureCount = ref(null);
   /**
-   * True when `rootPictureCount` stopped at the inspect endpoint's entry cap,
-   * so it is a floor rather than a total: a folder picker has to answer while
+   * True when `rootPictureCount` stopped short - at the inspect endpoint's
+   * entry cap, or at a folder read's `MAX_FOLDERS` - so it is a floor rather
+   * than a total: a folder picker has to answer while
    * somebody is looking at it. The copy says "at least N" instead of naming an
    * exact number the folder does not hold.
    */

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -70,6 +70,21 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
    * exact number the folder does not hold.
    */
   const rootPictureCountCapped = ref(false);
+  /**
+   * Bumped by `resetForSession`, so an inspect the outgoing owner started
+   * cannot land after the reset and repopulate the next session with the
+   * previous library's count. Same shape as `useLibrariesStore`, in a ref
+   * because the reads that write the count live in SideBar.
+   */
+  const rootCountEpoch = ref(0);
+
+  /** Record what the library's own folder holds, unless the session changed
+   *  since the read that counted it started. */
+  function setRootPictureCount(count, capped, epoch) {
+    if (epoch !== rootCountEpoch.value) return;
+    rootPictureCount.value = count;
+    rootPictureCountCapped.value = capped;
+  }
 
   /** Open the one wizard; `resume` is a saved entry, or null for a fresh add. */
   function openWizard(resume = null) {
@@ -106,6 +121,7 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
    *  import pictures that are not there. */
   function resetForSession() {
     clear();
+    rootCountEpoch.value += 1;
     rootPictureCount.value = null;
     rootPictureCountCapped.value = false;
   }
@@ -121,6 +137,9 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     wizardResume,
     rootPictureCount,
     rootPictureCountCapped,
+    rootCountEpoch,
+    setRootPictureCount,
+    resetForSession,
     openWizard,
     closeWizard,
   };

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -1,4 +1,4 @@
-import { onScopeDispose, ref } from "vue";
+import { computed, onScopeDispose, ref } from "vue";
 import { defineStore } from "pinia";
 
 import { onSessionReset } from "../utils/apiClient";
@@ -72,6 +72,17 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
    */
   const rootPictureCountCapped = ref(false);
   /**
+   * Whether the folder may hold pictures at all - the test both the button's
+   * route and its copy switch on. A capped zero counts: the walk stopped at
+   * the cap while it was still crossing folders, so it never reached a
+   * picture and proves nothing about whether there is one. Routing it as
+   * empty sent the owner to "Add a library", which refuses the folder the
+   * library already is.
+   */
+  const rootMayHoldPictures = computed(
+    () => rootPictureCount.value > 0 || rootPictureCountCapped.value === true,
+  );
+  /**
    * Bumped by `resetForSession`, so an inspect the outgoing owner started
    * cannot land after the reset and repopulate the next session with the
    * previous library's count. Same shape as `useLibrariesStore`, in a ref
@@ -142,6 +153,7 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     wizardResume,
     rootPictureCount,
     rootPictureCountCapped,
+    rootMayHoldPictures,
     rootCountEpoch,
     setRootPictureCount,
     resetForSession,

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -118,9 +118,13 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
 
   /** A session change forgets the pending entry AND what the folder held:
    *  the count is the previous library's, and the empty state would offer to
-   *  import pictures that are not there. */
+   *  import pictures that are not there. The open wizard goes too: Pinia
+   *  outlives a logout in the same tab, and the next credential must not
+   *  find the previous owner's host path and read result on screen. */
   function resetForSession() {
     clear();
+    wizardOpen.value = false;
+    wizardResume.value = null;
     rootCountEpoch.value += 1;
     rootPictureCount.value = null;
     rootPictureCountCapped.value = false;

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -51,6 +51,22 @@ function readStorage() {
   return null;
 }
 
+/**
+ * Whether a folder read describes less than the whole tree, so its
+ * `picture_count` is a floor rather than a total.
+ *
+ * Two ways, and the second is the one that keeps getting missed: the walk hit
+ * `MAX_FOLDERS` and stopped (`truncated`), or it could not open some folders
+ * and those subtrees are absent from the counts entirely
+ * (`unreadable_folders`, integration_architecture.md §20). One helper because
+ * three call sites derive this and drifted apart once already.
+ *
+ * @param {{truncated?: boolean, unreadable_folders?: number}|null|undefined} result
+ */
+export function readIsPartial(result) {
+  return result?.truncated === true || (result?.unreadable_folders ?? 0) > 0;
+}
+
 export const useFolderMappingStore = defineStore("folderMapping", () => {
   const pending = ref(readStorage());
   const wizardOpen = ref(false);
@@ -65,8 +81,8 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
   const rootPictureCount = ref(null);
   /**
    * True when `rootPictureCount` stopped short - at the inspect endpoint's
-   * entry cap, or at a folder read's `MAX_FOLDERS` - so it is a floor rather
-   * than a total: a folder picker has to answer while
+   * entry cap, or at anything `readIsPartial` calls a partial folder read - so
+   * it is a floor rather than a total: a folder picker has to answer while
    * somebody is looking at it. The copy says "at least N" instead of naming an
    * exact number the folder does not hold.
    */

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -94,7 +94,15 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     }
   }
 
-  const unsubscribeSessionReset = onSessionReset(clear);
+  /** A session change forgets the pending entry AND what the folder held:
+   *  the count is the previous library's, and the empty state would offer to
+   *  import pictures that are not there. */
+  function resetForSession() {
+    clear();
+    rootPictureCount.value = null;
+  }
+
+  const unsubscribeSessionReset = onSessionReset(resetForSession);
   onScopeDispose(unsubscribeSessionReset);
 
   return {

--- a/pixlstash/database.py
+++ b/pixlstash/database.py
@@ -979,6 +979,14 @@ class VaultDatabase:
         # decoded (issue #585). Shared by task threads (marking) and finder
         # threads (suppression); reachable from both via their ``self._db``.
         self.unprocessable_images = UnprocessableImageRegistry()
+        # Set while a ``local_import`` folder-mapping commit is pending, so the
+        # root scan can see one that started after its own gate read. Lives
+        # here, beside the registry above, for the same reason: it is shared by
+        # a task thread and the commit's thread and both reach it as
+        # ``self._db`` / ``server.vault.db``. Owned by
+        # ``folder_structure_commit_service``; ``Vault.__init__`` seeds it from
+        # the database so a crash-resumed import is covered too.
+        self.local_import_running = threading.Event()
         db_exists = os.path.exists(self._db_path)
         logger.debug(f"Vault init, db_path={self._db_path}, db_exists={db_exists}")
 

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -219,6 +219,24 @@ def parse_assignments(raw: list) -> list[Assignment]:
     return parsed
 
 
+def local_import_pending(session: Session) -> bool:
+    """Whether a ``local_import`` commit record is still pending.
+
+    The database half of ``vault.db.local_import_running``: what
+    ``Vault.__init__`` seeds the flag from, and what the settle path asks
+    before clearing it.
+    """
+    return (
+        session.exec(
+            select(FolderMappingCommit.id)
+            .where(FolderMappingCommit.mode == "local_import")
+            .where(FolderMappingCommit.state == STATE_PENDING)
+            .limit(1)
+        ).first()
+        is not None
+    )
+
+
 def record_pending_commit(
     server,
     *,
@@ -272,6 +290,13 @@ def record_pending_commit(
         )
         session.commit()
 
+    if mode == "local_import":
+        # BEFORE the row, and so before `local_import_pictures` walks: the
+        # root scan checks this flag after its own gate read and again per
+        # directory, so a commit that starts after that read is seen at the
+        # latest one directory later. Set first, written second, and the scan
+        # reading it stale can only be stale in the safe direction.
+        server.vault.db.local_import_running.set()
     server.vault.db.run_task(write, priority=DBPriority.IMMEDIATE)
 
 
@@ -335,14 +360,21 @@ def settle_pending_commit(server, task_id: str, state: str) -> None:
     """
 
     def write(session: Session) -> None:
-        _settle_in_session(session, task_id, state)
+        _settle_in_session(server, session, task_id, state)
         session.commit()
 
     server.vault.db.run_task(write, priority=DBPriority.IMMEDIATE)
 
 
-def _settle_in_session(session: Session, task_id: str, state: str) -> None:
-    """Settle the record on an open session, without committing it."""
+def _settle_in_session(server, session: Session, task_id: str, state: str) -> None:
+    """Settle the record on an open session, without committing it.
+
+    Also clears ``vault.db.local_import_running`` once no ``local_import``
+    record is pending any more - the read autoflushes, so it sees the row just
+    settled above. Cleared before the transaction commits, which is the safe
+    order: by the time anything settles, the pictures this flag protects are
+    already inserted.
+    """
     row = session.exec(
         select(FolderMappingCommit).where(FolderMappingCommit.task_id == task_id)
     ).first()
@@ -351,6 +383,8 @@ def _settle_in_session(session: Session, task_id: str, state: str) -> None:
     row.state = state
     row.updated_at = datetime.now(timezone.utc)
     session.add(row)
+    if not local_import_pending(session):
+        server.vault.db.local_import_running.clear()
 
 
 def record_commit_stage(server, task_id: str, stage: str) -> None:
@@ -1190,7 +1224,7 @@ def apply_mapping(
         _link_pictures(session, pictures, assignments, root_path, image_root, result)
         linked_ids.extend(int(pic.id) for pic in pictures)
         if task_id:
-            _settle_in_session(session, task_id, STATE_DONE)
+            _settle_in_session(server, session, task_id, STATE_DONE)
         session.commit()
         return result
 
@@ -1229,7 +1263,7 @@ def apply_local_mapping(
         result = CommitResult(pictures_indexed=len(pictures))
         _link_pictures(session, pictures, assignments, root_path, image_root, result)
         if task_id:
-            _settle_in_session(session, task_id, STATE_DONE)
+            _settle_in_session(server, session, task_id, STATE_DONE)
         session.commit()
         return result
 

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -13,6 +13,11 @@ import time
 from sqlmodel import Session, select
 
 from pixlstash.database import DBPriority
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_ABANDONED,
+    FolderMappingCommit,
+)
+from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
 from pixlstash.pixl_logging import get_logger
 from pixlstash.tasks.base_task_finder import BaseTaskFinder
@@ -68,6 +73,9 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         # owner renamed while the app was closed.
         self._root_last_scanned: float | None = None
         self._root_scanned_once = False
+        # Once the library holds a picture or the owner has answered the
+        # import offer it stays answered; the two queries run until then.
+        self._first_import_answered = False
 
     def mark_root_due(self) -> None:
         """Ask for the library root to be rescanned on the next planning cycle."""
@@ -164,10 +172,45 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
 
         return self._root_task(folders, now)
 
+    def first_import_answered(self) -> bool:
+        """Whether the root may be indexed yet.
+
+        A library that holds no picture and has never had a folder-mapping
+        commit is one whose owner has not been asked what the pictures in its
+        folder are. The app asks when it loads an empty library over a folder
+        that holds pictures - the first-run offer, and "Add a library" - and
+        the boot-time root scan used to answer first: a small library was
+        indexed, tags and all, before the screen came up, so the grid was no
+        longer empty and the questions never appeared. The root scan waits
+        for the answer. Any commit record counts - done, deferred ("organise
+        later"), pending - except an abandoned one, which is "bring nothing
+        in". A library with a picture in it was imported into some other way
+        and is scanned as before, so nothing changes for an existing library.
+        """
+        if self._first_import_answered:
+            return True
+
+        def read(session: Session) -> bool:
+            if session.exec(select(Picture.id).limit(1)).first() is not None:
+                return True
+            return (
+                session.exec(
+                    select(FolderMappingCommit.id)
+                    .where(FolderMappingCommit.state != STATE_ABANDONED)
+                    .limit(1)
+                ).first()
+                is not None
+            )
+
+        self._first_import_answered = bool(self._db.run_immediate_read_task(read))
+        return self._first_import_answered
+
     def _root_task(self, folders: list[ReferenceFolder], now: float):
         """The library-root scan, when it is due. Folders go first: a root scan
         walks the whole library, so it must not push a pending mount back."""
         if self._image_root is None or not os.path.isdir(self._image_root):
+            return None
+        if not self.first_import_answered():
             return None
         last = self._root_last_scanned
         if last is not None and (now - last) < _RESCAN_INTERVAL_S:

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -19,6 +19,7 @@ from pixlstash.db_models.folder_mapping_commit import (
     STATE_DEFERRED,
     STATE_DONE,
     STATE_PENDING,
+    STATE_SUPERSEDED,
     FolderMappingCommit,
 )
 from pixlstash.db_models.picture import Picture
@@ -209,9 +210,11 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         ``local_import`` commits every chunk, so after the first one the
         library holds pictures the owner has not answered for. A running
         commit wakes the planner while its record is still ``pending``, and
-        an aborted one leaves its chunks indexed behind ``abandoned``. Only
-        with no ``local_import`` record at all does a picture row count: that
-        library was filled some other way and is scanned as before.
+        an aborted one leaves its chunks indexed behind ``abandoned``, and a
+        ``superseded`` newest one was replaced by a reference commit with its
+        chunks just as unanswered. Only with no ``local_import`` record at all
+        does a picture row count: that library was filled some other way and
+        is scanned as before.
 
         The two facts are read in **one statement** so they describe one
         snapshot: this read runs outside the writer queue, so across separate
@@ -233,7 +236,11 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
             return session.exec(select(newest, select(Picture.id).exists())).one()
 
         newest_state, has_picture = self._db.run_immediate_read_task(read)
-        if newest_state in (STATE_PENDING, STATE_ABANDONED):
+        if newest_state in (STATE_PENDING, STATE_ABANDONED, STATE_SUPERSEDED):
+            # Superseded is a pending record a newer commit of either mode
+            # replaced. A newer local_import would be the newest row itself,
+            # so a superseded newest one was replaced by a reference commit
+            # and its chunks are as unanswered as a pending one's.
             return False
         self._first_import_answered = (
             newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -9,24 +9,17 @@ row, so its schedule lives on this finder rather than in a column.
 
 import os
 import time
-from typing import Optional
 
 from sqlmodel import Session, select
 
 from pixlstash.database import DBPriority
-from pixlstash.db_models.folder_mapping_commit import (
-    STATE_ABANDONED,
-    STATE_DEFERRED,
-    STATE_DONE,
-    STATE_PENDING,
-    STATE_SUPERSEDED,
-    FolderMappingCommit,
-)
-from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
 from pixlstash.pixl_logging import get_logger
 from pixlstash.tasks.base_task_finder import BaseTaskFinder
-from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
+from pixlstash.tasks.reference_folder_scan_task import (
+    ReferenceFolderScanTask,
+    root_import_answered,
+)
 from pixlstash.utils.reference_folder_validator import (
     validate_reference_folder_accessible,
     validate_reference_folder_path,
@@ -183,49 +176,13 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         return self._root_task(folders, now)
 
     def first_import_answered(self) -> bool:
-        """Whether the root may be indexed yet.
+        """Whether a root scan may be handed out now.
 
-        A library that holds no picture and has never had a folder-mapping
-        commit is one whose owner has not been asked what the pictures in its
-        folder are. The app asks when it loads an empty library over a folder
-        that holds pictures - the first-run offer, and "Add a library" - and
-        the boot-time root scan used to answer first: a small library was
-        indexed, tags and all, before the screen came up, so the grid was no
-        longer empty and the questions never appeared. The root scan waits
-        for the answer.
-
-        A ``local_import`` commit record counts only once it has **settled**:
-        ``done``, or ``deferred`` ("organise later", which is an answer -
-        index everything, map nothing). A ``pending`` one is the commit still
-        running, so it is the question being answered rather than the answer,
-        and treating it as one puts the 300-second root scan into a race with
-        it: the scan builds its own rows with the sidecar probe, wins, and the
-        commit's ``insert()`` reuses them without ever applying the owner's
-        caption choices. ``abandoned`` is "bring nothing in" and ``superseded``
-        was replaced by a newer record, so neither is an answer either. A
-        ``reference`` commit is not one at all: it registers some other folder
-        and says nothing about the root's own pictures.
-
-        The **newest** ``local_import`` record decides, because records are
-        kept and an older answer must not outrank a newer one: a ``done``
-        import followed by an aborted one is an owner who declined the second
-        batch, and reading the old ``done`` as the answer would scan in the
-        very files just aborted. A ``pending`` or ``abandoned`` newest record
-        wins over the picture row for the same reason: an unsettled
-        ``local_import`` commits every chunk, so after the first one the
-        library holds pictures the owner has not answered for. A running
-        commit wakes the planner while its record is still ``pending``, and
-        an aborted one leaves its chunks indexed behind ``abandoned``, and a
-        ``superseded`` newest one was replaced by a reference commit with its
-        chunks just as unanswered. Only with no ``local_import`` record at all
-        does a picture row count: that library was filled some other way and
-        is scanned as before.
-
-        The two facts are read in **one statement** so they describe one
-        snapshot: this read runs outside the writer queue, so across separate
-        statements a chunk committing in between shows no ``pending`` record
-        and a picture from that very commit, which would answer True with the
-        import still running.
+        The rule, and why the two facts are read in one statement, live with
+        :func:`~pixlstash.tasks.reference_folder_scan_task.root_import_answered`.
+        This read only decides the handoff: the task asks the same question
+        again when it starts, so a record written in between closes the gate
+        rather than being missed.
 
         Not cached: a finder lives as long as the process, and a later import
         must close the gate again the moment its record is pending. The read
@@ -233,25 +190,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         otherwise due and, while the answer is no, no more than once per
         `_GATE_RETRY_S`.
         """
-
-        def read(session: Session) -> tuple[Optional[str], bool]:
-            newest = (
-                select(FolderMappingCommit.state)
-                .where(FolderMappingCommit.mode == "local_import")
-                .order_by(FolderMappingCommit.id.desc())
-                .limit(1)
-                .scalar_subquery()
-            )
-            return session.exec(select(newest, select(Picture.id).exists())).one()
-
-        newest_state, has_picture = self._db.run_immediate_read_task(read)
-        if newest_state in (STATE_PENDING, STATE_ABANDONED, STATE_SUPERSEDED):
-            # Superseded is a pending record a newer commit of either mode
-            # replaced. A newer local_import would be the newest row itself,
-            # so a superseded newest one was replaced by a reference commit
-            # and its chunks are as unanswered as a pending one's.
-            return False
-        return newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
+        return self._db.run_immediate_read_task(root_import_answered)
 
     def _root_task(self, folders: list[ReferenceFolder], now: float):
         """The library-root scan, when it is due. Folders go first: a root scan

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -16,6 +16,7 @@ from pixlstash.database import DBPriority
 from pixlstash.db_models.folder_mapping_commit import (
     STATE_DEFERRED,
     STATE_DONE,
+    STATE_PENDING,
     FolderMappingCommit,
 )
 from pixlstash.db_models.picture import Picture
@@ -75,7 +76,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         self._root_last_scanned: float | None = None
         self._root_scanned_once = False
         # Once the library holds a picture or the owner has answered the
-        # import offer it stays answered; the two queries run until then.
+        # import offer it stays answered; the queries run until then.
         self._first_import_answered = False
 
     def mark_root_due(self) -> None:
@@ -195,14 +196,28 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         caption choices. ``abandoned`` is "bring nothing in" and ``superseded``
         was replaced by a newer record, so neither is an answer either. A
         ``reference`` commit is not one at all: it registers some other folder
-        and says nothing about the root's own pictures. A library with a
-        picture in it was imported into some other way and is scanned as
-        before, so nothing changes for an existing library.
+        and says nothing about the root's own pictures.
+
+        The ``pending`` check runs **first**, before the picture row, because a
+        running ``local_import`` commits every chunk and wakes the planner while
+        its record is still ``pending``: after the first chunk the library holds
+        pictures, and a picture-row check that ran first would read those as the
+        answer and cache it, starting the root scan mid-commit. Otherwise a
+        library with a picture in it was imported into some other way and is
+        scanned as before, so nothing changes for an existing library.
         """
         if self._first_import_answered:
             return True
 
         def read(session: Session) -> bool:
+            running = session.exec(
+                select(FolderMappingCommit.id)
+                .where(FolderMappingCommit.mode == "local_import")
+                .where(FolderMappingCommit.state == STATE_PENDING)
+                .limit(1)
+            ).first()
+            if running is not None:
+                return False
             if session.exec(select(Picture.id).limit(1)).first() is not None:
                 return True
             return (

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -36,6 +36,11 @@ logger = get_logger(__name__)
 
 # Re-scan active folders at most this often (seconds).
 _RESCAN_INTERVAL_S: float = 300.0
+#: How long a closed import gate is left alone before it is asked again. The
+#: planner sweeps every finder up to twenty times a second and the local
+#: importer wakes it after every chunk, so without this the gate's query
+#: would run on every sweep for the whole of a pending import.
+_GATE_RETRY_S: float = 5.0
 # Retry mount_error folders quickly so transient bind/access glitches clear
 # from UI without waiting for a full active re-scan interval.
 _MOUNT_ERROR_RETRY_INTERVAL_S: float = 15.0
@@ -78,10 +83,13 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         # owner renamed while the app was closed.
         self._root_last_scanned: float | None = None
         self._root_scanned_once = False
+        # When the import gate last said no, and when to ask it again.
+        self._gate_retry_at: float | None = None
 
     def mark_root_due(self) -> None:
         """Ask for the library root to be rescanned on the next planning cycle."""
         self._root_last_scanned = None
+        self._gate_retry_at = None
 
     def root_scan_complete(self) -> bool:
         """Whether the library root has been scanned at least once since boot.
@@ -222,7 +230,8 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         Not cached: a finder lives as long as the process, and a later import
         must close the gate again the moment its record is pending. The read
         is one statement, and `_root_task` asks only when a root scan is
-        otherwise due, so it costs one query per `_RESCAN_INTERVAL_S`.
+        otherwise due and, while the answer is no, no more than once per
+        `_GATE_RETRY_S`.
         """
 
         def read(session: Session) -> tuple[Optional[str], bool]:
@@ -253,9 +262,16 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         if last is not None and (now - last) < _RESCAN_INTERVAL_S:
             return None
         # After the interval check, so the gate's one query runs only when a
-        # scan would otherwise be handed out.
-        if not self.first_import_answered():
+        # scan would otherwise be handed out; and no more than once per
+        # `_GATE_RETRY_S` while it says no, since a closed gate never stamps
+        # `_root_last_scanned` and the interval check above would not throttle
+        # it.
+        if self._gate_retry_at is not None and now < self._gate_retry_at:
             return None
+        if not self.first_import_answered():
+            self._gate_retry_at = now + _GATE_RETRY_S
+            return None
+        self._gate_retry_at = None
         # Stamped when the task is handed out, not when it finishes, so a slow
         # scan is not queued a second time behind itself.
         self._root_last_scanned = now

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -78,9 +78,6 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         # owner renamed while the app was closed.
         self._root_last_scanned: float | None = None
         self._root_scanned_once = False
-        # Once the library holds a picture or the owner has answered the
-        # import offer it stays answered; the queries run until then.
-        self._first_import_answered = False
 
     def mark_root_due(self) -> None:
         """Ask for the library root to be rescanned on the next planning cycle."""
@@ -219,11 +216,14 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         The two facts are read in **one statement** so they describe one
         snapshot: this read runs outside the writer queue, so across separate
         statements a chunk committing in between shows no ``pending`` record
-        and a picture from that very commit, which caches the answer as True
-        with the import still running.
+        and a picture from that very commit, which would answer True with the
+        import still running.
+
+        Not cached: a finder lives as long as the process, and a later import
+        must close the gate again the moment its record is pending. The read
+        is one statement, and `_root_task` asks only when a root scan is
+        otherwise due, so it costs one query per `_RESCAN_INTERVAL_S`.
         """
-        if self._first_import_answered:
-            return True
 
         def read(session: Session) -> tuple[Optional[str], bool]:
             newest = (
@@ -242,20 +242,19 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
             # so a superseded newest one was replaced by a reference commit
             # and its chunks are as unanswered as a pending one's.
             return False
-        self._first_import_answered = (
-            newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
-        )
-        return self._first_import_answered
+        return newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
 
     def _root_task(self, folders: list[ReferenceFolder], now: float):
         """The library-root scan, when it is due. Folders go first: a root scan
         walks the whole library, so it must not push a pending mount back."""
         if self._image_root is None or not os.path.isdir(self._image_root):
             return None
-        if not self.first_import_answered():
-            return None
         last = self._root_last_scanned
         if last is not None and (now - last) < _RESCAN_INTERVAL_S:
+            return None
+        # After the interval check, so the gate's one query runs only when a
+        # scan would otherwise be handed out.
+        if not self.first_import_answered():
             return None
         # Stamped when the task is handed out, not when it finishes, so a slow
         # scan is not queued a second time behind itself.

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -198,39 +198,41 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         ``reference`` commit is not one at all: it registers some other folder
         and says nothing about the root's own pictures.
 
-        The ``pending`` check runs **first**, before the picture row, because a
-        running ``local_import`` commits every chunk and wakes the planner while
-        its record is still ``pending``: after the first chunk the library holds
-        pictures, and a picture-row check that ran first would read those as the
-        answer and cache it, starting the root scan mid-commit. Otherwise a
-        library with a picture in it was imported into some other way and is
-        scanned as before, so nothing changes for an existing library.
+        The ``pending`` record **wins** over the picture row, because a running
+        ``local_import`` commits every chunk and wakes the planner while its
+        record is still ``pending``: after the first chunk the library holds
+        pictures, and reading those as the answer would cache it and start the
+        root scan mid-commit. Otherwise a library with a picture in it was
+        imported into some other way and is scanned as before, so nothing
+        changes for an existing library.
+
+        The three facts are read in **one statement** so they describe one
+        snapshot: this read runs outside the writer queue, so across separate
+        statements a chunk committing in between shows no ``pending`` record
+        and a picture from that very commit, which caches the answer as True
+        with the import still running.
         """
         if self._first_import_answered:
             return True
 
-        def read(session: Session) -> bool:
-            running = session.exec(
-                select(FolderMappingCommit.id)
-                .where(FolderMappingCommit.mode == "local_import")
-                .where(FolderMappingCommit.state == STATE_PENDING)
-                .limit(1)
-            ).first()
-            if running is not None:
-                return False
-            if session.exec(select(Picture.id).limit(1)).first() is not None:
-                return True
-            return (
-                session.exec(
-                    select(FolderMappingCommit.id)
-                    .where(FolderMappingCommit.mode == "local_import")
-                    .where(FolderMappingCommit.state.in_((STATE_DONE, STATE_DEFERRED)))
-                    .limit(1)
-                ).first()
-                is not None
+        def read(session: Session) -> tuple[bool, bool, bool]:
+            local_import = select(FolderMappingCommit.id).where(
+                FolderMappingCommit.mode == "local_import"
             )
+            return session.exec(
+                select(
+                    local_import.where(
+                        FolderMappingCommit.state == STATE_PENDING
+                    ).exists(),
+                    select(Picture.id).exists(),
+                    local_import.where(
+                        FolderMappingCommit.state.in_((STATE_DONE, STATE_DEFERRED))
+                    ).exists(),
+                )
+            ).one()
 
-        self._first_import_answered = bool(self._db.run_immediate_read_task(read))
+        pending, has_picture, settled = self._db.run_immediate_read_task(read)
+        self._first_import_answered = not pending and (has_picture or settled)
         return self._first_import_answered
 
     def _root_task(self, folders: list[ReferenceFolder], now: float):

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -9,6 +9,7 @@ row, so its schedule lives on this finder rather than in a column.
 
 import os
 import time
+from typing import Optional
 
 from sqlmodel import Session, select
 
@@ -199,21 +200,20 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         ``reference`` commit is not one at all: it registers some other folder
         and says nothing about the root's own pictures.
 
-        The ``pending`` and ``abandoned`` records both **win** over the picture
-        row, for the same reason: an unsettled ``local_import`` commits every
-        chunk, so after the first one the library holds pictures the owner has
-        not answered for. A running commit wakes the planner while its record
-        is still ``pending``, and an aborted one leaves its chunks indexed
-        behind a record that says ``abandoned`` - "bring nothing in". Reading
-        either one's rows as the answer caches it and scans the root: mid-
-        commit in the first case, and in the second importing the very files
-        the owner just aborted. ``settled`` is checked **before** ``abandoned``
-        because a later settled import outranks an earlier abandoned one.
-        Otherwise a library with a picture in it was imported into some other
-        way and is scanned as before, so nothing changes for an existing
-        library.
+        The **newest** ``local_import`` record decides, because records are
+        kept and an older answer must not outrank a newer one: a ``done``
+        import followed by an aborted one is an owner who declined the second
+        batch, and reading the old ``done`` as the answer would scan in the
+        very files just aborted. A ``pending`` or ``abandoned`` newest record
+        wins over the picture row for the same reason: an unsettled
+        ``local_import`` commits every chunk, so after the first one the
+        library holds pictures the owner has not answered for. A running
+        commit wakes the planner while its record is still ``pending``, and
+        an aborted one leaves its chunks indexed behind ``abandoned``. Only
+        with no ``local_import`` record at all does a picture row count: that
+        library was filled some other way and is scanned as before.
 
-        The four facts are read in **one statement** so they describe one
+        The two facts are read in **one statement** so they describe one
         snapshot: this read runs outside the writer queue, so across separate
         statements a chunk committing in between shows no ``pending`` record
         and a picture from that very commit, which caches the answer as True
@@ -222,30 +222,21 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         if self._first_import_answered:
             return True
 
-        def read(session: Session) -> tuple[bool, bool, bool, bool]:
-            local_import = select(FolderMappingCommit.id).where(
-                FolderMappingCommit.mode == "local_import"
+        def read(session: Session) -> tuple[Optional[str], bool]:
+            newest = (
+                select(FolderMappingCommit.state)
+                .where(FolderMappingCommit.mode == "local_import")
+                .order_by(FolderMappingCommit.id.desc())
+                .limit(1)
+                .scalar_subquery()
             )
-            return session.exec(
-                select(
-                    local_import.where(
-                        FolderMappingCommit.state == STATE_PENDING
-                    ).exists(),
-                    select(Picture.id).exists(),
-                    local_import.where(
-                        FolderMappingCommit.state.in_((STATE_DONE, STATE_DEFERRED))
-                    ).exists(),
-                    local_import.where(
-                        FolderMappingCommit.state == STATE_ABANDONED
-                    ).exists(),
-                )
-            ).one()
+            return session.exec(select(newest, select(Picture.id).exists())).one()
 
-        pending, has_picture, settled, abandoned = self._db.run_immediate_read_task(
-            read
-        )
-        self._first_import_answered = not pending and (
-            settled or (not abandoned and has_picture)
+        newest_state, has_picture = self._db.run_immediate_read_task(read)
+        if newest_state in (STATE_PENDING, STATE_ABANDONED):
+            return False
+        self._first_import_answered = (
+            newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
         )
         return self._first_import_answered
 

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -14,6 +14,7 @@ from sqlmodel import Session, select
 
 from pixlstash.database import DBPriority
 from pixlstash.db_models.folder_mapping_commit import (
+    STATE_ABANDONED,
     STATE_DEFERRED,
     STATE_DONE,
     STATE_PENDING,
@@ -198,15 +199,21 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         ``reference`` commit is not one at all: it registers some other folder
         and says nothing about the root's own pictures.
 
-        The ``pending`` record **wins** over the picture row, because a running
-        ``local_import`` commits every chunk and wakes the planner while its
-        record is still ``pending``: after the first chunk the library holds
-        pictures, and reading those as the answer would cache it and start the
-        root scan mid-commit. Otherwise a library with a picture in it was
-        imported into some other way and is scanned as before, so nothing
-        changes for an existing library.
+        The ``pending`` and ``abandoned`` records both **win** over the picture
+        row, for the same reason: an unsettled ``local_import`` commits every
+        chunk, so after the first one the library holds pictures the owner has
+        not answered for. A running commit wakes the planner while its record
+        is still ``pending``, and an aborted one leaves its chunks indexed
+        behind a record that says ``abandoned`` - "bring nothing in". Reading
+        either one's rows as the answer caches it and scans the root: mid-
+        commit in the first case, and in the second importing the very files
+        the owner just aborted. ``settled`` is checked **before** ``abandoned``
+        because a later settled import outranks an earlier abandoned one.
+        Otherwise a library with a picture in it was imported into some other
+        way and is scanned as before, so nothing changes for an existing
+        library.
 
-        The three facts are read in **one statement** so they describe one
+        The four facts are read in **one statement** so they describe one
         snapshot: this read runs outside the writer queue, so across separate
         statements a chunk committing in between shows no ``pending`` record
         and a picture from that very commit, which caches the answer as True
@@ -215,7 +222,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         if self._first_import_answered:
             return True
 
-        def read(session: Session) -> tuple[bool, bool, bool]:
+        def read(session: Session) -> tuple[bool, bool, bool, bool]:
             local_import = select(FolderMappingCommit.id).where(
                 FolderMappingCommit.mode == "local_import"
             )
@@ -228,11 +235,18 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
                     local_import.where(
                         FolderMappingCommit.state.in_((STATE_DONE, STATE_DEFERRED))
                     ).exists(),
+                    local_import.where(
+                        FolderMappingCommit.state == STATE_ABANDONED
+                    ).exists(),
                 )
             ).one()
 
-        pending, has_picture, settled = self._db.run_immediate_read_task(read)
-        self._first_import_answered = not pending and (has_picture or settled)
+        pending, has_picture, settled, abandoned = self._db.run_immediate_read_task(
+            read
+        )
+        self._first_import_answered = not pending and (
+            settled or (not abandoned and has_picture)
+        )
         return self._first_import_answered
 
     def _root_task(self, folders: list[ReferenceFolder], now: float):

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -182,10 +182,13 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         the boot-time root scan used to answer first: a small library was
         indexed, tags and all, before the screen came up, so the grid was no
         longer empty and the questions never appeared. The root scan waits
-        for the answer. Any commit record counts - done, deferred ("organise
-        later"), pending - except an abandoned one, which is "bring nothing
-        in". A library with a picture in it was imported into some other way
-        and is scanned as before, so nothing changes for an existing library.
+        for the answer. Any ``local_import`` commit record counts - done,
+        deferred ("organise later"), pending - except an abandoned one, which
+        is "bring nothing in". A ``reference`` commit is not an answer: it
+        registers some other folder and says nothing about the root's own
+        pictures. A library with a picture in it was imported into some other
+        way and is scanned as before, so nothing changes for an existing
+        library.
         """
         if self._first_import_answered:
             return True
@@ -196,6 +199,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
             return (
                 session.exec(
                     select(FolderMappingCommit.id)
+                    .where(FolderMappingCommit.mode == "local_import")
                     .where(FolderMappingCommit.state != STATE_ABANDONED)
                     .limit(1)
                 ).first()

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -14,7 +14,8 @@ from sqlmodel import Session, select
 
 from pixlstash.database import DBPriority
 from pixlstash.db_models.folder_mapping_commit import (
-    STATE_ABANDONED,
+    STATE_DEFERRED,
+    STATE_DONE,
     FolderMappingCommit,
 )
 from pixlstash.db_models.picture import Picture
@@ -182,13 +183,21 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         the boot-time root scan used to answer first: a small library was
         indexed, tags and all, before the screen came up, so the grid was no
         longer empty and the questions never appeared. The root scan waits
-        for the answer. Any ``local_import`` commit record counts - done,
-        deferred ("organise later"), pending - except an abandoned one, which
-        is "bring nothing in". A ``reference`` commit is not an answer: it
-        registers some other folder and says nothing about the root's own
-        pictures. A library with a picture in it was imported into some other
-        way and is scanned as before, so nothing changes for an existing
-        library.
+        for the answer.
+
+        A ``local_import`` commit record counts only once it has **settled**:
+        ``done``, or ``deferred`` ("organise later", which is an answer -
+        index everything, map nothing). A ``pending`` one is the commit still
+        running, so it is the question being answered rather than the answer,
+        and treating it as one puts the 300-second root scan into a race with
+        it: the scan builds its own rows with the sidecar probe, wins, and the
+        commit's ``insert()`` reuses them without ever applying the owner's
+        caption choices. ``abandoned`` is "bring nothing in" and ``superseded``
+        was replaced by a newer record, so neither is an answer either. A
+        ``reference`` commit is not one at all: it registers some other folder
+        and says nothing about the root's own pictures. A library with a
+        picture in it was imported into some other way and is scanned as
+        before, so nothing changes for an existing library.
         """
         if self._first_import_answered:
             return True
@@ -200,7 +209,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
                 session.exec(
                     select(FolderMappingCommit.id)
                     .where(FolderMappingCommit.mode == "local_import")
-                    .where(FolderMappingCommit.state != STATE_ABANDONED)
+                    .where(FolderMappingCommit.state.in_((STATE_DONE, STATE_DEFERRED)))
                     .limit(1)
                 ).first()
                 is not None

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -11,6 +11,14 @@ from sqlmodel import Session, delete, select
 
 from pixlstash.database import DBPriority
 from pixlstash.db_models.deleted_file_log import DeletedFileLog
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_ABANDONED,
+    STATE_DEFERRED,
+    STATE_DONE,
+    STATE_PENDING,
+    STATE_SUPERSEDED,
+    FolderMappingCommit,
+)
 from pixlstash.db_models.library_settings import LibrarySettings
 from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
@@ -73,6 +81,76 @@ _ROOT_INTERNAL_DIRS = ROOT_INTERNAL_DIRS
 # owner drops in is picked up once it has settled, on the next scan. A rename
 # keeps the mtime, so a moved file is followed at once.
 _ROOT_SETTLE_S = 60.0
+
+
+def root_import_answered(session: Session) -> bool:
+    """Whether the library root may be indexed yet.
+
+    A library that holds no picture and has never had a folder-mapping commit
+    is one whose owner has not been asked what the pictures in its folder are.
+    The app asks when it loads an empty library over a folder that holds
+    pictures - the first-run offer, and "Add a library" - and the boot-time
+    root scan used to answer first: a small library was indexed, tags and all,
+    before the screen came up, so the grid was no longer empty and the
+    questions never appeared. The root scan waits for the answer.
+
+    A ``local_import`` commit record counts only once it has **settled**:
+    ``done``, or ``deferred`` ("organise later", which is an answer - index
+    everything, map nothing). A ``pending`` one is the commit still running,
+    so it is the question being answered rather than the answer, and treating
+    it as one puts the 300-second root scan into a race with it: the scan
+    builds its own rows with the sidecar probe, wins, and the commit's
+    ``insert()`` reuses them without ever applying the owner's caption
+    choices. ``abandoned`` is "bring nothing in" and ``superseded`` was
+    replaced by a newer record, so neither is an answer either. A
+    ``reference`` commit is not one at all: it registers some other folder and
+    says nothing about the root's own pictures.
+
+    The **newest** ``local_import`` record decides, because records are kept
+    and an older answer must not outrank a newer one: a ``done`` import
+    followed by an aborted one is an owner who declined the second batch, and
+    reading the old ``done`` as the answer would scan in the very files just
+    aborted. A ``pending`` or ``abandoned`` newest record wins over the picture
+    row for the same reason: an unsettled ``local_import`` commits every chunk,
+    so after the first one the library holds pictures the owner has not
+    answered for. A running commit wakes the planner while its record is still
+    ``pending``, and an aborted one leaves its chunks indexed behind
+    ``abandoned``, and a ``superseded`` newest one was replaced by a reference
+    commit with its chunks just as unanswered. Only with no ``local_import``
+    record at all does a picture row count: that library was filled some other
+    way and is scanned as before.
+
+    The two facts are read in **one statement** so they describe one snapshot:
+    this read runs outside the writer queue, so across separate statements a
+    chunk committing in between shows no ``pending`` record and a picture from
+    that very commit, which would answer True with the import still running.
+
+    Asked twice, by both halves of the handoff.
+    :meth:`~pixlstash.tasks.reference_folder_scan_finder.ReferenceFolderScanFinder.first_import_answered`
+    decides whether a root scan is handed out at all; the re-check at the start
+    of :meth:`ReferenceFolderScanTask._run_task` is what makes that handoff
+    fail closed, since `record_pending_commit` can write a pending record
+    between the finder's read and the runner starting the task. Never cached
+    on either side: a later import must close the gate again the moment its
+    record is pending.
+    """
+    newest = (
+        select(FolderMappingCommit.state)
+        .where(FolderMappingCommit.mode == "local_import")
+        .order_by(FolderMappingCommit.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    )
+    newest_state, has_picture = session.exec(
+        select(newest, select(Picture.id).exists())
+    ).one()
+    if newest_state in (STATE_PENDING, STATE_ABANDONED, STATE_SUPERSEDED):
+        # Superseded is a pending record a newer commit of either mode
+        # replaced. A newer local_import would be the newest row itself, so a
+        # superseded newest one was replaced by a reference commit and its
+        # chunks are as unanswered as a pending one's.
+        return False
+    return newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
 
 
 def _is_supported_file(file_path: str) -> bool:
@@ -154,6 +232,20 @@ class ReferenceFolderScanTask(BaseTask):
     def _run_task(self):
         resolved = self._resolved_path
         folder_id = self._folder_id
+
+        # The finder's read decided a root scan could be handed out; this asks
+        # again now the scan is actually starting, which is what makes the
+        # handoff fail closed. `record_pending_commit` can write a pending
+        # local_import in between - the owner answering the first-import offer
+        # while this task sat in the queue - and walking on that stale answer
+        # is the race the gate exists to prevent. `_root_last_scanned` stays
+        # stamped: `mark_root_due` or the next interval asks again.
+        if self._is_root and not self._db.run_immediate_read_task(root_import_answered):
+            logger.info(
+                "Library root scan skipped: an unanswered local import was "
+                "recorded after the scan was queued. Retried on a later cycle."
+            )
+            return {"status": "skipped", "folder_id": folder_id}
 
         if not os.path.isdir(resolved):
             logger.warning(

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -229,6 +229,41 @@ class ReferenceFolderScanTask(BaseTask):
         # "no layout", same as an unset column (v1.11 Phase 5).
         self._layout = None
 
+    def _import_started_mid_scan(self) -> bool:
+        """Whether a local import began after this root scan's gate read.
+
+        `root_import_answered` reads the database and releases it, and this
+        task does more work before `os.walk` even starts. In that window the
+        commit endpoint can write its pending row and set
+        `local_import_pictures` walking, and then both sides build a row for
+        the same file - exactly the race the gate exists to prevent. Another
+        preflight read cannot close it, because the window is *after* the
+        read, not before it.
+
+        `vault.db.local_import_running` closes it, and the ORDER is what makes
+        it fail closed. `record_pending_commit` SETS the flag **before** it
+        writes its row and therefore before its walk; the root scan checks it
+        **after** its own gate read and again once per directory. So a commit
+        that starts after the scan's read is seen at the latest one directory
+        later, and the rows built in that one directory are reused by the
+        commit's `insert()` rather than duplicated. The window is bounded to a
+        single directory instead of the whole walk, and it never runs the other
+        way: the flag cannot be stale in the direction that lets a scan walk on
+        during a live import.
+
+        Cheap on purpose - an in-process `Event.is_set()`, not a query - so
+        asking it per directory costs nothing. The database re-check stays for
+        the cases an in-memory flag cannot cover: a crash-resumed import (the
+        flag is seeded at vault start) and any second process.
+        """
+        if not self._is_root or not self._db.local_import_running.is_set():
+            return False
+        logger.info(
+            "Library root scan stopped: a local import is pending. Nothing "
+            "further is indexed; retried on a later cycle."
+        )
+        return True
+
     def _run_task(self):
         resolved = self._resolved_path
         folder_id = self._folder_id
@@ -245,6 +280,11 @@ class ReferenceFolderScanTask(BaseTask):
                 "Library root scan skipped: an unanswered local import was "
                 "recorded after the scan was queued. Retried on a later cycle."
             )
+            return {"status": "skipped", "folder_id": folder_id}
+
+        # And the same question the cheap way, for the commit that starts
+        # AFTER the read above. See `_import_started_mid_scan`.
+        if self._import_started_mid_scan():
             return {"status": "skipped", "folder_id": folder_id}
 
         if not os.path.isdir(resolved):
@@ -368,6 +408,14 @@ class ReferenceFolderScanTask(BaseTask):
             )
 
         for root, dirs, files in os.walk(resolved, topdown=True, onerror=_walk_error):
+            # One `is_set()` per directory: a commit accepted after the gate
+            # read above is seen at the latest one directory later, and this
+            # walk has built nothing yet, so stopping here leaves the whole
+            # import to the commit. `_root_last_scanned` stays stamped and
+            # `on_root_scanned` is not called, so the purge sweep keeps
+            # waiting. See `_import_started_mid_scan`.
+            if self._import_started_mid_scan():
+                return {"status": "skipped", "folder_id": folder_id}
             # Prune subdirectories that are roots of other reference folders so
             # their files are only indexed by their own scan task; dot-folders,
             # which are nobody's pictures - a vault's own caches or something

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -59,6 +59,7 @@ from pixlstash.services.set_lock_service import (
     locked_picture_id_subquery,
 )
 from pixlstash.utils.sql_chunking import chunked
+from pixlstash.services.folder_structure_commit_service import local_import_pending
 from pixlstash.services.scrapheap_service import DEFAULT_RETENTION_DAYS
 from pixlstash.services.snapshot_service import SnapshotService
 from pixlstash.services.restore import RestoreService
@@ -155,6 +156,12 @@ class Vault:
             )
         else:
             self.db = VaultDatabase(self._db_path)
+        # A local import that was pending when the process died is resumed, so
+        # the flag that holds the root scan off it has to survive the restart
+        # too. Read once, here: after this instant only the commit service
+        # moves it.
+        if self.db.run_immediate_read_task(local_import_pending):
+            self.db.local_import_running.set()
         self.set_description(description or "")
 
         self.snapshot_service = SnapshotService(self)

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -1006,6 +1006,57 @@ def test_an_interrupted_commit_is_recorded_pending_with_what_it_needs(owner_env)
     )
 
 
+def test_a_pending_local_import_raises_the_flag_the_root_scan_watches(owner_env):
+    """`vault.db.local_import_running` is the in-process half of the gate.
+
+    The root scan's database re-check reads and releases, and the task does
+    more work before `os.walk`; a commit accepted in that window would build
+    the same files twice. The flag closes it, so it has to go up with the
+    record and come down with the settle. A `reference` commit never raises
+    it: it says nothing about the root's own pictures.
+    """
+    from pixlstash.services import folder_structure_commit_service as svc
+
+    server = owner_env["server"]
+    flag = server.vault.db.local_import_running
+    assert not flag.is_set(), "nothing is importing yet"
+
+    svc.record_pending_commit(
+        server,
+        task_id="test-flag-reference",
+        root_path=os.path.join(owner_env["tmp"], "flag-reference"),
+        mode="reference",
+        label=None,
+        expected_pictures=0,
+        assignments=[],
+    )
+    try:
+        assert not flag.is_set(), "a reference commit is not a local import"
+    finally:
+        svc.settle_pending_commit(server, "test-flag-reference", "abandoned")
+
+    svc.record_pending_commit(
+        server,
+        task_id="test-flag-local",
+        root_path=server.vault.image_root,
+        mode="local_import",
+        label=None,
+        expected_pictures=0,
+        assignments=[],
+    )
+    try:
+        assert flag.is_set(), (
+            "set before the row is written and before the commit walks, so a "
+            "scan checking it after its own gate read cannot miss this import"
+        )
+    finally:
+        svc.settle_pending_commit(server, "test-flag-local", "abandoned")
+    assert not flag.is_set(), (
+        "settling the last pending local import lowers it again; a gate that "
+        "stayed shut would stop the root scan for the life of the process"
+    )
+
+
 def test_stopping_a_commit_that_is_over_reports_what_it_actually_is(owner_env):
     """Same honesty as the read's cancel: no claim the client cannot check."""
     owner, server = owner_env["owner"], owner_env["server"]

--- a/tests/test_library_root_scan.py
+++ b/tests/test_library_root_scan.py
@@ -19,6 +19,10 @@ from sqlmodel import Session, select
 
 from pixlstash.db_models import Character, Picture, Tag
 from pixlstash.db_models.external_move_review import ExternalMoveReview
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_DEFERRED,
+    FolderMappingCommit,
+)
 from pixlstash.db_models.library_settings import LibrarySettings
 from pixlstash.db_models.picture_move import PictureMove
 from pixlstash.server import Server
@@ -254,11 +258,6 @@ def test_the_finder_hands_out_the_root_scan_once_per_interval(server):
     # The root is only scanned once the first import offer is answered (see
     # test_root_scan_first_import.py). On a shard where this test runs first
     # the module vault is empty, so answer it here rather than rely on order.
-    from pixlstash.db_models.folder_mapping_commit import (
-        STATE_DEFERRED,
-        FolderMappingCommit,
-    )
-
     def answer(session):
         session.add(
             FolderMappingCommit(

--- a/tests/test_library_root_scan.py
+++ b/tests/test_library_root_scan.py
@@ -251,6 +251,27 @@ def test_an_owner_move_in_a_laid_out_root_is_queued_for_review(server):
 
 
 def test_the_finder_hands_out_the_root_scan_once_per_interval(server):
+    # The root is only scanned once the first import offer is answered (see
+    # test_root_scan_first_import.py). On a shard where this test runs first
+    # the module vault is empty, so answer it here rather than rely on order.
+    from pixlstash.db_models.folder_mapping_commit import (
+        STATE_DEFERRED,
+        FolderMappingCommit,
+    )
+
+    def answer(session):
+        session.add(
+            FolderMappingCommit(
+                task_id="answered-by-test",
+                root_path=server.vault.image_root,
+                mode="local_import",
+                expected_pictures=0,
+                state=STATE_DEFERRED,
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(answer)
     finder = ReferenceFolderScanFinder(
         database=server.vault.db,
         path_mapper=PathMapper(),

--- a/tests/test_library_root_scan.py
+++ b/tests/test_library_root_scan.py
@@ -53,7 +53,28 @@ def server():
             for task_type in _CONFLICTING_FINDERS:
                 srv.vault._planner_work_finders.pop(task_type)
             srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
+            # The root is only scanned once the first import offer is answered,
+            # and the task asks as well as the finder (see
+            # test_root_scan_first_import.py). This module runs scans by hand
+            # on a vault that starts empty, so answer it once for all of them.
+            srv.vault.db.run_task(_answer_the_import_offer(srv))
             yield srv
+
+
+def _answer_the_import_offer(server):
+    def answer(session: Session):
+        session.add(
+            FolderMappingCommit(
+                task_id="answered-by-test",
+                root_path=server.vault.image_root,
+                mode="local_import",
+                expected_pictures=0,
+                state=STATE_DEFERRED,
+            )
+        )
+        session.commit()
+
+    return answer
 
 
 def _make_image(path, color, *, settled=True):
@@ -255,22 +276,8 @@ def test_an_owner_move_in_a_laid_out_root_is_queued_for_review(server):
 
 
 def test_the_finder_hands_out_the_root_scan_once_per_interval(server):
-    # The root is only scanned once the first import offer is answered (see
-    # test_root_scan_first_import.py). On a shard where this test runs first
-    # the module vault is empty, so answer it here rather than rely on order.
-    def answer(session):
-        session.add(
-            FolderMappingCommit(
-                task_id="answered-by-test",
-                root_path=server.vault.image_root,
-                mode="local_import",
-                expected_pictures=0,
-                state=STATE_DEFERRED,
-            )
-        )
-        session.commit()
-
-    server.vault.db.run_task(answer)
+    # The import offer is answered in the module fixture; without it neither
+    # the finder nor the task would hand out a root scan at all.
     finder = ReferenceFolderScanFinder(
         database=server.vault.db,
         path_mapper=PathMapper(),

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -223,8 +223,27 @@ def test_an_aborted_local_import_holds_the_root_scan_off_over_its_own_rows(serve
     )
     assert finder.find_task() is None
     # Nothing was cached, so a later import that does settle still releases
-    # the scan: settled is read before abandoned.
+    # the scan: the newest record decides.
     _record(server, STATE_DONE)
     task = finder.find_task()
     assert task is not None and task.params["folder_id"] is None
     assert finder.first_import_answered() is True
+
+
+def test_an_abort_after_an_earlier_import_still_holds_the_root_scan_off(server):
+    """The reverse order. Records are kept, so a `done` from last week must
+    not outrank the abort the owner just made: the newest record is the
+    answer, and it says bring nothing in."""
+    _drop_picture(server.vault.image_root, "kept.png")
+
+    def add(session: Session):
+        session.add(Picture(file_path="kept.png", pixel_sha="y" * 64))
+        session.commit()
+
+    server.vault.db.run_task(add)
+    _record(server, STATE_DONE)
+    _record(server, STATE_ABANDONED)
+
+    finder = _finder(server)
+    assert finder.first_import_answered() is False
+    assert finder.find_task() is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -282,3 +282,26 @@ def test_the_same_finder_closes_the_gate_again_for_a_later_import(server):
     finder.mark_root_due()
     assert finder.first_import_answered() is False
     assert finder.find_task() is None
+
+
+def test_a_closed_gate_is_not_asked_on_every_planner_sweep(server, monkeypatch):
+    """The planner sweeps up to twenty times a second and the importer wakes
+    it after every chunk; while the gate says no it is asked again only after
+    a short deadline, not on every sweep."""
+    _record(server, STATE_PENDING)
+    finder = _finder(server)
+    real = server.vault.db.run_immediate_read_task
+    calls = []
+
+    def counted(func, *args, **kwargs):
+        calls.append(1)
+        return real(func, *args, **kwargs)
+
+    monkeypatch.setattr(server.vault.db, "run_immediate_read_task", counted)
+    now = 1_000.0
+    assert finder._root_task([], now) is None
+    assert finder._root_task([], now + 0.05) is None
+    assert finder._root_task([], now + 1.0) is None
+    assert len(calls) == 1, "one query per retry window, not one per sweep"
+    assert finder._root_task([], now + 6.0) is None
+    assert len(calls) == 2

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -266,3 +266,19 @@ def test_a_superseded_local_import_holds_the_root_scan_off_too(server):
     finder = _finder(server)
     assert finder.first_import_answered() is False
     assert finder.find_task() is None
+
+
+def test_the_same_finder_closes_the_gate_again_for_a_later_import(server):
+    """A finder lives as long as the process. Once one import has settled it
+    must still notice the next one starting: a positive answer is not
+    remembered, it is asked again before every due scan."""
+    _record(server, STATE_DONE)
+    finder = _finder(server)
+    assert finder.first_import_answered() is True
+    task = finder.find_task()
+    assert task is not None and task.params["folder_id"] is None
+
+    _record(server, STATE_PENDING)
+    finder.mark_root_due()
+    assert finder.first_import_answered() is False
+    assert finder.find_task() is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -42,11 +42,12 @@ _CONFLICTING_FINDERS = (
 )
 
 
-@pytest.fixture(scope="module")
-def _module_server():
-    """One Server for the module: starting it is what these tests cost, and
-    every case here reads the same two tables. Same shape as
-    tests/test_library_root_scan.py."""
+@pytest.fixture
+def server():
+    """A Server per test. A module-scoped one outlived the other modules a CI
+    shard runs beside it and came back to "no such table" once their servers
+    had torn the shared vault location down under it; the few seconds a
+    fresh server costs per case buy a library that is really empty."""
     with tempfile.TemporaryDirectory() as temp_dir:
         config_path = os.path.join(temp_dir, "server-config.json")
         with Server(config_path) as srv:
@@ -54,28 +55,6 @@ def _module_server():
                 srv.vault._planner_work_finders.pop(task_type)
             srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
             yield srv
-
-
-@pytest.fixture
-def server(_module_server):
-    """The shared server with an empty library: no commit record, no picture
-    row and nothing in the root folder, so each case starts from "the owner
-    has not been asked yet" the way a per-test Server used to."""
-    srv = _module_server
-
-    def wipe(session: Session):
-        for model in (FolderMappingCommit, Picture):
-            for row in session.exec(select(model)).all():
-                session.delete(row)
-        session.commit()
-
-    root = srv.vault.image_root
-    for name in os.listdir(root):
-        path = os.path.join(root, name)
-        if os.path.isfile(path):
-            os.remove(path)
-    srv.vault.db.run_task(wipe)
-    yield srv
 
 
 def _drop_picture(root, name):
@@ -313,14 +292,16 @@ def test_a_closed_gate_is_not_asked_on_every_planner_sweep(server, monkeypatch):
     a short deadline, not on every sweep."""
     _record(server, STATE_PENDING)
     finder = _finder(server)
-    real = server.vault.db.run_immediate_read_task
     calls = []
+    real = finder.first_import_answered
 
-    def counted(func, *args, **kwargs):
+    def counted():
+        # Counted on the finder itself: the server's other finders share the
+        # database handle, and their own reads are not the question here.
         calls.append(1)
-        return real(func, *args, **kwargs)
+        return real()
 
-    monkeypatch.setattr(server.vault.db, "run_immediate_read_task", counted)
+    monkeypatch.setattr(finder, "first_import_answered", counted)
     now = 1_000.0
     assert finder._root_task([], now) is None
     assert finder._root_task([], now + 0.05) is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -28,7 +28,7 @@ from pixlstash.db_models.folder_mapping_commit import (
 )
 from pixlstash.db_models.picture import Picture
 from pixlstash.server import Server
-from pixlstash.tasks import TaskType
+from pixlstash.tasks import TaskType, reference_folder_scan_task
 from pixlstash.tasks.reference_folder_scan_finder import ReferenceFolderScanFinder
 from pixlstash.utils.path_mapper import PathMapper
 
@@ -115,6 +115,19 @@ def _settle_pending(server, state):
         session.commit()
 
     server.vault.db.run_task(write)
+
+
+def _managed(server):
+    """The library's own pictures, oldest id first."""
+    return server.vault.db.run_task(
+        lambda s: list(
+            s.exec(
+                select(Picture)
+                .where(Picture.reference_folder_id.is_(None))
+                .order_by(Picture.id)
+            ).all()
+        )
+    )
 
 
 def _due(finder):
@@ -313,3 +326,34 @@ def test_a_closed_gate_is_not_asked_on_every_planner_sweep(server, monkeypatch):
     assert len(calls) == 1, "one query per retry window, not one per sweep"
     assert finder._root_task([], now + 6.0) is None
     assert len(calls) == 2
+
+
+def test_a_scan_handed_out_before_a_pending_import_walks_nothing(server, monkeypatch):
+    """The handoff, not the read. The finder's gate said yes and handed the
+    task out; `record_pending_commit` then wrote a pending record before the
+    runner started it. The task asks the same question again at start, so the
+    stale answer it was handed out on cannot make it walk."""
+    _drop_picture(server.vault.image_root, "handoff.png")
+    _record(server, STATE_DONE)
+    task = _due(_finder(server)).find_task()
+    assert task is not None and task.params["folder_id"] is None
+
+    walked: list[str] = []
+    real_walk = os.walk
+
+    def spy(path, *args, **kwargs):
+        walked.append(path)
+        return real_walk(path, *args, **kwargs)
+
+    monkeypatch.setattr(reference_folder_scan_task.os, "walk", spy)
+
+    _record(server, STATE_PENDING)
+    assert task._run_task() == {"status": "skipped", "folder_id": None}
+    assert walked == [], "the gate closed after the hand-out; nothing is walked"
+    assert _managed(server) == [], "so no row is built and no move reconciled"
+
+    # The control: the same task, with the record settled, scans as before.
+    _settle_pending(server, STATE_DONE)
+    assert task._run_task()["status"] == "active"
+    assert server.vault.image_root in walked
+    assert [p.file_path for p in _managed(server)] == ["handoff.png"]

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -40,8 +40,11 @@ _CONFLICTING_FINDERS = (
 )
 
 
-@pytest.fixture
-def server():
+@pytest.fixture(scope="module")
+def _module_server():
+    """One Server for the module: starting it is what these tests cost, and
+    every case here reads the same two tables. Same shape as
+    tests/test_library_root_scan.py."""
     with tempfile.TemporaryDirectory() as temp_dir:
         config_path = os.path.join(temp_dir, "server-config.json")
         with Server(config_path) as srv:
@@ -49,6 +52,28 @@ def server():
                 srv.vault._planner_work_finders.pop(task_type)
             srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
             yield srv
+
+
+@pytest.fixture
+def server(_module_server):
+    """The shared server with an empty library: no commit record, no picture
+    row and nothing in the root folder, so each case starts from "the owner
+    has not been asked yet" the way a per-test Server used to."""
+    srv = _module_server
+
+    def wipe(session: Session):
+        for model in (FolderMappingCommit, Picture):
+            for row in session.exec(select(model)).all():
+                session.delete(row)
+        session.commit()
+
+    root = srv.vault.image_root
+    for name in os.listdir(root):
+        path = os.path.join(root, name)
+        if os.path.isfile(path):
+            os.remove(path)
+    srv.vault.db.run_task(wipe)
+    yield srv
 
 
 def _drop_picture(root, name):
@@ -175,3 +200,31 @@ def test_a_running_local_import_holds_the_root_scan_off_though_it_has_committed_
     _settle_pending(server, STATE_DONE)
     task = finder.find_task()
     assert task is not None and task.params["folder_id"] is None
+
+
+def test_an_aborted_local_import_holds_the_root_scan_off_over_its_own_rows(server):
+    """An abort settles the record `abandoned` and leaves every chunk the
+    commit had already inserted indexed. Those rows are the files the owner
+    just refused, so reading them as the answer would scan the root and import
+    exactly what the abort declined."""
+    _drop_picture(server.vault.image_root, "aborted.png")
+
+    def add(session: Session):
+        session.add(Picture(file_path="aborted.png", pixel_sha="z" * 64))
+        session.commit()
+
+    server.vault.db.run_task(add)
+    _record(server, STATE_ABANDONED)
+
+    finder = _finder(server)
+    assert finder.first_import_answered() is False, (
+        "a chunk the aborted commit had already inserted is not an answer to "
+        "import; scanning on it imports the very files the owner declined"
+    )
+    assert finder.find_task() is None
+    # Nothing was cached, so a later import that does settle still releases
+    # the scan: settled is read before abandoned.
+    _record(server, STATE_DONE)
+    task = finder.find_task()
+    assert task is not None and task.params["folder_id"] is None
+    assert finder.first_import_answered() is True

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -11,6 +11,7 @@ answer puts the root scan into a race with it.
 """
 
 import os
+import shutil
 import tempfile
 import time
 
@@ -28,6 +29,7 @@ from pixlstash.db_models.folder_mapping_commit import (
 )
 from pixlstash.db_models.picture import Picture
 from pixlstash.server import Server
+from pixlstash.vault import Vault
 from pixlstash.tasks import TaskType, reference_folder_scan_task
 from pixlstash.tasks.reference_folder_scan_finder import ReferenceFolderScanFinder
 from pixlstash.utils.path_mapper import PathMapper
@@ -357,3 +359,88 @@ def test_a_scan_handed_out_before_a_pending_import_walks_nothing(server, monkeyp
     assert task._run_task()["status"] == "active"
     assert server.vault.image_root in walked
     assert [p.file_path for p in _managed(server)] == ["handoff.png"]
+
+
+def test_an_import_that_starts_mid_walk_stops_the_scan_one_directory_later(
+    server, monkeypatch
+):
+    """The window the re-check alone cannot close.
+
+    `root_import_answered` reads the database and releases it, and the task
+    does more work before `os.walk` starts. `vault.db.local_import_running`
+    is raised by `record_pending_commit` BEFORE its row and before its own
+    walk, and the scan asks it once per directory, so an import accepted mid
+    walk costs at most the one directory already in hand - whose rows the
+    commit's `insert()` reuses - rather than the whole tree.
+    """
+    root = server.vault.image_root
+    _drop_picture(root, "top.png")
+    sub = os.path.join(root, "later")
+    os.makedirs(sub, exist_ok=True)
+    _drop_picture(sub, "deep.png")
+    _record(server, STATE_DONE)
+    task = _due(_finder(server)).find_task()
+    assert task is not None and task.params["folder_id"] is None
+
+    walked: list[str] = []
+    real_walk = os.walk
+
+    def spy(path, *args, **kwargs):
+        for entry in real_walk(path, *args, **kwargs):
+            walked.append(entry[0])
+            yield entry
+            # The owner's click landing between two directories, which is
+            # exactly where `record_pending_commit` raises the flag.
+            server.vault.db.local_import_running.set()
+
+    monkeypatch.setattr(reference_folder_scan_task.os, "walk", spy)
+    try:
+        assert task._run_task() == {"status": "skipped", "folder_id": None}
+        assert walked == [root, sub], (
+            "one directory, not the rest of the tree: the flag is asked per "
+            "directory, so the walk stops at the next one"
+        )
+        assert _managed(server) == [], (
+            "the scan returns before it builds anything, so the import owns "
+            "every file including the ones this walk had already listed"
+        )
+
+        # The control: the same task, walking plainly with the flag down,
+        # indexes both directories.
+        monkeypatch.undo()
+        server.vault.db.local_import_running.clear()
+        assert task._run_task()["status"] == "active"
+        assert sorted(p.file_path for p in _managed(server)) == [
+            os.path.join("later", "deep.png"),
+            "top.png",
+        ]
+    finally:
+        server.vault.db.local_import_running.clear()
+        shutil.rmtree(sub, ignore_errors=True)
+
+
+def test_a_vault_resuming_a_pending_import_starts_with_the_flag_up(tmp_path):
+    """A crash mid-import is resumed at the next start-up, so the flag that
+    holds the root scan off it has to survive the restart. `Vault.__init__`
+    seeds it from the record; an in-memory flag alone would come up down and
+    let the boot scan race the resumed commit."""
+    root = str(tmp_path / "resumed-library")
+    with Vault(image_root=root, disable_background_workers=True) as vault:
+        assert not vault.db.local_import_running.is_set(), "a fresh library"
+
+        def write(session: Session):
+            session.add(
+                FolderMappingCommit(
+                    task_id="interrupted-import",
+                    root_path=root,
+                    mode="local_import",
+                    expected_pictures=1,
+                    state=STATE_PENDING,
+                )
+            )
+            session.commit()
+
+        vault.db.run_task(write)
+
+    with Vault(image_root=root, disable_background_workers=True) as resumed:
+        assert resumed.db.local_import_running.is_set()

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -52,13 +52,13 @@ def _drop_picture(root, name):
     os.utime(path, (old, old))
 
 
-def _record(server, state):
+def _record(server, state, mode="local_import"):
     def write(session: Session):
         session.add(
             FolderMappingCommit(
-                task_id=f"t-{state}",
+                task_id=f"t-{mode}-{state}",
                 root_path=server.vault.image_root,
-                mode="local_import",
+                mode=mode,
                 expected_pictures=1,
                 state=state,
             )
@@ -86,6 +86,12 @@ def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answere
 
     _record(server, STATE_ABANDONED)
     assert finder.find_task() is None, "an abort is not an answer to import"
+
+    _record(server, STATE_DEFERRED, mode="reference")
+    assert finder.find_task() is None, (
+        "a reference-folder commit registers some other folder; it says "
+        "nothing about the root's own pictures"
+    )
 
     _record(server, STATE_DEFERRED)
     task = finder.find_task()

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -16,14 +16,17 @@ import time
 
 import pytest
 from PIL import Image
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from pixlstash.db_models.folder_mapping_commit import (
     STATE_ABANDONED,
     STATE_DEFERRED,
+    STATE_DONE,
     STATE_PENDING,
+    STATE_SUPERSEDED,
     FolderMappingCommit,
 )
+from pixlstash.db_models.picture import Picture
 from pixlstash.server import Server
 from pixlstash.tasks import TaskType
 from pixlstash.tasks.reference_folder_scan_finder import ReferenceFolderScanFinder
@@ -71,6 +74,24 @@ def _record(server, state, mode="local_import"):
     server.vault.db.run_task(write)
 
 
+def _settle_pending(server, state):
+    """Move every pending record to *state*, the way the commit's own settle
+    (or `record_pending_commit` superseding it) does. A pending row never
+    survives alongside a newer answer in the real flow."""
+
+    def write(session: Session):
+        for row in session.exec(
+            select(FolderMappingCommit).where(
+                FolderMappingCommit.state == STATE_PENDING
+            )
+        ).all():
+            row.state = state
+            session.add(row)
+        session.commit()
+
+    server.vault.db.run_task(write)
+
+
 def _finder(server):
     return ReferenceFolderScanFinder(
         database=server.vault.db,
@@ -97,6 +118,7 @@ def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answere
         "builds its own rows with the sidecar probe and insert() reuses them "
         "without applying the owner's caption choices"
     )
+    _settle_pending(server, STATE_SUPERSEDED)
 
     _record(server, STATE_DEFERRED, mode="reference")
     assert finder.find_task() is None, (
@@ -119,12 +141,37 @@ def test_a_library_that_holds_a_picture_is_scanned_as_before(server):
     finder = _finder(server)
     assert finder.find_task() is None
 
-    from pixlstash.db_models.picture import Picture
-
     def add(session: Session):
         session.add(Picture(file_path="first.png", pixel_sha="x" * 64))
         session.commit()
 
     server.vault.db.run_task(add)
+    task = finder.find_task()
+    assert task is not None and task.params["folder_id"] is None
+
+
+def test_a_running_local_import_holds_the_root_scan_off_though_it_has_committed_rows(
+    server,
+):
+    """`local_import_pictures` commits every chunk and wakes the planner while
+    its record is still pending, so the library holds pictures long before the
+    owner's answer is applied. The pending record wins, and the answer is not
+    cached: the commit's own settle is what releases the scan."""
+    _drop_picture(server.vault.image_root, "chunk.png")
+
+    def add(session: Session):
+        session.add(Picture(file_path="chunk.png", pixel_sha="y" * 64))
+        session.commit()
+
+    server.vault.db.run_task(add)
+    _record(server, STATE_PENDING)
+
+    finder = _finder(server)
+    assert finder.first_import_answered() is False, (
+        "a chunk the running commit already inserted is not the owner's answer"
+    )
+    assert finder.find_task() is None
+    # Nothing was cached, so the commit settling still releases the scan.
+    _settle_pending(server, STATE_DONE)
     task = finder.find_task()
     assert task is not None and task.params["folder_id"] is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -247,3 +247,22 @@ def test_an_abort_after_an_earlier_import_still_holds_the_root_scan_off(server):
     finder = _finder(server)
     assert finder.first_import_answered() is False
     assert finder.find_task() is None
+
+
+def test_a_superseded_local_import_holds_the_root_scan_off_too(server):
+    """`record_pending_commit` supersedes a pending record of either mode, so a
+    partial local import can be replaced by a reference commit and stay the
+    newest local-import row. Its chunks are as unanswered as a pending one's."""
+    _drop_picture(server.vault.image_root, "partial.png")
+
+    def add(session: Session):
+        session.add(Picture(file_path="partial.png", pixel_sha="x" * 64))
+        session.commit()
+
+    server.vault.db.run_task(add)
+    _record(server, STATE_SUPERSEDED)
+    _record(server, STATE_DONE, mode="reference")
+
+    finder = _finder(server)
+    assert finder.first_import_answered() is False
+    assert finder.find_task() is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -1,0 +1,113 @@
+"""The boot-time root scan waits for the first import offer to be answered.
+
+A fresh library whose folder already holds pictures is asked what those
+pictures are - the first-run offer, and "Add a library" - and the app makes
+the offer only while the library is empty. The root scan is due the moment
+the backend boots, so on a small library it indexed everything before the
+screen came up and the questions never appeared. It now waits until the
+library holds a picture or a folder-mapping commit has been recorded.
+"""
+
+import os
+import tempfile
+import time
+
+import pytest
+from PIL import Image
+from sqlmodel import Session
+
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_ABANDONED,
+    STATE_DEFERRED,
+    FolderMappingCommit,
+)
+from pixlstash.server import Server
+from pixlstash.tasks import TaskType
+from pixlstash.tasks.reference_folder_scan_finder import ReferenceFolderScanFinder
+from pixlstash.utils.path_mapper import PathMapper
+
+_CONFLICTING_FINDERS = (
+    TaskType.THUMBNAIL_GENERATION,
+    TaskType.REFERENCE_FOLDER_SCAN,
+    TaskType.MISSING_FILE_PURGE,
+    TaskType.TAGGER,
+)
+
+
+@pytest.fixture
+def server():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = os.path.join(temp_dir, "server-config.json")
+        with Server(config_path) as srv:
+            for task_type in _CONFLICTING_FINDERS:
+                srv.vault._planner_work_finders.pop(task_type)
+            srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
+            yield srv
+
+
+def _drop_picture(root, name):
+    path = os.path.join(root, name)
+    Image.new("RGB", (8, 8), color=(3, 4, 5)).save(path, format="PNG")
+    old = time.time() - 600
+    os.utime(path, (old, old))
+
+
+def _record(server, state):
+    def write(session: Session):
+        session.add(
+            FolderMappingCommit(
+                task_id=f"t-{state}",
+                root_path=server.vault.image_root,
+                mode="local_import",
+                expected_pictures=1,
+                state=state,
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(write)
+
+
+def _finder(server):
+    return ReferenceFolderScanFinder(
+        database=server.vault.db,
+        path_mapper=PathMapper(),
+        image_root=server.vault.image_root,
+    )
+
+
+def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answered(
+    server,
+):
+    _drop_picture(server.vault.image_root, "loose.png")
+    finder = _finder(server)
+    assert finder.first_import_answered() is False
+    assert finder.find_task() is None, "the owner has not been asked yet"
+
+    _record(server, STATE_ABANDONED)
+    assert finder.find_task() is None, "an abort is not an answer to import"
+
+    _record(server, STATE_DEFERRED)
+    task = finder.find_task()
+    assert task is not None and task.params["folder_id"] is None, (
+        "organise later is an answer: index everything, map nothing"
+    )
+    assert finder.first_import_answered() is True
+
+
+def test_a_library_that_holds_a_picture_is_scanned_as_before(server):
+    """Nothing changes for an existing library: a picture row, however it got
+    there, is the answer."""
+    _drop_picture(server.vault.image_root, "first.png")
+    finder = _finder(server)
+    assert finder.find_task() is None
+
+    from pixlstash.db_models.picture import Picture
+
+    def add(session: Session):
+        session.add(Picture(file_path="first.png", pixel_sha="x" * 64))
+        session.commit()
+
+    server.vault.db.run_task(add)
+    task = finder.find_task()
+    assert task is not None and task.params["folder_id"] is None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -5,7 +5,9 @@ pictures are - the first-run offer, and "Add a library" - and the app makes
 the offer only while the library is empty. The root scan is due the moment
 the backend boots, so on a small library it indexed everything before the
 screen came up and the questions never appeared. It now waits until the
-library holds a picture or a folder-mapping commit has been recorded.
+library holds a picture or a local_import commit has SETTLED - done or
+deferred. A pending one is the commit still running, and treating it as an
+answer puts the root scan into a race with it.
 """
 
 import os
@@ -19,6 +21,7 @@ from sqlmodel import Session
 from pixlstash.db_models.folder_mapping_commit import (
     STATE_ABANDONED,
     STATE_DEFERRED,
+    STATE_PENDING,
     FolderMappingCommit,
 )
 from pixlstash.server import Server
@@ -86,6 +89,14 @@ def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answere
 
     _record(server, STATE_ABANDONED)
     assert finder.find_task() is None, "an abort is not an answer to import"
+
+    _record(server, STATE_PENDING)
+    assert finder.find_task() is None, (
+        "a pending record is the commit still running - the question, not the "
+        "answer. Counting it lets the 300 s root scan race the commit: it "
+        "builds its own rows with the sidecar probe and insert() reuses them "
+        "without applying the owner's caption choices"
+    )
 
     _record(server, STATE_DEFERRED, mode="reference")
     assert finder.find_task() is None, (

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -117,6 +117,14 @@ def _settle_pending(server, state):
     server.vault.db.run_task(write)
 
 
+def _due(finder):
+    """The next planning cycle after something changed: a closed gate is asked
+    again only after `_GATE_RETRY_S`, and `mark_root_due` is what clears that
+    deadline (and the scan interval) so the tests do not wait it out."""
+    finder.mark_root_due()
+    return finder
+
+
 def _finder(server):
     return ReferenceFolderScanFinder(
         database=server.vault.db,
@@ -131,13 +139,13 @@ def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answere
     _drop_picture(server.vault.image_root, "loose.png")
     finder = _finder(server)
     assert finder.first_import_answered() is False
-    assert finder.find_task() is None, "the owner has not been asked yet"
+    assert _due(finder).find_task() is None, "the owner has not been asked yet"
 
     _record(server, STATE_ABANDONED)
-    assert finder.find_task() is None, "an abort is not an answer to import"
+    assert _due(finder).find_task() is None, "an abort is not an answer to import"
 
     _record(server, STATE_PENDING)
-    assert finder.find_task() is None, (
+    assert _due(finder).find_task() is None, (
         "a pending record is the commit still running - the question, not the "
         "answer. Counting it lets the 300 s root scan race the commit: it "
         "builds its own rows with the sidecar probe and insert() reuses them "
@@ -146,13 +154,13 @@ def test_a_fresh_library_over_pictures_is_not_scanned_until_the_offer_is_answere
     _settle_pending(server, STATE_SUPERSEDED)
 
     _record(server, STATE_DEFERRED, mode="reference")
-    assert finder.find_task() is None, (
+    assert _due(finder).find_task() is None, (
         "a reference-folder commit registers some other folder; it says "
         "nothing about the root's own pictures"
     )
 
     _record(server, STATE_DEFERRED)
-    task = finder.find_task()
+    task = _due(finder).find_task()
     assert task is not None and task.params["folder_id"] is None, (
         "organise later is an answer: index everything, map nothing"
     )
@@ -164,14 +172,14 @@ def test_a_library_that_holds_a_picture_is_scanned_as_before(server):
     there, is the answer."""
     _drop_picture(server.vault.image_root, "first.png")
     finder = _finder(server)
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
 
     def add(session: Session):
         session.add(Picture(file_path="first.png", pixel_sha="x" * 64))
         session.commit()
 
     server.vault.db.run_task(add)
-    task = finder.find_task()
+    task = _due(finder).find_task()
     assert task is not None and task.params["folder_id"] is None
 
 
@@ -195,10 +203,10 @@ def test_a_running_local_import_holds_the_root_scan_off_though_it_has_committed_
     assert finder.first_import_answered() is False, (
         "a chunk the running commit already inserted is not the owner's answer"
     )
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
     # Nothing was cached, so the commit settling still releases the scan.
     _settle_pending(server, STATE_DONE)
-    task = finder.find_task()
+    task = _due(finder).find_task()
     assert task is not None and task.params["folder_id"] is None
 
 
@@ -221,11 +229,11 @@ def test_an_aborted_local_import_holds_the_root_scan_off_over_its_own_rows(serve
         "a chunk the aborted commit had already inserted is not an answer to "
         "import; scanning on it imports the very files the owner declined"
     )
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
     # Nothing was cached, so a later import that does settle still releases
     # the scan: the newest record decides.
     _record(server, STATE_DONE)
-    task = finder.find_task()
+    task = _due(finder).find_task()
     assert task is not None and task.params["folder_id"] is None
     assert finder.first_import_answered() is True
 
@@ -246,7 +254,7 @@ def test_an_abort_after_an_earlier_import_still_holds_the_root_scan_off(server):
 
     finder = _finder(server)
     assert finder.first_import_answered() is False
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
 
 
 def test_a_superseded_local_import_holds_the_root_scan_off_too(server):
@@ -265,7 +273,7 @@ def test_a_superseded_local_import_holds_the_root_scan_off_too(server):
 
     finder = _finder(server)
     assert finder.first_import_answered() is False
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
 
 
 def test_the_same_finder_closes_the_gate_again_for_a_later_import(server):
@@ -275,13 +283,13 @@ def test_the_same_finder_closes_the_gate_again_for_a_later_import(server):
     _record(server, STATE_DONE)
     finder = _finder(server)
     assert finder.first_import_answered() is True
-    task = finder.find_task()
+    task = _due(finder).find_task()
     assert task is not None and task.params["folder_id"] is None
 
     _record(server, STATE_PENDING)
     finder.mark_root_due()
     assert finder.first_import_answered() is False
-    assert finder.find_task() is None
+    assert _due(finder).find_task() is None
 
 
 def test_a_closed_gate_is_not_asked_on_every_planner_sweep(server, monkeypatch):


### PR DESCRIPTION
On a small library the boot-time root scan (`ReferenceFolderScanFinder`, `folder_id=None`, due at boot) indexed every picture before the app loaded, so the grid was no longer empty, `onLibraryLoaded({empty})` never called `offerLoosePictures`, and the folder-mapping questions never appeared after a first-run import. The pictures were tagged from their sidecars by convention probing, with no chance to confirm.

The finder now skips the root scan until the first import has actually been answered, and remembers the answer once it has one (`first_import_answered`). Only a **settled** `local_import` record counts as the answer: `done`, or `deferred` ("organise later", which is an answer - index everything, map nothing). A `pending` or an `abandoned` one holds the scan off instead, because both leave chunk-committed pictures behind that the owner has not answered for: a running commit would race the scan mid-import, and an aborted one would have the scan import the very files the abort declined. Existing `Picture` rows count as the answer only when there is no pending and no abandoned import, so a library with pictures in it is scanned exactly as before and existing libraries are unaffected. A later settled import outranks an earlier abandoned one. The one behaviour that changes: an empty library's first pictures arrive through the import offer rather than by the watcher, which is what the offer exists for.

Test: `tests/test_root_scan_first_import.py` on a fresh vault. Docs: the root-scan bullet in `backend_architecture.md`. Changelog fragment included.
