### PR TITLE
Caption files on import: detect the conventions, confirm them, and let the offer come first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,7 @@ jobs:
           tests/test_restore.py
           tests/test_reviews_api.py
           tests/test_rocm_device_check.py
+          tests/test_root_scan_first_import.py
           tests/test_scope_table.py
           tests/test_score_agreement_stats.py
           tests/test_scrapheap_retention.py

--- a/changelog.d/caption-files-on-import.md
+++ b/changelog.d/caption-files-on-import.md
@@ -1,0 +1,9 @@
+- Caption files beside your pictures are read when a library is imported in
+  place. The import lists each naming pattern it found (`photo.txt`,
+  `photo_tags.txt`, `photo.caption`...) with a sample, and you confirm which
+  hold tags, which hold descriptions and which to leave alone before anything
+  is written. Pictures with a tags file are not tagged from scratch.
+- Fixed: a small library was sometimes indexed before the first-run import
+  offer could appear, so the folder-mapping questions were never asked. The
+  library now waits for your answer, and an empty library over a folder that
+  already holds pictures offers "Import them" as the way back in.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -4075,8 +4075,22 @@ and updates `file_path` on the existing row instead.
   from a reference folder exactly where `layout_move_service.LayoutRoot` says it
   does: pictures are the `reference_folder_id IS NULL` rows, `file_path` is
   written root-relative (`_stored`), the layout comes from `LibrarySettings`,
-  and there is no status, sidecar sync or suffix detection. The walk prunes
-  dot-directories and `_ROOT_INTERNAL_DIRS` (`snapshots`, `tmp`), the same set
+  and there is no status, sidecar sync or suffix detection. **The root scan
+  waits for the first import offer to be answered** (`root_import_answered`,
+  `folder_structure_commit_service`): an empty library over a folder that
+  holds pictures is one whose owner has not been asked what those pictures
+  are, and the scan, due at boot, used to index a small library before the
+  screen came up, so the offer never appeared. The newest `local_import`
+  commit record decides: `done` or `deferred` is an answer; `pending`,
+  `abandoned` and `superseded` hold the scan off (a running commit would race
+  it, an abort left chunks the owner never answered for); with no
+  `local_import` record at all, a library that already holds a picture is
+  scanned as before. The finder asks when a root scan is otherwise due, at
+  most once per `_GATE_RETRY_S` while the answer is no, and the task asks again
+  as it starts so an import accepted while it sat in the queue closes the gate.
+  The empty-library screen keeps a way back in ("Import them…") because a
+  dismissed offer would otherwise leave the library empty for good. The walk
+  prunes dot-directories and `_ROOT_INTERNAL_DIRS` (`snapshots`, `tmp`), the same set
   `folder_structure_commit_service.LIBRARY_OWN_FOLDERS` refuses to import. A file
   younger than `_ROOT_SETTLE_S` is on disk but neither new nor removed: PixlStash's
   own imports write the file before the row, so a young file belongs to whoever
@@ -6010,6 +6024,20 @@ their evidence lines but propose no kind, so the folder reads as a Person with
 filesystem fact rather than a prior, and it keeps its existing standing
 against `faces` (the two still narrow to candidates).
 
+**The walk also collects the caption files themselves** (`_collect_captions`):
+every non-media file with a text extension whose name starts with the stem of
+a media file in the same folder, grouped case-insensitively by the suffix
+after the stem, longest stem winning. Up to `CAPTION_SAMPLES` files per suffix
+(at most two from any one folder) are kept, and `_caption_patterns` sniffs
+them once the walk is over (`caption_file_utils.sniff_caption`, the one place
+a kind is decided from a file: NUL bytes, JSON and markup are not captions, an
+unambiguous name decides, a bare `.txt` is decided by content). The majority
+kind is reported, a tie going to description, with an excerpt of a file of
+that kind. Only the first `MAX_CAPTION_PATTERNS` suffixes by file count are
+opened, so a tree of one-off notes costs a bounded number of reads. The result
+carries them as `captions` (§20 of the integration doc); the sidecar signal's
+`with_sidecar` comes from the same pairing, so the two cannot disagree.
+
 ### Why cardinality is level-scoped and nothing else is
 
 Cardinality is a property of a *level* — "four names under 118 parents" cannot
@@ -6277,6 +6305,17 @@ mid-batch for reasons that have nothing to do with completion. It has a
 30-minute bound (`INDEX_TIMEOUT_S`) for the same reason §24's read has a
 deadline: a stuck scan must fail the commit rather than hang the screen
 forever.
+
+**`local_import_pictures` reads the caption files beside each picture.**
+`_build_managed_picture` calls `caption_file_utils.attach_sidecars`, the same
+read `ReferenceFolderScanTask._build_picture` and the watch-folder import go
+through, at the suffixes the owner confirmed (`caption_suffixes` turns the
+commit's `CaptionPattern` rows into one list per kind; `None`, no answer,
+probes the known conventions; `[]` reads nothing). Tags land as real `Tag`
+rows in the same transaction as the picture, and only a picture with no tags
+file gets the pending sentinel, so the tagger runs where nothing was written
+and nowhere else. The answers are stored on `FolderMappingCommit.captions`
+(migration 0115, JSON `null` for no answer) so a resume honours them.
 
 **`local_import_pictures` wakes the planner after every chunk it inserts.**
 The rows are visible to the finders the moment a chunk's transaction commits,

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -428,7 +428,21 @@ sidebar accessory nobody was pointed at.
 **Every route reuses wiring App.vue already had.** `local-import` reaches
 `SideBar.startLocalImport`, `open-settings` reaches `SideBar.openSettingsDialog`
 (with `"workflows"`, where the ComfyUI URL lives), and `choose-folder` is the one
-new signal, for `SideBar.openReferenceFolderEditor`.
+new signal, for `SideBar.chooseLibraryFolder`.
+
+**A dismissed offer has a way back in.** `SideBar.chooseLibraryFolder` resumes
+this library's pending `local_import` entry if there is one, else re-inspects
+the library's own path and, when it holds pictures, opens the same
+`local_import` wizard the offer opens; only an empty folder falls through to
+the ordinary add. "Add a library" refuses the folder the library already is, so
+without this route a dismissed offer left no way to import those pictures at
+all, and the root scan no longer indexes them behind the owner's back (backend
+§25). The count the offer or the click last read lives in
+`useFolderMappingStore.rootPictureCount` (`rootPictureCountCapped` when the
+inspect stopped at its cap), and `LibraryEmptyState` reads it to say "Import
+the pictures already in this folder" with an `Import them…` button instead of
+"Use a folder you already have". A session reset forgets the count and closes
+the wizard along with the entry.
 
 **The empty library asks whether its own folder is empty.** The desktop's
 first-run setup creates the vault in whatever folder was chosen, and the web
@@ -924,13 +938,28 @@ with `match_existing: false`, because the library it would match against does
 not exist and some other one is active. Then the mapping and preview steps as
 before; only `Yes, build this library` (or `Organise later`, with no
 assignments) does `addLibrary`, saves a store entry with `autoCommit: true`,
-the accepted `assignments` and `pictureCount`, and starts the switch. After the
+the accepted `assignments`, the caption answers (`captions`) and
+`pictureCount`, and starts the switch. After the
 reload `SideBar` auto-opens the wizard on that entry, straight into the preview
 step, which commits on mount (`commitOnMount`) and immediately re-saves the
 entry without `autoCommit`, so a deferred or interrupted commit resumes as a
 plain "Finish organising…" and never commits twice. Cancel or the header close
 anywhere before the build cancels a running read, clears the entry and leaves
 nothing behind; a resumed entry is left alone, as its read is real.
+
+**The preview step asks about caption files.** A `local_import` read reports
+the caption-file patterns it found beside the pictures (`result.captions`, one
+row per suffix such as `.txt` or `_tags.txt`, with a file count and an excerpt,
+integration §20). `FolderMappingPreviewStep` lists them on a "Caption files
+beside your pictures" card, each pre-filled with the read's guess (Tags /
+Description / Ignore), and sends the answers as `captions` on the commit; the
+facts card counts the files read as tags, as descriptions and left unread. The
+answers are held in the wizard, not the step, so `Back to the mapping` keeps
+them, and they ride in the pending entry so a resumed commit sends what the
+owner chose rather than the read's guesses. `Organise later` answers "read
+nothing" (`[]`); a read from before the card existed has no `captions` array
+and the commit then sends no key at all, which the server treats as "probe the
+known conventions". A reference-mode commit never carries the key.
 
 A `Call it` field sits inside the addable card, prefilled from the verdict's
 `suggested_name` and left alone once the owner edits it. It is not decoration:

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -1612,9 +1612,25 @@ indeterminate bar rather than 0%.
     "restricted": 0             //   below the root and on the system blocklist
   },
   "face_signal_ran": true,      // false = no inference engine; nobody is a Person
+  "captions": [                 // caption-file conventions found beside the pictures
+    {"suffix": ".txt", "kind": "tags", "files": 27_800, "folders": 340,
+     "sample": "1girl, solo, red hair, looking at viewer"},
+    {"suffix": "_caption.txt", "kind": "description", "files": 612, "folders": 4,
+     "sample": "A woman with red hair stands by a window."}
+  ],
   "levels": [ /* one per depth, ascending, level 1 = the root itself */ ]
 }
 ```
+
+**`captions`** is every text file that pairs with a picture by name, grouped by
+the suffix after the picture's stem (`a.txt`, `a_tags.txt`, `a.jpg.caption`
+beside `a.jpg` are the suffixes `.txt`, `_tags.txt`, `.jpg.caption`), most
+files first. `kind` is the read's guess from a few sampled files (comma lists
+read as `tags`, prose as `description`); `sample` is an excerpt so the owner
+can check it without opening a file. Binary files, JSON and markup are never
+offered, and only text extensions (`.txt`, `.caption`) are considered. The
+owner confirms or corrects each row on the commit (§22, `captions`). Empty
+when there are none.
 
 Two fields the screen must not ignore, because both mean *this map is not the
 whole library*:
@@ -1937,6 +1953,11 @@ newly-indexed picture gets, exactly as any other import produces.
   "read_result": { /* … */ },  // or the read's own result, from §20's status
   "label": "Generations",       // optional; defaults to the folder's own name
   "mode": "reference",          // "reference" (default) | "local_import"
+  "captions": [                 // local_import only: one row per §20 caption pattern
+    {"suffix": ".txt", "kind": "tags"},
+    {"suffix": "_caption.txt", "kind": "description"},
+    {"suffix": "_notes.txt", "kind": "ignore"}
+  ],
   "assignments": [
     // One entry per folder the owner accepted as something. A folder left
     // "just a folder" or undecided is simply absent — there is nothing here
@@ -2004,6 +2025,21 @@ indexed under this path (an overlapping earlier `local_import`, or an ordinary
 import that reached it independently) is reused by id, never re-imported as a
 second row — same spirit as `mode: "reference"`'s own "don't redo what already
 happened" rule for a resumed commit (§25).
+
+**`captions` says what each caption file beside the pictures is.** A picture
+built by the import reads the files at the confirmed suffixes: a `tags` file
+becomes its tags (and it is not queued for the tagger), a `description` file
+its description, and an `ignore` pattern is never opened however tag-like its
+content. **Absent and empty are different answers.** A request with no
+`captions` key is a client that never asked (an older one), and the import
+probes the known conventions as it always did (`_tags.txt`, `.caption`, a
+content-sniffed `.txt`). `[]` is the owner having been asked with nothing to
+confirm, and reads no caption file at all. The answer is recorded on the
+durable commit record, so a commit resumed after a crash honours it. A row's
+`suffix` must be a bare filename fragment and `kind` one of `tags`,
+`description`, `ignore`, else `400`. `mode: "reference"` refuses the field
+outright (`400`), `null` and `[]` included: a reference folder's sidecar
+suffixes are its own `PATCH /reference-folders/{folder_id}` fields.
 
 **The root must be inside `image_root` or the commit fails.** There is no
 separate error status for this — the check runs inside the background commit,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -364,13 +364,15 @@ function openSettingsDialog(tab = "") {
   sidebarRef.value?.openSettingsDialog?.(typeof tab === "string" ? tab : "");
 }
 
-/** The empty library's "Choose a folder…" - a reference folder, read in place.
+/** The empty library's "Choose a folder…" / "Import them…".
  *
- * Not the add-folder type chooser: its other option is an import folder, which
- * copies files in, and the button that reaches this promises the opposite.
+ * The sidebar picks the route: the local_import wizard over the library's own
+ * folder when it already holds pictures (the way back in once the offer was
+ * dismissed), else a folder read in place. Not the add-folder type chooser:
+ * its other option copies files in, and the button promises the opposite.
  */
 function openAddReferenceFolder() {
-  sidebarRef.value?.openReferenceFolderEditor?.();
+  sidebarRef.value?.chooseLibraryFolder?.();
 }
 
 /** The library is empty: let the sidebar ask whether its folder is. */

--- a/frontend/src/api/folderStructure.js
+++ b/frontend/src/api/folderStructure.js
@@ -81,6 +81,10 @@ export async function cancelFolderStructureRead(taskId) {
  * @param {Object|null} [readResult] - the read's own result, for a caller that
  *   has one but no task the server still remembers. Exactly one of `taskId` and
  *   `readResult` reaches the server.
+ * @param {Array<{suffix: string, kind: "tags"|"description"|"ignore"}>|null} [captions] -
+ *   the owner's answer per caption-file pattern the read reported. Sent for
+ *   `local_import` only: `[]` means "read nothing", `null` omits the key and
+ *   lets the import probe the known conventions (a client that never asked).
  * @returns {Promise<Object>} `{ task_id }`.
  */
 export async function startFolderStructureCommit(
@@ -89,6 +93,7 @@ export async function startFolderStructureCommit(
   label,
   mode = "reference",
   readResult = null,
+  captions = null,
 ) {
   // A read lives in one server process's memory. The desktop's first run reads
   // the library folder while the GPU runtime downloads and then restarts the
@@ -99,6 +104,7 @@ export async function startFolderStructureCommit(
     ? { task_id: taskId, assignments, mode }
     : { read_result: readResult, assignments, mode };
   if (label) body.label = label;
+  if (mode === "local_import" && captions !== null) body.captions = captions;
   return unwrap(apiClient.post(COMMIT_URL, body));
 }
 

--- a/frontend/src/api/folderStructure.test.js
+++ b/frontend/src/api/folderStructure.test.js
@@ -84,4 +84,19 @@ describe("starting a folder-structure commit", () => {
 
     expect(apiClient.post.mock.calls[0][1]).not.toHaveProperty("label");
   });
+
+  it("sends the caption answers for a local import only, and never null", async () => {
+    const captions = [{ suffix: ".txt", kind: "ignore" }];
+    await startFolderStructureCommit("read-1", [], "", "local_import", null, captions);
+    expect(apiClient.post.mock.calls[0][1].captions).toEqual(captions);
+
+    await startFolderStructureCommit("read-1", [], "", "local_import", null, []);
+    expect(apiClient.post.mock.calls[1][1].captions).toEqual([]);
+
+    await startFolderStructureCommit("read-1", [], "", "local_import");
+    expect(apiClient.post.mock.calls[2][1]).not.toHaveProperty("captions");
+
+    await startFolderStructureCommit("read-1", [], "", "reference", null, captions);
+    expect(apiClient.post.mock.calls[3][1]).not.toHaveProperty("captions");
+  });
 });

--- a/frontend/src/components/folders/FolderMappingPreviewStep.test.js
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.test.js
@@ -108,6 +108,7 @@ describe("FolderMappingPreviewStep", () => {
       "",
       "reference",
       null,
+      null,
     );
   });
 
@@ -219,6 +220,60 @@ describe("FolderMappingPreviewStep", () => {
       for (const noun of ["projects", "sets", "people", "tags"]) {
         expect(text).toContain(noun);
       }
+    });
+  });
+
+  describe("the caption-file card", () => {
+    const TXT = { suffix: ".txt", kind: "tags", files: 3, folders: 1, sample: "a, b" };
+
+    it("lists each pattern and sends the owner's answer with the commit", async () => {
+      startFolderStructureCommit.mockResolvedValue({ task_id: "commit-1" });
+      const wrapper = mountStep({
+        commitOnMount: false,
+        mode: "local_import",
+        readResult: { captions: [TXT] },
+      });
+      await flushPromises();
+
+      expect(wrapper.find(".preview-step__caption-suffix").text()).toBe("*.txt");
+      await wrapper.find('select[aria-label="Read *.txt as"]').setValue("ignore");
+      expect(wrapper.emitted("update:captions").at(-1)[0]).toEqual([
+        { suffix: ".txt", kind: "ignore" },
+      ]);
+      await buttonWith(wrapper, "Yes, build this library").trigger("click");
+      await flushPromises();
+
+      expect(startFolderStructureCommit.mock.calls[0][5]).toEqual([
+        { suffix: ".txt", kind: "ignore" },
+      ]);
+    });
+
+    it("organise later answers 'read nothing' rather than the read's guesses", async () => {
+      startFolderStructureCommit.mockResolvedValue({ task_id: "commit-1" });
+      const wrapper = mountStep({
+        commitOnMount: false,
+        mode: "local_import",
+        readResult: { captions: [TXT] },
+      });
+      await flushPromises();
+
+      await buttonWith(wrapper, "Organise later").trigger("click");
+      await flushPromises();
+
+      expect(startFolderStructureCommit.mock.calls[0][5]).toEqual([]);
+    });
+
+    it("commits the saved answers on mount, not the read's guesses", async () => {
+      startFolderStructureCommit.mockResolvedValue({ task_id: "commit-1" });
+      const saved = [{ suffix: ".txt", kind: "description" }];
+      mountStep({
+        mode: "local_import",
+        readResult: { captions: [TXT] },
+        captions: saved,
+      });
+      await flushPromises();
+
+      expect(startFolderStructureCommit.mock.calls[0][5]).toEqual(saved);
     });
   });
 });

--- a/frontend/src/components/folders/FolderMappingPreviewStep.vue
+++ b/frontend/src/components/folders/FolderMappingPreviewStep.vue
@@ -6,7 +6,7 @@
  * either way - committing registers the folder for in-place indexing and
  * writes database rows only.
  */
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 
 import {
   getFolderStructureCommitStatus,
@@ -16,6 +16,7 @@ import {
 import { errorDetail } from "../../utils/apiError";
 import { FACET_KINDS, kindStyle } from "../../utils/folderMappingKinds";
 import AppButton from "../widgets/AppButton.vue";
+import AppSelect from "../widgets/AppSelect.vue";
 
 const props = defineProps({
   path: { type: String, required: true },
@@ -28,6 +29,12 @@ const props = defineProps({
    */
   readResult: { type: Object, default: null },
   assignments: { type: Array, required: true },
+  /**
+   * Saved answers for the read's caption-file patterns, `[{suffix, kind}]`,
+   * for a resumed commit. Seeds the card; a saved `[]` ("read nothing")
+   * seeds every row as Ignore. `null` is "nobody was asked yet".
+   */
+  captions: { type: Array, default: null },
   label: { type: String, default: "" },
   pictureCount: { type: Number, default: 0 },
   // "reference" registers the scanned root as an external reference folder;
@@ -53,6 +60,7 @@ const emit = defineEmits([
   "cancel",
   "committed",
   "commit-started",
+  "update:captions",
   "update:committing",
 ]);
 
@@ -72,6 +80,67 @@ const total = ref(0);
 
 let pollTimer = null;
 let disposed = false;
+
+/**
+ * The caption-file conventions the read found beside the pictures, with its
+ * guess at what each holds. Asked, not assumed: a prose convention read as
+ * tags puts a sentence's words on every picture in the library.
+ */
+const CAPTION_CHOICES = [
+  { value: "tags", label: "Tags" },
+  { value: "description", label: "Description" },
+  { value: "ignore", label: "Ignore" },
+];
+// Only a local import asks; the commit refuses the key in reference mode.
+const patterns = computed(() =>
+  props.mode === "local_import" ? (props.readResult?.captions ?? []) : [],
+);
+// suffix -> the owner's answer. Null-prototype: the keys are filename
+// fragments, and `__proto__` or `constructor` as a key would misbehave.
+const answers = reactive(Object.create(null));
+watch(
+  patterns,
+  (rows) => {
+    const readNothing = props.captions?.length === 0;
+    for (const row of rows) {
+      if (answers[row.suffix]) continue;
+      answers[row.suffix] =
+        props.captions?.find((c) => c.suffix === row.suffix)?.kind ??
+        (readNothing ? "ignore" : row.kind);
+    }
+  },
+  { immediate: true },
+);
+/** One answer per reported pattern. With no rows: the saved answer, else
+ *  `[]` for a read that reported its (empty) patterns, else `null` for a
+ *  read from before the card existed, which the commit sends as no key. */
+function chosenCaptions() {
+  if (props.mode !== "local_import") return null;
+  if (!patterns.value.length) {
+    if (Array.isArray(props.captions)) return props.captions;
+    return Array.isArray(props.readResult?.captions) ? [] : null;
+  }
+  return patterns.value.map((row) => ({
+    suffix: row.suffix,
+    kind: answers[row.suffix] ?? row.kind,
+  }));
+}
+// Reported as made, not at commit: "Back to the mapping" unmounts this step
+// and the wizard re-seeds it from what it was told.
+function answerChosen(suffix, kind) {
+  answers[suffix] = kind;
+  emit("update:captions", chosenCaptions());
+}
+function captionFiles(kind) {
+  return patterns.value.reduce(
+    (sum, row) =>
+      sum + ((answers[row.suffix] ?? row.kind) === kind ? row.files : 0),
+    0,
+  );
+}
+const captionFilesAsTags = computed(() => captionFiles("tags"));
+const captionFilesAsDescriptions = computed(() => captionFiles("description"));
+const captionFilesIgnored = computed(() => captionFiles("ignore"));
 
 const grouped = computed(() => {
   const byKind = new Map(FACET_KINDS.map((k) => [k.value, new Map()]));
@@ -169,9 +238,14 @@ async function poll(taskId) {
   }
 }
 
-async function commit(assignments = props.assignments) {
+// `captions` defaults from the card only for "Yes, build this library"; the
+// commit on mount and Organise later both pass their own.
+async function commit(
+  assignments = props.assignments,
+  captions = chosenCaptions(),
+) {
   if (!props.libraryExists) {
-    emit("build", assignments);
+    emit("build", assignments, captions);
     return;
   }
   committing.value = true;
@@ -183,6 +257,7 @@ async function commit(assignments = props.assignments) {
       props.label,
       props.mode,
       props.readResult,
+      captions,
     );
     commitTaskId.value = started.task_id;
     emit("commit-started", started.task_id);
@@ -206,7 +281,9 @@ async function commit(assignments = props.assignments) {
  */
 async function organiseLater() {
   if (!committing.value) {
-    commit([]);
+    // Declining to decide is not confirming the read's guesses: a read that
+    // reported its patterns is answered "read nothing".
+    commit([], Array.isArray(props.readResult?.captions) ? [] : null);
     return;
   }
   try {
@@ -226,7 +303,9 @@ async function abort() {
 }
 
 onMounted(() => {
-  if (props.commitOnMount) commit();
+  // The card is never seen on this path, so only the saved answers count;
+  // the read's guesses are not an answer.
+  if (props.commitOnMount) commit(props.assignments, props.captions);
 });
 
 onUnmounted(() => {
@@ -284,6 +363,50 @@ onUnmounted(() => {
       </div>
     </div>
 
+    <div
+      v-if="patterns.length && !committing"
+      class="preview-step__card"
+    >
+      <div class="preview-step__card-title">Caption files beside your pictures</div>
+      <p class="preview-step__card-lead">
+        Text files named after a picture are read as its tags or description.
+        Check each pattern.
+      </p>
+      <ul class="preview-step__captions">
+        <li
+          v-for="row in patterns"
+          :key="row.suffix"
+          class="preview-step__caption"
+          :class="{
+            'preview-step__caption--ignored':
+              (answers[row.suffix] ?? row.kind) === 'ignore',
+          }"
+        >
+          <div class="preview-step__caption-what">
+            <code class="preview-step__caption-suffix">*{{ row.suffix }}</code>
+            <span class="preview-step__caption-count">
+              {{ row.files.toLocaleString() }}
+              {{ row.files === 1 ? "file" : "files" }} in
+              {{ row.folders.toLocaleString() }}
+              {{ row.folders === 1 ? "folder" : "folders" }}
+            </span>
+            <span class="preview-step__caption-sample" :title="row.sample">
+              {{ row.sample }}
+            </span>
+          </div>
+          <AppSelect
+            :model-value="answers[row.suffix]"
+            :options="CAPTION_CHOICES"
+            :label="`Read *${row.suffix} as`"
+            hide-label
+            compact
+            class="preview-step__caption-choice"
+            @update:model-value="answerChosen(row.suffix, $event)"
+          />
+        </li>
+      </ul>
+    </div>
+
     <div class="preview-step__card">
       <div class="preview-step__card-title">
         What happens when you press the button
@@ -302,6 +425,28 @@ onUnmounted(() => {
           >
           {{ entityCount.toLocaleString() }} {{ entityKinds }}
           {{ entityCount === 1 ? "is" : "are" }} created or matched
+        </div>
+        <div v-if="captionFilesAsTags" class="preview-step__fact">
+          <span class="preview-step__fact-mark preview-step__fact-mark--yes"
+            >✓</span
+          >
+          {{ captionFilesAsTags.toLocaleString() }} caption
+          {{ captionFilesAsTags === 1 ? "file is" : "files are" }} read as tags;
+          {{ captionFilesAsTags === 1 ? "that picture is" : "those pictures are" }}
+          not tagged from scratch
+        </div>
+        <div v-if="captionFilesAsDescriptions" class="preview-step__fact">
+          <span class="preview-step__fact-mark preview-step__fact-mark--yes"
+            >✓</span
+          >
+          {{ captionFilesAsDescriptions.toLocaleString() }} caption
+          {{ captionFilesAsDescriptions === 1 ? "file is" : "files are" }} read
+          as descriptions
+        </div>
+        <div v-if="captionFilesIgnored" class="preview-step__fact">
+          <span class="preview-step__fact-mark">—</span>
+          {{ captionFilesIgnored.toLocaleString() }} caption
+          {{ captionFilesIgnored === 1 ? "file is" : "files are" }} left unread
         </div>
         <div class="preview-step__fact">
           <span class="preview-step__fact-mark">—</span>
@@ -459,6 +604,67 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
   margin-bottom: var(--space-4);
+}
+
+.preview-step__card-lead {
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-background), 0.65);
+}
+
+.preview-step__captions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.preview-step__caption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.preview-step__caption--ignored .preview-step__caption-what {
+  opacity: 0.55;
+}
+
+.preview-step__caption-what {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2) var(--space-3);
+  min-width: 0;
+  font-size: var(--text-sm);
+}
+
+.preview-step__caption-suffix {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  background: rgb(var(--v-theme-panel));
+}
+
+.preview-step__caption-count {
+  color: rgba(var(--v-theme-on-background), 0.72);
+}
+
+.preview-step__caption-sample {
+  flex-basis: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-background), 0.55);
+}
+
+.preview-step__caption-choice {
+  flex-shrink: 0;
+  width: 10rem;
 }
 
 .preview-step__facts {

--- a/frontend/src/components/folders/FolderMappingWizard.test.js
+++ b/frontend/src/components/folders/FolderMappingWizard.test.js
@@ -286,6 +286,7 @@ describe("building the library", () => {
       label: "Generations",
       mode: "local_import",
       assignments: ASSIGNMENTS,
+      captions: null,
       pictureCount: 5,
       autoCommit: true,
     });
@@ -309,6 +310,41 @@ describe("building the library", () => {
       autoCommit: true,
     });
     expect(setActiveLibrary).toHaveBeenCalledWith("uuid-new");
+  });
+
+  it("keeps the caption answers across 'Back to the mapping'", async () => {
+    const wrapper = mountWizard();
+    await settle();
+    getFolderStructureReadStatus.mockResolvedValue({
+      status: "completed",
+      stage: "done",
+      processed: 2,
+      total: 2,
+      result: {
+        ...READ_RESULT,
+        captions: [{ suffix: ".txt", kind: "tags", files: 3, folders: 1, sample: "a" }],
+      },
+    });
+    await bringThemIn(wrapper);
+    await button(wrapper, "Set up my library").trigger("click");
+    await settle();
+    await wrapper.find(".tree-stub .emit-next").trigger("click");
+    await settle();
+
+    await wrapper.find('select[aria-label="Read *.txt as"]').setValue("ignore");
+    await button(wrapper, "Back to the mapping").trigger("click");
+    await settle();
+    await wrapper.find(".tree-stub .emit-next").trigger("click");
+    await settle();
+
+    expect(wrapper.find('select[aria-label="Read *.txt as"]').element.value).toBe(
+      "ignore",
+    );
+    await button(wrapper, "Yes, build this library").trigger("click");
+    await settle();
+    expect(useFolderMappingStore().pending).toMatchObject({
+      captions: [{ suffix: ".txt", kind: "ignore" }],
+    });
   });
 
   it("stays open with the server's refusal when the create fails", async () => {
@@ -356,6 +392,7 @@ describe("resuming after the switch", () => {
       "Generations",
       "local_import",
       null,
+      null,
     );
     expect(addLibrary).not.toHaveBeenCalled();
     expect(startFolderStructureRead).not.toHaveBeenCalled();
@@ -365,6 +402,7 @@ describe("resuming after the switch", () => {
       path: PATH,
       label: "Generations",
       mode: "local_import",
+      captions: null,
     });
   });
 
@@ -429,6 +467,7 @@ describe("the empty library's own folder", () => {
       "",
       "local_import",
       READ_RESULT,
+      null,
     );
   });
 });
@@ -664,6 +703,7 @@ describe("the branches nobody walks on purpose", () => {
       "",
       "local_import",
       READ_RESULT,
+      null,
     );
     expect(addLibrary).not.toHaveBeenCalled();
 

--- a/frontend/src/components/folders/FolderMappingWizard.vue
+++ b/frontend/src/components/folders/FolderMappingWizard.vue
@@ -64,6 +64,12 @@ const label = ref("");
 const readTaskId = ref("");
 const readResult = ref(null);
 const assignments = ref([]);
+// The owner's answers for the read's caption-file patterns, kept beside the
+// assignments for the same reason: the commit runs after the library switch.
+// The Preview step reports them as they are made, so "Back to the mapping"
+// (which unmounts that step) keeps them. `null` is "nobody has been asked",
+// which the commit sends as no key at all; `[]` is an answer of nothing.
+const captions = ref(null);
 const pictureCount = ref(0);
 // The library exists (a resumed entry) - the Preview step commits directly.
 // Before that, the Preview step's "build" is this component's `build()`.
@@ -96,6 +102,7 @@ watch(
     // was sitting right here.
     readResult.value = entry?.result ?? null;
     assignments.value = entry?.assignments ?? [];
+    captions.value = entry?.captions ?? null;
     pictureCount.value = entry?.pictureCount ?? 0;
     libraryExists.value = Boolean(entry);
     autoCommit.value = Boolean(entry?.autoCommit);
@@ -197,8 +204,12 @@ function onMappingNext(built) {
  * add, so it is the Preview step's commit with no assignments.
  */
 function later() {
+  // Declining to decide is not confirming the read's guesses: a read that
+  // reported its patterns is answered "read nothing", one from before the
+  // caption card existed is answered nothing at all.
+  captions.value = Array.isArray(readResult.value?.captions) ? [] : null;
   if (!libraryExists.value) {
-    build([]);
+    build([], captions.value);
     return;
   }
   assignments.value = [];
@@ -210,19 +221,21 @@ function later() {
  * The library does not exist yet: create it, remember what to commit, and
  * switch to it. The commit itself runs after the reload - see the header.
  */
-async function build(accepted) {
+async function build(accepted, answered = null) {
   if (building.value) return;
   building.value = true;
   buildError.value = "";
   try {
     const library = await addLibrary(path.value, label.value);
     assignments.value = accepted;
+    captions.value = answered;
     mappingStore.save({
       taskId: readTaskId.value,
       path: path.value,
       label: label.value,
       mode: "local_import",
       assignments: accepted,
+      captions: answered,
       pictureCount: pictureCount.value,
       autoCommit: true,
     });
@@ -245,6 +258,9 @@ function onCommitStarted() {
     path: entry.path,
     label: entry.label,
     mode: entry.mode,
+    // The answer outlives the commit: a failed or interrupted one must reopen
+    // onto the owner's choices, not the read's guesses.
+    captions: captions.value,
   });
 }
 
@@ -322,6 +338,7 @@ function onCommitted(result) {
       :read-task-id="readTaskId"
       :read-result="readResult"
       :assignments="assignments"
+      :captions="captions"
       :label="label"
       mode="local_import"
       :picture-count="pictureCount"
@@ -329,6 +346,7 @@ function onCommitted(result) {
       :commit-on-mount="autoCommit"
       @back="backToMapping"
       @build="build"
+      @update:captions="captions = $event"
       @commit-started="onCommitStarted"
       @cancel="close"
       @committed="onCommitted"

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -750,6 +750,47 @@ function chooseFolderType(type) {
   openReferenceFolderEditor();
 }
 
+/**
+ * The empty library's "Choose a folder…" / "Import them…".
+ *
+ * When the library's own folder holds pictures the way in is the mapping
+ * wizard over that folder, the same one the offer opens, never "Add a
+ * library", which refuses the folder because the library already is it. So a
+ * dismissed offer has a way back. Otherwise the ordinary add.
+ */
+async function chooseLibraryFolder() {
+  if (!librariesStore.hasLoadedSuccessfully) await librariesStore.refresh();
+  // Read after the refresh: `pendingForThisLibrary` matches the entry against
+  // the active library's path, and with no list yet a good entry looks absent.
+  const entry = pendingForThisLibrary.value;
+  if (entry?.mode === "local_import") {
+    openFolderMappingWizard(entry);
+    return;
+  }
+  const path = librariesStore.activeLibrary?.path;
+  if (path && librariesStore.canManage) {
+    // Re-inspected on every click: a root that was empty when the count was
+    // cached may hold pictures now. A failed inspect leaves the count alone.
+    try {
+      const verdict = await inspectLibraryPath(path);
+      mappingStore.setRootPictureCount(
+        verdict?.picture_count ?? 0,
+        verdict?.picture_count_capped ?? false,
+      );
+    } catch (error) {
+      console.warn("Could not check the library folder for pictures", {
+        path,
+        error,
+      });
+    }
+    if (mappingStore.rootMayHoldPictures) {
+      openFolderMappingWizard({ path, mode: "local_import" });
+      return;
+    }
+  }
+  openReferenceFolderEditor();
+}
+
 function openReferenceFolderEditor(rf = null) {
   if (rf === null) {
     // Adding a folder is "Add a library" now: a folder indexed in place as
@@ -826,10 +867,14 @@ function offerLoosePictures() {
   // AND no offer, for the life of the install; there was no way into the
   // library at all. This has to stay the same test as the auto-open, so state
   // it the same way.
-  if (
-    isReadOnly.value ||
-    pendingForThisLibrary.value?.mode === "local_import"
-  ) {
+  if (isReadOnly.value) return Promise.resolve();
+  const entry = pendingForThisLibrary.value;
+  if (entry?.mode === "local_import") {
+    // Nothing to offer, but the empty state's wording reads the count, and on
+    // a reload onto a persisted entry nobody has filled it yet.
+    if (mappingStore.rootPictureCount === null && entry.pictureCount != null) {
+      mappingStore.setRootPictureCount(entry.pictureCount);
+    }
     return Promise.resolve();
   }
   loosePicturesOffer ??= _offerLoosePictures();
@@ -865,6 +910,7 @@ async function _offerLoosePictures() {
   // progress bar over an empty grid.
   const parked = await takeParkedFolderRead();
   if (parked?.result && _samePath(parked.path, path)) {
+    mappingStore.setRootPictureCount(parked.result.picture_count ?? 0);
     autoOpenedPendingMapping = true;
     openFolderMappingWizard({
       path,
@@ -875,7 +921,13 @@ async function _offerLoosePictures() {
   }
   try {
     const verdict = await inspectLibraryPath(path);
-    if (verdict?.picture_count > 0) {
+    mappingStore.setRootPictureCount(
+      verdict?.picture_count ?? 0,
+      verdict?.picture_count_capped ?? false,
+    );
+    // The store's reading, not `picture_count > 0`: a count capped at zero
+    // stopped before it reached a picture and proves nothing.
+    if (mappingStore.rootMayHoldPictures) {
       // The read the wizard starts saves a pending entry, which the watch
       // above would otherwise take as its cue to open the wizard again.
       autoOpenedPendingMapping = true;
@@ -4491,6 +4543,7 @@ defineExpose({
   // "Nothing is moved" one screen earlier, so routing through the chooser would
   // have the release's headline claim falsified by the next click.
   openReferenceFolderEditor,
+  chooseLibraryFolder,
   offerLoosePictures,
   startLocalImport,
   currentProjectId,

--- a/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
+++ b/frontend/src/components/panels/SideBarFolderMappingAutoOpen.test.js
@@ -484,4 +484,50 @@ describe("the loose-pictures offer for an empty library", () => {
     delete window.pixlstashDesktop;
     wrapper.unmount();
   });
+
+  // The empty library's button once the offer has been dismissed: the way
+  // back in is the same wizard, never "Add a library" over the library's own
+  // folder.
+  it("chooseLibraryFolder opens the local_import wizard over a folder that holds pictures", async () => {
+    const path = "/home/me/Pictures";
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    apiGet.mockImplementation((url) =>
+      url.includes("inspect")
+        ? Promise.resolve({ data: { picture_count: 12 } })
+        : Promise.resolve(respond()),
+    );
+    const wrapper = await mountSidebar();
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(useFolderMappingStore().rootPictureCount).toBe(12);
+    expect(useFolderMappingStore().wizardResume).toEqual({
+      path,
+      mode: "local_import",
+    });
+
+    wrapper.unmount();
+  });
+
+  it("chooseLibraryFolder resumes this library's pending entry instead of reading again", async () => {
+    const path = "/home/me/Pictures";
+    const entry = { taskId: "task-4", path, label: "Pictures", mode: "local_import" };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    activeLibraryAt(path);
+    const libraries = useLibrariesStore();
+    libraries.hasLoadedSuccessfully = true;
+    libraries.canManage = true;
+    const wrapper = await mountSidebar();
+    useFolderMappingStore().closeWizard();
+
+    await wrapper.vm.chooseLibraryFolder();
+
+    expect(useFolderMappingStore().wizardOpen).toBe(true);
+    expect(useFolderMappingStore().wizardResume).toEqual(entry);
+
+    wrapper.unmount();
+  });
 });

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -497,7 +497,7 @@
       <!-- All three routes reuse wiring App.vue already had: `local-import`
            reaches `SideBar.startLocalImport`, `open-settings` reaches
            `SideBar.openSettingsDialog`, and `choose-folder` is the one new
-           signal, for the reference-folder editor the sidebar owns. -->
+           signal, for `SideBar.chooseLibraryFolder`. -->
       <LibraryEmptyState
         v-if="showLibraryEmptyState"
         @choose-folder="emit('choose-folder')"

--- a/frontend/src/components/views/LibraryEmptyState.test.js
+++ b/frontend/src/components/views/LibraryEmptyState.test.js
@@ -7,17 +7,22 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 
 vi.mock("vuetify/components", () => ({
   VIcon: { name: "v-icon", template: "<i><slot /></i>" },
 }));
 
 import LibraryEmptyState from "./LibraryEmptyState.vue";
+import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
 function mountState() {
+  const pinia = createPinia();
+  setActivePinia(pinia);
   return mount(LibraryEmptyState, {
     global: {
+      plugins: [pinia],
       stubs: {
         // No manual `$emit("click")`: the real AppButton declares no emits, so
         // `@click` on it is plain attribute fallthrough onto its own <button>
@@ -149,5 +154,19 @@ describe("what the buttons do", () => {
     await input.trigger("change");
 
     expect(input.element.value).toBe("");
+  });
+
+  it("offers to import the pictures the library's own folder already holds", async () => {
+    // The state a dismissed import offer leaves: "Choose a folder…" would lead
+    // to "Add a library", which refuses the folder the library already is.
+    const wrapper = mountState();
+    useFolderMappingStore().setRootPictureCount(12);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".library-empty__heading").text()).toBe(
+      "Import the pictures already in this folder",
+    );
+    expect(wrapper.find(".library-empty__detail").text()).toContain("12 pictures");
+    expect(buttonLabels(wrapper)[0]).toBe("Import them…");
   });
 });

--- a/frontend/src/components/views/LibraryEmptyState.vue
+++ b/frontend/src/components/views/LibraryEmptyState.vue
@@ -10,13 +10,25 @@
  * are handed up unfiltered because the grid already drops what PixlStash
  * cannot read for both drop paths.
  */
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { VIcon } from "vuetify/components";
 
 import AppButton from "../widgets/AppButton.vue";
+import { useFolderMappingStore } from "../../stores/useFolderMappingStore";
 import { IMPORT_FILE_ACCEPT } from "../../utils/media";
 
 const emit = defineEmits(["choose-folder", "add-files", "connect-comfyui"]);
+
+// The one fact this screen reads for itself: whether the library's own folder
+// already holds pictures. Then the first route is "import them", because
+// "choose a folder" leads to "Add a library", which refuses the folder this
+// library already is - the state a dismissed import offer leaves.
+const mappingStore = useFolderMappingStore();
+const rootMayHoldPictures = computed(() => mappingStore.rootMayHoldPictures);
+const rootPictureCount = computed(() => mappingStore.rootPictureCount ?? 0);
+const rootPictureCountCapped = computed(
+  () => mappingStore.rootPictureCountCapped,
+);
 
 const fileInput = ref(null);
 
@@ -63,7 +75,22 @@ function filesChosen(event) {
           <span class="library-empty__mark" aria-hidden="true">
             <v-icon size="19">mdi-folder-outline</v-icon>
           </span>
-          <span class="library-empty__text">
+          <span v-if="rootMayHoldPictures" class="library-empty__text">
+            <span class="library-empty__heading"
+              >Import the pictures already in this folder</span
+            >
+            <span v-if="rootPictureCountCapped" class="library-empty__detail">
+              This library's folder already holds pictures. They are read
+              where they sit; nothing is moved.
+            </span>
+            <span v-else class="library-empty__detail">
+              {{ rootPictureCount.toLocaleString() }}
+              {{ rootPictureCount === 1 ? "picture is" : "pictures are" }} in
+              this library's folder. They are read where they sit; nothing is
+              moved.
+            </span>
+          </span>
+          <span v-else class="library-empty__text">
             <span class="library-empty__heading"
               >Use a folder you already have</span
             >
@@ -73,7 +100,7 @@ function filesChosen(event) {
             </span>
           </span>
           <AppButton size="sm" variant="primary" @click="emit('choose-folder')">
-            Choose a folder…
+            {{ rootMayHoldPictures ? "Import them…" : "Choose a folder…" }}
           </AppButton>
         </li>
 

--- a/frontend/src/components/widgets/AppDialog.test.js
+++ b/frontend/src/components/widgets/AppDialog.test.js
@@ -79,4 +79,17 @@ describe("AppDialog keyboard contract", () => {
     await w.find(".txt").trigger("keydown", { key: "Enter", ctrlKey: true });
     expect(w.emitted("accept")).toBeFalsy();
   });
+
+  it("closes from update:model-value only, never from click:outside", async () => {
+    // Vuetify emits click:outside even on a persistent dialog, which let a
+    // stray click dismiss the folder-mapping wizard mid-answer.
+    const w = mountDialog({ persistent: true });
+    const dialog = w.findComponent({ name: "v-dialog" });
+
+    dialog.vm.$emit("click:outside");
+    expect(w.emitted("close")).toBeFalsy();
+
+    dialog.vm.$emit("update:modelValue", false);
+    expect(w.emitted("close")).toHaveLength(1);
+  });
 });

--- a/frontend/src/components/widgets/AppDialog.vue
+++ b/frontend/src/components/widgets/AppDialog.vue
@@ -6,7 +6,6 @@
     :persistent="persistent"
     transition="dialog-bottom-transition"
     @update:model-value="(v) => !v && emit('close')"
-    @click:outside="emit('close')"
   >
     <div
       class="app-dialog"
@@ -64,6 +63,11 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["close", "accept"]);
+
+// `update:model-value` is the one close source. Vuetify emits `click:outside`
+// even on a persistent dialog (it only stops closing itself), which let a stray
+// click dismiss the folder-mapping wizard, and on a non-persistent one it
+// doubled the close `update:model-value` already reports.
 
 // Enter is inert wherever the key already means something: multiline fields,
 // buttons and links (native activation must win, so Enter on Cancel cancels),

--- a/frontend/src/components/widgets/AppSelect.vue
+++ b/frontend/src/components/widgets/AppSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app-select">
-    <FieldLabel v-if="label">{{ label }}</FieldLabel>
+    <FieldLabel v-if="label && !hideLabel">{{ label }}</FieldLabel>
     <div
       v-if="multiple"
       class="app-select__multiple"
@@ -59,6 +59,9 @@ const props = defineProps({
   // Array of strings OR { label, value } objects.
   options: { type: Array, default: () => [] },
   compact: { type: Boolean, default: false },
+  // Keep `label` as the accessible name only, for a row whose text already
+  // says what the select decides.
+  hideLabel: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   multiple: { type: Boolean, default: false },
 });

--- a/frontend/src/stores/useFolderMappingStore.js
+++ b/frontend/src/stores/useFolderMappingStore.js
@@ -1,4 +1,4 @@
-import { onScopeDispose, ref } from "vue";
+import { computed, onScopeDispose, ref } from "vue";
 import { defineStore } from "pinia";
 
 import { onSessionReset } from "../utils/apiClient";
@@ -55,6 +55,24 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
   const pending = ref(readStorage());
   const wizardOpen = ref(false);
   const wizardResume = ref(null);
+  /**
+   * How many pictures the open library's OWN folder holds on disk, as the
+   * sidebar last asked the server; `null` until it has. The empty library
+   * reads it to offer "Import them…" instead of "Choose a folder…", so a
+   * dismissed import offer still has a way back in. `capped` means the count
+   * stopped at the inspect endpoint's cap and is a floor, not a total.
+   */
+  const rootPictureCount = ref(null);
+  const rootPictureCountCapped = ref(false);
+  // A capped zero is not an empty folder: the walk stopped before a picture.
+  const rootMayHoldPictures = computed(
+    () => rootPictureCount.value > 0 || rootPictureCountCapped.value,
+  );
+
+  function setRootPictureCount(count, capped = false) {
+    rootPictureCount.value = count;
+    rootPictureCountCapped.value = capped;
+  }
 
   /** Open the one wizard; `resume` is a saved entry, or null for a fresh add. */
   function openWizard(resume = null) {
@@ -66,7 +84,7 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     wizardOpen.value = false;
   }
 
-  /** @param {{taskId: string, path: string, label?: string, mode?: "reference"|"local_import", autoCommit?: boolean, assignments?: Array, pictureCount?: number}} entry */
+  /** @param {{taskId: string, path: string, label?: string, mode?: "reference"|"local_import", autoCommit?: boolean, assignments?: Array, captions?: Array|null, pictureCount?: number}} entry */
   function save(entry) {
     pending.value = entry;
     try {
@@ -86,8 +104,32 @@ export const useFolderMappingStore = defineStore("folderMapping", () => {
     }
   }
 
-  const unsubscribeSessionReset = onSessionReset(clear);
+  // A session change forgets the entry, the count (it is the previous
+  // library's) and the open wizard: Pinia outlives a logout in the same tab,
+  // and the next credential must not find the previous owner's folder on screen.
+  function resetForSession() {
+    clear();
+    wizardOpen.value = false;
+    wizardResume.value = null;
+    rootPictureCount.value = null;
+    rootPictureCountCapped.value = false;
+  }
+
+  const unsubscribeSessionReset = onSessionReset(resetForSession);
   onScopeDispose(unsubscribeSessionReset);
 
-  return { pending, save, clear, wizardOpen, wizardResume, openWizard, closeWizard };
+  return {
+    pending,
+    save,
+    clear,
+    wizardOpen,
+    wizardResume,
+    rootPictureCount,
+    rootPictureCountCapped,
+    rootMayHoldPictures,
+    setRootPictureCount,
+    resetForSession,
+    openWizard,
+    closeWizard,
+  };
 });

--- a/pixlstash/db_models/folder_mapping_commit.py
+++ b/pixlstash/db_models/folder_mapping_commit.py
@@ -68,6 +68,10 @@ class FolderMappingCommit(SQLModel, table=True):
             take the same one.
         label: The reference folder's label, when the owner gave one.
         expected_pictures: The read's own count, the progress total.
+        captions: The owner's answer to the read's caption-file patterns as
+            JSON, in the wire form ``parse_captions`` reads. ``"null"`` is
+            no answer at all (the import probes the known conventions);
+            ``"[]"`` is an answer of nothing and reads no caption file.
         assignments: The accepted mapping as JSON, in the wire form
             ``folder_structure_commit_service.parse_assignments`` reads. Stored
             rather than re-derived: the read that produced it is gone after a
@@ -94,6 +98,7 @@ class FolderMappingCommit(SQLModel, table=True):
     label: Optional[str] = None
     expected_pictures: int = 0
     assignments: str = "[]"
+    captions: str = "null"
     stage: str = "registering"
     state: str = Field(default=STATE_PENDING, index=True)
     started_at: datetime = Field(default_factory=_now)

--- a/pixlstash/migrations/versions/0115_add_folder_mapping_commit_captions.py
+++ b/pixlstash/migrations/versions/0115_add_folder_mapping_commit_captions.py
@@ -1,0 +1,52 @@
+"""Record the owner's caption-file choices on the folder-mapping commit.
+
+The read reports the caption-file patterns beside the pictures and the owner
+says which are tags, which are descriptions and which to ignore. A commit
+resumed after a crash must honour that answer rather than probe the
+conventions again and import a file the owner said to leave alone. ``"null"``
+on every existing row: no answer at all, which is what every commit before
+this column meant, as opposed to ``"[]"``, an answer of nothing.
+
+Revision ID: 0115_add_folder_mapping_commit_captions
+Revises: 0114_remove_views_and_project_cover
+Create Date: 2026-09-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0115_add_folder_mapping_commit_captions"
+down_revision: Union[str, None] = "0114_remove_views_and_project_cover"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def _columns(bind) -> set[str]:
+    return {c["name"] for c in sa.inspect(bind).get_columns("folder_mapping_commit")}
+
+
+def upgrade() -> None:
+    if "captions" not in _columns(op.get_bind()):
+        op.add_column(
+            "folder_mapping_commit",
+            # `sa.text` so the default is the four-character JSON string
+            # "null"; a bare server_default="null" renders SQL NULL, which
+            # this NOT NULL column would refuse.
+            sa.Column(
+                "captions",
+                sa.String(),
+                nullable=False,
+                server_default=sa.text("'null'"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if "captions" in _columns(op.get_bind()):
+        with op.batch_alter_table("folder_mapping_commit") as batch:
+            batch.drop_column("captions")

--- a/pixlstash/routes/folder_structure.py
+++ b/pixlstash/routes/folder_structure.py
@@ -105,6 +105,16 @@ class FolderStructureAssignmentPayload(BaseModel):
     match_id: Optional[int] = None
 
 
+class FolderStructureCaptionPayload(BaseModel):
+    """The owner's answer for one caption-file pattern the read reported."""
+
+    suffix: str
+    #: A plain ``str``, as `FolderStructureAssignmentPayload.kind` is:
+    #: `parse_captions` owns the vocabulary and answers an unknown kind with
+    #: a 400 naming the row.
+    kind: str
+
+
 class FolderStructureCommitRequest(BaseModel):
     task_id: Optional[str] = None
     """The read to commit, when this server is the one that performed it."""
@@ -126,6 +136,16 @@ class FolderStructureCommitRequest(BaseModel):
     """
 
     assignments: list[FolderStructureAssignmentPayload] = []
+    captions: Optional[list[FolderStructureCaptionPayload]] = None
+    """One row per caption pattern from the read's ``captions``, saying what
+    to read it as: ``tags``, ``description`` or ``ignore``.
+
+    Absent and empty are different answers. Absent is a client that never
+    asked (an older one), and the import probes the known conventions;
+    ``[]`` is the owner having been asked with nothing to confirm, and reads
+    no caption file. ``local_import`` only: with ``mode: "reference"`` the
+    field is refused (400), since a reference folder's suffixes are its own
+    ``PATCH /reference-folders/{folder_id}`` fields."""
     label: Optional[str] = None
     mode: Literal["reference", "local_import"] = "reference"
     """``reference`` (default): register the scanned root as an ordinary
@@ -512,6 +532,7 @@ def create_router(server) -> APIRouter:
         assignments: list,
         label: Optional[str],
         mode: str,
+        captions: Optional[list] = None,
     ) -> None:
         """Hold a library read lease for the whole commit, then run it.
 
@@ -544,7 +565,13 @@ def create_router(server) -> APIRouter:
             return
         try:
             _run_commit_holding_the_library(
-                task_id, root_path, expected_pictures, assignments, label, mode
+                task_id,
+                root_path,
+                expected_pictures,
+                assignments,
+                label,
+                mode,
+                captions,
             )
         finally:
             server.library_coordinator.release_read(lease)
@@ -556,6 +583,7 @@ def create_router(server) -> APIRouter:
         assignments: list,
         label: Optional[str],
         mode: str,
+        captions: Optional[list] = None,
     ) -> None:
         with server.folder_structure_commit_lock:
             state = server.folder_structure_commit
@@ -576,6 +604,7 @@ def create_router(server) -> APIRouter:
                         task_id, "indexing", processed, total
                     ),
                     should_stop=should_stop,
+                    captions=captions,
                 )
                 _commit_progress(
                     task_id, "assigning", expected_pictures, expected_pictures
@@ -741,6 +770,7 @@ def create_router(server) -> APIRouter:
                 record["assignments"],
                 record["label"],
                 record["mode"],
+                record["captions"],
             ),
             daemon=True,
             name="folder-structure-commit-resume",
@@ -842,8 +872,25 @@ def create_router(server) -> APIRouter:
             assignments = commit_service.parse_assignments(
                 [a.model_dump() for a in payload.assignments]
             )
+            captions = commit_service.parse_captions(
+                None
+                if payload.captions is None
+                else [c.model_dump() for c in payload.captions]
+            )
         except commit_service.CommitError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if "captions" in payload.model_fields_set and payload.mode == "reference":
+            # The field being present at all is what §22 refuses, `null`
+            # included, so this asks the request rather than the parsed
+            # answer. A reference folder's suffixes are its own contract.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "captions apply to mode=local_import. A reference folder's "
+                    "sidecar suffixes are its own: set them on "
+                    "PATCH /reference-folders/{folder_id}."
+                ),
+            )
 
         # A read commits once. Re-checked (not just re-validated) here, inside
         # the lock, immediately before the commit actually starts: two
@@ -904,6 +951,7 @@ def create_router(server) -> APIRouter:
             label=payload.label,
             expected_pictures=expected_pictures,
             assignments=assignments,
+            captions=captions,
         )
 
         threading.Thread(
@@ -915,6 +963,7 @@ def create_router(server) -> APIRouter:
                 assignments,
                 payload.label,
                 payload.mode,
+                captions,
             ),
             daemon=True,
             name="folder-structure-commit",

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -63,7 +63,6 @@ from pixlstash.db_models.character import Character
 from pixlstash.db_models.face import Face
 from pixlstash.db_models.folder_mapping_commit import (
     FolderMappingCommit,
-    STATE_ABANDONED,
     STATE_DEFERRED,
     STATE_DONE,
     STATE_PENDING,
@@ -428,11 +427,10 @@ def root_import_answered(session: Session) -> bool:
     The newest ``local_import`` record decides. ``done`` or ``deferred``
     ("organise later": index everything, map nothing) is an answer.
     ``pending`` is the commit still running and holds the scan off so the
-    two do not build rows for the same files; ``abandoned`` and
-    ``superseded`` left chunks indexed that the owner never answered for and
-    hold it off too, until a later import settles. With no ``local_import``
-    record at all a library that already holds pictures was filled some other
-    way and is scanned as before.
+    two do not build rows for the same files. ``abandoned`` and
+    ``superseded`` are no answer, so the empty library keeps waiting for the
+    offer; a library that already holds pictures is scanned as before, or an
+    aborted import would switch its rescan off for good.
 
     Both facts come from one statement so they describe one snapshot: this
     read runs outside the writer queue.
@@ -447,7 +445,7 @@ def root_import_answered(session: Session) -> bool:
     newest_state, has_picture = session.exec(
         select(newest, select(Picture.id).exists())
     ).one()
-    if newest_state in (STATE_PENDING, STATE_ABANDONED, STATE_SUPERSEDED):
+    if newest_state == STATE_PENDING:
         return False
     return newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
 

--- a/pixlstash/services/folder_structure_commit_service.py
+++ b/pixlstash/services/folder_structure_commit_service.py
@@ -63,6 +63,8 @@ from pixlstash.db_models.character import Character
 from pixlstash.db_models.face import Face
 from pixlstash.db_models.folder_mapping_commit import (
     FolderMappingCommit,
+    STATE_ABANDONED,
+    STATE_DEFERRED,
     STATE_DONE,
     STATE_PENDING,
     STATE_SUPERSEDED,
@@ -80,6 +82,12 @@ from pixlstash.services.project_membership_service import (
 )
 from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.utils.service.label_ledger import POS, record_human_labels
+from pixlstash.utils.caption_file_utils import (
+    SIDECAR_TYPE_DESCRIPTION,
+    SIDECAR_TYPE_TAGS,
+    attach_sidecars,
+    is_safe_sidecar_suffix,
+)
 from pixlstash.utils.sql_chunking import chunked
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
@@ -111,6 +119,12 @@ _POLL_INTERVAL_S = 0.25
 #: The facets a folder can be accepted as, plus "tag" which is a `Facet` value
 #: too - every accepted `kind` the mapping screen sends is one of these.
 _ACCEPTED_KINDS = frozenset(f.value for f in Facet)
+
+#: What the owner can say a caption pattern is. ``ignore`` is an answer, not
+#: the absence of one: an ignored ``.txt`` is never read, while a commit that
+#: carries no answer at all probes the known conventions.
+CAPTION_IGNORE = "ignore"
+CAPTION_KINDS = frozenset({SIDECAR_TYPE_TAGS, SIDECAR_TYPE_DESCRIPTION, CAPTION_IGNORE})
 
 
 class CommitError(Exception):
@@ -159,6 +173,76 @@ class Assignment:
             "kind": self.kind,
             "match_id": self.match_id,
         }
+
+
+@dataclass(frozen=True)
+class CaptionPattern:
+    """The owner's answer for one caption-file pattern the read found.
+
+    Attributes:
+        suffix: What follows the picture's stem (``_tags.txt``, ``.caption``,
+            ``.jpg.txt``), as the read reported it.
+        kind: ``tags``, ``description`` or ``ignore``.
+    """
+
+    suffix: str
+    kind: str
+
+    def as_dict(self) -> dict:
+        return {"suffix": self.suffix, "kind": self.kind}
+
+
+def parse_captions(raw) -> Optional[list[CaptionPattern]]:
+    """Validate the wire form of ``captions`` into `CaptionPattern` rows.
+
+    ``None`` in, ``None`` out: no answer, and the import probes the known
+    conventions. ``[]`` is an answer of nothing and reads no caption file.
+
+    Raises:
+        CommitError: A row is malformed, names an unknown kind, or carries a
+            suffix that is not a bare filename fragment, the rule the
+            reference-folder API enforces because the suffix is appended to
+            a picture path to find the file to read.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise CommitError("captions must be a list")
+    parsed: list[CaptionPattern] = []
+    seen: set[str] = set()
+    for index, row in enumerate(raw):
+        if not isinstance(row, dict):
+            raise CommitError(f"captions[{index}] must be an object")
+        suffix, kind = row.get("suffix"), row.get("kind")
+        if not isinstance(suffix, str) or not is_safe_sidecar_suffix(suffix):
+            raise CommitError(
+                f"captions[{index}].suffix must be a bare filename fragment"
+            )
+        if suffix.lower() in seen:
+            raise CommitError(f"captions[{index}] repeats suffix {suffix!r}")
+        if kind not in CAPTION_KINDS:
+            raise CommitError(
+                f"captions[{index}].kind must be one of {sorted(CAPTION_KINDS)}, got {kind!r}"
+            )
+        seen.add(suffix.lower())
+        parsed.append(CaptionPattern(suffix, kind))
+    return parsed
+
+
+def caption_suffixes(captions) -> tuple[Optional[list[str]], Optional[list[str]]]:
+    """``(tags_suffixes, description_suffixes)`` for `attach_sidecars`.
+
+    ``(None, None)`` for no answer, which probes the known conventions. An
+    empty answer gives ``([], [])``: read nothing. The order is the read's,
+    most files first, so where two confirmed suffixes both sit beside one
+    picture the library's main convention is the one read.
+    """
+    if captions is None:
+        return None, None
+    return (
+        [c.suffix for c in captions if c.kind == SIDECAR_TYPE_TAGS],
+        [c.suffix for c in captions if c.kind == SIDECAR_TYPE_DESCRIPTION],
+    )
 
 
 @dataclass
@@ -228,6 +312,7 @@ def record_pending_commit(
     label: Optional[str],
     expected_pictures: int,
     assignments: list[Assignment],
+    captions: Optional[list[CaptionPattern]] = None,
 ) -> None:
     """Write the accepted mapping down before the commit thread starts.
 
@@ -266,6 +351,11 @@ def record_pending_commit(
                 label=label,
                 expected_pictures=expected_pictures,
                 assignments=json.dumps([a.as_dict() for a in assignments]),
+                # "null", not "[]": no answer probes, an empty answer reads
+                # nothing, and a resume has to tell them apart.
+                captions=json.dumps(
+                    None if captions is None else [c.as_dict() for c in captions]
+                ),
                 stage="registering",
                 state=STATE_PENDING,
             )
@@ -302,6 +392,7 @@ def pending_commit(server) -> Optional[dict]:
             "label": row.label,
             "expected_pictures": row.expected_pictures,
             "assignments": row.assignments,
+            "captions": row.captions,
             "stage": row.stage,
         }
 
@@ -310,18 +401,55 @@ def pending_commit(server) -> Optional[dict]:
         return None
     try:
         record["assignments"] = parse_assignments(json.loads(record["assignments"]))
+        record["captions"] = parse_captions(json.loads(record["captions"]))
     except (ValueError, CommitError) as exc:
         # Unreadable is not resumable, and a start-up that raises here would
         # be a library that cannot open at all. Say so and leave the row for
         # a person; the pictures already indexed are unaffected.
         logger.error(
             "Cannot resume the folder-mapping commit %s: its recorded "
-            "assignments are unreadable (%s). Nothing was changed.",
+            "assignments or captions are unreadable (%s). Nothing was changed.",
             record["task_id"],
             exc,
         )
         return None
     return record
+
+
+def root_import_answered(session: Session) -> bool:
+    """Whether the library root may be indexed by the root scan yet.
+
+    An empty library over a folder that holds pictures is one whose owner has
+    not been asked what those pictures are: the app asks when it loads (the
+    first-run import offer). The boot-time root scan used to answer first, so
+    a small library was indexed, tags and all, before the screen came up and
+    the questions never appeared. The scan waits for the answer.
+
+    The newest ``local_import`` record decides. ``done`` or ``deferred``
+    ("organise later": index everything, map nothing) is an answer.
+    ``pending`` is the commit still running and holds the scan off so the
+    two do not build rows for the same files; ``abandoned`` and
+    ``superseded`` left chunks indexed that the owner never answered for and
+    hold it off too, until a later import settles. With no ``local_import``
+    record at all a library that already holds pictures was filled some other
+    way and is scanned as before.
+
+    Both facts come from one statement so they describe one snapshot: this
+    read runs outside the writer queue.
+    """
+    newest = (
+        select(FolderMappingCommit.state)
+        .where(FolderMappingCommit.mode == "local_import")
+        .order_by(FolderMappingCommit.id.desc())
+        .limit(1)
+        .scalar_subquery()
+    )
+    newest_state, has_picture = session.exec(
+        select(newest, select(Picture.id).exists())
+    ).one()
+    if newest_state in (STATE_PENDING, STATE_ABANDONED, STATE_SUPERSEDED):
+        return False
+    return newest_state in (STATE_DONE, STATE_DEFERRED) or has_picture
 
 
 def settle_pending_commit(server, task_id: str, state: str) -> None:
@@ -581,7 +709,11 @@ def validate_local_import_root(server, root_path: str) -> None:
 
 
 def _build_managed_picture(
-    abs_path: str, relative_path: str, image_root: str
+    abs_path: str,
+    relative_path: str,
+    image_root: str,
+    tags_suffixes: Optional[list[str]] = None,
+    description_suffixes: Optional[list[str]] = None,
 ) -> Picture:
     """Build a managed Picture for a file already sitting under *image_root*.
 
@@ -592,6 +724,9 @@ def _build_managed_picture(
     moved for the picture itself; only the thumbnail is generated, exactly as
     the reference-folder path does - the source file already lives where it
     is going to stay.
+
+    *tags_suffixes* / *description_suffixes* are `caption_suffixes`' answer
+    for the whole import, resolved once by the caller.
     """
     pixel_sha = ImageUtils.calculate_hash_from_file_path(abs_path)
     with open(abs_path, "rb") as fh:
@@ -652,6 +787,10 @@ def _build_managed_picture(
     )
     if created_at:
         pic.created_at = created_at
+    # A caption file the owner already has beside the picture beats the
+    # tagger's guess: the same read the reference-folder scan does, at the
+    # suffixes the owner confirmed (or the known conventions, unanswered).
+    attach_sidecars(pic, abs_path, tags_suffixes, description_suffixes)
     return pic
 
 
@@ -662,6 +801,7 @@ def local_import_pictures(
     expected_pictures: int,
     on_progress=None,
     should_stop=None,
+    captions: Optional[list[CaptionPattern]] = None,
 ) -> list[int]:
     """Import every supported file under *root_path* as a managed Picture.
 
@@ -686,6 +826,10 @@ def local_import_pictures(
             Checked *between* chunks and never inside one, so a stop can never
             tear a half-written chunk: every picture already inserted is
             complete and stays indexed.
+        captions: The owner's answers to the read's caption patterns, read
+            into tags and descriptions as each picture is built. ``None`` is
+            no answer and probes the known conventions; ``[]`` is an answer
+            of nothing and reads no file.
 
     Returns:
         Every matching file's Picture id, existing and newly-created alike.
@@ -742,9 +886,18 @@ def local_import_pictures(
     if on_progress is not None:
         on_progress(processed, total)
 
+    # One answer for the whole import, resolved once rather than per picture.
+    tags_suffixes, description_suffixes = caption_suffixes(captions)
+
     def _build(abs_path: str) -> Optional[Picture]:
         try:
-            return _build_managed_picture(abs_path, rel_by_abs[abs_path], image_root)
+            return _build_managed_picture(
+                abs_path,
+                rel_by_abs[abs_path],
+                image_root,
+                tags_suffixes,
+                description_suffixes,
+            )
         except Exception as exc:
             logger.warning(
                 "Local import: failed to build picture for %s: %s", abs_path, exc
@@ -795,11 +948,18 @@ def local_import_pictures(
                 )
                 built = [p for p in built if p.file_path not in taken]
             session.add_all(built)
-            session.commit()
-            for pic in built:
-                session.refresh(pic)
+            # Flush, not commit: the picture rows and their tag rows land in
+            # one transaction, since a resume reuses any picture already
+            # indexed and would never read its sidecar again.
+            session.flush()
+            # Sidecar tags land as real tags; a picture without any waits for
+            # the tagger under the sentinel, as the scan's `_insert_pictures` does.
             session.add_all(
-                Tag(picture_id=pic.id, tag=TAG_PENDING_SENTINEL) for pic in built
+                Tag(picture_id=pic.id, tag=tag)
+                for pic in built
+                for tag in (
+                    getattr(pic, "_sidecar_tags", None) or [TAG_PENDING_SENTINEL]
+                )
             )
             session.commit()
             return [pic.id for pic in built] + list(taken.values())

--- a/pixlstash/services/folder_structure_service.py
+++ b/pixlstash/services/folder_structure_service.py
@@ -63,6 +63,11 @@ import numpy as np
 from PIL import Image
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.caption_file_utils import (
+    SIDECAR_TYPE_DESCRIPTION,
+    is_safe_sidecar_suffix,
+    sniff_caption,
+)
 from pixlstash.utils.library_layout import Facet
 from pixlstash.utils.media_files import (
     SUPPORTED_IMAGE_EXTS,
@@ -92,6 +97,16 @@ MIN_FACE_SAMPLE = 5
 #: matters at level scope too: a level of one-picture folders would otherwise
 #: clear the 60% vote and be proposed as Set entire.
 MIN_SIDECAR_PICTURES = 3
+
+#: Caption files read per detected suffix to say what the pattern holds. A
+#: convention is one exporter writing every file the same way, so a handful
+#: settles it; at most two come from any one folder, so a suffix used for
+#: tags in one export and prose in another is judged across the tree.
+CAPTION_SAMPLES = 8
+_CAPTION_SAMPLES_PER_FOLDER = 2
+#: Distinct suffixes reported, most files first. More than this is stray
+#: notes, not conventions. Applied before any file is opened.
+MAX_CAPTION_PATTERNS = 12
 
 #: Below this many direct pictures the leaf and batch-numbering signals stay
 #: silent, for the reason `MIN_SIDECAR_PICTURES` does: two pictures and nothing
@@ -363,6 +378,10 @@ class FolderStructureRead:
         self._progress = progress or (lambda stage, processed, total: None)
         self._cancel = threading.Event()
         self._folders: list[_Folder] = []
+        #: lower-cased suffix -> {"suffix", "files", "folders", "samples"}:
+        #: every caption file the walk passed, grouped by the suffix after
+        #: its picture's stem. See `_collect_captions`.
+        self._captions: dict[str, dict[str, Any]] = {}
         self._truncated = False
         self._unreadable = 0
         self._skipped_hidden = 0
@@ -514,7 +533,6 @@ class FolderStructureRead:
                 parent_index=by_path.get(parent_path) if rel else None,
                 child_count=len(dirnames),
             )
-            lowered = {f.lower() for f in filenames}
             # `is_supported_media_file` drops our own `_thumb.webp` files, which
             # a library indexed before #1164 is full of, sitting beside every
             # original. Counting them made the total grow on every re-read
@@ -532,18 +550,119 @@ class FolderStructureRead:
                 and not is_hidden_entry(f)
                 and not is_pixlstash_thumbnail(f)
             )
-            for picture in folder.direct_pictures:
-                lowered_name = picture.lower()
-                stem = os.path.splitext(lowered_name)[0]
-                # Both conventions: `a.txt` beside `a.jpg`, and `a.jpg.txt`.
-                if any(
-                    stem + ext in lowered or lowered_name + ext in lowered
-                    for ext in _SIDECAR_EXTS
-                ):
-                    folder.with_sidecar += 1
+            self._collect_captions(dirpath, filenames, folder)
             by_path[dirpath] = folder.index
             self._folders.append(folder)
             self._progress("walking", len(self._folders), 0)
+
+    def _collect_captions(
+        self, dirpath: str, filenames: list[str], folder: _Folder
+    ) -> None:
+        """Group this folder's caption files by the suffix after the media stem.
+
+        A caption file is a non-media file with a caption extension whose name
+        starts with the stem of a media file in the same folder: ``a.txt``,
+        ``a_tags.txt`` and ``a.jpg.caption`` beside ``a.jpg`` are the suffixes
+        ``.txt``, ``_tags.txt`` and ``.jpg.caption``. Longest stem wins, so
+        ``foo_tags.txt`` beside both ``foo.png`` and ``foo_tags.png`` belongs
+        to the latter. Suffixes are grouped case-insensitively under the first
+        spelling seen. ``folder.with_sidecar`` (pictures with a caption file,
+        each counted once), the Set signal's evidence, comes from the same
+        pairing so the two cannot disagree.
+
+        ponytail: stems match by exact spelling, so a caption whose case
+        differs from its picture's is not paired; fold case here and in the
+        import if that shows up.
+        """
+        stems = {
+            os.path.splitext(name)[0]
+            for name in filenames
+            if not is_hidden_entry(name) and is_supported_media_file(name)
+        }
+        if not stems:
+            return
+        captioned: set[str] = set()
+        for name in sorted(filenames):
+            if (
+                is_hidden_entry(name)
+                or is_supported_media_file(name)
+                or os.path.splitext(name)[1].lower() not in _SIDECAR_EXTS
+            ):
+                continue
+            # Longest prefix that is a media stem: one set lookup per cut.
+            cut = next(
+                (i for i in range(len(name) - 1, 0, -1) if name[:i] in stems), None
+            )
+            if cut is None or not is_safe_sidecar_suffix(name[cut:]):
+                continue
+            suffix = name[cut:]
+            entry = self._captions.setdefault(
+                suffix.lower(),
+                {"suffix": suffix, "files": 0, "folders": set(), "samples": []},
+            )
+            captioned.add(name[:cut])
+            entry["files"] += 1
+            entry["folders"].add(folder.index)
+            samples = entry["samples"]
+            if (
+                len(samples) < CAPTION_SAMPLES
+                and sum(os.path.dirname(s) == dirpath for s in samples)
+                < _CAPTION_SAMPLES_PER_FOLDER
+            ):
+                samples.append(os.path.join(dirpath, name))
+        folder.with_sidecar = sum(
+            os.path.splitext(picture)[0] in captioned
+            for picture in folder.direct_pictures
+        )
+
+    def _caption_patterns(self) -> list[dict[str, Any]]:
+        """The caption conventions found, most files first, each one sniffed.
+
+        ``kind`` is the majority of the sampled files, a tie going to
+        description: a prose convention pre-filled as tags puts a sentence's
+        words on every picture, while the other mistake puts one tag list in
+        one description field. ``sample`` is an excerpt of a file of that
+        kind. A suffix none of whose samples read as a caption (binary, JSON,
+        markup) is left out. Only the first `MAX_CAPTION_PATTERNS` suffixes
+        are opened; a cancel or the deadline mid-sniff keeps what is
+        classified so far.
+        """
+        rows: list[dict[str, Any]] = []
+        ranked = sorted(
+            self._captions.values(), key=lambda e: (-e["files"], e["suffix"])
+        )
+        try:
+            for entry in ranked[:MAX_CAPTION_PATTERNS]:
+                self._checkpoint()
+                votes: Counter = Counter()
+                excerpts: dict[str, str] = {}
+                for path in entry["samples"]:
+                    sniffed = sniff_caption(path)
+                    if sniffed is None:
+                        continue
+                    votes[sniffed[0]] += 1
+                    excerpts.setdefault(sniffed[0], sniffed[1])
+                if not votes:
+                    continue
+                kind = max(
+                    votes, key=lambda k: (votes[k], k == SIDECAR_TYPE_DESCRIPTION)
+                )
+                rows.append(
+                    {
+                        "suffix": entry["suffix"],
+                        "kind": kind,
+                        "files": entry["files"],
+                        "folders": len(entry["folders"]),
+                        "sample": excerpts[kind],
+                    }
+                )
+        except ReadCancelled:
+            logger.info(
+                "Folder-structure read cancelled while reading caption files; "
+                "reporting the %d pattern(s) already classified",
+                len(rows),
+            )
+        return rows
 
     def _total_picture_counts(self) -> None:
         """Fill every folder's recursive count, deepest first.
@@ -702,11 +821,13 @@ class FolderStructureRead:
             )
 
         root = self._folders[0] if self._folders else None
+        captions = self._caption_patterns()
         # The filename lists were only ever input to the signals, and the route
         # holds this object for the process lifetime. A 28,000-picture library
         # would otherwise pin all 28,000 filenames until the next read.
         for folder in self._folders:
             folder.direct_pictures = []
+        self._captions = {}
         return {
             "root": {
                 "path": self._root,
@@ -735,6 +856,10 @@ class FolderStructureRead:
             # answers differently depending on whether models had loaded, and
             # the client cannot tell that from a library with nobody in it.
             "face_signal_ran": self._faces_ran,
+            # The caption-file conventions beside the pictures, most files
+            # first, for the owner to confirm as tags, description or ignore
+            # before the commit reads them (§20). Empty when there are none.
+            "captions": captions,
             "levels": level_docs,
         }
 

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -203,6 +203,7 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
                 self._path_mapper.resolve(rf.folder) for rf in folders
             ),
             on_root_scanned=self._note_root_scanned,
+            on_root_skipped=self.mark_root_due,
         )
 
     def _mark_mount_error(self, folder_id: int) -> None:

--- a/pixlstash/tasks/reference_folder_scan_finder.py
+++ b/pixlstash/tasks/reference_folder_scan_finder.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, select
 from pixlstash.database import DBPriority
 from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services.folder_structure_commit_service import root_import_answered
 from pixlstash.tasks.base_task_finder import BaseTaskFinder
 from pixlstash.tasks.reference_folder_scan_task import ReferenceFolderScanTask
 from pixlstash.utils.reference_folder_validator import (
@@ -26,6 +27,10 @@ logger = get_logger(__name__)
 
 # Re-scan active folders at most this often (seconds).
 _RESCAN_INTERVAL_S: float = 300.0
+#: How long a closed import gate is left alone before it is asked again. The
+#: planner sweeps up to twenty times a second, and a closed gate never stamps
+#: `_root_last_scanned`, so without this its query would run on every sweep.
+_GATE_RETRY_S: float = 5.0
 # Retry mount_error folders quickly so transient bind/access glitches clear
 # from UI without waiting for a full active re-scan interval.
 _MOUNT_ERROR_RETRY_INTERVAL_S: float = 15.0
@@ -68,10 +73,13 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         # owner renamed while the app was closed.
         self._root_last_scanned: float | None = None
         self._root_scanned_once = False
+        # When the import gate last said no, and when to ask it again.
+        self._gate_retry_at: float | None = None
 
     def mark_root_due(self) -> None:
         """Ask for the library root to be rescanned on the next planning cycle."""
         self._root_last_scanned = None
+        self._gate_retry_at = None
 
     def root_scan_complete(self) -> bool:
         """Whether the library root has been scanned at least once since boot.
@@ -172,6 +180,15 @@ class ReferenceFolderScanFinder(BaseTaskFinder):
         last = self._root_last_scanned
         if last is not None and (now - last) < _RESCAN_INTERVAL_S:
             return None
+        # The root waits for the first import offer to be answered (see
+        # `root_import_answered`). Asked only when a scan is otherwise due,
+        # and no more than once per `_GATE_RETRY_S` while the answer is no.
+        if self._gate_retry_at is not None and now < self._gate_retry_at:
+            return None
+        if not self._db.run_immediate_read_task(root_import_answered):
+            self._gate_retry_at = now + _GATE_RETRY_S
+            return None
+        self._gate_retry_at = None
         # Stamped when the task is handed out, not when it finishes, so a slow
         # scan is not queued a second time behind itself.
         self._root_last_scanned = now

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -128,6 +128,7 @@ class ReferenceFolderScanTask(BaseTask):
         resolved_path: str,
         other_resolved_paths: frozenset[str] = frozenset(),
         on_root_scanned=None,
+        on_root_skipped=None,
     ):
         super().__init__(
             task_type="ReferenceFolderScanTask",
@@ -145,6 +146,7 @@ class ReferenceFolderScanTask(BaseTask):
         # ``None`` is the library's own picture root (see the class docstring).
         self._is_root = folder_id is None
         self._on_root_scanned = on_root_scanned
+        self._on_root_skipped = on_root_skipped
         # Sidecar filename suffixes for this folder, loaded at the start of
         # _run_task(); None means "use known conventions / module defaults".
         self._tags_suffix: str | None = None
@@ -164,8 +166,10 @@ class ReferenceFolderScanTask(BaseTask):
         if self._is_root and not self._db.run_immediate_read_task(root_import_answered):
             logger.info(
                 "Library root scan skipped: a local import is unanswered. "
-                "Retried on a later cycle."
+                "Retried on the next cycle."
             )
+            if self._on_root_skipped:
+                self._on_root_skipped()
             return {"status": "skipped", "folder_id": folder_id}
 
         if not os.path.isdir(resolved):

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -18,11 +18,13 @@ from pixlstash.db_models.tag import Tag, TAG_PENDING_SENTINEL, is_tag_sentinel
 from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.tasks.base_task import BaseTask
 from pixlstash.tasks.missing_file_purge_task import MissingFilePurgeTask
+from pixlstash.services.folder_structure_commit_service import root_import_answered
 from pixlstash.utils.caption_file_utils import (
     DEFAULT_DESCRIPTION_SUFFIX,
     DEFAULT_TAGS_SUFFIX,
     SIDECAR_TYPE_DESCRIPTION,
     SIDECAR_TYPE_TAGS,
+    attach_sidecars,
     detect_folder_suffixes,
     get_sidecar_mtime,
     is_safe_sidecar_suffix,
@@ -154,6 +156,17 @@ class ReferenceFolderScanTask(BaseTask):
     def _run_task(self):
         resolved = self._resolved_path
         folder_id = self._folder_id
+
+        # The finder asked before handing this out; asked again now the scan
+        # is starting, so a local import accepted while the task sat in the
+        # queue closes the gate instead of being walked over. See
+        # `root_import_answered`.
+        if self._is_root and not self._db.run_immediate_read_task(root_import_answered):
+            logger.info(
+                "Library root scan skipped: a local import is unanswered. "
+                "Retried on a later cycle."
+            )
+            return {"status": "skipped", "folder_id": folder_id}
 
         if not os.path.isdir(resolved):
             logger.warning(
@@ -1314,30 +1327,15 @@ class ReferenceFolderScanTask(BaseTask):
         if created_at:
             pic.created_at = created_at
 
-        # Detect and read the tags and description sidecars independently, using
-        # the folder's configured suffixes (falling back to known conventions).
-        tags_path = resolve_typed_sidecar(
-            file_path, SIDECAR_TYPE_TAGS, self._tags_suffix
+        # A configured suffix is read at exactly that name; an unset one
+        # probes the known conventions. Any tags read are stashed on the row
+        # for `_insert_pictures` to persist once it has an id.
+        attach_sidecars(
+            pic,
+            file_path,
+            [self._tags_suffix] if self._tags_suffix else None,
+            [self._description_suffix] if self._description_suffix else None,
         )
-        if tags_path:
-            pic.tags_file = tags_path
-            pic.tags_file_mtime = get_sidecar_mtime(tags_path)
-            sidecar_tags = read_tags_sidecar(tags_path)
-            # Tags are stored via the Tag relationship and cannot be set on the
-            # unsaved Picture directly; stash them as a transient attribute so
-            # the caller can persist them after the Picture is inserted.
-            if sidecar_tags:
-                pic._sidecar_tags = sidecar_tags  # type: ignore[attr-defined]
-
-        description_path = resolve_typed_sidecar(
-            file_path, SIDECAR_TYPE_DESCRIPTION, self._description_suffix
-        )
-        if description_path:
-            pic.description_file = description_path
-            pic.description_file_mtime = get_sidecar_mtime(description_path)
-            sidecar_description = read_description_sidecar(description_path)
-            if sidecar_description and not pic.description:
-                pic.description = sidecar_description
 
         return pic
 

--- a/pixlstash/tasks/watch_folder_import_task.py
+++ b/pixlstash/tasks/watch_folder_import_task.py
@@ -9,14 +9,7 @@ from pixlstash.database import DBPriority
 from pixlstash.db_models.import_folder import ImportFolder
 from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.tag import Tag, TAG_PENDING_SENTINEL
-from pixlstash.utils.caption_file_utils import (
-    SIDECAR_TYPE_DESCRIPTION,
-    SIDECAR_TYPE_TAGS,
-    get_sidecar_mtime,
-    read_description_sidecar,
-    read_tags_sidecar,
-    resolve_typed_sidecar,
-)
+from pixlstash.utils.caption_file_utils import attach_sidecars
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.pixl_logging import get_logger
 from pixlstash.stacking import (
@@ -129,23 +122,9 @@ class WatchFolderImportTask(BaseTask):
 
                 # Detect tags + description sidecars next to the source image.
                 # Import folders have no per-folder suffix config, so probe the
-                # known conventions (configured_suffix=None).
-                tags_path = resolve_typed_sidecar(file_path, SIDECAR_TYPE_TAGS, None)
-                if tags_path:
-                    pic.tags_file = tags_path
-                    pic.tags_file_mtime = get_sidecar_mtime(tags_path)
-                    sidecar_tags = read_tags_sidecar(tags_path)
-                    if sidecar_tags:
-                        pic._sidecar_tags = sidecar_tags  # type: ignore[attr-defined]
-                desc_path = resolve_typed_sidecar(
-                    file_path, SIDECAR_TYPE_DESCRIPTION, None
-                )
-                if desc_path:
-                    pic.description_file = desc_path
-                    pic.description_file_mtime = get_sidecar_mtime(desc_path)
-                    sidecar_description = read_description_sidecar(desc_path)
-                    if sidecar_description and not pic.description:
-                        pic.description = sidecar_description
+                # known conventions; any tags are stashed on the row for the
+                # inserter below.
+                attach_sidecars(pic, file_path)
 
                 new_pictures.append(pic)
 

--- a/pixlstash/utils/caption_file_utils.py
+++ b/pixlstash/utils/caption_file_utils.py
@@ -18,8 +18,11 @@ import os
 import re
 import tempfile
 from collections import Counter
+from collections.abc import Collection
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.image_processing.video_utils import VIDEO_EXTENSIONS
+from pixlstash.utils.media_files import SUPPORTED_IMAGE_EXTS, is_hidden_entry
 
 logger = get_logger(__name__)
 
@@ -63,6 +66,11 @@ _DESCRIPTION_NAME_RE = re.compile(
 # suffix, and ``sidecar_path`` enforces it again at the point of use.
 _SAFE_SUFFIX_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
+# A suffix ending in a media extension names a picture, not a caption:
+# ``photo.jpg`` + ``.png`` is ``photo.png``, and a write-back there replaces
+# a picture with text.
+_MEDIA_EXTS = tuple(sorted(SUPPORTED_IMAGE_EXTS | frozenset(VIDEO_EXTENSIONS)))
+
 
 def is_safe_sidecar_suffix(suffix: str | None) -> bool:
     """Return True when *suffix* is a bare filename fragment safe to append.
@@ -72,13 +80,16 @@ def is_safe_sidecar_suffix(suffix: str | None) -> bool:
 
     Returns:
         True when appending *suffix* to an image stem cannot leave the image's
-        directory; False for empty values, ``..``, or any path separator.
+        directory and cannot name a picture or video; False for empty values,
+        ``..``, any path separator, or a media extension.
     """
     if not suffix or ".." in suffix:
         return False
     if "/" in suffix or "\\" in suffix:
         return False
     if os.sep in suffix or (os.altsep and os.altsep in suffix):
+        return False
+    if suffix.lower().endswith(_MEDIA_EXTS):
         return False
     return bool(_SAFE_SUFFIX_RE.match(suffix))
 
@@ -117,30 +128,55 @@ def sidecar_path(image_path: str, suffix: str) -> str:
 
 
 def classify_sidecar(path: str) -> str | None:
-    """Classify a sidecar file as tags or a description.
+    """The kind `sniff_caption` reads out of *path*, or ``None`` for a non-caption."""
+    sniffed = sniff_caption(path)
+    return sniffed and sniffed[0]
 
-    Filename first: an unambiguous suffix (``_tags.txt``, ``_description.txt``,
-    ``.caption`` …) decides immediately.  An ambiguous bare ``.txt`` falls back
-    to a content sniff (comma-separated short tokens -> tags; prose ->
-    description; tags when unsure).
 
-    Returns ``SIDECAR_TYPE_TAGS`` / ``SIDECAR_TYPE_DESCRIPTION``, or ``None`` if
-    the file cannot be read.
+#: How much of a caption file the sniff reads. A caption is a line or a
+#: paragraph; anything that needs more than this to classify is not one.
+_SNIFF_BYTES = 4096
+_EXCERPT_CHARS = 100
+
+
+def sniff_caption(path: str) -> tuple[str, str] | None:
+    """Classify one caption file and say what it starts with.
+
+    The one place a kind is decided from a file: the folder read's caption
+    card and the suffix probe both come through here, so what the owner is
+    shown and what the import reads agree by construction.
+
+    Returns ``(kind, excerpt)`` with *kind* ``"tags"`` or ``"description"``
+    and *excerpt* the first line or so, whitespace collapsed. ``None`` when
+    the file is not a caption at all: unreadable, binary (a NUL byte in the
+    head), JSON or markup (a generator's metadata, an XMP sidecar), or empty
+    without a name that says what it is. An unambiguous name (``_tags.txt``,
+    ``.caption`` ...) decides before the content does, an empty file
+    included; a bare ``.txt`` is decided by `_looks_like_tags`.
     """
     name = os.path.basename(path)
-    if _TAGS_NAME_RE.search(name):
-        return SIDECAR_TYPE_TAGS
-    if _DESCRIPTION_NAME_RE.search(name):
-        return SIDECAR_TYPE_DESCRIPTION
-
-    # Ambiguous (bare ``.txt`` or unknown) - decide by content.
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            raw = fh.read()
+        with open(path, "rb") as fh:
+            head = fh.read(_SNIFF_BYTES)
     except OSError as exc:
-        logger.warning("Could not read sidecar %s for classification: %s", path, exc)
+        logger.warning("Could not read caption file %s: %s", path, exc)
         return None
-    return SIDECAR_TYPE_TAGS if _looks_like_tags(raw) else SIDECAR_TYPE_DESCRIPTION
+    if b"\x00" in head:
+        return None
+    # utf-8-sig: a BOM would otherwise survive .strip() and become part of
+    # the first tag.
+    text = head.decode("utf-8-sig", errors="replace").strip()
+    if text[:1] in ("{", "[", "<"):
+        return None
+    excerpt = " ".join(text.split())[:_EXCERPT_CHARS]
+    if _TAGS_NAME_RE.search(name):
+        return SIDECAR_TYPE_TAGS, excerpt
+    if _DESCRIPTION_NAME_RE.search(name):
+        return SIDECAR_TYPE_DESCRIPTION, excerpt
+    if not text:
+        return None
+    kind = SIDECAR_TYPE_TAGS if _looks_like_tags(text) else SIDECAR_TYPE_DESCRIPTION
+    return kind, excerpt
 
 
 def resolve_typed_sidecar(
@@ -227,19 +263,120 @@ def writeback_path(
         return None
 
 
+def read_caption_text(path: str) -> str | None:
+    """The raw text of a caption file, or ``None`` when it could not be read.
+
+    An empty file reads as ``""``, so callers can tell the owner clearing a
+    caption from a read that failed.
+    """
+    try:
+        with open(path, "r", encoding="utf-8-sig", errors="replace") as fh:
+            return fh.read()
+    except OSError as exc:
+        logger.warning("Could not read sidecar %s: %s", path, exc)
+        return None
+
+
+def parse_caption_tags(raw_text: str) -> list[str]:
+    """Parse a comma-separated tag string into a deduplicated, normalised list."""
+    text = (raw_text or "").strip()
+    if not text:
+        return []
+
+    parts = [p.strip() for p in text.replace("\n", ",").split(",")]
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw_tag in parts:
+        normalised = " ".join(raw_tag.replace("_", " ").lower().split())
+        if normalised and normalised not in seen:
+            seen.add(normalised)
+            result.append(normalised)
+    return result
+
+
 def read_tags_sidecar(path: str) -> list[str]:
     """Read a tags sidecar into a normalised, de-duplicated list of tags."""
-    raw = _read_text(path)
-    return _parse_txt_tags(raw) if raw is not None else []
+    raw = read_caption_text(path)
+    return parse_caption_tags(raw) if raw is not None else []
 
 
 def read_description_sidecar(path: str) -> str | None:
     """Read a description sidecar into stripped text, or ``None`` when empty."""
-    raw = _read_text(path)
+    raw = read_caption_text(path)
     if raw is None:
         return None
     text = raw.strip()
     return text or None
+
+
+def _first_existing_sidecar(
+    image_path: str, sidecar_type: str, suffixes: list[str] | None
+) -> str | None:
+    """The sidecar of *sidecar_type* beside *image_path*, by the owner's rule.
+
+    ``None`` probes the known conventions (a bare ``.txt`` is content-sniffed);
+    a list is tried in order and the first existing file wins, so ``[]`` reads
+    nothing of that kind.
+    """
+    if suffixes is None:
+        return resolve_typed_sidecar(image_path, sidecar_type, None)
+    for suffix in suffixes:
+        try:
+            candidate = sidecar_path(image_path, suffix)
+        except ValueError as exc:
+            logger.warning("Cannot resolve sidecar for %s: %s", image_path, exc)
+            continue
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def attach_sidecars(
+    pic,
+    file_path: str,
+    tags_suffixes: list[str] | None = None,
+    description_suffixes: list[str] | None = None,
+) -> list[str]:
+    """Record the sidecars beside *file_path* on an unsaved picture.
+
+    Sets ``tags_file`` / ``description_file`` and their mtimes when a sidecar
+    exists and could be read, fills ``description`` from the description
+    sidecar when the picture has none, and returns the tags read. The list is
+    empty when there is no tags sidecar and when the file is empty; the caller
+    decides what that means (the scan and the local import both fall back to
+    the pending-tag sentinel so the tagger runs). A file that would not open
+    is not recorded at all, so the next scan tries it again.
+
+    Tags cannot be set on an unsaved `Picture` (they are a relationship), so
+    they are stashed on ``pic._sidecar_tags`` for the inserter to persist.
+
+    *tags_suffixes* / *description_suffixes*: ``None`` probes the known
+    conventions; a list is the suffixes the owner confirmed for that kind, in
+    order of preference; ``[]`` reads nothing of that kind.
+    """
+    tags: list[str] = []
+    tags_path = _first_existing_sidecar(file_path, SIDECAR_TYPE_TAGS, tags_suffixes)
+    if tags_path:
+        text = read_caption_text(tags_path)
+        if text is not None:
+            pic.tags_file = tags_path
+            pic.tags_file_mtime = get_sidecar_mtime(tags_path)
+            tags = parse_caption_tags(text)
+
+    description_path = _first_existing_sidecar(
+        file_path, SIDECAR_TYPE_DESCRIPTION, description_suffixes
+    )
+    if description_path:
+        raw = read_caption_text(description_path)
+        if raw is not None:
+            pic.description_file = description_path
+            pic.description_file_mtime = get_sidecar_mtime(description_path)
+            if raw.strip() and not pic.description:
+                pic.description = raw.strip()
+
+    if tags:
+        pic._sidecar_tags = tags  # type: ignore[attr-defined]
+    return tags
 
 
 def write_sidecar(path: str, content: str) -> float | None:
@@ -290,22 +427,36 @@ def write_sidecar(path: str, content: str) -> float | None:
     return get_sidecar_mtime(path)
 
 
-def detect_folder_suffixes(folder: str, sample_limit: int = 200) -> dict:
+def detect_folder_suffixes(
+    folder: str, sample_limit: int = 200, skip_dirs: Collection[str] = ()
+) -> dict:
     """Infer the sidecar naming convention already in use inside *folder*.
 
     Walks the folder, matches each sidecar text file to its image, derives the
     suffix that follows the image stem, classifies the sidecar (filename then
     content), and returns the most common suffix observed for each type.
+    Hidden entries and the absolute directories in *skip_dirs* (subtrees the
+    caller's own scan does not index) are not walked: a convention found in
+    one of those is not this folder's.
 
     Returns a dict ``{"tags_suffix", "description_suffix", "found_tags",
     "found_descriptions"}``; the suffix values are ``None`` when that type was
     not found.
     """
+    skipped = {os.path.normpath(path) for path in skip_dirs}
     image_stems: set[str] = set()
     sidecar_files: list[str] = []
     seen_images = 0
-    for root, _dirs, files in os.walk(folder):
+    for root, dirs, files in os.walk(folder):
+        dirs[:] = [
+            name
+            for name in dirs
+            if not is_hidden_entry(name)
+            and os.path.normpath(os.path.join(root, name)) not in skipped
+        ]
         for name in files:
+            if is_hidden_entry(name):
+                continue
             full = os.path.join(root, name)
             ext = os.path.splitext(name)[1].lower()
             if ext in _IMAGE_EXTS_FOR_DETECTION:
@@ -346,15 +497,6 @@ _IMAGE_EXTS_FOR_DETECTION = frozenset(
     {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".heic", ".heif", ".avif", ".gif"}
 )
 _SIDECAR_EXTS_FOR_DETECTION = frozenset({".txt", ".caption"})
-
-
-def _read_text(path: str) -> str | None:
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            return fh.read()
-    except OSError as exc:
-        logger.warning("Could not read sidecar %s: %s", path, exc)
-        return None
 
 
 def _suffix_for_sidecar(sidecar_path_str: str, image_stems: set[str]) -> str | None:
@@ -422,20 +564,3 @@ def _looks_like_tags(text: str) -> bool:
 
     # Short content without prose signals -> tags.
     return not has_sentence_punct
-
-
-def _parse_txt_tags(raw_text: str) -> list[str]:
-    """Parse a comma-separated tag string into a deduplicated, normalised list."""
-    text = (raw_text or "").strip()
-    if not text:
-        return []
-
-    parts = [p.strip() for p in text.replace("\n", ",").split(",")]
-    seen: set[str] = set()
-    result: list[str] = []
-    for raw_tag in parts:
-        normalised = " ".join(raw_tag.replace("_", " ").lower().split())
-        if normalised and normalised not in seen:
-            seen.add(normalised)
-            result.append(normalised)
-    return result

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -453,12 +453,6 @@ _LABEL_SINK_EXEMPT = {
         "async staging import of NEW pictures (#459) - sentinel Tag on freshly "
         "created rows that cannot yet be in a locked set"
     ),
-    ("pixlstash/tasks/watch_folder_import_task.py", "_run_task"): (
-        "watch-folder import of NEW pictures (sidecar description)"
-    ),
-    ("pixlstash/tasks/reference_folder_scan_task.py", "_build_picture"): (
-        "builds NEW picture rows during a reference-folder scan"
-    ),
     ("pixlstash/vault.py", "import_default_data"): (
         "logo / default-data import (new pictures)"
     ),

--- a/tests/test_folder_structure_commit.py
+++ b/tests/test_folder_structure_commit.py
@@ -495,6 +495,105 @@ def test_local_import_mode_imports_as_managed_pictures_and_assigns(owner_env):
         assert os.path.isfile(thumb), f"{relative} should have a thumbnail at {thumb}"
 
 
+def test_local_import_reads_the_confirmed_caption_files(owner_env):
+    """The owner's answers decide what a caption file is: a confirmed tags
+    file becomes the picture's tags, a confirmed description file its
+    description, and an ignored pattern is never opened however tag-like it
+    reads. A picture with no tags file waits for the tagger under the
+    sentinel."""
+    from sqlmodel import select
+
+    from pixlstash.db_models import Picture, Tag
+    from pixlstash.db_models.tag import TAG_PENDING_SENTINEL
+
+    server = owner_env["server"]
+    owner = owner_env["owner"]
+    root = os.path.join(server.vault.image_root, "captioned-library")
+    _make_tree(root, {"": ["a.jpg", "a.txt", "a_notes.txt", "b.jpg", "b_caption.txt"]})
+    with open(os.path.join(root, "a.txt"), "w") as fh:
+        fh.write("1girl, red_hair, solo\n")
+    with open(os.path.join(root, "a_notes.txt"), "w") as fh:
+        fh.write("reshoot, tighter crop\n")
+    with open(os.path.join(root, "b_caption.txt"), "w") as fh:
+        fh.write("A woman by a window.\n")
+
+    started = owner.post(_READ, json={"path": root})
+    read_task_id = started.json()["task_id"]
+    read = _drain_read(owner, read_task_id)
+    assert {row["suffix"] for row in read["result"]["captions"]} == {
+        ".txt",
+        "_notes.txt",
+        "_caption.txt",
+    }
+
+    commit_started = owner.post(
+        _COMMIT,
+        json={
+            "task_id": read_task_id,
+            "mode": "local_import",
+            "assignments": [],
+            "captions": [
+                {"suffix": ".txt", "kind": "tags"},
+                {"suffix": "_notes.txt", "kind": "ignore"},
+                {"suffix": "_caption.txt", "kind": "description"},
+            ],
+        },
+    )
+    assert commit_started.status_code == 200, commit_started.text
+    body = _drain_commit(owner, commit_started.json()["task_id"], timeout_s=60.0)
+    assert body["status"] == "completed", body
+
+    def read_rows(session):
+        pics = {
+            os.path.basename(p.file_path): p
+            for p in session.exec(
+                select(Picture).where(
+                    Picture.file_path.startswith("captioned-library/")
+                )
+            )
+        }
+        tags = {
+            name: sorted(
+                t.tag for t in session.exec(select(Tag).where(Tag.picture_id == pic.id))
+            )
+            for name, pic in pics.items()
+        }
+        return pics, tags
+
+    pics, tags = server.vault.db.run_task(read_rows)
+    assert tags["a.jpg"] == ["1girl", "red hair", "solo"]
+    assert pics["a.jpg"].tags_file == os.path.join(root, "a.txt")
+    assert pics["a.jpg"].description is None, "an ignored pattern is never read"
+    assert tags["b.jpg"] == [TAG_PENDING_SENTINEL]
+    assert pics["b.jpg"].description == "A woman by a window."
+
+
+def test_captions_are_refused_in_reference_mode_and_validated(owner_env):
+    from pixlstash.services import folder_structure_commit_service as commit_service
+
+    owner = owner_env["owner"]
+    root = os.path.join(owner_env["tmp"], "captions-reference")
+    _make_tree(root, {"": ["a.jpg", "a.txt"]})
+    started = owner.post(_READ, json={"path": root})
+    read_task_id = started.json()["task_id"]
+    _drain_read(owner, read_task_id)
+
+    refused = owner.post(
+        _COMMIT, json={"task_id": read_task_id, "mode": "reference", "captions": []}
+    )
+    assert refused.status_code == 400, refused.text
+    assert "local_import" in refused.json()["detail"]
+
+    for bad in (
+        [{"suffix": "../x", "kind": "tags"}],
+        [{"suffix": ".txt", "kind": "x"}],
+    ):
+        with pytest.raises(commit_service.CommitError):
+            commit_service.parse_captions(bad)
+    assert commit_service.parse_captions(None) is None
+    assert commit_service.parse_captions([]) == []
+
+
 def test_local_import_wakes_the_planner_as_each_chunk_lands(
     owner_env, monkeypatch, caplog
 ):
@@ -984,6 +1083,7 @@ def test_an_interrupted_commit_is_recorded_pending_with_what_it_needs(owner_env)
         assignments=svc.parse_assignments(
             [{"relative_path": "Anna", "kind": "person"}]
         ),
+        captions=svc.parse_captions([{"suffix": ".txt", "kind": "ignore"}]),
     )
     try:
         pending = svc.pending_commit(server)
@@ -993,6 +1093,7 @@ def test_an_interrupted_commit_is_recorded_pending_with_what_it_needs(owner_env)
         assert pending["mode"] == "reference"
         assert [a.relative_path for a in pending["assignments"]] == ["Anna"]
         assert [a.kind for a in pending["assignments"]] == ["person"]
+        assert pending["captions"] == [svc.CaptionPattern(".txt", "ignore")]
     finally:
         svc.settle_pending_commit(server, "test-interrupted", "abandoned")
 

--- a/tests/test_folder_structure_read.py
+++ b/tests/test_folder_structure_read.py
@@ -355,6 +355,60 @@ def test_a_caption_beside_most_pictures_says_nothing_at_all():
 
 
 # ===========================================================================
+# Caption files: the conventions beside the pictures, for the owner to confirm
+# ===========================================================================
+
+
+def _write(root, rel, text):
+    with open(os.path.join(root, *rel.split("/")), "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def test_caption_patterns_are_grouped_by_suffix_and_sniffed_for_kind():
+    spec = {
+        "": [],
+        "wd14": ["a.jpg", "a.txt", "b.jpg", "b.txt"],
+        "florence": ["c.jpg", "c_caption.txt", "d.jpg", "d_caption.txt", "e.jpg"],
+    }
+    with _tree(spec) as root:
+        for name in ("wd14/a.txt", "wd14/b.txt"):
+            _write(root, name, "1girl, solo, red hair\n")
+        for name in ("florence/c_caption.txt", "florence/d_caption.txt"):
+            _write(root, name, "A woman with red hair stands by a window.\n")
+        result = FolderStructureRead(root).run()
+
+    rows = {row["suffix"]: row for row in result["captions"]}
+    assert set(rows) == {".txt", "_caption.txt"}
+    assert rows[".txt"]["kind"] == "tags" and rows[".txt"]["files"] == 2
+    assert rows["_caption.txt"]["kind"] == "description"
+    assert rows["_caption.txt"]["folders"] == 1
+    assert rows["_caption.txt"]["sample"].startswith("A woman")
+
+
+def test_metadata_beside_a_picture_is_not_offered_as_a_caption():
+    """A generator's JSON and an XMP sidecar are never captions, and a `.txt`
+    holding JSON is metadata too: none of them may be pre-filled as tags."""
+    spec = {"": ["a.jpg", "a.json", "a.xmp", "a.txt", "b.jpg", "b.txt"]}
+    with _tree(spec) as root:
+        _write(root, "a.txt", '{"prompt": "1girl"}')
+        _write(root, "b.txt", "[1, 2, 3]")
+        result = FolderStructureRead(root).run()
+
+    assert result["captions"] == []
+
+
+def test_a_caption_file_is_paired_with_the_longest_picture_stem():
+    with _tree(
+        {"": ["foo.jpg", "foo_tags.jpg", "foo_tags.txt", "bar.jpg", "bar_tags.txt"]}
+    ) as root:
+        _write(root, "foo_tags.txt", "cat, dog")
+        _write(root, "bar_tags.txt", "cat, dog")
+        result = FolderStructureRead(root).run()
+
+    assert sorted(row["suffix"] for row in result["captions"]) == [".txt", "_tags.txt"]
+
+
+# ===========================================================================
 # Signal: faces (folder-scoped, sampled)
 # ===========================================================================
 

--- a/tests/test_library_root_scan.py
+++ b/tests/test_library_root_scan.py
@@ -19,6 +19,10 @@ from sqlmodel import Session, select
 
 from pixlstash.db_models import Character, Picture, Tag
 from pixlstash.db_models.external_move_review import ExternalMoveReview
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_DEFERRED,
+    FolderMappingCommit,
+)
 from pixlstash.db_models.library_settings import LibrarySettings
 from pixlstash.db_models.picture_move import PictureMove
 from pixlstash.server import Server
@@ -49,6 +53,22 @@ def server():
             for task_type in _CONFLICTING_FINDERS:
                 srv.vault._planner_work_finders.pop(task_type)
             srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
+
+            # The root scan waits for the first import offer to be answered
+            # (tests/test_root_scan_first_import.py); this module runs scans
+            # by hand on a vault that starts empty, so answer it once for all.
+            def answer(session: Session):
+                session.add(
+                    FolderMappingCommit(
+                        task_id="answered-by-test",
+                        root_path=srv.vault.image_root,
+                        mode="local_import",
+                        state=STATE_DEFERRED,
+                    )
+                )
+                session.commit()
+
+            srv.vault.db.run_task(answer)
             yield srv
 
 

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -1,0 +1,151 @@
+"""The boot-time root scan waits for the first import offer to be answered.
+
+A fresh library over a folder that already holds pictures is asked what those
+pictures are (the first-run import offer). The root scan is due the moment
+the backend boots, so on a small library it indexed everything before the
+screen came up and the questions never appeared. It waits until the newest
+``local_import`` commit has settled, or, with no such record at all, until
+the library holds a picture. See ``root_import_answered``.
+"""
+
+import os
+import tempfile
+import time
+
+import pytest
+from PIL import Image
+from sqlmodel import Session, select
+
+from pixlstash.db_models.folder_mapping_commit import (
+    STATE_ABANDONED,
+    STATE_DEFERRED,
+    STATE_DONE,
+    STATE_PENDING,
+    FolderMappingCommit,
+)
+from pixlstash.db_models.picture import Picture
+from pixlstash.server import Server
+from pixlstash.tasks import TaskType
+from pixlstash.tasks.reference_folder_scan_finder import ReferenceFolderScanFinder
+from pixlstash.utils.path_mapper import PathMapper
+
+_CONFLICTING_FINDERS = (
+    TaskType.THUMBNAIL_GENERATION,
+    TaskType.REFERENCE_FOLDER_SCAN,
+    TaskType.MISSING_FILE_PURGE,
+    TaskType.TAGGER,
+)
+
+
+@pytest.fixture
+def server():
+    """A Server per test: the gate is about a library that is really empty."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_path = os.path.join(temp_dir, "server-config.json")
+        with Server(config_path) as srv:
+            for task_type in _CONFLICTING_FINDERS:
+                srv.vault._planner_work_finders.pop(task_type)
+            srv.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
+            yield srv
+
+
+def _drop_picture(root, name):
+    path = os.path.join(root, name)
+    Image.new("RGB", (8, 8), color=(3, 4, 5)).save(path, format="PNG")
+    old = time.time() - 600
+    os.utime(path, (old, old))
+
+
+def _record(server, state, mode="local_import"):
+    def write(session: Session):
+        session.add(
+            FolderMappingCommit(
+                task_id=f"t-{mode}-{state}-{time.monotonic_ns()}",
+                root_path=server.vault.image_root,
+                mode=mode,
+                state=state,
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(write)
+
+
+def _settle_pending(server, state):
+    def write(session: Session):
+        for row in session.exec(
+            select(FolderMappingCommit).where(
+                FolderMappingCommit.state == STATE_PENDING
+            )
+        ).all():
+            row.state = state
+            session.add(row)
+        session.commit()
+
+    server.vault.db.run_task(write)
+
+
+def _managed(server):
+    return server.vault.db.run_task(
+        lambda s: list(
+            s.exec(select(Picture).where(Picture.reference_folder_id.is_(None)))
+        )
+    )
+
+
+def _finder(server):
+    return ReferenceFolderScanFinder(
+        database=server.vault.db,
+        path_mapper=PathMapper(),
+        image_root=server.vault.image_root,
+    )
+
+
+def _due(finder):
+    """Clear the interval and the gate's retry deadline: the next cycle asks."""
+    finder.mark_root_due()
+    return finder.find_task()
+
+
+def test_a_fresh_library_over_pictures_waits_for_the_offer_to_be_answered(server):
+    _drop_picture(server.vault.image_root, "loose.png")
+    finder = _finder(server)
+    assert _due(finder) is None, "the owner has not been asked yet"
+
+    _record(server, STATE_PENDING)
+    assert _due(finder) is None, "the import is still running"
+    _settle_pending(server, STATE_ABANDONED)
+    assert _due(finder) is None, "an abort is not an answer to import"
+
+    _record(server, STATE_DEFERRED)
+    task = _due(finder)
+    assert task is not None, "organise later is an answer: index everything"
+    task._run_task()
+    assert [p.file_path for p in _managed(server)] == ["loose.png"]
+
+
+def test_a_settled_import_answers_and_a_scan_queued_before_it_recheck(server):
+    _drop_picture(server.vault.image_root, "loose.png")
+    _record(server, STATE_DONE)
+    finder = _finder(server)
+    task = _due(finder)
+    assert task is not None
+
+    # Accepted while the task sat in the queue: the task asks again and skips.
+    _record(server, STATE_PENDING)
+    assert task._run_task()["status"] == "skipped"
+    assert _managed(server) == []
+
+
+def test_a_reference_commit_says_nothing_about_the_root(server):
+    _drop_picture(server.vault.image_root, "loose.png")
+    _record(server, STATE_DONE, mode="reference")
+    assert _due(_finder(server)) is None
+
+
+def test_a_library_that_already_holds_pictures_is_scanned_as_before(server):
+    _drop_picture(server.vault.image_root, "loose.png")
+    server.vault.db.run_task(
+        lambda s: (s.add(Picture(file_path="old.png", pixel_sha="x" * 40)), s.commit())
+    )
+    assert _due(_finder(server)) is not None

--- a/tests/test_root_scan_first_import.py
+++ b/tests/test_root_scan_first_import.py
@@ -131,10 +131,12 @@ def test_a_settled_import_answers_and_a_scan_queued_before_it_recheck(server):
     task = _due(finder)
     assert task is not None
 
-    # Accepted while the task sat in the queue: the task asks again and skips.
+    # Accepted while the task sat in the queue: the task asks again and skips,
+    # and the finder asks again on its next cycle, not after the interval.
     _record(server, STATE_PENDING)
     assert task._run_task()["status"] == "skipped"
     assert _managed(server) == []
+    assert finder._root_last_scanned is None
 
 
 def test_a_reference_commit_says_nothing_about_the_root(server):
@@ -148,4 +150,9 @@ def test_a_library_that_already_holds_pictures_is_scanned_as_before(server):
     server.vault.db.run_task(
         lambda s: (s.add(Picture(file_path="old.png", pixel_sha="x" * 40)), s.commit())
     )
+    assert _due(_finder(server)) is not None
+    # An aborted import is not an answer, but it must not switch the rescan
+    # off for a library that was already indexed.
+    _record(server, STATE_PENDING)
+    _settle_pending(server, STATE_ABANDONED)
     assert _due(_finder(server)) is not None


### PR DESCRIPTION
Replaces #1260 and #1264, rewritten from scratch onto \`main\` at a fraction of the size. Companion PR for the root's caption-file sync follows separately.

**Read caption files on import.** The in-place library import (\`local_import_pictures\`) built every picture under the pending-tag sentinel and never looked at the caption files beside them. It now goes through \`caption_file_utils.attach_sidecars\`, the one read the reference-folder scan and the watch-folder import share: tags land as real \`Tag\` rows in the same transaction as the picture, and only a picture with no tags file is queued for the tagger.

**Detect the conventions and let the owner confirm them.** The folder read collects every text file that pairs with a picture by name, grouped by the suffix after the stem (\`.txt\`, \`_tags.txt\`, \`.jpg.caption\`...), sniffs a few of each to tell tag lists from prose (\`sniff_caption\`, the single classifier; JSON, markup and binary are never offered) and reports them as \`captions\` on the result. The preview step lists each pattern pre-filled as Tags / Description / Ignore. The commit carries the answers: an ignored pattern is never opened, no answer at all (older client) keeps probing the known conventions, and the answer is written onto the \`FolderMappingCommit\` row (migration 0115) so a resumed commit honours it. \`mode: "reference"\` refuses the field.

**The root scan waits for the first import offer to be answered.** On a small library the boot-time root scan indexed everything before the app loaded, so the grid was never empty and the folder-mapping questions never appeared. \`root_import_answered\` decides from the newest \`local_import\` record: \`done\` or \`deferred\` is an answer; \`pending\`, \`abandoned\` and \`superseded\` hold the scan off; with no record at all, a library that already holds pictures is scanned as before. The finder asks when a root scan is due (throttled while the answer is no) and the task asks again as it starts. Since a dismissed offer would otherwise leave the library empty for good, the empty-library screen offers "Import them" as the way back into the wizard.

Also: a suffix ending in a media extension is refused everywhere a suffix is validated (it would name a picture), and \`AppDialog\` no longer closes a persistent dialog on a backdrop click.

Contract: \`docs/integration_architecture.md\` §20 (\`captions\` on the result) and §22 (\`captions\` on the commit). Mechanism: \`docs/backend_architecture.md\` §13 root-scan bullet, §24, §25; \`docs/frontend_architecture.md\`. Changelog fragment included.