### PR TITLE
Hold the work planner while a folder-structure read runs

### DIFF
--- a/changelog.d/folder-read-holds-workers.md
+++ b/changelog.d/folder-read-holds-workers.md
@@ -1,0 +1,5 @@
+- Fixed: reading a folder tree on the mapping screen no longer fights the
+  background workers for the GPU. Each face-detection batch of the read used to
+  alternate with a queued tagging or embedding task, swapping models every time;
+  the read now pauses the planner for a minute at a time, renewed on every batch,
+  so a stalled read still hands the workers back on its own.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -5922,8 +5922,10 @@ again on every face batch, each call setting the lease to one minute from now
 (never accumulating). While the lease runs no finder is swept; tasks already
 queued still run, so the first batches share the GPU with that bounded backlog
 and then have it alone. A lease rather than `stop()`: a read that stalls or dies
-hands the workers back on its own. The deadline still matters, since an URGENT
-task that cannot finish starves the queue it jumped.
+hands the workers back on its own, and a read that finishes calls
+`WorkPlanner.release()` at once, because the commit that follows imports through
+the planner and must not wait out the minute. The deadline still matters, since
+an URGENT task that cannot finish starves the queue it jumped.
 
 ### The shape signals: what a photo library looks like
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -5913,12 +5913,17 @@ frame, and a date-ordered folder would otherwise be judged on its first minute.
 
 `faces` runs through the shipped `FaceDetectionTask` on the shared GPU queue
 rather than opening its own InsightFace session, so there is one model in memory
-rather than two. **It does not queue politely**: `FaceDetectionTask.priority` is
-`URGENT` — "user-triggered interactive tasks, skip ahead of everything" — so
-every batch of the read jumps ahead of background work. That is arguably right
-(the owner is watching a progress bar) but it is worth knowing rather than
-assuming, and it is the reason the read has a deadline: an URGENT task that
-cannot finish starves the queue it jumped.
+rather than two. `FaceDetectionTask.priority` is `URGENT`, but URGENT only wins
+the queue position: the read submits one batch at a time and waits for it, so
+between two batches the single GPU worker took whatever background task the
+planner had queued next, and every switch swapped models. The read therefore
+**holds the work planner**: `WorkPlanner.hold(60)` at the start of the read and
+again on every face batch, each call setting the lease to one minute from now
+(never accumulating). While the lease runs no finder is swept; tasks already
+queued still run, so the first batches share the GPU with that bounded backlog
+and then have it alone. A lease rather than `stop()`: a read that stalls or dies
+hands the workers back on its own. The deadline still matters, since an URGENT
+task that cannot finish starves the queue it jumped.
 
 ### The shape signals: what a photo library looks like
 

--- a/pixlstash/routes/folder_structure.py
+++ b/pixlstash/routes/folder_structure.py
@@ -45,6 +45,13 @@ logger = get_logger(__name__)
 #: times the measured cost of a hundred-picture batch on a CPU-only box.
 _FACE_BATCH_TIMEOUT_S = 180.0
 
+#: How long the read keeps the work planner from submitting background work,
+#: renewed from "now" at the start of the read and on every face batch. A
+#: lease rather than a stop: a read that stalls or dies hands the workers back
+#: on its own, and a walk that outlasts it simply shares the machine again
+#: until the face stage renews it.
+_WORKER_HOLD_S = 60.0
+
 # Matches any non-empty string with no null bytes or newlines. Applied with
 # fullmatch() after realpath so CodeQL recognises the result as a path-injection
 # barrier (realpath alone does not break the taint chain in its model). Same
@@ -245,12 +252,13 @@ def create_router(server) -> APIRouter:
         ``FaceDetectionTask`` rather than opening its own InsightFace session, so
         there is one model in memory rather than two.
 
-        **It does not queue politely.** ``FaceDetectionTask.priority`` is
-        ``URGENT`` - "skip ahead of everything" - so every batch of the read
-        jumps the queue ahead of background work. Defensible (the owner is
-        watching a progress bar) but worth knowing rather than assuming, and it
-        is why the read carries a deadline: an URGENT task that cannot finish
-        starves the queue it jumped. See ``backend_architecture.md`` §24.
+        ``FaceDetectionTask.priority`` is ``URGENT``, but URGENT only wins the
+        queue position: between two batches the single GPU worker takes
+        whatever background task is queued next, and every switch swaps
+        models. So each batch also renews the planner hold (``_WORKER_HOLD_S``)
+        and nothing new is queued behind it while the read is alive. The
+        deadline still matters: an URGENT task that cannot finish starves the
+        queue it jumped. See ``backend_architecture.md`` §24.
         """
         from pixlstash.tasks.face_detection_task import FaceDetectionTask
 
@@ -260,11 +268,17 @@ def create_router(server) -> APIRouter:
             return None
 
         def detect(images: list):
+            _hold_workers()
             return task_runner.submit_and_wait(
                 FaceDetectionTask(engine, images), _FACE_BATCH_TIMEOUT_S
             )
 
         return detect
+
+    def _hold_workers() -> None:
+        planner = getattr(server.vault, "_work_planner", None)
+        if planner is not None:
+            planner.hold(_WORKER_HOLD_S)
 
     @router.post(
         "/folder-structure/read",
@@ -352,6 +366,7 @@ def create_router(server) -> APIRouter:
         state = server.folder_structure_read
         if state and state["task_id"] == task_id:
             state["status"] = "running"
+        _hold_workers()
         try:
             result = read.run()
         except BaseException as exc:  # noqa: BLE001 - the slot must never wedge

--- a/pixlstash/routes/folder_structure.py
+++ b/pixlstash/routes/folder_structure.py
@@ -280,6 +280,13 @@ def create_router(server) -> APIRouter:
         if planner is not None:
             planner.hold(_WORKER_HOLD_S)
 
+    def _release_workers() -> None:
+        # The lease would expire on its own, but the commit that follows a
+        # read imports through the planner and must not wait out the minute.
+        planner = getattr(server.vault, "_work_planner", None)
+        if planner is not None:
+            planner.release()
+
     @router.post(
         "/folder-structure/read",
         summary="Start the folder-structure read",
@@ -370,6 +377,7 @@ def create_router(server) -> APIRouter:
         try:
             result = read.run()
         except BaseException as exc:  # noqa: BLE001 - the slot must never wedge
+            _release_workers()
             logger.error(
                 "Folder-structure read %s failed (%s): %s",
                 task_id,
@@ -390,6 +398,7 @@ def create_router(server) -> APIRouter:
                 raise
             return
 
+        _release_workers()
         state = server.folder_structure_read
         if not state or state["task_id"] != task_id:
             return

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -242,6 +242,10 @@ class WorkPlanner:
         self._stalled_since: dict[str, float] = {}
         self._gpu_util_unavailable = False
         self._gpu_util_torch_missing_logged = False
+        # Monotonic time until which no finder is swept. A lease, not a switch:
+        # the holder renews it while it works and a holder that stalls or dies
+        # lets background work back in by itself.
+        self._hold_until = 0.0
         self._lock = threading.Lock()
         # Serialises start()/stop() so a restart cannot interleave with a
         # shutdown that is still joining the outgoing thread.
@@ -340,6 +344,14 @@ class WorkPlanner:
         with self._lock:
             return int(self._inflight_by_finder.get(finder_name, 0))
 
+    def hold(self, seconds: float) -> None:
+        """Keep every finder from submitting work for *seconds* from now.
+
+        Renewing resets the lease to ``now + seconds``; it never accumulates.
+        Tasks already queued or running are not touched.
+        """
+        self._hold_until = time.monotonic() + seconds
+
     def wake(self):
         self._wake.set()
 
@@ -393,6 +405,11 @@ class WorkPlanner:
 
     def _run(self):
         while not self._stop.is_set():
+            held_for = self._hold_until - time.monotonic()
+            if held_for > 0:
+                self._wake.wait(held_for)
+                self._wake.clear()
+                continue
             try:
                 submitted = self._run_finders_once()
             except Exception:

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -348,14 +348,23 @@ class WorkPlanner:
         """Keep every finder from submitting work for *seconds* from now.
 
         Renewing resets the lease to ``now + seconds``; it never accumulates.
-        Tasks already queued or running are not touched.
+        Tasks already queued or running are not touched, and a sweep that is
+        under way stops at its next finder rather than mid-turn.
         """
-        self._hold_until = time.monotonic() + seconds
+        with self._lock:
+            self._hold_until = time.monotonic() + seconds
+        self._wake.set()
 
     def release(self) -> None:
         """End the hold now rather than letting the lease run out."""
-        self._hold_until = 0.0
+        with self._lock:
+            self._hold_until = 0.0
         self._wake.set()
+
+    def _held_for(self) -> float:
+        """Seconds left on the hold; zero or negative when not held."""
+        with self._lock:
+            return self._hold_until - time.monotonic()
 
     def wake(self):
         self._wake.set()
@@ -410,7 +419,7 @@ class WorkPlanner:
 
     def _run(self):
         while not self._stop.is_set():
-            held_for = self._hold_until - time.monotonic()
+            held_for = self._held_for()
             if held_for > 0:
                 self._wake.wait(held_for)
                 self._wake.clear()
@@ -495,6 +504,8 @@ class WorkPlanner:
             _PlannerStopping: Shutdown began mid-turn; the caller must abandon
                 the whole cycle rather than move on to the next finder.
         """
+        if self._held_for() > 0:
+            return submitted_any
         finder_name = finder.finder_name()
         max_inflight = max(1, int(finder.max_inflight_tasks()))
 

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -352,6 +352,11 @@ class WorkPlanner:
         """
         self._hold_until = time.monotonic() + seconds
 
+    def release(self) -> None:
+        """End the hold now rather than letting the lease run out."""
+        self._hold_until = 0.0
+        self._wake.set()
+
     def wake(self):
         self._wake.set()
 

--- a/tests/test_folder_structure_read.py
+++ b/tests/test_folder_structure_read.py
@@ -788,6 +788,46 @@ def test_a_read_completes_and_reports_its_result(owner_env):
     assert shoot["proposal"]["kind"] == "set"
 
 
+def test_the_read_holds_the_planner_per_batch_and_releases_it(owner_env, monkeypatch):
+    """The route leases the planner at read start and again on every face
+    batch, then releases it the moment the read settles. Both the planner and
+    the task runner are fakes: the point is the calls the route makes, not what
+    InsightFace would say about five blank pictures."""
+    from pixlstash.routes.folder_structure import _WORKER_HOLD_S
+
+    vault = owner_env["server"].vault
+    calls: list[tuple[str, float | None]] = []
+
+    class _Planner:
+        def hold(self, seconds):
+            calls.append(("hold", seconds))
+
+        def release(self):
+            calls.append(("release", None))
+
+    class _Runner:
+        def submit_and_wait(self, task, timeout_s):
+            calls.append(("batch", None))
+            return [[] for _ in task._bgr_images]
+
+    monkeypatch.setattr(vault, "_work_planner", _Planner(), raising=False)
+    monkeypatch.setattr(vault, "_task_runner", _Runner(), raising=False)
+    monkeypatch.setattr(vault, "_engine", object(), raising=False)
+
+    root = os.path.join(owner_env["tmp"], "held")
+    _make_tree(root, {"shoot": [f"{i}.jpg" for i in range(MIN_FACE_SAMPLE)]})
+    started = owner_env["owner"].post(_READ, json={"path": root})
+    assert started.status_code == 200, started.text
+    body = _drain(owner_env["owner"], started.json()["task_id"])
+    assert body["status"] == "completed", body
+
+    assert calls[0] == ("hold", _WORKER_HOLD_S)
+    assert ("batch", None) in calls
+    assert calls.index(("hold", _WORKER_HOLD_S), 1) < calls.index(("batch", None))
+    assert calls[-1] == ("release", None)
+    assert calls.count(("release", None)) == 1
+
+
 def test_the_read_writes_nothing(owner_env):
     """The release's headline, asserted rather than eyeballed."""
     owner = owner_env["owner"]

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -1104,3 +1104,33 @@ def test_tag_timing_line_splits_the_models_and_the_crop_build(caplog, tmp_path):
         "wall_throughput=",
     ):
         assert field in line, line
+
+
+def test_hold_leases_the_planner_and_expires_on_its_own():
+    """A held planner sweeps nothing, stays alive (no "restart the server"
+    wording from worker_unavailable_reason), and resumes when the lease ends."""
+    runner = _FastCompleteRunner()
+    submitted = []
+    runner.on_submit = submitted.append
+    planner = WorkPlanner(task_runner=runner, task_finders=[_OneShotFinder()])
+
+    planner.hold(0.4)
+    planner.start()
+    try:
+        time.sleep(0.2)
+        assert submitted == []
+        assert planner.is_running()
+
+        deadline = time.monotonic() + 3.0
+        while not submitted and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert [task.id for task in submitted] == ["task-1"]
+    finally:
+        planner.stop()
+
+
+def test_hold_is_from_now_and_does_not_accumulate():
+    planner = WorkPlanner(task_runner=_FastCompleteRunner(), task_finders=[])
+    planner.hold(60)
+    planner.hold(60)
+    assert planner._hold_until - time.monotonic() <= 60.0

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -1133,7 +1133,10 @@ def test_hold_is_from_now_and_does_not_accumulate():
     planner = WorkPlanner(task_runner=_FastCompleteRunner(), task_finders=[])
     planner.hold(60)
     planner.hold(60)
-    assert planner._hold_until - time.monotonic() <= 60.0
+    # Bounded on both sides: a lease that accumulated would read near 120, and
+    # the upper bound holds by construction because monotonic() never runs
+    # backwards between the hold and the read.
+    assert 59.0 < planner._held_for() <= 60.0
 
 
 def test_release_ends_the_hold_without_waiting_for_the_lease():

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -1134,3 +1134,20 @@ def test_hold_is_from_now_and_does_not_accumulate():
     planner.hold(60)
     planner.hold(60)
     assert planner._hold_until - time.monotonic() <= 60.0
+
+
+def test_release_ends_the_hold_without_waiting_for_the_lease():
+    runner = _FastCompleteRunner()
+    submitted = []
+    runner.on_submit = submitted.append
+    planner = WorkPlanner(task_runner=runner, task_finders=[_OneShotFinder()])
+    planner.hold(60)
+    planner.start()
+    try:
+        planner.release()
+        deadline = time.monotonic() + 3.0
+        while not submitted and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert [task.id for task in submitted] == ["task-1"]
+    finally:
+        planner.stop()


### PR DESCRIPTION
## Problem

During the folder-structure read (the library mapping screen) every worker competed with InsightFace. The read's `FaceDetectionTask` is URGENT, but URGENT only wins the queue position: the read submits one batch of 100 sampled images and waits for it, so between two batches the single GPU worker took whatever tagging, embedding or face-extraction task the planner had queued next, and every switch swapped models in and out of VRAM. The planner kept those refilled to 3 in flight each, so the interleave lasted the whole read.

## Fix

- `WorkPlanner.hold(seconds)`: a lease, not a stop. No finder is swept until the lease ends. Each call sets it to `now + seconds` and never accumulates. The planner thread stays alive, so `is_running()` stays True and `worker_unavailable_reason` never says "restart the server" during a read.
- The read holds for 60 s at its start and renews on every face batch. A read that stalls or dies hands the workers back on its own within a minute.
- `WorkPlanner.release()` ends the hold the moment the read finishes or fails. The commit that follows a read wakes the planner and waits for the first scan, so it must not wait out the minute.
- Tasks already queued when the read starts still run (a bounded backlog); nothing new lands behind them.

## Tests

Three planner tests: a held planner submits nothing, stays alive, and resumes when the lease expires; renewing does not accumulate; release resumes at once. `tests/test_work_planner.py`, `tests/test_folder_structure_read.py` and `tests/test_folder_structure_commit.py` pass locally.